### PR TITLE
F#110 exclude mismatched rows in hive snapshot

### DIFF
--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-dataflow-rule.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-dataflow-rule.component.ts
@@ -5794,7 +5794,7 @@ export class EditDataflowRuleComponent extends AbstractPopupComponent implements
       columnNames.push( _column.name );
     }
     var functionNames = [
-      'add_time', 'concat', 'concat_ws', 'day', 'hour', 'if', 'isnan', 'isnull', 'length', 'lower', 'ltrim', 'math.abs', 'math.acos', 'math.asin', 'math.atan', 'math.cbrt', 'math.ceil', 'math.cos', 'math.cosh', 'math.exp', 'math.expm1', 'math.getExponent', 'math.round', 'math.signum', 'math.sin', 'math.sinh', 'math.sqrt', 'math.tan', 'math.tanh', 'millisecond', 'minute', 'month', 'now', 'rtrim', 'second', 'substring', 'time_diff', 'timestamp', 'trim', 'upper','year'
+      'add_time', 'concat', 'concat_ws', 'day', 'hour', 'if', 'ismismatched', ''isnan', 'isnull', 'length', 'lower', 'ltrim', 'math.abs', 'math.acos', 'math.asin', 'math.atan', 'math.cbrt', 'math.ceil', 'math.cos', 'math.cosh', 'math.exp', 'math.expm1', 'math.getExponent', 'math.round', 'math.signum', 'math.sin', 'math.sinh', 'math.sqrt', 'math.tan', 'math.tanh', 'millisecond', 'minute', 'month', 'now', 'rtrim', 'second', 'substring', 'time_diff', 'timestamp', 'trim', 'upper','year'
     ];
     var functionAggrNames = [
       'sum','avg','max','min','count',
@@ -5812,7 +5812,7 @@ export class EditDataflowRuleComponent extends AbstractPopupComponent implements
         columnNames.push( _column.name );
       }
       var functionNames = [
-        'add_time', 'concat', 'concat_ws', 'day', 'hour', 'if', 'isnan', 'isnull', 'length', 'lower', 'ltrim', 'math.abs', 'math.acos', 'math.asin', 'math.atan', 'math.cbrt', 'math.ceil', 'math.cos', 'math.cosh', 'math.exp', 'math.expm1', 'math.getExponent', 'math.round', 'math.signum', 'math.sin', 'math.sinh', 'math.sqrt', 'math.tan', 'math.tanh', 'millisecond', 'minute', 'month', 'now', 'rtrim', 'second', 'substring', 'time_diff', 'timestamp', 'trim', 'upper','year'
+        'add_time', 'concat', 'concat_ws', 'day', 'hour', 'if', 'ismismatched', 'isnan', 'isnull', 'length', 'lower', 'ltrim', 'math.abs', 'math.acos', 'math.asin', 'math.atan', 'math.cbrt', 'math.ceil', 'math.cos', 'math.cosh', 'math.exp', 'math.expm1', 'math.getExponent', 'math.round', 'math.signum', 'math.sin', 'math.sinh', 'math.sqrt', 'math.tan', 'math.tanh', 'millisecond', 'minute', 'month', 'now', 'rtrim', 'second', 'substring', 'time_diff', 'timestamp', 'trim', 'upper','year'
       ];
       // 2018.5.23  'now','month','day','hour','minute','second','millisecond','if','isnull','isnan','length','trim','ltrim','rtrim','upper','lower','substring','math.abs','math.acos','math.asin','math.atan','math.cbrt','math.ceil','math.cos','math.cosh','math.exp','math.expm1','math.getExponent','math.round','math.signum','math.sin','math.sinh','math.sqrt','math.tan','math.tanh','left','right','if','substring','add_time','concat','concat_ws'
       var functionAggrNames = [

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/rule-condition-input.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/rule-condition-input.component.ts
@@ -311,7 +311,7 @@ export class RuleConditionInputComponent extends AbstractComponent implements On
         columnNames.push(_column.name);
       }
       let functionNames = [
-        'add_time', 'concat', 'concat_ws', 'day', 'hour', 'if', 'isnan', 'isnull', 'length', 'lower', 'ltrim', 'math.abs', 'math.acos', 'math.asin', 'math.atan', 'math.cbrt', 'math.ceil', 'math.cos', 'math.cosh', 'math.exp', 'math.expm1', 'math.getExponent', 'math.round', 'math.signum', 'math.sin', 'math.sinh', 'math.sqrt', 'math.tan', 'math.tanh', 'millisecond', 'minute', 'month', 'now', 'rtrim', 'second', 'substring', 'time_diff', 'timestamp', 'trim', 'upper', 'year'
+        'add_time', 'concat', 'concat_ws', 'day', 'hour', 'if', 'ismismatched', 'isnan', 'isnull', 'length', 'lower', 'ltrim', 'math.abs', 'math.acos', 'math.asin', 'math.atan', 'math.cbrt', 'math.ceil', 'math.cos', 'math.cosh', 'math.exp', 'math.expm1', 'math.getExponent', 'math.round', 'math.signum', 'math.sin', 'math.sinh', 'math.sqrt', 'math.tan', 'math.tanh', 'millisecond', 'minute', 'month', 'now', 'rtrim', 'second', 'substring', 'time_diff', 'timestamp', 'trim', 'upper', 'year'
       ];
       // 2018.5.23  'now','month','day','hour','minute','second','millisecond','if','isnull','isnan','length','trim','ltrim','rtrim','upper','lower','substring','math.abs','math.acos','math.asin','math.atan','math.cbrt','math.ceil','math.cos','math.cosh','math.exp','math.expm1','math.getExponent','math.round','math.signum','math.sin','math.sinh','math.sqrt','math.tan','math.tanh','left','right','if','substring','add_time','concat','concat_ws'
       let functionAggrNames = [

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/extend-input-formula.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/extend-input-formula.component.ts
@@ -435,6 +435,9 @@ export class ExtendInputFormulaComponent extends AbstractComponent implements On
       new FormulaFunction(FunctionCategory.LOGICAL, 'if', '조건문을 검사하여 TRUE나 FALSE에 해당하는 값을 반환합니다.')
     );
     this._functionList.push(
+      new FormulaFunction(FunctionCategory.LOGICAL, 'ismismatched', '입력된 컬럼의 값과 타입이 일치하는지 판단합니다. 일치하면 TRUE, 아니면 FALSE를 반환합니다.')
+    );
+    this._functionList.push(
       new FormulaFunction(FunctionCategory.LOGICAL, 'isnull', '입력된 컬럼의 값이 null 인지 판단합니다. null이면 TRUE, 아니면 FALSE를 반환합니다.')
     );
     this._functionList.push(

--- a/discovery-prep-parser/src/main/java/app/metatron/discovery/prep/parser/preparation/PrepRuleVisitorParser.java
+++ b/discovery-prep-parser/src/main/java/app/metatron/discovery/prep/parser/preparation/PrepRuleVisitorParser.java
@@ -45,7 +45,7 @@ public class PrepRuleVisitorParser implements PrepParser {
 
     // 2018.05.23 "(?i).*(sum|avg|max|min|count|now|month|day|hour|minute|second|millisecond|if|isnull|isnan|length|trim|ltrim|rtrim|upper|lower|substring|math[.]abs|math[.]acos|math[.]asin|math[.]atan|math[.]cbrt|math[.]ceil|math[.]cos|math[.]cosh|math[.]exp|math[.]expm1|math[.]getExponent|math[.]round|math[.]signum|math[.]sin|math[.]sinh|math[.]sqrt|math[.]tan|math[.]tanh|left|right|if|substring|add_time|concat|concat_ws)\\s*$"
     private static final Pattern patternFunctionName = Pattern.compile(
-            "(?i).*(add_time| concat| concat_ws| day| hour| if| isnan| isnull| length| lower| ltrim| math[.]abs| math[.]acos| math[.]asin| math[.]atan| math[.]cbrt| math[.]ceil| math[.]cos| math[.]cosh| math[.]exp| math[.]expm1| math[.]getExponent| math[.]round| math[.]signum| math[.]sin| math[.]sinh| math[.]sqrt| math[.]tan| math[.]tanh| millisecond| minute| month| now| rtrim| second| substring| time_diff| timestamp| trim| upper| year)\\s*$"
+            "(?i).*(add_time| concat| concat_ws| day| hour| if| ismismatched| isnan| isnull| length| lower| ltrim| math[.]abs| math[.]acos| math[.]asin| math[.]atan| math[.]cbrt| math[.]ceil| math[.]cos| math[.]cosh| math[.]exp| math[.]expm1| math[.]getExponent| math[.]round| math[.]signum| math[.]sin| math[.]sinh| math[.]sqrt| math[.]tan| math[.]tanh| millisecond| minute| month| now| rtrim| second| substring| time_diff| timestamp| trim| upper| year)\\s*$"
     );
 
     private static final Map<String, Supplier<Function>> functions = Maps.newHashMap();

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepSnapshotService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepSnapshotService.java
@@ -34,6 +34,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Map;
 
 @Service
 public class PrepSnapshotService {
@@ -166,6 +167,22 @@ public class PrepSnapshotService {
             for(PrepSnapshot ss : listAll) {
                 if(ssId.equals(ss.getSsId())) {
                    return ss.getStatusEnum();
+                }
+            }
+        } catch (Exception e) {
+            throw PrepException.create(PrepErrorCodes.PREP_TRANSFORM_ERROR_CODE, e);
+        }
+
+        return null;
+    }
+
+    public Map<String,Object> getSnapshotLineageInfo(String ssId) {
+        try {
+            Sort sort = new Sort(Sort.Direction.DESC, "launchTime");
+            List<PrepSnapshot> listAll = this.snapshotRepository.findAll(sort);
+            for(PrepSnapshot ss : listAll) {
+                if(ssId.equals(ss.getSsId())) {
+                    return ss.getJsonLineageInfo();
                 }
             }
         } catch (Exception e) {

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/TeddyExecutor.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/TeddyExecutor.java
@@ -28,11 +28,13 @@ import app.metatron.discovery.domain.datasource.connection.jdbc.*;
 import app.metatron.discovery.prep.parser.exceptions.RuleException;
 import app.metatron.discovery.prep.parser.preparation.RuleVisitorParser;
 import app.metatron.discovery.prep.parser.preparation.rule.Rule;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Maps;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.hibernate.annotations.Synchronize;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
@@ -430,7 +432,6 @@ public class TeddyExecutor {
 
     // multi-thread
     for (int ruleNo = 1; ruleNo < ruleStrings.size(); ruleNo++) {
-      cancelCheck(ssId);
       String ruleString = ruleStrings.get(ruleNo);
 
       List<Future<List<Row>>> futures = new ArrayList<>();
@@ -463,6 +464,7 @@ public class TeddyExecutor {
               futures.add(dataFrameService.gatherAsync(df, newDf, preparedArgs, rowno, Math.min(partSize, rowcnt - rowno), limitRows));
             }
 
+            cancelCheck(ssId);
             addJob(ssId, futures);
 
             for (int i = 0; i < futures.size(); i++) {
@@ -716,7 +718,7 @@ public class TeddyExecutor {
 
   public String writeToHdfs(String ssId, String dsId, String extHdfsDir, String dbName, String tblName,
                             FORMAT format, COMPRESSION compression) throws IOException {
-    Integer rowCnt = null;
+    Integer[] rowCnt = new Integer[2];
     FileSystem fs = FileSystem.get(conf);
 
     LOGGER.trace("writeToHdfs(): start");
@@ -735,7 +737,7 @@ public class TeddyExecutor {
         Path file = new Path(dir.toString() + File.separator + "part-00000-" + dsId + ".csv");
         OutputStream os = fs.create(file);
         BufferedWriter br = new BufferedWriter(new OutputStreamWriter(os, "UTF-8"));
-        rowCnt = writeCsv(ssId, df, br, null);
+        rowCnt[0] = writeCsv(ssId, df, br, null);
         break;
       case ORC:
         file = new Path(dir.toString() + File.separator + "part-00000-" + dsId + ".orc");
@@ -755,7 +757,14 @@ public class TeddyExecutor {
     fin = fs.create(byTeddy);
     fin.close();
 
-    updateSnapshot("totalLines", String.valueOf(rowCnt), ssId);
+    updateSnapshot("totalLines", String.valueOf(rowCnt[0]), ssId);
+
+    if(rowCnt[1]!=null && rowCnt[1]>0) {
+      Map<String, Object> lineageInfo = snapshotService.getSnapshotLineageInfo(ssId);
+      lineageInfo.put("excludedLines", rowCnt[1]);
+      ObjectMapper mapper = new ObjectMapper();
+      updateSnapshot("lineageInfo", mapper.writeValueAsString(lineageInfo), ssId);
+    }
 
     LOGGER.trace("writeToHdfs(): end");
     return dir.toUri().toString();
@@ -879,7 +888,7 @@ public class TeddyExecutor {
     return (List<Future<List<Row>>>) jobList.get(key);
   }
 
-  private void addJob(String key, Object value) {
+  synchronized private void addJob(String key, Object value) {
     jobList.put(key, value);
   }
 
@@ -912,7 +921,7 @@ public class TeddyExecutor {
     snapshotRuleDoneCnt.remove(ssId);
   }
 
-  public void updateAsCanceling(String ssId) {
+  synchronized public void updateAsCanceling(String ssId) {
     updateSnapshot("status", PrepSnapshot.STATUS.CANCELING.name(), ssId);
   }
 
@@ -921,7 +930,7 @@ public class TeddyExecutor {
     snapshotRuleDoneCnt.remove(ssId);
   }
 
-  public void cancelCheck(String ssId) throws CancellationException{
+  synchronized public void cancelCheck(String ssId) throws CancellationException{
     if(snapshotService.getSnapshotStatus(ssId).equals(PrepSnapshot.STATUS.CANCELING)) {
       throw new CancellationException("This snapshot generating was canceled by user. ssid: " + ssId);
     }


### PR DESCRIPTION
### Description
Hive-ORC 를 선택해 snapshot을 생성할 때 null 값이나 type mismatched인 row를 제거하도록 개선.

**Related Issue** : <!--- Please link to the issue here. -->
https://github.com/metatron-app/metatron-discovery/issues/110


### How Has This Been Tested?
Missing(null), Mismatched 값을 가진 dataset을 hive-ORC 규격으로 snapshot 생성.
1. 스냅샷 생성 성공.
2. null과 mismatched value가 있는 row가 결과에서 제거되어있음.
3. lineageInfo에 excludedLine 값이 기록됨.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
