### PR TITLE
#164 add property in source preview used metadata

### DIFF
--- a/discovery-frontend/src/app/common/component/data-preview/data.preview.component.ts
+++ b/discovery-frontend/src/app/common/component/data-preview/data.preview.component.ts
@@ -934,6 +934,18 @@ export class DataPreviewComponent extends AbstractPopupComponent implements OnIn
       field['codeTable'] = fieldMetaData.codeTable;
       // dictionary
       field['dictionary'] = fieldMetaData.dictionary;
+      // type
+      if (fieldMetaData.type) {
+        field['logicalType'] = fieldMetaData.type;
+      }
+      // description
+      if (fieldMetaData.description) {
+        field['description'] = fieldMetaData.description;
+      }
+      // format
+      if (fieldMetaData.format) {
+        field['format'] = fieldMetaData.format;
+      }
     }
   }
 

--- a/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/column-detail-data-source/column-detail-data-source.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/column-detail-data-source/column-detail-data-source.component.ts
@@ -992,5 +992,17 @@ export class ColumnDetailDataSourceComponent extends AbstractPopupComponent impl
     field['codeTable'] = fieldMetaData.codeTable;
     // dictionary
     field['dictionary'] = fieldMetaData.dictionary;
+    // type
+    if (fieldMetaData.type) {
+      field['logicalType'] = fieldMetaData.type;
+    }
+    // description
+    if (fieldMetaData.description) {
+      field['description'] = fieldMetaData.description;
+    }
+    // format
+    if (fieldMetaData.format) {
+      field['format'] = fieldMetaData.format;
+    }
   }
 }

--- a/discovery-frontend/src/app/meta-data-management/metadata/metadata-detail-columnschema.component.ts
+++ b/discovery-frontend/src/app/meta-data-management/metadata/metadata-detail-columnschema.component.ts
@@ -516,6 +516,18 @@ export class MetadataDetailColumnschemaComponent extends AbstractComponent imple
       delete item['nameChangeFl'];
       delete item['typeListFl'];
       delete item['codeTableShowFl'];
+      // name이 있고 255자가 넘어간다면
+      if (item.name && item.name.length > 255) {
+        item.name = item.name.substr(0, 254);
+      }
+      // description이 있고 1000자가 넘어간다면
+      if (item.description && item.description.length > 1000) {
+        item.description = item.description.substr(0, 999);
+      }
+      // format이 있고 255자가 넘어간다면
+      if (item.format && item.format.length > 255) {
+        item.format = item.format.substr(0, 254);
+      }
       // dictionary가 있다면
       item.dictionary && (item['dictionary'] = `/api/dictionaries/${item.dictionary.id}`);
       // code table이 있다면


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
메타데이터 생성 후, logicalType과 해당 값 변경시 변경된 컬럼이 실제 데이터소스와 대시보드에 적용되지 않는 문제 수정 
![2018-09-12 8 24 33](https://user-images.githubusercontent.com/42233627/45422004-e2874e00-b6c9-11e8-8b6f-353013bfd0ba.png)


**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#164 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 데이터소스 생성 
2. 메타데이터 생성 > 데이터소스로 생성 
3. 생성된 메타데이터 상세화면 > 컬럼 탭
4. 컬럼의 logicalType과 description 수정
5. 데이터소스 상세화면 > 컬럼 탭 > 변경된 logicalType과 description 확인
5-1. 워크북 > 데이터소스로 대시보드 생성 > 데이터 미리보기 > 변경된 logicalType과 description 확인

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project. _it will be added soon_
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
