### PR TITLE
F#140 data preparation function minor changes

### DIFF
--- a/discovery-prep-parser/src/main/java/app/metatron/discovery/prep/parser/preparation/rule/expr/BuiltinFunctions.java
+++ b/discovery-prep-parser/src/main/java/app/metatron/discovery/prep/parser/preparation/rule/expr/BuiltinFunctions.java
@@ -1177,8 +1177,8 @@ public interface BuiltinFunctions extends Function.Library {
 
       @Override
       public boolean validate(List<Expr> args) {
-        if (args.size() != 3) {
-          LOGGER.warn("function 'substring' needs 3 argument");
+        if (args.size() > 3 || args.size() < 2) {
+          LOGGER.warn("function 'substring' allows 2 or 3 arguments");
           return false;
         }
 

--- a/discovery-prep-parser/src/main/java/app/metatron/discovery/prep/parser/preparation/rule/expr/Expr.java
+++ b/discovery-prep-parser/src/main/java/app/metatron/discovery/prep/parser/preparation/rule/expr/Expr.java
@@ -293,19 +293,31 @@ public interface Expr extends Expression {
       }
       else if (function instanceof BuiltinFunctions.Str.SubstringFunc) {
         // substring(expr)
-        assert (args.size() == 3) : args.size();
+        assert (args.size() == 2 || args.size() == 3) : args.size();
 
         try{
           ExprEval exprEval = args.get(0).eval(bindings);
-          int beginIndex = args.get(1).eval(bindings).intValue();
-          int endIndex = args.get(2).eval(bindings).intValue();
           String exprStr = exprEval.stringValue();
 
-          if(beginIndex > exprStr.length())
-            beginIndex=exprStr.length();
-          if(endIndex > exprStr.length())
-            endIndex=exprStr.length();
-          return (exprEval.value() == null) ? exprEval : ExprEval.bestEffortOf(exprStr.substring(beginIndex, endIndex));
+          int beginIndex = args.get(1).eval(bindings).intValue();
+          if(beginIndex > exprStr.length()) {
+            beginIndex = exprStr.length();
+          } else if (beginIndex < 0) {
+            beginIndex = exprStr.length()+beginIndex;
+          }
+
+          if(args.size()==2) {
+            exprStr = exprStr.substring(beginIndex);
+          } else {
+            int endIndex = beginIndex + args.get(2).eval(bindings).intValue();
+            if(endIndex > exprStr.length()) {
+              endIndex = exprStr.length();
+            }
+
+            exprStr = exprStr.substring(beginIndex, endIndex);
+          }
+
+          return (exprEval.value() == null) ? exprEval : ExprEval.bestEffortOf(exprStr);
         } catch (StringIndexOutOfBoundsException se) {
           throw new FunctionInvalidIndexNumberException("ExprEval.eval() substring: Wrong index param");
         } catch (NullPointerException ne){

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepSnapshotService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepSnapshotService.java
@@ -176,6 +176,22 @@ public class PrepSnapshotService {
         return null;
     }
 
+    public void updateSnapshotStatus(String ssId, PrepSnapshot.STATUS status) {
+        try {
+            Sort sort = new Sort(Sort.Direction.DESC, "launchTime");
+            List<PrepSnapshot> listAll = this.snapshotRepository.findAll(sort);
+            for(PrepSnapshot ss : listAll) {
+                if(ssId.equals(ss.getSsId())) {
+                    ss.setStatus(status);
+                    this.snapshotRepository.saveAndFlush(ss);
+                    break;
+                }
+            }
+        } catch (Exception e) {
+            throw PrepException.create(PrepErrorCodes.PREP_TRANSFORM_ERROR_CODE, e);
+        }
+    }
+
     public Map<String,Object> getSnapshotLineageInfo(String ssId) {
         try {
             Sort sort = new Sort(Sort.Direction.DESC, "launchTime");

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DataFrame.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DataFrame.java
@@ -561,25 +561,27 @@ public class DataFrame implements Serializable, Transformable {
     return newDf;
   }
 
-  private void assertArgc(int desirable, List<Expr> args, String func) throws TeddyException {
+  //check if Args size are exactly matched with desirable size.
+  private void assertArgsEq(int desirable, List<Expr> args, String func) throws TeddyException {
     if (args.size() != desirable) {
       LOGGER.error("decideType(): invalid function arguments: func={} argc={} desirable={}", func, args.size(), desirable);
       throw new InvalidFunctionArgsException("decideType(): invalid function arguments");
     }
   }
 
-  private void assertArgc(int desirable, List<Expr> args, String func, int option) throws TeddyException { // TeddyException {
-    if (option==1) {
-      if(args.size() < desirable){
-        LOGGER.error("decideType(): invalid function arguments: func={} argc={} desirable={}", func, args.size(), desirable);
-        throw new InvalidFunctionArgsException("decideType(): invalid function arguments");
-      }
+  //check if Args size are greater than matched with desirable size.
+  private void assertArgsGt(int desirable, List<Expr> args, String func) throws TeddyException {
+    if (args.size() < desirable) {
+      LOGGER.error("decideType(): invalid function arguments: func={} argc={} desirable= greater than {}", func, args.size(), desirable);
+      throw new InvalidFunctionArgsException("decideType(): invalid function arguments");
     }
-    else if (option==2) {
-      if(args.size() > desirable){
-        LOGGER.error("decideType(): invalid function arguments: func={} argc={} desirable={}", func, args.size(), desirable);
-        throw new InvalidFunctionArgsException("decideType(): invalid function arguments");
-      }
+  }
+
+  //check if Args size are in between desirable nubmers.
+  private void assertArgsBw(int min, int max, List<Expr> args, String func) throws TeddyException {
+    if (args.size() < min || args.size() > max) {
+      LOGGER.error("decideType(): invalid function arguments: func={} argc={} desirable= between {} and {}", func, args.size(), min, max);
+      throw new InvalidFunctionArgsException("decideType(): invalid function arguments");
     }
   }
 
@@ -684,17 +686,17 @@ public class DataFrame implements Serializable, Transformable {
         case "math.getExponent":
         case "math.round":
           resultType = ColumnType.LONG;
-          assertArgc(1, args, func);
+          assertArgsEq(1, args, func);
           break;
         case "isnull":
         case "isnan":
         case "ismissing":
           resultType = ColumnType.BOOLEAN;
-          assertArgc(1, args, func);
+          assertArgsEq(1, args, func);
           break;
         case "ismismatched":
           resultType = ColumnType.BOOLEAN;
-          assertArgc(2, args, func);
+          assertArgsEq(2, args, func);
           break;
         case "upper":
         case "lower":
@@ -702,11 +704,11 @@ public class DataFrame implements Serializable, Transformable {
         case "ltrim":
         case "rtrim":
           resultType = ColumnType.STRING;
-          assertArgc(1, args, func);
+          assertArgsEq(1, args, func);
           break;
         case "math.abs":
           resultType = decideType(args.get(0));
-          assertArgc(1, args, func);
+          assertArgsEq(1, args, func);
           break;
         case "math.acos":
         case "math.asin":
@@ -724,17 +726,17 @@ public class DataFrame implements Serializable, Transformable {
         case "math.tan":
         case "math.tanh":
           resultType = ColumnType.DOUBLE;
-          assertArgc(1, args, func);
+          assertArgsEq(1, args, func);
           break;
         // 2-argument functions
         case "math.max":
         case "math.min":
           resultType = ColumnType.LONG;
-          assertArgc(2, args, func);
+          assertArgsEq(2, args, func);
           break;
         case "math.pow":
           resultType = ColumnType.DOUBLE;
-          assertArgc(2, args, func);
+          assertArgsEq(2, args, func);
           break;
         case "coalesce":
           resultType = ColumnType.UNKNOWN;
@@ -742,18 +744,18 @@ public class DataFrame implements Serializable, Transformable {
         // 3-argument functions
         case "substring":
           resultType = ColumnType.STRING;
-          assertArgc(3, args, func);
+          assertArgsBw(2, 3, args, func);
           break;
         case "timestamptostring":
           resultType = ColumnType.STRING;
-          assertArgc(2, args, func);
+          assertArgsEq(2, args, func);
           break;
         case "concat":
-          assertArgc(1, args, func, 1);
+          assertArgsGt(1, args, func);
           resultType=ColumnType.STRING;
           break;
         case "concat_ws":
-          assertArgc(2, args, func, 1);
+          assertArgsGt(2, args, func);
           resultType=ColumnType.STRING;
           break;
         case "sum":
@@ -761,7 +763,7 @@ public class DataFrame implements Serializable, Transformable {
         case "mean":
         case "max":
         case "min":
-          assertArgc(2, args, func, 1);
+          assertArgsGt(2, args, func);
           resultType=ColumnType.DOUBLE;
           break;
         case "year":
@@ -772,27 +774,27 @@ public class DataFrame implements Serializable, Transformable {
         case "second":
         case "millisecond":
           resultType = ColumnType.LONG;
-          assertArgc(1, args, func);
+          assertArgsEq(1, args, func);
           break;
         case "weekday":
           resultType = ColumnType.STRING;
-          assertArgc(1, args, func);
+          assertArgsEq(1, args, func);
           break;
         case "now":
           resultType = ColumnType.TIMESTAMP;
-          assertArgc(1, args, func, 2);
+          assertArgsBw(0, 1, args, func);
           break;
         case "add_time":
           resultType = ColumnType.TIMESTAMP;
-          assertArgc(3, args, func);
+          assertArgsEq(3, args, func);
           break;
         case "time_diff":
           resultType = ColumnType.LONG;
-          assertArgc(2, args, func);
+          assertArgsEq(2, args, func);
           break;
         case "timestamp":
           resultType = ColumnType.TIMESTAMP;
-          assertArgc(2, args, func);
+          assertArgsEq(2, args, func);
           break;
         default:
           LOGGER.error("decideType(): invalid function type: " + expr.toString());

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DfWindow.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DfWindow.java
@@ -247,7 +247,7 @@ public class DfWindow extends DataFrame {
                         case "rolling_sum":
                             targetColName = func.getArgs().get(0).toString();
                             start = i - func.getArgs().get(1).eval(row).asInt();
-                            end = i + func.getArgs().get(2).eval(row).asInt();
+                            end = i + func.getArgs().get(2).eval(row).asInt()+1;
 
                             if (this.getColTypeByColName(targetColName) ==ColumnType.LONG) {
                                 long value = 0L;

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/TeddyExecutor.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/TeddyExecutor.java
@@ -922,17 +922,13 @@ public class TeddyExecutor {
     snapshotRuleDoneCnt.remove(ssId);
   }
 
-  synchronized public void updateAsCanceling(String ssId) {
-    updateSnapshot("status", PrepSnapshot.STATUS.CANCELING.name(), ssId);
-  }
-
-  public void updateAsCanceled(String ssId) {
+  private void updateAsCanceled(String ssId) {
     updateSnapshot("status", PrepSnapshot.STATUS.CANCELED.name(), ssId);
     snapshotRuleDoneCnt.remove(ssId);
   }
 
   synchronized public void cancelCheck(String ssId) throws CancellationException{
-    if(snapshotService.getSnapshotStatus(ssId).equals(PrepSnapshot.STATUS.CANCELING)) {
+    if(snapshotService.getSnapshotStatus(ssId).equals(PrepSnapshot.STATUS.CANCELED)) {
       throw new CancellationException("This snapshot generating was canceled by user. ssid: " + ssId);
     }
   }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
@@ -1781,10 +1781,10 @@ public class PrepTransformService {
           case INITIALIZING:
           case WRITING:
           case TABLE_CREATING:
-              teddyExecutor.updateAsCanceling(ssId);
+              snapshotService.updateSnapshotStatus(ssId, PrepSnapshot.STATUS.CANCELED);
               return "OK";
           case RUNNING:
-              teddyExecutor.updateAsCanceling(ssId);
+              snapshotService.updateSnapshotStatus(ssId, PrepSnapshot.STATUS.CANCELED);
               List<Future<List<Row>>> jobs = teddyExecutor.getJob(ssId);
               if( jobs != null && !jobs.isEmpty()) {
                   for (Future<List<Row>> job : jobs) {


### PR DESCRIPTION
### Description
1. substring함수의 사용 방법을 번경합니다.
    : 현행 substring(text, start_index, end_index) >> substring(text, start_index, lenght)
    : substring(text, start_index)사용을 허용합니다. 이때 start_index 부터 text의 끝까지 반환.
2. Snapshot Cancel 기능에서 상태 업데이트를 위해 JPA를 사용하도록 변경합니다.
3. Window rule의 rolling_sum()함수의 로직 변경.

**Related Issue** : <!--- Please link to the issue here. -->
https://github.com/metatron-app/metatron-discovery/issues/140


### How Has This Been Tested?
1. substring 함수
substring('hello world', 2) > 'llo world'
substring('hello world', 5, 2) > 'wo'
substring('hello world' -3) > 'rld'

2. snapshot cancel
preparing 상태로 비정상적으로 종료된 snapshot이 있는 상태에서 서버를 재시작한뒤 정상적으로 삭제되는지 확인.

3. window > rolling_sum
window value: [row_count(), rolling_sum(col1, 2, 3)] partition: col2 order: col3
테스트 결과 rolling_sum이 정상적으로 출력되는지 확인.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
