### PR TITLE
#143 change css in connection

### DIFF
--- a/discovery-frontend/src/app/data-storage/data-connection/handler-data-connection/create-data-connection/create-connection.component.html
+++ b/discovery-frontend/src/app/data-storage/data-connection/handler-data-connection/create-data-connection/create-connection.component.html
@@ -29,7 +29,7 @@
     <div class="ddp-ui-dbconnect">
       <!-- db type -->
       <div class="ddp-wrap-edit2 ">
-        <label class="ddp-label-type ddp-bold">{{'msg.storage.th.db_type' | translate}}</label>
+        <label class="ddp-label-type ddp-bold">{{'msg.storage.ui.db.connection' | translate}}</label>
         <!-- edit option -->
         <div class="ddp-ui-edit-option ddp-type ddp-white-space">
           <ul class="ddp-list-dbtype">
@@ -45,11 +45,10 @@
       <!-- //db type -->
       <!-- Server -->
       <div class="ddp-wrap-edit2 ">
-        <label class="ddp-label-type ddp-bold">{{'msg.storage.ui.server' | translate}}</label>
         <div class="ddp-box-sub">
-          <!-- URL (enable) -->
-          <div class="ddp-clear" *ngIf="isEnableUrl">
-            <div class="ddp-wrap-edit2 ddp-col-6" [class.ddp-error]="isShowUrlRequired">
+          <div class="ddp-clear ddp-db-url">
+            <!-- URL -->
+            <div class="ddp-wrap-edit2 ddp-col-12" *ngIf="isEnableUrl" [class.ddp-error]="isShowUrlRequired">
               <label class="ddp-label-type">{{'msg.storage.ui.conn.url' | translate}}</label>
               <input type="text" class="ddp-input-type" placeholder="{{'msg.storage.ui.conn.url.ph' | translate}}"
                      [ngModel]="url"
@@ -57,22 +56,10 @@
               <!-- error -->
               <span class="ddp-ui-error">{{'msg.storage.ui.required' | translate}}</span>
               <!-- error -->
-              <!-- check -->
-              <div class="ddp-check">
-                <label class="ddp-label-checkbox" (click)="onChangeEnableURL()">
-                  <input type="checkbox" [checked]="isEnableUrl" tabindex="-1">
-                  <i class="ddp-icon-checkbox"></i>
-                  <span class="ddp-txt-checkbox">{{'msg.storage.ui.conn.url.only' | translate}}</span>
-                </label>
-              </div>
-              <!-- //check -->
             </div>
-          </div>
-          <!-- //URL (enable) -->
-          <!-- URL (disable) -->
-          <div class="ddp-clear" *ngIf="!isEnableUrl">
+            <!-- //URL -->
             <!-- HOST -->
-            <div class="ddp-wrap-edit2 ddp-col-4" [class.ddp-error]="isShowHostRequired">
+            <div class="ddp-wrap-edit2 ddp-col-4" *ngIf="!isEnableUrl" [class.ddp-error]="isShowHostRequired">
               <label class="ddp-label-type">{{'msg.comm.th.host' | translate}}</label>
               <input type="text" class="ddp-input-type" placeholder="{{'msg.comm.th.host' | translate}}"
                      [ngModel]="hostname"
@@ -80,19 +67,10 @@
               <!-- error -->
               <span class="ddp-ui-error">{{'msg.storage.ui.required' | translate}}</span>
               <!-- error -->
-              <!-- check -->
-              <div class="ddp-check">
-                <label class="ddp-label-checkbox" (click)="onChangeEnableURL()">
-                  <input type="checkbox" [checked]="isEnableUrl" tabindex="-1">
-                  <i class="ddp-icon-checkbox"></i>
-                  <span class="ddp-txt-checkbox">{{'msg.storage.ui.conn.url.only' | translate}}</span>
-                </label>
-              </div>
-              <!-- //check -->
             </div>
             <!-- //HOST -->
             <!-- PORT -->
-            <div class="ddp-wrap-edit2 ddp-col-2" [class.ddp-error]="isShowPortRequired">
+            <div class="ddp-wrap-edit2 ddp-col-2" *ngIf="!isEnableUrl" [class.ddp-error]="isShowPortRequired">
               <label class="ddp-label-type">{{'msg.comm.th.port' | translate}}</label>
               <input type="text" class="ddp-input-type" placeholder="{{'msg.comm.th.port' | translate}}" maxlength="5" input-mask="number"
                      [ngModel]="port"
@@ -103,7 +81,7 @@
             </div>
             <!-- //PORT -->
             <!-- SID -->
-            <div *ngIf="isRequiredSid()"
+            <div *ngIf="!isEnableUrl && isRequiredSid()"
                  [class.ddp-error]="isShowSidRequired"
                  class="ddp-wrap-edit2 ddp-col-6" >
               <!--(ngModelChange)="sid = $event; initConnectionPresetData()">-->
@@ -118,7 +96,7 @@
             <!-- //SID -->
             <!-- DATABASE -->
             <div class="ddp-wrap-edit2 ddp-col-6" [class.ddp-error]="isShowDatabaseRequired"
-                 *ngIf="isRequiredDatabase()">
+                 *ngIf="!isEnableUrl &&  isRequiredDatabase()">
               <label class="ddp-label-type">{{'msg.storage.th.db_name' | translate}}</label>
               <input type="text" class="ddp-input-type" placeholder="{{'msg.storage.th.db_name.ph' | translate}}"
                      [ngModel]="database"
@@ -130,7 +108,7 @@
             <!-- //DATABASE -->
             <!-- Catalog -->
             <div class="ddp-wrap-edit2 ddp-col-6"  [class.ddp-error]="isShowCatalogRequired"
-                 *ngIf="isRequiredCatalog()">
+                 *ngIf="!isEnableUrl &&  isRequiredCatalog()">
               <label class="ddp-label-type">{{'msg.storage.th.catalog' | translate}}</label>
               <input type="text" class="ddp-input-type" placeholder="{{'msg.storage.ui.conn.catalog.ph' | translate}}"
                      [ngModel]="catalog"
@@ -140,6 +118,15 @@
               <!-- error -->
             </div>
             <!-- //Catalog -->
+            <!-- check -->
+            <div class="ddp-check ddp-col-12">
+              <label class="ddp-label-checkbox" (click)="onChangeEnableURL(); $event.defaultPrevented">
+                <input type="checkbox" [checked]="isEnableUrl" tabindex="-1">
+                <i class="ddp-icon-checkbox"></i>
+                <span class="ddp-txt-checkbox">{{'msg.storage.ui.conn.url.only' | translate}}</span>
+              </label>
+            </div>
+            <!-- //check -->
           </div>
           <!-- //URL (disable) -->
           <div class="ddp-clear" *ngIf="!isConnectUserAccount()">

--- a/discovery-frontend/src/app/data-storage/data-connection/handler-data-connection/update-data-connection/update-connection.component.html
+++ b/discovery-frontend/src/app/data-storage/data-connection/handler-data-connection/update-data-connection/update-connection.component.html
@@ -56,7 +56,7 @@
       </div>
       <!-- db type -->
       <div class="ddp-wrap-edit2 ">
-        <label class="ddp-label-type ddp-bold">{{'msg.storage.th.db_type' | translate}}</label>
+        <label class="ddp-label-type ddp-bold">{{'msg.storage.ui.db.connection' | translate}}</label>
         <!-- edit option -->
         <div class="ddp-ui-edit-option ddp-type ddp-white-space">
           <ul class="ddp-list-dbtype">
@@ -73,11 +73,9 @@
       <!-- //db type -->
       <!-- Server -->
       <div class="ddp-wrap-edit2 ">
-        <label class="ddp-label-type ddp-bold">{{'msg.storage.ui.server' | translate}}</label>
         <div class="ddp-box-sub">
-          <!-- Enable URL -->
-          <div class="ddp-clear" *ngIf="isEnableUrl">
-            <div class="ddp-wrap-edit2 ddp-col-6" [class.ddp-error]="isShowUrlRequired">
+          <div class="ddp-clear ddp-db-url">
+            <div class="ddp-wrap-edit2 ddp-col-12" *ngIf="isEnableUrl" [class.ddp-error]="isShowUrlRequired">
               <label class="ddp-label-type">{{'msg.storage.ui.conn.url' | translate}}</label>
               <input type="text" class="ddp-input-type" placeholder="{{'msg.storage.ui.conn.url.ph' | translate}}"
                      [ngModel]="url"
@@ -85,22 +83,9 @@
               <!-- error -->
               <span class="ddp-ui-error">{{'msg.storage.ui.required' | translate}}</span>
               <!-- error -->
-              <!-- check -->
-              <div class="ddp-check">
-                <label class="ddp-label-checkbox" (click)="onChangeEnableURL()">
-                  <input type="checkbox" [checked]="isEnableUrl" tabindex="-1">
-                  <i class="ddp-icon-checkbox"></i>
-                  <span class="ddp-txt-checkbox">{{'msg.storage.ui.conn.url.only' | translate}}</span>
-                </label>
-              </div>
-              <!-- //check -->
             </div>
-          </div>
-          <!-- //Enable URL -->
-          <!-- Diable URL -->
-          <div class="ddp-clear" *ngIf="!isEnableUrl">
             <!-- HOST -->
-            <div class="ddp-wrap-edit2 ddp-col-4" [class.ddp-error]="isShowHostRequired">
+            <div class="ddp-wrap-edit2 ddp-col-4" *ngIf="!isEnableUrl" [class.ddp-error]="isShowHostRequired">
               <label class="ddp-label-type">{{'msg.comm.th.host' | translate}}</label>
               <input type="text" class="ddp-input-type" placeholder="{{'msg.comm.th.host' | translate}}"
                      [ngModel]="hostname"
@@ -108,19 +93,10 @@
               <!-- error -->
               <span class="ddp-ui-error">{{'msg.storage.ui.required' | translate}}</span>
               <!-- error -->
-              <!-- check -->
-              <div class="ddp-check">
-                <label class="ddp-label-checkbox" (click)="onChangeEnableURL()">
-                  <input type="checkbox" [checked]="isEnableUrl" tabindex="-1">
-                  <i class="ddp-icon-checkbox"></i>
-                  <span class="ddp-txt-checkbox">{{'msg.storage.ui.conn.url.only' | translate}}</span>
-                </label>
-              </div>
-              <!-- //check -->
             </div>
             <!-- //HOST -->
             <!-- PORT -->
-            <div class="ddp-wrap-edit2 ddp-col-2" [class.ddp-error]="isShowPortRequired">
+            <div class="ddp-wrap-edit2 ddp-col-2" *ngIf="!isEnableUrl" [class.ddp-error]="isShowPortRequired">
               <label class="ddp-label-type">{{'msg.comm.th.port' | translate}}</label>
               <input type="text" class="ddp-input-type" placeholder="{{'msg.comm.th.port' | translate}}" maxlength="5" input-mask="number"
                      [ngModel]="port"
@@ -131,7 +107,7 @@
             </div>
             <!-- //PORT -->
             <!-- SID -->
-            <div *ngIf="isRequiredSid()"
+            <div *ngIf="!isEnableUrl && isRequiredSid()"
                  [class.ddp-error]="isShowSidRequired"
                  class="ddp-wrap-edit2 ddp-col-6" >
               <!--(ngModelChange)="sid = $event; initConnectionPresetData()">-->
@@ -146,7 +122,7 @@
             <!-- //SID -->
             <!-- DATABASE -->
             <div class="ddp-wrap-edit2 ddp-col-6" [class.ddp-error]="isShowDatabaseRequired"
-                 *ngIf="isRequiredDatabase()">
+                 *ngIf="!isEnableUrl && isRequiredDatabase()">
               <label class="ddp-label-type">{{'msg.storage.th.db_name' | translate}}</label>
               <input type="text" class="ddp-input-type" placeholder="{{'msg.storage.th.db_name.ph' | translate}}"
                      [ngModel]="database"
@@ -158,7 +134,7 @@
             <!-- //DATABASE -->
             <!-- Catalog -->
             <div class="ddp-wrap-edit2 ddp-col-6"  [class.ddp-error]="isShowCatalogRequired"
-                 *ngIf="isRequiredCatalog()">
+                 *ngIf="!isEnableUrl && isRequiredCatalog()">
               <label class="ddp-label-type">{{'msg.storage.th.catalog' | translate}}</label>
               <input type="text" class="ddp-input-type" placeholder="{{'msg.storage.ui.conn.catalog.ph' | translate}}"
                      [ngModel]="catalog"
@@ -168,6 +144,15 @@
               <!-- error -->
             </div>
             <!-- //Catalog -->
+            <!-- check -->
+            <div class="ddp-check ddp-col-12">
+              <label class="ddp-label-checkbox" (click)="onChangeEnableURL(); $event.defaultPrevented;">
+                <input type="checkbox" [checked]="isEnableUrl" tabindex="-1">
+                <i class="ddp-icon-checkbox"></i>
+                <span class="ddp-txt-checkbox">{{'msg.storage.ui.conn.url.only' | translate}}</span>
+              </label>
+            </div>
+            <!-- //check -->
           </div>
           <div class="ddp-clear" *ngIf="!isConnectUserAccount()">
             <!-- username -->

--- a/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/db-create-component/db-set-data-connection/db-set-data-connection.html
+++ b/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/db-create-component/db-set-data-connection/db-set-data-connection.html
@@ -67,7 +67,6 @@
         <!-- //preset box -->
         <!-- Database type -->
         <div class="ddp-wrap-edit2">
-          <label class="ddp-label-type ddp-bold">{{'msg.storage.th.db_type' | translate}}</label>
           <!-- edit option -->
           <div class="ddp-ui-edit-option ddp-type ddp-white-space">
             <ul class="ddp-list-dbtype">
@@ -83,12 +82,11 @@
         <!-- //Database type -->
         <!-- Server -->
         <div class="ddp-wrap-edit2">
-          <label class="ddp-label-type ddp-bold">{{'msg.storage.ui.server' | translate}}</label>
           <div class="ddp-box-sub">
             <!-- enable URL -->
-            <div class="ddp-clear" *ngIf="isEnableUrl">
+            <div class="ddp-clear ddp-db-url">
               <!-- URL -->
-              <div class="ddp-wrap-edit2 ddp-col-6" [class.ddp-error]="isShowUrlRequired">
+              <div class="ddp-wrap-edit2 ddp-col-12" *ngIf="isEnableUrl" [class.ddp-error]="isShowUrlRequired" [class.ddp-disabled]="selectedConnectionPreset?.id">
                 <label class="ddp-label-type">{{'msg.storage.ui.conn.url' | translate}}</label>
                 <input type="text" class="ddp-input-type" placeholder="{{'msg.storage.ui.conn.url.ph' | translate}}"
                        [ngModel]="url"
@@ -97,22 +95,10 @@
                 <!-- error -->
                 <span class="ddp-ui-error">{{'msg.storage.ui.required' | translate}}</span>
                 <!-- error -->
-                <!-- check -->
-                <div class="ddp-check">
-                  <label class="ddp-label-checkbox" (click)="onChangeEnableURL()">
-                    <input type="checkbox" [checked]="isEnableUrl" tabindex="-1">
-                    <i class="ddp-icon-checkbox"></i>
-                    <span class="ddp-txt-checkbox">{{'msg.storage.ui.conn.url.only' | translate}}</span>
-                  </label>
-                </div>
-                <!-- //check -->
               </div>
               <!-- //URL -->
-            </div>
-            <!-- //URL 허용이면 show -->
-            <div class="ddp-clear" *ngIf="!isEnableUrl">
               <!-- HOST -->
-              <div class="ddp-wrap-edit2 ddp-col-4" [class.ddp-error]="isShowHostRequired">
+              <div class="ddp-wrap-edit2 ddp-col-4" *ngIf="!isEnableUrl" [class.ddp-error]="isShowHostRequired" [class.ddp-disabled]="selectedConnectionPreset?.id">
                 <label class="ddp-label-type">{{'msg.comm.th.host' | translate}}</label>
                 <input type="text" class="ddp-input-type" placeholder="{{'msg.comm.th.host' | translate}}"
                        [ngModel]="hostname"
@@ -121,19 +107,10 @@
                 <!-- error -->
                 <span class="ddp-ui-error">{{'msg.storage.ui.required' | translate}}</span>
                 <!-- error -->
-                <!-- check -->
-                <div class="ddp-check">
-                  <label class="ddp-label-checkbox" (click)="onChangeEnableURL()">
-                    <input type="checkbox" [checked]="isEnableUrl" tabindex="-1">
-                    <i class="ddp-icon-checkbox"></i>
-                    <span class="ddp-txt-checkbox">{{'msg.storage.ui.conn.url.only' | translate}}</span>
-                  </label>
-                </div>
-                <!-- //check -->
               </div>
               <!-- //HOST -->
               <!-- PORT -->
-              <div class="ddp-wrap-edit2 ddp-col-2" [class.ddp-error]="isShowPortRequired">
+              <div class="ddp-wrap-edit2 ddp-col-2" *ngIf="!isEnableUrl" [class.ddp-error]="isShowPortRequired">
                 <label class="ddp-label-type">{{'msg.comm.th.port' | translate}}</label>
                 <input type="text" class="ddp-input-type" placeholder="{{'msg.comm.th.port' | translate}}" maxlength="5" input-mask="number"
                        [ngModel]="port"
@@ -145,7 +122,7 @@
               </div>
               <!-- //PORT -->
               <!-- SID -->
-              <div *ngIf="isRequiredSid()"
+              <div *ngIf="!isEnableUrl && isRequiredSid()"
                    [class.ddp-error]="isShowSidRequired"
                    class="ddp-wrap-edit2 ddp-col-6" >
                 <!--(ngModelChange)="sid = $event">-->
@@ -161,7 +138,7 @@
               <!-- //SID -->
               <!-- DATABASE -->
               <div class="ddp-wrap-edit2 ddp-col-6" [class.ddp-error]="isShowDatabaseRequired"
-                   *ngIf="isRequiredDatabase()">
+                   *ngIf="!isEnableUrl && isRequiredDatabase()">
                 <label class="ddp-label-type">{{'msg.storage.th.db_name' | translate}}</label>
                 <input type="text" class="ddp-input-type" placeholder="{{'msg.storage.th.db_name.ph' | translate}}"
                        [ngModel]="database"
@@ -174,7 +151,7 @@
               <!-- //DATABASE -->
               <!-- Catalog -->
               <div class="ddp-wrap-edit2 ddp-col-6"  [class.ddp-error]="isShowCatalogRequired"
-                   *ngIf="isRequiredCatalog()">
+                   *ngIf="!isEnableUrl && isRequiredCatalog()">
                 <label class="ddp-label-type">{{'msg.storage.th.catalog' | translate}}</label>
                 <input type="text" class="ddp-input-type" placeholder="{{'msg.storage.ui.conn.catalog.ph' | translate}}"
                        [ngModel]="catalog"
@@ -185,6 +162,15 @@
                 <!-- error -->
               </div>
               <!-- //Catalog -->
+              <!-- check -->
+              <div class="ddp-check ddp-col-12" [class.ddp-disabled]="selectedConnectionPreset?.id">
+                <label class="ddp-label-checkbox" (click)="onChangeEnableURL()">
+                  <input type="checkbox" [checked]="isEnableUrl" tabindex="-1">
+                  <i class="ddp-icon-checkbox"></i>
+                  <span class="ddp-txt-checkbox">{{'msg.storage.ui.conn.url.only' | translate}}</span>
+                </label>
+              </div>
+              <!-- //check -->
             </div>
             <div class="ddp-clear" *ngIf="!isConnectUserAccount()">
               <!-- username -->

--- a/discovery-frontend/src/app/meta-data-management/metadata/create-metadata/hive-set-connection.component.html
+++ b/discovery-frontend/src/app/meta-data-management/metadata/create-metadata/hive-set-connection.component.html
@@ -48,34 +48,21 @@
         <!-- Server -->
         <div class="ddp-edit-setting">
           <div class="ddp-wrap-edit2">
-            <label class="ddp-label-type ddp-bold">{{'msg.storage.ui.server' | translate}}</label>
             <div class="ddp-box-sub">
-              <!-- enable URL -->
-              <div class="ddp-clear" *ngIf="isEnableUrl">
+              <div class="ddp-clear ddp-db-url">
                 <!-- URL -->
-                <div class="ddp-wrap-edit2 ddp-col-6">
+                <div class="ddp-wrap-edit2 ddp-col-12" *ngIf="isEnableUrl" [class.ddp-error]="isShowUrlRequired">
                   <label class="ddp-label-type">{{'msg.storage.ui.conn.url' | translate}}</label>
                   <input type="text" class="ddp-input-type" placeholder="{{'msg.storage.ui.conn.url.ph' | translate}}"
-                         [ngModel]="url">
+                         [ngModel]="url"
+                         readonly="readonly">
                   <!-- error -->
                   <span class="ddp-ui-error">{{'msg.storage.ui.required' | translate}}</span>
                   <!-- error -->
-                  <!-- check -->
-                  <div class="ddp-check">
-                    <label class="ddp-label-checkbox" (click)="$event.defaultPrevented">
-                      <input type="checkbox" [checked]="isEnableUrl" tabindex="-1" [disabled]="!selectedConnectionPreset">
-                      <i class="ddp-icon-checkbox"></i>
-                      <span class="ddp-txt-checkbox">{{'msg.storage.ui.conn.url.only' | translate}}</span>
-                    </label>
-                  </div>
-                  <!-- //check -->
                 </div>
                 <!-- //URL -->
-              </div>
-              <!-- //URL 허용이면 show -->
-              <div class="ddp-clear" *ngIf="!isEnableUrl">
                 <!-- HOST -->
-                <div class="ddp-wrap-edit2 ddp-col-4" [class.ddp-error]="isShowHostRequired">
+                <div class="ddp-wrap-edit2 ddp-col-4" *ngIf="!isEnableUrl" [class.ddp-error]="isShowHostRequired">
                   <label class="ddp-label-type">{{'msg.comm.th.host' | translate}}</label>
                   <input type="text" class="ddp-input-type" placeholder="{{'msg.comm.th.host' | translate}}"
                          [ngModel]="hostname"
@@ -83,19 +70,10 @@
                   <!-- error -->
                   <span class="ddp-ui-error">{{'msg.storage.ui.required' | translate}}</span>
                   <!-- error -->
-                  <!-- check -->
-                  <div class="ddp-check">
-                    <label class="ddp-label-checkbox" (click)="$event.defaultPrevented">
-                      <input type="checkbox" [checked]="isEnableUrl" tabindex="-1" [disabled]="!selectedConnectionPreset">
-                      <i class="ddp-icon-checkbox"></i>
-                      <span class="ddp-txt-checkbox">{{'msg.storage.ui.conn.url.only' | translate}}</span>
-                    </label>
-                  </div>
-                  <!-- //check -->
                 </div>
                 <!-- //HOST -->
                 <!-- PORT -->
-                <div class="ddp-wrap-edit2 ddp-col-2" [class.ddp-error]="isShowPortRequired">
+                <div class="ddp-wrap-edit2 ddp-col-2" *ngIf="!isEnableUrl" [class.ddp-error]="isShowPortRequired">
                   <label class="ddp-label-type">{{'msg.comm.th.port' | translate}}</label>
                   <input type="text" class="ddp-input-type" placeholder="{{'msg.comm.th.port' | translate}}" maxlength="5" input-mask="number"
                          [ngModel]="port"
@@ -105,6 +83,15 @@
                   <!-- error -->
                 </div>
                 <!-- //PORT -->
+                <!-- check -->
+                <div class="ddp-check ddp-col-12 ddp-disabled">
+                  <label class="ddp-label-checkbox" (click)="$event.defaultPrevented">
+                    <input type="checkbox" [checked]="isEnableUrl" tabindex="-1">
+                    <i class="ddp-icon-checkbox"></i>
+                    <span class="ddp-txt-checkbox">{{'msg.storage.ui.conn.url.only' | translate}}</span>
+                  </label>
+                </div>
+                <!-- //check -->
               </div>
               <div class="ddp-clear" *ngIf="selectedSecurityType.value !== 'USERINFO'">
                 <!-- username -->

--- a/discovery-frontend/src/assets/css/polaris.v2.component.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.component.css
@@ -331,7 +331,9 @@ input.ddp-input-type:disabled {color:rgba(75, 81, 91,0.3)}
 .ddp-wrap-edit2 .ddp-ui-option-sub .ddp-radio-set {float:left;}
 .ddp-wrap-edit2 .ddp-ui-option-sub .ddp-radio-hidden {overflow:hidden;}
 .ddp-wrap-edit2 .ddp-ui-option-sub .ddp-radio-hidden .ddp-ui-calen {width:320px; padding:10px 0 0 16px;}
-.ddp-wrap-edit2 .ddp-check {padding-top:4px;}
+.ddp-wrap-edit2 .ddp-check {position:relative; padding-top:4px;}
+.ddp-wrap-edit2 .ddp-check.ddp-disabled {opacity:0.5;}
+.ddp-wrap-edit2 .ddp-check.ddp-disabled:after {display:inline-block; position:absolute; top:0; left:0; right:0; bottom:0; content:'';}
 .ddp-wrap-edit2 .ddp-box-datanone {padding:20px 0; border-radius:2px; background-color:#fafafb; text-align:center; color:#b7bac1; font-size:13px;}
 .ddp-wrap-edit2 .ddp-error {display:block; color:#eb5f58; font-size:12px;}
 .ddp-wrap-edit2.ddp-mgt0 {margin-top:0;}
@@ -469,7 +471,7 @@ input.ddp-input-type:disabled {color:rgba(75, 81, 91,0.3)}
 .ddp-edit-setting .ddp-edit-sub .ddp-ui-message .ddp-data-ok,
 .ddp-edit-setting .ddp-edit-sub .ddp-ui-message .ddp-data-error {margin-left:12px;}
 
-.ddp-edit-setting.ddp-type {margin-top:40px; padding-top:40px; border-top:1px dotted #ccc; }
+.ddp-edit-setting.ddp-type {margin-top:30px; padding-top:30px; border-top:1px dotted #ccc; }
 .ddp-edit-setting .ddp-fold-link {display:inline-block; padding-bottom:20px; color:#4c515a; font-size:13px; text-decoration:underline;}
 .ddp-edit-setting .ddp-fold-link:after {display:inline-block; width:7px; height:4px; margin-left:10px; background:url(../images/icon_select.png) no-repeat; background-position:-16px top; vertical-align:middle; content:'';}
 .ddp-edit-setting.ddp-selected .ddp-fold-link:after {transform:rotate(180deg)}

--- a/discovery-frontend/src/assets/css/polaris.v2.page.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.page.css
@@ -5794,12 +5794,13 @@ dl.ddp-dl-store dd {display:block; padding:28px 0 0 0; overflow:hidden;}
 .ddp-ui-dbconnect .ddp-wrap-edit2 {margin-top:30px;}
 .ddp-ui-dbconnect .ddp-wrap-edit2 .ddp-data-result {padding-bottom:9px;color:#4b515b; font-weight:300;}
 .ddp-ui-dbconnect .ddp-wrap-edit2 .ddp-data-result .ddp-link-edit2 {margin-left:5px;}
-.ddp-white-space {}
+.ddp-wrap-edit2 label.ddp-label-type + .ddp-white-space {margin:0 0 -10px 0;}
+.ddp-white-space {margin:-10px 0;}
 ul.ddp-list-dbtype {display:inline-block; overflow:hidden; white-space:nowrap;}
 ul.ddp-list-dbtype li {position:relative; display:inline-block; padding-right:4px;}
 ul.ddp-list-dbtype li.ddp-disabled a {opacity:0.5; cursor:no-drop;}
-ul.ddp-list-dbtype li.ddp-disabled:before {display:inline-block; position:absolute; top:0; left:0; right:4px; bottom:0; content:''; z-index:1;}
-ul.ddp-list-dbtype li:last-of-type.ddp-disabled:before {right:0;}
+ul.ddp-list-dbtype li.ddp-disabled:before {display:inline-block; position:absolute; top:0; left:0; right:4px; bottom:0; content:''; z-index:1;cursor:no-drop;}
+ul.ddp-list-dbtype li.ddp-disabled.ddp-selected a {opacity:1;}ul.ddp-list-dbtype li:last-of-type.ddp-disabled:before {right:0;}
 ul.ddp-list-dbtype li:last-of-type {padding-right:0px;}
 ul.ddp-list-dbtype li.ddp-selected [class*="ddp-label-"] {border:1px solid #91969e; color:#4b515b; font-weight:bold;}
 ul.ddp-list-dbtype li.ddp-selected [class*="ddp-label-"]:after {display:inline-block; position:absolute; top:50%; right:10px; margin-top:-4px;width:11px; height:8px; background:url(../images/icon_select2.png) no-repeat; background-position:-68px top; content:'';}
@@ -5883,6 +5884,9 @@ ul.ddp-list-dbtype li .ddp-label-dbtype.type-tibero:before{width:19px; height:22
 .ddp-ui-dbconnect .ddp-ui-db-option {float:right; width:435px; padding-top:45px;}
 .ddp-ui-dbconnect .ddp-ui-db-option .ddp-ui-buttons .ddp-ui-message {margin-top:10px;}
 .ddp-ui-dbconnect .ddp-clear [class*="ddp-col-"] {padding-left: 8px; padding-right:8px;}
+.ddp-ui-dbconnect .ddp-clear.ddp-db-url .ddp-ui-error {display:none;}
+.ddp-ui-dbconnect .ddp-clear.ddp-db-url .ddp-error .ddp-ui-error {display:block;}
+.ddp-ui-dbconnect .ddp-clear.ddp-db-url .ddp-ui-error {position:relative; bottom:0; left:0;}
 .ddp-ui-dbconnect .ddp-clear {margin:0 -8px;}
 
 .ddp-ui-dbconnect .ddp-ui-db-option .ddp-ui-message {float:left; width:100%; margin-top:30px;}


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
![2018-09-12 11 28 59](https://user-images.githubusercontent.com/42233627/45398434-112c0700-b67f-11e8-8251-1612a3f6beb2.png)
DB type, Server가 DB connection이라는 명칭으로 통합됨
커넥션 프리셋 선택시, 해당 프리셋의 데이터베이스의 타입이 잘 보이지 않는 상태 개선
커넥션 프리셋 선택시, URL only 가 비활성화 상태인것을 사용자가 인지할 수 없는 점을 개선  

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
https://github.com/metatron-app/metatron-discovery/issues/143

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
데이터 커넥션 > 커넥션 생성 > url타입과 host/password 타입의 커넥션 생성
```
// mysql
host: localhost
port: 3306
URL: jdbc:mysql://localhost:3306

// hive
host:localhost
port:10000
URL:jdbc:hive2://localhost:10000
```
데이터 커넥션 > 커넥션 수정 > 해당 커넥션 db 타입 비활성화 상태 확인
데이터 소스 > 데이터베이스로 생성 > 커넥션 설정 > 해당 커넥션 프리셋 선택 > URL 설정 비활성화 상태 확인
메타데이터 > HIVE로 생성 > 커넥션 설정 > 해당 커넥션 프리셋 선택 > URL 설정 비활성화 상태 확인

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project. _it will be added soon_
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
