### PR TITLE
F#3 add guide connect multi ds

### DIFF
--- a/discovery-frontend/src/app/dashboard/component/create-dashboard/create-board-ds-network.component.html
+++ b/discovery-frontend/src/app/dashboard/component/create-dashboard/create-board-ds-network.component.html
@@ -63,6 +63,7 @@
             </div>
           </div>
           <!-- // motion -->
+          <div (click)="toggleGuide()" class="ddp-guide-link"><a href="javascript:" class="ddp-link-txt">got it!</a></div>
         </div>
       </div>
     </div>

--- a/discovery-frontend/src/app/dashboard/component/create-dashboard/create-board-ds-network.component.html
+++ b/discovery-frontend/src/app/dashboard/component/create-dashboard/create-board-ds-network.component.html
@@ -35,16 +35,38 @@
 
   <!-- Edit Relation Message Area -->
   <div *ngIf="isRelationEditMode" class="ddp-multidata-option">
-    <a (click)="offEditRelationMode()" href="javascript:" class="ddp-link-back">{{ 'msg.board.create.edit-associations' | translate }}</a>
+    <a (click)="toggleGuide()" href="javascript:" class="ddp-btn-guide">Guide</a>
+    <span class="ddp-edit-title">{{ 'msg.board.create.edit-associations' | translate }}</span>
     <a (click)="offEditRelationMode()" href="javascript:" class="ddp-btn-line ddp-type">
-      <em class="ddp-icon-btn-done"></em> {{ 'msg.comm.btn.done' | translate }}
+      <em class="ddp-icon-btn-done"></em>{{ 'msg.comm.btn.done' | translate }}
     </a>
   </div>
   <!-- // Edit Relation Message Area -->
 
   <!-- Board Network Area -->
-  <div *ngIf="isRenderedNetwork" class="sys-create-board-top-panel ddp-ui-multidata"
-       [ngStyle]="selectedDataSource ? {'height': 'calc(45.7666% - 5px);' } : {}" >
+  <div *ngIf="isRenderedNetwork" class="sys-create-board-top-panel ddp-ui-multidata" >
+
+    <!-- 가이드 영역 -->
+    <div *ngIf="isRelationEditMode && isShowMultiDsGuide" class="ddp-view-guide">
+      <div class="ddp-wrap-guide">
+        <div class="ddp-ui-guide">
+          <span class="ddp-txt-det">{{'msg.board.create.guide-msg1' | translate}}</span>
+          <span class="ddp-sub-det">{{'msg.board.create.guide-msg2' | translate}}</span>
+          <!-- motion -->
+          <div class="ddp-guide-motion">
+            <div class="ddp-motion ">
+              <span class="ddp-box-nodes ddp-first">Datasource 1</span>
+              <div #guideLine class="ddp-line-bar " style="padding-left:27.2978px;">
+                <em class="ddp-icon-handler"></em>
+              </div>
+              <span class="ddp-box-nodes ddp-last">Datasource 1</span>
+            </div>
+          </div>
+          <!-- // motion -->
+        </div>
+      </div>
+    </div>
+    <!-- // 가이드 영역 -->
 
     <div class="ddp-view-multidata" >
 

--- a/discovery-frontend/src/app/dashboard/component/create-dashboard/create-board-ds-network.component.html
+++ b/discovery-frontend/src/app/dashboard/component/create-dashboard/create-board-ds-network.component.html
@@ -59,7 +59,7 @@
               <div #guideLine class="ddp-line-bar " style="padding-left:27.2978px;">
                 <em class="ddp-icon-handler"></em>
               </div>
-              <span class="ddp-box-nodes ddp-last">Datasource 1</span>
+              <span class="ddp-box-nodes ddp-last">Datasource 2</span>
             </div>
           </div>
           <!-- // motion -->

--- a/discovery-frontend/src/app/dashboard/component/create-dashboard/create-board.component.html
+++ b/discovery-frontend/src/app/dashboard/component/create-dashboard/create-board.component.html
@@ -33,7 +33,7 @@
 
   </div>
   <!-- buttons -->
-  <div class="ddp-ui-buttons">
+  <div *ngIf="isShowButtons" class="ddp-ui-buttons">
     <a (click)="closeComp()" href="javascript:" class="ddp-btn-type-popup ">{{ 'msg.comm.btn.cancl' | translate }}</a>
     <!-- disabled 시 ddp-disabled 추가 -->
     <a (click)="next()" [class.ddp-disabled]="isDenyNext"

--- a/discovery-frontend/src/app/dashboard/component/create-dashboard/create-board.component.ts
+++ b/discovery-frontend/src/app/dashboard/component/create-dashboard/create-board.component.ts
@@ -27,8 +27,8 @@ export class CreateBoardComponent extends AbstractPopupComponent implements OnIn
    | Private Variables
    |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
 
-  @ViewChild( CreateBoardCompleteComponent)
-  private _completeComp:CreateBoardCompleteComponent;
+  @ViewChild(CreateBoardCompleteComponent)
+  private _completeComp: CreateBoardCompleteComponent;
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Protected Variables
@@ -44,12 +44,13 @@ export class CreateBoardComponent extends AbstractPopupComponent implements OnIn
   public workbookId: string;
 
   @Input()
-  public workbookName:string;
+  public workbookName: string;
 
   @Input()
   public workspaceId: string;
 
-  public isDenyNext:boolean = false;
+  public isDenyNext: boolean = false;
+  public isShowButtons: boolean = true;
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Constructor
@@ -88,7 +89,7 @@ export class CreateBoardComponent extends AbstractPopupComponent implements OnIn
    * 데이터소스 추가 라벨 표시 여부
    * @returns {boolean}
    */
-  public get isShowLabelAddDataSource():boolean {
+  public get isShowLabelAddDataSource(): boolean {
     return 0 === this.networkBoardComp.getCntDataSources()
   } // get - isShowLabelAddDataSource
 
@@ -96,32 +97,34 @@ export class CreateBoardComponent extends AbstractPopupComponent implements OnIn
    * 다음 단계로 이동
    */
   public next() {
-    if( this.networkBoardComp.isInvalidate() ) {
+    if (this.networkBoardComp.isInvalidate()) {
       return;
     }
     const data = this.networkBoardComp.getData();
-    this._completeComp.openComp( this.workbookId, this.workbookName, data.boardDataSources, data.relations );
+    this._completeComp.openComp(this.workbookId, this.workbookName, data.boardDataSources, data.relations);
   } // function - next
 
   /**
    * 컴포넌트 닫기
    */
-  public closeComp(isForceClose:boolean = false) {
-    if( isForceClose ) {
+  public closeComp(isForceClose: boolean = false) {
+    if (isForceClose) {
       this.close();
     } else {
-      this.unloadConfirmSvc.confirm().subscribe( (isClose) => {
-        ( isClose ) && ( this.close() );
+      this.unloadConfirmSvc.confirm().subscribe((isClose) => {
+        (isClose) && (this.close());
       });
     }
   } // function - closeComp
 
   /**
    * Next 가능 여부 체크
-   * @param {boolean} isDenyNext
+   * @param {{isDenyNext?: boolean, isShowButtons?: boolean}} data
    */
-  public checkAllowNext(isDenyNext:boolean) {
-    this.isDenyNext = isDenyNext;
+  public checkAllowNext(data: { isDenyNext?: boolean, isShowButtons?: boolean }) {
+    (data.hasOwnProperty('isDenyNext')) && (this.isDenyNext = data.isDenyNext);
+    (data.hasOwnProperty('isShowButtons')) && (this.isShowButtons = data.isShowButtons);
+    this.safelyDetectChanges();
   } // function - checkAllowNext
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/discovery-frontend/src/assets/css/polaris.v2.page.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.page.css
@@ -7941,10 +7941,14 @@ ul.ddp-list-essential li .ddp-data-det .ddp-txt-label {color:#b7b9c2;}
 
 .ddp-guide-motion .ddp-line-bar {display:inline-block;  position:absolute; top:25px; left:180px; width:45px; height:61px;  }
 .ddp-guide-motion .ddp-line-bar em.ddp-icon-handler {display:inline-block; position:absolute; top:0; right:0; width:45px; height:61px; background:url(../images/icon_handle.png) no-repeat; z-index:20;}
+.ddp-guide-link {padding:35px 0 0 0; }
+.ddp-guide-link .ddp-link-txt {padding:8px 20px 9px 20px; border:1px solid #d0d1d8; border-radius:2px; color:#fff; font-size:16px;}
+.ddp-guide-link .ddp-link-txt:hover {background-color:rgba(255,255,255,0.3);}
 
 /*.ddp-guide-motion.ddp-move .ddp-line-bar {left:180px; padding-left:178px; -webkit-transition: all 1.5s; !* Safari *!*/
-	/*transition: all 1.5s;}*/
+/*transition: all 1.5s;}*/
 .ddp-guide-motion .ddp-line-bar:before {display:inline-block; position:absolute; top:-10px; left:0; right:27px; height:40px; background-color:#d0d1d8; content:''; z-index:5}
+
 
 /**************************************************************
   network

--- a/discovery-frontend/src/assets/i18n/en.json
+++ b/discovery-frontend/src/assets/i18n/en.json
@@ -1087,6 +1087,8 @@
   "msg.board.create.edit-associations" : "Edit associations",
   "msg.board.create.select-association" : "Please select a association key",
   "msg.board.create.association-key" : "Association key",
+  "msg.board.create.guide-msg1" : "Click on a datasource and drag the edge",
+  "msg.board.create.guide-msg2" : "to another datasource to connect them",
   "msg.board.ui.no.widget": "No widgets",
   "msg.board.th.allowance": "Show open data only",
   "msg.board.btn.add.datasource.join": "Add datasource to join",

--- a/discovery-frontend/src/assets/i18n/ko.json
+++ b/discovery-frontend/src/assets/i18n/ko.json
@@ -1087,6 +1087,8 @@
   "msg.board.create.edit-associations" : "연결 수정",
   "msg.board.create.select-association" : "연결 키를 선택하세요.",
   "msg.board.create.association-key" : "연결 키",
+  "msg.board.create.guide-msg1" : "데이터 소스의 가장자리에서 드래그하십시오.",
+  "msg.board.create.guide-msg2" : "다른 데이터소스로 연결합니다.",
   "msg.board.ui.no.widget": "위젯이 없습니다",
   "msg.board.th.allowance": "오픈 데이터만 보기",
   "msg.board.btn.add.datasource.join": "조인을 위하여 데이터소스를 추가해 주세요",


### PR DESCRIPTION
### Description
* 대시보드 생성 시, association 설정 화면에서 가이드 화면을 추가합니다.

**Related Issue** : #3 

### How Has This Been Tested?
1. 대시보드 생성 화면을 띄웁니다.
2. 데이터소스 선택 팝업에서 복수의 데이터소스를 선택합니다.
3. (최초실행시) 가이드 화면에 표시되는지 확인합니다.
4. got it! 버튼을 클릭 시, 가이드 화면에 없어지는지 확인합니다.
5. 상단의 guide 버튼을 클릭했을 때, 다시 가이드 화면이 표시되는지 확인합니다.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
