### PR TITLE
#64 chart zoom changing minimap on/off

### DIFF
--- a/discovery-frontend/src/app/common/component/chart/base-chart.ts
+++ b/discovery-frontend/src/app/common/component/chart/base-chart.ts
@@ -131,6 +131,10 @@ export abstract class BaseChart extends AbstractComponent implements OnInit, OnD
   @Output()
   protected chartSelectInfo = new EventEmitter();
 
+  // 차트 데이터줌 변경정보를 UI로 전송
+  @Output()
+  protected chartDatazoomInfo = new EventEmitter<any>();
+
   // No Data
   @Output()
   protected noData = new EventEmitter();
@@ -775,6 +779,12 @@ export abstract class BaseChart extends AbstractComponent implements OnInit, OnD
     if (!this.isPage) {
       this.selection();
     }
+
+    ////////////////////////////////////////////////////////
+    // Datazoom 이벤트 등록
+    ////////////////////////////////////////////////////////
+
+    this.datazoom();
   }
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
@@ -1491,7 +1501,7 @@ export abstract class BaseChart extends AbstractComponent implements OnInit, OnD
   }
 
   ////////////////////////////////////////////////////////
-  // Selection
+  // Event
   ////////////////////////////////////////////////////////
 
   /**
@@ -1500,6 +1510,15 @@ export abstract class BaseChart extends AbstractComponent implements OnInit, OnD
    */
   protected selection(): void {
 
+  }
+
+  /**
+   * 데이터줌 이벤트를 등록한다.
+   * - 필요시 각 차트에서 Override
+   */
+  protected datazoom(): void {
+
+    this.addChartDatazoomEventListener();
   }
 
 
@@ -2273,6 +2292,17 @@ export abstract class BaseChart extends AbstractComponent implements OnInit, OnD
         console.info(type);
     }
     this.mouseMode = type;
+  }
+
+  /**
+   * Chart Datazoom Event Listener
+   */
+  public addChartDatazoomEventListener(): void {
+
+    // this.chart.off('datazoom');
+    // this.chart.on('datazoom', (params) => {
+    //   this.chartDatazoomInfo.emit(params);
+    // });
   }
 
   /**

--- a/discovery-frontend/src/app/common/component/chart/type/bar-chart/bar-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/bar-chart/bar-chart.component.ts
@@ -217,6 +217,23 @@ export class BarChartComponent extends BaseChart implements OnInit, OnDestroy, A
   }
 
   /**
+   * Chart Datazoom Event Listener
+   */
+  public addChartDatazoomEventListener(): void {
+
+    this.chart.off('datazoom');
+    this.chart.on('datazoom', (param) => {
+
+      this.chartOption.dataZoom.map((zoom, index) => {
+        if( _.eq(zoom.type, DataZoomType.SLIDER) ) {
+          this.uiOption.chartZooms[index].start = param.start;
+          this.uiOption.chartZooms[index].end = param.end;
+        }
+      });
+    });
+  }
+
+  /**
    * 바차트의 dataZoom
    */
   protected additionalDataZoom(): BaseOption {

--- a/discovery-frontend/src/app/common/component/chart/type/combine-chart/combine-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/combine-chart/combine-chart.component.ts
@@ -35,6 +35,7 @@ import { UICombineChart } from '../../option/ui-option/ui-combine-chart';
 import {UIChartAxis, UIChartAxisGrid, UIChartAxisLabelValue} from "../../option/ui-option/ui-axis";
 import {AxisOptionConverter} from "../../option/converter/axis-option-converter";
 import {Axis} from "../../option/define/axis";
+import {DataZoomType} from '../../option/define/datazoom';
 
 @Component({
   selector: 'combine-chart',
@@ -361,6 +362,23 @@ export class CombineChartComponent extends BaseChart implements OnInit, OnDestro
     this.addChartSelectEventListener();
     this.addChartMultiSelectEventListener();
     this.addLegendSelectEventListener();
+  }
+
+  /**
+   * Chart Datazoom Event Listener
+   */
+  public addChartDatazoomEventListener(): void {
+
+    this.chart.off('datazoom');
+    this.chart.on('datazoom', (param) => {
+
+      this.chartOption.dataZoom.map((zoom, index) => {
+        if( _.eq(zoom.type, DataZoomType.SLIDER) ) {
+          this.uiOption.chartZooms[index].start = param.start;
+          this.uiOption.chartZooms[index].end = param.end;
+        }
+      });
+    });
   }
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/discovery-frontend/src/app/common/component/chart/type/line-chart/line-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/line-chart/line-chart.component.ts
@@ -55,6 +55,7 @@ import Toolbox = OptionGenerator.Toolbox;
 import {UIChartAxis, UIChartAxisGrid, UIChartAxisLabelValue} from "../../option/ui-option/ui-axis";
 import {AxisOptionConverter} from "../../option/converter/axis-option-converter";
 import {Axis as AxisDefine} from "../../option/define/axis";
+import {DataZoomType} from '../../option/define/datazoom';
 
 const transparentSymbolImage: string = 'image://' + window.location.origin + '/assets/images/icon_transparent_symbol.png';
 
@@ -280,6 +281,23 @@ export class LineChartComponent extends BaseChart implements OnInit, AfterViewIn
     }
 
     return this.chartOption;
+  }
+
+  /**
+   * Chart Datazoom Event Listener
+   */
+  public addChartDatazoomEventListener(): void {
+
+    this.chart.off('datazoom');
+    this.chart.on('datazoom', (param) => {
+
+      this.chartOption.dataZoom.map((zoom, index) => {
+        if( _.eq(zoom.type, DataZoomType.SLIDER) ) {
+          this.uiOption.chartZooms[index].start = param.start;
+          this.uiOption.chartZooms[index].end = param.end;
+        }
+      });
+    });
   }
 
   /**

--- a/discovery-frontend/src/app/common/component/chart/type/scatter-chart/scatter-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/scatter-chart/scatter-chart.component.ts
@@ -544,7 +544,10 @@ export class ScatterChartComponent extends BaseChart implements OnInit, AfterVie
 
       this.chartOption.dataZoom.map((zoom, index) => {
 
-        if( _.eq(zoom.type, DataZoomType.SLIDER) && param.dataZoomId.indexOf(index) != -1 ) {
+        if( _.eq(zoom.type, DataZoomType.SLIDER)
+            && !_.isUndefined(param)
+            && !_.isUndefined(param.dataZoomId)
+            && param.dataZoomId.indexOf(index) != -1 ) {
           this.uiOption.chartZooms[index].start = param.start;
           this.uiOption.chartZooms[index].end = param.end;
         }

--- a/discovery-frontend/src/app/common/component/chart/type/scatter-chart/scatter-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/scatter-chart/scatter-chart.component.ts
@@ -46,6 +46,7 @@ import { UIChartFormat } from '../../option/ui-option/ui-format';
 import {UIChartAxisGrid} from "../../option/ui-option/ui-axis";
 import {AxisOptionConverter} from "../../option/converter/axis-option-converter";
 import {Axis} from "../../option/define/axis";
+import {DataZoomType} from '../../option/define/datazoom';
 
 @Component({
   selector: 'scatter-chart',
@@ -531,6 +532,24 @@ export class ScatterChartComponent extends BaseChart implements OnInit, AfterVie
         });
       });
     }
+  }
+
+  /**
+   * Chart Datazoom Event Listener
+   */
+  public addChartDatazoomEventListener(): void {
+
+    this.chart.off('datazoom');
+    this.chart.on('datazoom', (param) => {
+
+      this.chartOption.dataZoom.map((zoom, index) => {
+
+        if( _.eq(zoom.type, DataZoomType.SLIDER) && param.dataZoomId.indexOf(index) != -1 ) {
+          this.uiOption.chartZooms[index].start = param.start;
+          this.uiOption.chartZooms[index].end = param.end;
+        }
+      });
+    });
   }
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
마지막 저장시점의 데이터줌만 기억하여 차트 편집시 minmap on/off를 할 경우 위치가 리셋되어지는 오류를 수정합니다.

**Related Issue** : #64<!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

- 축이 있는 차트를 그린 후 데이터줌의 크기 및 위치를 이동 합니다.

- 미니맵을 on/off하여 위치가 유지되는지 확인합니다.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
