### PR TITLE
#102 escape unexpected value in query result from druid

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/data/result/PivotResultFormat.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/data/result/PivotResultFormat.java
@@ -255,7 +255,10 @@ public class PivotResultFormat extends SearchResultFormat {
       while (fields.hasNext()) {
         Map.Entry<String, JsonNode> nodeMap = fields.next();
         String nodeKey = nodeMap.getKey();
+        // Escape separator if nodeKey start with separator. ex. -SUM(m1)
+        nodeKey = nodeKey.startsWith(separator) ? nodeKey.substring(1) : nodeKey;
         JsonNode nodeValue = nodeMap.getValue();
+
         // Percentage Case
         if (includePercentage && StringUtils.endsWith(nodeKey, ChartResultFormat.POSTFIX_PERCENTAGE)) {
           String originalKey = StringUtils.substring(nodeKey, 0, nodeKey.length() - ChartResultFormat.POSTFIX_PERCENTAGE.length());


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
기존 수정본에 추가하여 Druid 내에서 쿼리 결과에 대한 처리 오류로 파생된  차트 표현 오류(Category 처리)를 수정하였습니다.

**Related Issue** : #102 
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
- 기존 Heatmap 오류 확인 외 Bar 차트내 행/열 차원값을 각각 1개씩 , 측정값 1개를 선반에 올려두어 차트가 잘 나오는지 확인합니다.
- 이후 데이터레이블/툴팁레이블에 Category Name/Value/Percentage 가 잘 표시되는지 확인합니다.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
