### PR TITLE
#66 build RevisionSet before snapshot generation

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
@@ -950,6 +950,10 @@ public class PrepTransformService {
 
     LOGGER.trace("transform_snapshot(): start");
 
+    if (teddyImpl.revisionSetCache.containsKey(wrangledDsId) == false) {
+      load_internal(wrangledDsId);
+    }
+
     PrepSnapshot snapshot = new PrepSnapshot();
 
     DateTime launchTime = DateTime.now(DateTimeZone.UTC);


### PR DESCRIPTION
### Description
편집 창에 들어가지 않고 스냅샷을 생성할 때, 서버 부팅 후 한번도 편집하지 않은 경우 에러 발생
스냅샷 생성 전에 RevisionSet 생성하도록 수정

**Related Issue** : https://github.com/metatron-app/metatron-discovery/issues/66

### How Has This Been Tested?
서버 재부팅 후 편집 창에 들어가지 않고 스냅샷 생성 -> 성공함

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
