### PR TITLE
f#29-add_snapshot_cancelation_feature

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/TeddyExecutor.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/TeddyExecutor.java
@@ -59,6 +59,7 @@ import java.sql.Statement;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.*;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -159,6 +160,18 @@ public class TeddyExecutor {
         updateAsFailed();
         throw new IllegalArgumentException("run(): ssType not supported: ssType=" + snapshotInfo.get("ssType"));
       }
+    } catch(CancellationException ce) {
+      LOGGER.info("run(): snapshot canceled from run_internal(): ", ce);
+      updateSnapshot("finishTime", DateTime.now(DateTimeZone.UTC).toString());
+      updateAsCanceled();
+      StringBuffer sb = new StringBuffer();
+
+      for(StackTraceElement ste : ce.getStackTrace()) {
+        sb.append("\n");
+        sb.append(ste.toString());
+      }
+      updateSnapshot("custom", "{'fail_msg':'"+sb.toString()+"'}");
+      throw ce;
     } catch (Exception e) {
       LOGGER.error("run(): error while creating a snapshot: ", e);
       updateSnapshot("finishTime", DateTime.now(DateTimeZone.UTC).toString());
@@ -331,6 +344,10 @@ public class TeddyExecutor {
   }
 
   void updateSnapshot(String colname, String value) {
+    updateSnapshot(colname, value, ssId);
+  }
+
+  void updateSnapshot(String colname, String value, String ssId) {
     LOGGER.debug("updateSnapshot(): ssId={}: update {} as {}", ssId, colname, value);
 
     URI snapshot_uri = UriComponentsBuilder.newInstance()
@@ -897,5 +914,13 @@ public class TeddyExecutor {
 
   private void updateAsFailed() {
     updateSnapshot("status", PrepSnapshot.STATUS.FAILED.name());
+  }
+
+  public void updateAsCanceling(String ssId) {
+    updateSnapshot("status", PrepSnapshot.STATUS.CANCELING.name(), ssId);
+  }
+
+  public void updateAsCanceled() {
+    updateSnapshot("status", PrepSnapshot.STATUS.CANCELED.name());
   }
 }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
@@ -2414,10 +2414,12 @@ public class PrepTransformService {
 
     List<Future<List<Row>>> jobs = teddyExecutor.getJob(ssId);
 
-    for(Future<List<Row>> job : jobs) {
-      job.cancel(true);
+    if(!jobs.isEmpty()) {
+      teddyExecutor.updateAsCanceling(ssId);
+
+      for (Future<List<Row>> job : jobs) {
+        job.cancel(true);
+      }
     }
-
   }
-
 }


### PR DESCRIPTION
Snapshot 생성 중 취소를 위한 API(preparationsnapshots/{sanpshot_id}/cancel) 호출시,
running 중인 thread 들을 cancel 하고, snapshot의 상태를 canceled로 설정하도록 기능을 추가하였습니다.