### PR TITLE
F#121 check hive naming rule

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DataFrame.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DataFrame.java
@@ -3552,12 +3552,12 @@ public class DataFrame implements Serializable, Transformable {
   }
 
   // Hive 테이블로 만들 때에만 이 함수를 사용해서 컬럼명을 제약함.
-  public void checkNonAlphaNumerical(String colName) throws IllegalColumnNameForHiveException {
-    Pattern p = Pattern.compile("[^\\\\p{IsAlphabetic}^\\\\p{Digit}_]");
+  public void checkAlphaNumerical(String colName) throws IllegalColumnNameForHiveException {
+    Pattern p = Pattern.compile("^[a-zA-Z0-9_]*$");
     Matcher m = p.matcher(colName);
 
     // 영문자, 숫자, _만 허용
-    if (m.matches()) {
+    if (m.matches() == false) {
       throw new IllegalColumnNameForHiveException("The column name contains non-alphanumerical characters: " + colName);
     }
 
@@ -3569,9 +3569,9 @@ public class DataFrame implements Serializable, Transformable {
   }
 
   // Hive 테이블로 만들 때에만 이 함수를 사용해서 컬럼명을 제약함
-  public void checkNonAlphaNumericalColNames() throws IllegalColumnNameForHiveException {
+  public void checkAlphaNumericalColNames() throws IllegalColumnNameForHiveException {
     for (String colName : colNames) {
-      checkNonAlphaNumerical(colName);
+      checkAlphaNumerical(colName);
     }
   }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/TeddyExecutor.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/TeddyExecutor.java
@@ -311,6 +311,10 @@ public class TeddyExecutor {
     transformRecursive(datasetInfo, ssId);
     String masterFullDsId = replaceMap.get(masterTeddyDsId);
 
+    // Some rules like pivot may break Hive column naming rule.
+    DataFrame finalDf = cache.get(masterFullDsId);
+    finalDf.checkAlphaNumericalColNames();
+
     List<String> ruleStrings = (List<String>) datasetInfo.get("ruleStrings");
     List<String> partKeys = (List<String>) snapshotInfo.get("partKeys");
     String format = (String) snapshotInfo.get("format");

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/TeddyExecutor.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/TeddyExecutor.java
@@ -414,8 +414,7 @@ public class TeddyExecutor {
     // single thread
     if (cores == 0) {
       List<DataFrame> slaveDfs = new ArrayList<>();
-      for (int ruleNo = 1; ruleNo < ruleStrings.size(); ruleNo++) {
-        String ruleString = ruleStrings.get(ruleNo);
+      for (String ruleString : ruleStrings) {   // create rule has been removed already
         List<String> slaveDsIds = DataFrameService.getSlaveDsIds(ruleString);
         if (slaveDsIds != null) {
           for (String slaveDsId : slaveDsIds) {
@@ -431,9 +430,7 @@ public class TeddyExecutor {
     }
 
     // multi-thread
-    for (int ruleNo = 1; ruleNo < ruleStrings.size(); ruleNo++) {
-      String ruleString = ruleStrings.get(ruleNo);
-
+    for (String ruleString : ruleStrings) {     // create rule has been removed already
       List<Future<List<Row>>> futures = new ArrayList<>();
       List<DataFrame> slaveDfs = new ArrayList<>();
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
@@ -860,9 +860,9 @@ public class PrepTransformService {
 
     // put ruleStrings
     List<String> ruleStrings = new ArrayList<>();
-    for (PrepTransformRule transformRule : getRulesInOrder(wrangledDsId)) {
-      String ruleString = transformRule.getRuleString();
-      ruleStrings.add(ruleString);
+    List<PrepTransformRule> transformRules = getRulesInOrder(wrangledDsId);
+    for (int i = 1; i < transformRules.size(); i++) {
+      ruleStrings.add(transformRules.get(i).getRuleString());
     }
     datasetInfo.put("ruleStrings", ruleStrings);
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/TeddyImpl.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/TeddyImpl.java
@@ -66,7 +66,7 @@ public class TeddyImpl {
   public void checkNonAlphaNumericalColNames(String dsId) throws IllegalColumnNameForHiveException {
     Revision rev = getCurRev(dsId);
     DataFrame df = rev.get(-1);
-    df.checkNonAlphaNumericalColNames();
+    df.checkAlphaNumericalColNames();
   }
 
   public void remove(String dsId) throws PrepException {


### PR DESCRIPTION
### Description
Checking column names of Hive snapshots

**Related Issue** : https://github.com/metatron-app/metatron-discovery/issues/121


### How Has This Been Tested?
I made Hive snapshots with Korean letter column names.
File snapshot succeeded, Hive snapshot failed. -> This is the right behavior.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
The naming check comes before making a snapshot entity.

Some rules like pivot can produce columns which were not existed, so that we need to check again.
This comes just before sending CREATE TABLE.