### PR TITLE
F#99 snapshot fail

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepProperties.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepProperties.java
@@ -14,14 +14,13 @@
 
 package app.metatron.discovery.domain.dataprep;
 
-import app.metatron.discovery.domain.dataprep.exceptions.PrepErrorCodes;
-import app.metatron.discovery.domain.dataprep.exceptions.PrepException;
-import app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
 import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 
 @Component
 @ConfigurationProperties(prefix="polaris.dataprep")
@@ -228,10 +227,6 @@ public class PrepProperties {
     }
 
     public String getJar() {
-      if (jar == null) {
-        throw PrepException.create(PrepErrorCodes.PREP_INVALID_CONFIG_CODE,
-                PrepMessageKey.MSG_DP_ALERT_REQUIRED_PROPERTY_MISSING, ETL_JAR);
-      }
       return jar;
     }
 
@@ -288,18 +283,10 @@ public class PrepProperties {
   }
 
   public String getStagingBaseDir() {
-    if (stagingBaseDir == null) {
-      throw PrepException.create(PrepErrorCodes.PREP_INVALID_CONFIG_CODE,
-              PrepMessageKey.MSG_DP_ALERT_REQUIRED_PROPERTY_MISSING, STAGING_BASE_DIR);
-    }
     return stagingBaseDir;
   }
 
   public String getHadoopConfDir() {
-    if (hadoopConfDir == null) {
-      throw PrepException.create(PrepErrorCodes.PREP_INVALID_CONFIG_CODE,
-              PrepMessageKey.MSG_DP_ALERT_REQUIRED_PROPERTY_MISSING, HADOOP_CONF_DIR);
-    }
     return hadoopConfDir;
   }
 
@@ -356,5 +343,29 @@ public class PrepProperties {
 
   public boolean isAutoTyping() {
     return sampling.getAutoTyping();
+  }
+
+  // Everything for ETL
+  public Map<String, Object> getEveryForEtl() {
+    Map<String, Object> map = new HashMap();
+
+    map.put(HADOOP_CONF_DIR,  getHadoopConfDir());
+
+    HiveInfo hive = getHive();
+    map.put(HIVE_HOSTNAME,       hive.getHostname());
+    map.put(HIVE_PORT,           hive.getPort());
+    map.put(HIVE_USERNAME,       hive.getUsername());
+    map.put(HIVE_PASSWORD,       hive.getPassword());
+    map.put(HIVE_CUSTOM_URL,     hive.getCustomUrl());
+    map.put(HIVE_METASTORE_URIS, hive.getMetastoreUris());
+
+    EtlInfo etl = getEtl();
+    map.put(ETL_CORES,       etl.getCores());
+    map.put(ETL_TIMEOUT,     etl.getTimeout());
+    map.put(ETL_LIMIT_ROWS,  etl.getLimitRows());
+    map.put(ETL_JAR,         etl.getJar());
+    map.put(ETL_JVM_OPTIONS, etl.getJvmOptions());
+
+    return map;
   }
 }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/TeddyExecutor.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/TeddyExecutor.java
@@ -425,7 +425,8 @@ public class TeddyExecutor {
     // single thread
     if (cores == 0) {
       List<DataFrame> slaveDfs = new ArrayList<>();
-      for (String ruleString : ruleStrings) {
+      for (int ruleNo = 1; ruleNo < ruleStrings.size(); ruleNo++) {
+        String ruleString = ruleStrings.get(ruleNo);
         List<String> slaveDsIds = DataFrameService.getSlaveDsIds(ruleString);
         if (slaveDsIds != null) {
           for (String slaveDsId : slaveDsIds) {
@@ -441,7 +442,8 @@ public class TeddyExecutor {
     }
 
     // multi-thread
-    for (String ruleString : ruleStrings) {
+    for (int ruleNo = 1; ruleNo < ruleStrings.size(); ruleNo++) {
+      String ruleString = ruleStrings.get(ruleNo);
       List<Future<List<Row>>> futures = new ArrayList<>();
       List<DataFrame> slaveDfs = new ArrayList<>();
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/TeddyExecutor.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/TeddyExecutor.java
@@ -118,17 +118,17 @@ public class TeddyExecutor {
   }
 
   private void setPrepPropertiesInfo(Map<String, Object> prepPropertiesInfo) {
-    hadoopConfDir =     (String)  prepPropertiesInfo.get(HADOOP_CONF_DIR);
+    hadoopConfDir = (String)  prepPropertiesInfo.get(HADOOP_CONF_DIR);
 
-    hiveHostname =      (String)  prepPropertiesInfo.get(HIVE_HOSTNAME);
-    hivePort =          (Integer) prepPropertiesInfo.get(HIVE_PORT);
-    hiveUsername =      (String)  prepPropertiesInfo.get(HIVE_USERNAME);
-    hivePassword =      (String)  prepPropertiesInfo.get(HIVE_PASSWORD);
-    hiveCustomUrl =     (String)  prepPropertiesInfo.get(HIVE_CUSTOM_URL);
+    hiveHostname  = (String)  prepPropertiesInfo.get(HIVE_HOSTNAME);
+    hivePort      = (Integer) prepPropertiesInfo.get(HIVE_PORT);
+    hiveUsername  = (String)  prepPropertiesInfo.get(HIVE_USERNAME);
+    hivePassword  = (String)  prepPropertiesInfo.get(HIVE_PASSWORD);
+    hiveCustomUrl = (String)  prepPropertiesInfo.get(HIVE_CUSTOM_URL);
 
-    cores =             (Integer) prepPropertiesInfo.get(ETL_CORES);
-    timeout =           (Integer) prepPropertiesInfo.get(ETL_TIMEOUT);
-    limitRows =         (Integer) prepPropertiesInfo.get(ETL_LIMIT_ROWS);
+    cores         = (Integer) prepPropertiesInfo.get(ETL_CORES);
+    timeout       = (Integer) prepPropertiesInfo.get(ETL_TIMEOUT);
+    limitRows     = (Integer) prepPropertiesInfo.get(ETL_LIMIT_ROWS);
 
     if (hadoopConfDir != null) {
       conf = new Configuration();

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
@@ -545,11 +545,8 @@ public class PrepTransformService {
       return teddyImpl.getCurDf(dsId);
     }
 
-    for (int i = 0; i < ruleStrings.size(); i++) {
+    for (int i = 1; i < ruleStrings.size(); i++) {
       String ruleString = ruleStrings.get(i);
-      if(ruleString.startsWith("create")) {
-        continue;
-      }
       gridResponse = teddyImpl.append(dsId, ruleString);
     }
     LOGGER.trace("load_internal(): end (applied rules)");
@@ -1054,7 +1051,6 @@ public class PrepTransformService {
     assert dataset != null : dsId;
 
     int lastIdx = teddyImpl.getCurStageIdx(dsId);
-    PrepTransformResponse response;
 
     // increase ruleNos after the new rule.
     List<PrepTransformRule> rules = getRulesInOrder(dsId);
@@ -1071,10 +1067,8 @@ public class PrepTransformService {
     dataset.setRuleCurIdx(lastIdx + 1);
     datasetRepository.save(dataset);
 
-    response = append_internal(dsId, lastIdx, ruleString);
-
-    teddyImpl.setStageIdx(dsId, lastIdx + 1);
-    return response;
+    DataFrame gridResponse = teddyImpl.append(dsId, ruleString);
+    return new PrepTransformResponse(teddyImpl.getCurStageIdx(dsId), gridResponse);
   }
 
   private PrepTransformResponse preview(PrepDataset dataset, String ruleString) throws Exception {

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/TeddyImpl.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/TeddyImpl.java
@@ -124,6 +124,7 @@ public class TeddyImpl {
     for (int i = lastIdx + 1; i < rev.size(); i++) {
       newRev.add(apply(newRev.get(i), rev.get(i).ruleString));    // apply trailing rules of the original revision into the new revision.
     }
+    newRev.setCurStageIdx(rev.getCurStageIdx() + 1);
     addRev(dsId, newRev);
     return newDf;
   }


### PR DESCRIPTION
### Description
Snapshot 생성 실패 해결 및 전수 처리시 설정값 전달 코드 개선

**Related Issue** : https://github.com/metatron-app/metatron-discovery/issues/99

### How Has This Been Tested?
File dataset -> File snapshot done.
StagingDB dataest -> File snapshot done.
File dataset -> Hive snapshot done.
StagingDB dataset -> Hive snapshot done.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context
개별 설정값들을 얻을 때 error를 내던 방식에서,
dataset, snapshot의 각 case들을 먼저 체크를 하고, (에러낼 것은 내고)
한번에 묶어서 전달하는 방식으로 바꿈.