### PR TITLE
#73 FILE snapshots also need hadoop configuration.

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/TeddyExecutor.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/TeddyExecutor.java
@@ -129,6 +129,12 @@ public class TeddyExecutor {
     cores =             (Integer) prepPropertiesInfo.get(ETL_CORES);
     timeout =           (Integer) prepPropertiesInfo.get(ETL_TIMEOUT);
     limitRows =         (Integer) prepPropertiesInfo.get(ETL_LIMIT_ROWS);
+
+    if (hadoopConfDir != null) {
+      conf = new Configuration();
+      conf.addResource(new Path(hadoopConfDir + File.separator + "core-site.xml"));
+      conf.addResource(new Path(hadoopConfDir + File.separator + "hdfs-site.xml"));
+    }
   }
 
   @Async("threadPoolTaskExecutor")
@@ -237,9 +243,6 @@ public class TeddyExecutor {
 
   private Future<String> createHdfsSnapshot(String hadoopConfDir, String[] argv) throws Throwable {
     LOGGER.info("createHdfsSnapshot(): adding hadoop config files (if exists): " + hadoopConfDir);
-    conf = new Configuration();
-    conf.addResource(new Path(hadoopConfDir + File.separator + "core-site.xml"));
-    conf.addResource(new Path(hadoopConfDir + File.separator + "hdfs-site.xml"));
 
     fs = FileSystem.get(conf);
 
@@ -305,9 +308,6 @@ public class TeddyExecutor {
     LOGGER.info("callback: restAPIserverPort={} oauth_token={}", restAPIserverPort, oauth_token.substring(0, 10));
 
     LOGGER.info("run(): adding hadoop config files (if exists): " + hadoopConfDir);
-    conf = new Configuration();
-    conf.addResource(new Path(hadoopConfDir + File.separator + "core-site.xml"));
-    conf.addResource(new Path(hadoopConfDir + File.separator + "hdfs-site.xml"));
 
     fs = FileSystem.get(conf);
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
@@ -189,7 +189,8 @@ public class PrepTransformService {
 
     switch (ssType) {
       case FILE:
-        // no more extra properties
+        // CSVs are stored on HDFS first.  (FILE dataset != FILE snapshot)
+        map.put(PrepProperties.HADOOP_CONF_DIR, prepProperties.getHadoopConfDir());
         break;
       case HDFS:
         map.put(PrepProperties.HADOOP_CONF_DIR, prepProperties.getHadoopConfDir());


### PR DESCRIPTION
### Description
FILE type dataset의 원본을 HDFS에 우선 저장하는 기능을 구현한 후,
snapshot 생성이 되지 않았던 문제.
Local file snapshot의 경우도 hadoop 설정을 해주도록 수정.


**Related Issue** :
https://github.com/metatron-app/metatron-discovery/issues/73


### How Has This Been Tested?
I made a FILE snapshot after creating a FILE dataset on HDFS.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
