### PR TITLE
#91 Datasource detail view of workspace doesn't work

### DIFF
--- a/discovery-frontend/src/app/common/component/data-preview/data.preview.component.html
+++ b/discovery-frontend/src/app/common/component/data-preview/data.preview.component.html
@@ -16,18 +16,23 @@
 <div class="ddp-pop-preview ddp-type">
   <!-- Top title -->
   <div class="ddp-ui-top">
-    <!-- 대시보드용 tab -->
-    <div class="ddp-wrap-source-name">
+    <!-- 대시보드용 데이터소스 선택 콤보박스 -->
+    <div *ngIf="isDashboard" class="ddp-wrap-source-name" >
       <dashboard-datasource-combo
         [dataSources]="datasources"
         [initialValue]="mainDatasource"
         (selectOption)="selectDataSource($event)" ></dashboard-datasource-combo>
       <div class="ddp-txt-description">
         {{'msg.storage.ui.title.data.detail' | translate}}
-        <span *ngIf="isDashboard" class="ddp-txt-detail">- {{'msg.storage.ui.dsource.preview.usedin' | translate : {value : source.name} }}</span>
+        <span class="ddp-txt-detail">- {{'msg.storage.ui.dsource.preview.usedin' | translate : {value : source.name} }}</span>
       </div>
     </div>
-    <!-- //대시보드용 tab -->
+    <!-- // 대시보드용 데이터소스 선택 콤보박스 -->
+    <!-- 데이터소스 이름 표시 -->
+    <div *ngIf="!isDashboard" class="ddp-wrap-source-name" >
+      <div class="ddp-txt-description"> {{mainDatasource.name}} </div>
+    </div>
+    <!-- // 데이터소스 이름 표시 -->
     <em class="ddp-btn-popup-close" (click)="close()"></em>
   </div>
 

--- a/discovery-frontend/src/app/common/component/data-preview/data.preview.component.ts
+++ b/discovery-frontend/src/app/common/component/data-preview/data.preview.component.ts
@@ -79,6 +79,8 @@ export class DataPreviewComponent extends AbstractPopupComponent implements OnIn
   private barOption: any;
   private scatterOption: any;
 
+  private _zIndex:string;
+
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Protected Variables
    |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
@@ -176,6 +178,10 @@ export class DataPreviewComponent extends AbstractPopupComponent implements OnIn
   public ngOnInit() {
     super.ngOnInit();
 
+    // z-index 강제 설정
+    this._zIndex = $('.ddp-wrap-tab-popup').css( 'z-index' );
+    $('.ddp-wrap-tab-popup').css( 'z-index', '127' );
+
     // ui init
     this.initView();
 
@@ -204,6 +210,8 @@ export class DataPreviewComponent extends AbstractPopupComponent implements OnIn
    */
   public ngOnDestroy() {
     super.ngOnDestroy();
+    // z-index 설정 해제
+    $('.ddp-wrap-tab-popup').css( 'z-index', this._zIndex );
   }
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
@@ -986,7 +994,6 @@ export class DataPreviewComponent extends AbstractPopupComponent implements OnIn
 
     // 마스터 소스 타입
     this.connType = this.mainDatasource.hasOwnProperty('connType') ? this.mainDatasource.connType.toString() : 'ENGINE';
-    console.info(this.source);
 
     // singleTab
     const field = this.singleTab ? this.field : this.columns[0];

--- a/discovery-frontend/src/app/common/data.preview.module.ts
+++ b/discovery-frontend/src/app/common/data.preview.module.ts
@@ -17,6 +17,7 @@ import { CommonModule } from './common.module';
 import { DataPreviewComponent } from './component/data-preview/data.preview.component';
 import { DatasourceAliasService } from '../datasource/service/datasource-alias.service';
 import { DataDownloadComponent } from './component/data-download/data.download.component';
+import { WidgetService } from '../dashboard/service/widget.service';
 
 @NgModule({
   imports: [
@@ -30,6 +31,6 @@ import { DataDownloadComponent } from './component/data-download/data.download.c
     DataPreviewComponent,
     DataDownloadComponent
   ],
-  providers: [DatasourceAliasService]
+  providers: [DatasourceAliasService,WidgetService]
 })
 export class DataPreviewModule { }


### PR DESCRIPTION
### Description
* 워크스페이스 화면에서 데이터소스의 데이터 미리보기가 표시되지 않는 문제를 수정합니다.

**Related Issue** : #91  

### How Has This Been Tested?
1.  사용자 워크스페이스 화면에 접속합니다.
2. 상단 메뉴의 데이터소스 목록을 누르고, 표시되는 데이터소스 목록에서 하나의 데이터 소스를 선택합니다.
3. 우측에 표시되는 데이터소스 상세 정보에서 상단의 'Details' 버튼을 클릭합니다.
4. 데이터소스의 상세 정보가 표시되는 팝업이 정상적으로 표시되는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

### Additional Context<!-- if not appropriate, remove this topic. -->
