### PR TITLE
#1 set version info into LNB using ENV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ hive-site.xml
 discovery-server/src/main/resources/hive-site.xml
 !/discovery-server/src/main/java/com/metatron/discovery/domain/workbook/configurations/PageConfiguration.java
 !/discovery-server/src/main/java/com/metatron/discovery/domain/workbook/configurations/filter/ExpressionFilter.java
+discovery-frontend/src/environments/build.env.ts
 
 # dataprep local base dir
 dataprep/uploads

--- a/discovery-frontend/build.env.js
+++ b/discovery-frontend/build.env.js
@@ -1,0 +1,4 @@
+exports.vars = [
+  'METATRON_APP_VERSION',
+  'METATRON_DEPLOY_SERVER'
+];

--- a/discovery-frontend/package.json
+++ b/discovery-frontend/package.json
@@ -12,7 +12,8 @@
     "lint": "ng lint",
     "lint-fix": "ng lint --fix",
     "e2e": "ng e2e",
-    "dummy-db": "json-server --watch dummy.json"
+    "dummy-db": "json-server --watch dummy.json",
+    "prebuild": "node prebuild.js"
   },
   "private": true,
   "dependencies": {

--- a/discovery-frontend/pom.xml
+++ b/discovery-frontend/pom.xml
@@ -52,6 +52,13 @@
             <goals>
               <goal>npm</goal>
             </goals>
+
+            <configuration>
+              <environmentVariables>
+                <METATRON_APP_VERSION>${metatron.app.version}</METATRON_APP_VERSION>
+              </environmentVariables>
+              <arguments>run prebuild</arguments>
+            </configuration>
           </execution>
 
           <execution>

--- a/discovery-frontend/prebuild.js
+++ b/discovery-frontend/prebuild.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const vars = require('./build.env').vars;
+
+const env_vars = {};
+
+vars.forEach(x => {
+  if (vars.indexOf(x) !== -1) {
+  env_vars[x] = process.env[x];
+}
+});
+
+
+const buildinfo_path = path.join(__dirname, 'src', 'environments', 'build.env.ts');
+const buildinfo = JSON.stringify(env_vars, null, ' ');
+
+fs.writeFileSync(buildinfo_path, `export const BuildInfo = ${buildinfo};`);
+
+process.exit(0);

--- a/discovery-frontend/src/app/layout/layout/component/lnb/lnb.component.html
+++ b/discovery-frontend/src/app/layout/layout/component/lnb/lnb.component.html
@@ -283,6 +283,10 @@
         <dt>{{ 'msg.lnb.label.admin' | translate }}</dt>
         <dd><a href="mailto:metatron@sk.com">metatron@sk.com</a></dd>
       </dl>
+      <dl *ngIf="buildInfo.appVersion !== 'STABLE'">
+        <dt>{{ 'msg.cluster.ui.create.version' | translate }}</dt>
+        <dd>{{buildInfo.appVersion}}</dd>
+      </dl>
     </div>
   </div>
   <!-- //help -->

--- a/discovery-frontend/src/app/layout/layout/component/lnb/lnb.component.ts
+++ b/discovery-frontend/src/app/layout/layout/component/lnb/lnb.component.ts
@@ -26,6 +26,7 @@ import { SYSTEM_PERMISSION } from '../../../../common/permission/permission';
 import { CommonUtil } from '../../../../common/util/common.util';
 import { Modal } from '../../../../common/domain/modal';
 import { ConfirmModalComponent } from '../../../../common/component/modal/confirm/confirm.component';
+import { BuildInfo } from "../../../../../environments/build.env";
 
 @Component({
   selector: 'app-lnb',
@@ -107,6 +108,11 @@ export class LNBComponent extends AbstractComponent implements OnInit, OnDestroy
       users: { fold: true },
       workspaces: { fold: true }
     }
+  };
+
+  // Metatron App. 빌드 정보
+  public  buildInfo = {
+    appVersion: BuildInfo.METATRON_APP_VERSION
   };
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,8 @@
         <!-- used in dataprep -->
         <hadoop.version>2.7.2</hadoop.version>
 
+        <!-- Metatron Build Version -->
+        <metatron.app.version>STABLE</metatron.app.version>
     </properties>
     <build>
         <plugins>


### PR DESCRIPTION
Related Issue #1.

I (optionally) set version information into bottom of LNB.
Version is loaded from maven property **metatron.app.version**.

So, you can use command line parameter like
> mvn clean install **-Dmetatron.app.version=3.0.1**

If not set, nothing will be displayed.