### PR TITLE
#153 The sorting method of the filter is initialized without saving

### DIFF
--- a/discovery-frontend/src/app/dashboard/filters/essential-filter/essential-filter.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/essential-filter/essential-filter.component.ts
@@ -355,8 +355,6 @@ export class EssentialFilterComponent extends AbstractFilterPopupComponent imple
             const inclusionFilter: InclusionFilter = FilterUtil.getBasicInclusionFilter(field, 'essential');
             // 정렬을 위함 임시정보 설정
             inclusionFilter['showSortLayer'] = false;
-            inclusionFilter['sortTarget'] = 'FREQUENCY';
-            inclusionFilter['sortType'] = 'DESC';
             filters.push(inclusionFilter);
           }
         } else if (FieldRole.MEASURE === field.role) {

--- a/discovery-frontend/src/app/dashboard/filters/inclusion-filter/configure-filters-inclusion.component.html
+++ b/discovery-frontend/src/app/dashboard/filters/inclusion-filter/configure-filters-inclusion.component.html
@@ -233,23 +233,23 @@
           <!-- popup -->
           <div class="ddp-wrap-popup2">
             <ul class="ddp-list-popup">
-              <li [class.ddp-selected]="targetFilter['sortTarget'] === 'FREQUENCY' && targetFilter['sortType'] === 'ASC'">
-                <a href="javascript:" (click)="sortCandidateValues(targetFilter, 'FREQUENCY','ASC');">
+              <li [class.ddp-selected]="sortBy.COUNT === targetFilter.sort.by && sortDirection.ASC === targetFilter.sort.direction">
+                <a href="javascript:" (click)="sortCandidateValues(targetFilter, sortBy.COUNT, sortDirection.ASC );">
                   {{'msg.comm.ui.soring.frequency.asc' | translate}} <em class="ddp-icon-check"></em>
                 </a>
               </li>
-              <li [class.ddp-selected]="targetFilter['sortTarget'] === 'FREQUENCY' && targetFilter['sortType'] === 'DESC'">
-                <a href="javascript:" (click)="sortCandidateValues(targetFilter, 'FREQUENCY','DESC');">
+              <li [class.ddp-selected]="sortBy.COUNT === targetFilter.sort.by && sortDirection.DESC === targetFilter.sort.direction">
+                <a href="javascript:" (click)="sortCandidateValues(targetFilter, sortBy.COUNT, sortDirection.DESC);">
                   {{'msg.comm.ui.soring.frequency.desc' | translate}} <em class="ddp-icon-check"></em>
                 </a>
               </li>
-              <li [class.ddp-selected]="targetFilter['sortTarget'] === 'ALPHNUMERIC' && targetFilter['sortType'] === 'ASC'">
-                <a href="javascript:" (click)="sortCandidateValues(targetFilter, 'ALPHNUMERIC','ASC');">
+              <li [class.ddp-selected]="sortBy.TEXT === targetFilter.sort.by && sortDirection.ASC === targetFilter.sort.direction">
+                <a href="javascript:" (click)="sortCandidateValues(targetFilter, sortBy.TEXT, sortDirection.ASC );">
                   {{'msg.comm.ui.soring.alphnumeric.asc' | translate}} <em class="ddp-icon-check"></em>
                 </a>
               </li>
-              <li [class.ddp-selected]="targetFilter['sortTarget'] === 'ALPHNUMERIC' && targetFilter['sortType'] === 'DESC'">
-                <a href="javascript:" (click)="sortCandidateValues(targetFilter, 'ALPHNUMERIC','DESC');">
+              <li [class.ddp-selected]="sortBy.TEXT === targetFilter.sort.by && sortDirection.DESC === targetFilter.sort.direction">
+                <a href="javascript:" (click)="sortCandidateValues(targetFilter, sortBy.TEXT, sortDirection.DESC);">
                   {{'msg.comm.ui.soring.alphnumeric.desc' | translate}} <em class="ddp-icon-check"></em>
                 </a>
               </li>

--- a/discovery-frontend/src/app/dashboard/filters/inclusion-filter/configure-filters-inclusion.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/inclusion-filter/configure-filters-inclusion.component.ts
@@ -15,8 +15,10 @@
 import * as _ from 'lodash';
 import { Component, ElementRef, EventEmitter, Injector, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
 import {
-  Candidate, InclusionFilter,
-  InclusionSelectorType
+  Candidate,
+  InclusionFilter,
+  InclusionSelectorType,
+  InclusionSortBy
 } from '../../../domain/workbook/configurations/filter/inclusion-filter';
 import { Field, FieldRole } from '../../../domain/datasource/datasource';
 import { CustomField } from '../../../domain/workbook/configurations/field/custom-field';
@@ -39,6 +41,7 @@ import { AbstractFilterPopupComponent } from '../abstract-filter-popup.component
 import { StringUtil } from '../../../common/util/string.util';
 import { SelectComponent } from '../../../common/component/select/select.component';
 import { DashboardUtil } from '../../util/dashboard.util';
+import { DIRECTION } from '../../../domain/workbook/configurations/sort';
 
 @Component({
   selector: 'app-config-filter-inclusion',
@@ -466,24 +469,28 @@ export class ConfigureFiltersInclusionComponent extends AbstractFilterPopupCompo
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
   | Public Method - 목록 정렬 관련
   |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
+  public sortBy = InclusionSortBy;
+  public sortDirection = DIRECTION;
 
   /**
    * 후보값을 정렬한다.
    * @param {InclusionFilter} filter
-   * @param {string} target
-   * @param {string} type
+   * @param {InclusionSortBy} sortBy
+   * @param {DIRECTION} direction
    */
-  public sortCandidateValues(filter: InclusionFilter, target: string, type: string) {
+  public sortCandidateValues(filter: InclusionFilter, sortBy?: InclusionSortBy, direction?: DIRECTION) {
     // 정렬 정보 저장
-    filter['sortTarget'] = target;
-    filter['sortType'] = type;
+    ( sortBy ) && ( filter.sort.by = sortBy );
+    ( direction ) && ( filter.sort.direction = direction );
+
+    console.info( '>>>>>> filter.sort', filter.sort );
 
     // 데이터 정렬
     const allCandidates: Candidate[] = _.cloneDeep(this._candidateList);
-    if ('FREQUENCY' === target) {
+    if (InclusionSortBy.COUNT === filter.sort.by ) {
       // value 기준으로 정렬
       allCandidates.sort((val1: Candidate, val2: Candidate) => {
-        return ('ASC' === type) ? val1.count - val2.count : val2.count - val1.count;
+        return ( DIRECTION.ASC === filter.sort.direction ) ? val1.count - val2.count : val2.count - val1.count;
       });
     } else {
       // name 기준으로 정렬
@@ -491,10 +498,10 @@ export class ConfigureFiltersInclusionComponent extends AbstractFilterPopupCompo
         const name1: string = (val1.name) ? val1.name.toUpperCase() : '';
         const name2: string = (val2.name) ? val2.name.toUpperCase() : '';
         if (name1 < name2) {
-          return ('ASC' === type) ? -1 : 1;
+          return (DIRECTION.ASC === filter.sort.direction ) ? -1 : 1;
         }
         if (name1 > name2) {
-          return ('ASC' === type) ? 1 : -1;
+          return (DIRECTION.ASC === filter.sort.direction ) ? 1 : -1;
         }
         return 0;
       });
@@ -759,7 +766,7 @@ export class ConfigureFiltersInclusionComponent extends AbstractFilterPopupCompo
     (targetFilter.candidateValues) || (targetFilter.candidateValues = []);
 
     // 정렬
-    this.sortCandidateValues(targetFilter, 'ALPHNUMERIC', 'ASC');
+    this.sortCandidateValues(targetFilter);
   }// function - _setCandidateResult
 
   // noinspection JSMethodCanBeStatic

--- a/discovery-frontend/src/app/dashboard/filters/inclusion-filter/inclusion-filter-panel.component.html
+++ b/discovery-frontend/src/app/dashboard/filters/inclusion-filter/inclusion-filter-panel.component.html
@@ -36,23 +36,23 @@
           <span class="ddp-label">{{'msg.comm.ui.soring.by' | translate }}</span>
           <!-- 정렬 버튼 목록 -->
           <ul class="ddp-list-popup ddp-type">
-            <li [class.ddp-selected]="filter['sortTarget'] === 'FREQUENCY' && filter['sortType'] === 'ASC'">
-              <a href="javascript:" (click)="sortCandidateValues(filter, 'FREQUENCY','ASC');">
+            <li [class.ddp-selected]="sortBy.COUNT === filter.sort.by && sortDirection.ASC === filter.sort.direction">
+              <a href="javascript:" (click)="sortCandidateValues(filter, sortBy.COUNT, sortDirection.ASC );">
                 {{'msg.comm.ui.soring.frequency.asc' | translate}} <em class="ddp-icon-check"></em>
               </a>
             </li>
-            <li [class.ddp-selected]="filter['sortTarget'] === 'FREQUENCY' && filter['sortType'] === 'DESC'">
-              <a href="javascript:" (click)="sortCandidateValues(filter, 'FREQUENCY','DESC');">
+            <li [class.ddp-selected]="sortBy.COUNT === filter.sort.by && sortDirection.DESC === filter.sort.direction">
+              <a href="javascript:" (click)="sortCandidateValues(filter, sortBy.COUNT, sortDirection.DESC);">
                 {{'msg.comm.ui.soring.frequency.desc' | translate}} <em class="ddp-icon-check"></em>
               </a>
             </li>
-            <li [class.ddp-selected]="filter['sortTarget'] === 'ALPHNUMERIC' && filter['sortType'] === 'ASC'">
-              <a href="javascript:" (click)="sortCandidateValues(filter, 'ALPHNUMERIC','ASC');">
+            <li [class.ddp-selected]="sortBy.TEXT === filter.sort.by && sortDirection.ASC === filter.sort.direction">
+              <a href="javascript:" (click)="sortCandidateValues(filter, sortBy.TEXT, sortDirection.ASC );">
                 {{'msg.comm.ui.soring.alphnumeric.asc' | translate}} <em class="ddp-icon-check"></em>
               </a>
             </li>
-            <li [class.ddp-selected]="filter['sortTarget'] === 'ALPHNUMERIC' && filter['sortType'] === 'DESC'">
-              <a href="javascript:" (click)="sortCandidateValues(filter, 'ALPHNUMERIC','DESC');">
+            <li [class.ddp-selected]="sortBy.TEXT === filter.sort.by && sortDirection.DESC === filter.sort.direction">
+              <a href="javascript:" (click)="sortCandidateValues(filter, sortBy.TEXT, sortDirection.DESC);">
                 {{'msg.comm.ui.soring.alphnumeric.desc' | translate}} <em class="ddp-icon-check"></em>
               </a>
             </li>

--- a/discovery-frontend/src/app/dashboard/filters/inclusion-filter/inclusion-filter-panel.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/inclusion-filter/inclusion-filter-panel.component.ts
@@ -25,7 +25,7 @@ import {
 import {
   Candidate,
   InclusionFilter,
-  InclusionSelectorType
+  InclusionSelectorType, InclusionSortBy
 } from '../../../domain/workbook/configurations/filter/inclusion-filter';
 import { DatasourceService } from '../../../datasource/service/datasource.service';
 import { SubscribeArg } from '../../../common/domain/subscribe-arg';
@@ -35,6 +35,10 @@ import { AbstractFilterPanelComponent } from '../abstract-filter-panel.component
 import { Field } from '../../../domain/datasource/datasource';
 import { StringUtil } from '../../../common/util/string.util';
 import { FilterUtil } from '../../util/filter.util';
+import { DIRECTION } from '../../../domain/workbook/configurations/sort';
+import { DashboardUtil } from '../../util/dashboard.util';
+import { EventBroadcaster } from '../../../common/event/event.broadcaster';
+import { FilterWidget } from '../../../domain/dashboard/widget/filter-widget';
 
 @Component({
   selector: 'inclusion-filter-panel',
@@ -80,7 +84,8 @@ export class InclusionFilterPanelComponent extends AbstractFilterPanelComponent 
    |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
 
   // 생성자
-  constructor(private popupService: PopupService,
+  constructor(private broadCaster: EventBroadcaster,
+              private popupService: PopupService,
               protected datasourceService: DatasourceService,
               protected elementRef: ElementRef,
               protected injector: Injector) {
@@ -105,6 +110,13 @@ export class InclusionFilterPanelComponent extends AbstractFilterPanelComponent 
     super.ngAfterViewInit();
 
     this._initComponent(this.originalFilter);
+
+    // 필터 선택 변경
+    this.subscriptions.push(
+      this.broadCaster.on<any>('CHANGE_FILTER_SELECTOR').subscribe(data => {
+        this.filter.selector = (<FilterWidget>data.widget).configuration.filter['selector'];
+      })
+    );
 
     // 위젯에서 필터를 업데이트 popup은 아니지만 동일한 기능이 필요해서 popupService를 사용
     const popupSubscribe = this.popupService.filterView$.subscribe((data: SubscribeArg) => {
@@ -222,23 +234,26 @@ export class InclusionFilterPanelComponent extends AbstractFilterPanelComponent 
     this.isShowDetailMenu = !this.isShowDetailMenu;
   } // function resetFilter
 
+  public sortBy = InclusionSortBy;
+  public sortDirection = DIRECTION;
+
   /**
    * 후보값을 정렬한다.
    * @param {InclusionFilter} filter
-   * @param {string} target
-   * @param {string} type
+   * @param {InclusionSortBy} sortBy
+   * @param {DIRECTION} direction
    */
-  public sortCandidateValues(filter: InclusionFilter, target: string, type: string) {
+  public sortCandidateValues(filter: InclusionFilter, sortBy?: InclusionSortBy, direction?: DIRECTION) {
     // 정렬 정보 저장
-    filter['sortTarget'] = target;
-    filter['sortType'] = type;
+    ( sortBy ) && ( filter.sort.by = sortBy );
+    ( direction ) && ( filter.sort.direction = direction );
 
     // 데이터 정렬
     const allCandidates: Candidate[] = _.cloneDeep(this._candidateList);
-    if ('FREQUENCY' === target) {
+    if (InclusionSortBy.COUNT === filter.sort.by ) {
       // value 기준으로 정렬
       allCandidates.sort((val1: Candidate, val2: Candidate) => {
-        return ('ASC' === type) ? val1.count - val2.count : val2.count - val1.count;
+        return ( DIRECTION.ASC === filter.sort.direction ) ? val1.count - val2.count : val2.count - val1.count;
       });
     } else {
       // name 기준으로 정렬
@@ -246,10 +261,10 @@ export class InclusionFilterPanelComponent extends AbstractFilterPanelComponent 
         const name1: string = (val1.name) ? val1.name.toUpperCase() : '';
         const name2: string = (val2.name) ? val2.name.toUpperCase() : '';
         if (name1 < name2) {
-          return ('ASC' === type) ? -1 : 1;
+          return (DIRECTION.ASC === filter.sort.direction ) ? -1 : 1;
         }
         if (name1 > name2) {
-          return ('ASC' === type) ? 1 : -1;
+          return (DIRECTION.ASC === filter.sort.direction ) ? 1 : -1;
         }
         return 0;
       });
@@ -258,6 +273,9 @@ export class InclusionFilterPanelComponent extends AbstractFilterPanelComponent 
 
     // 페이징 설정
     this.setCandidatePage(1, true);
+
+    this.safelyDetectChanges();
+    this.updateFilterEvent.emit(this.filter);
   } // function - sortCandidateValues
 
 
@@ -396,7 +414,7 @@ export class InclusionFilterPanelComponent extends AbstractFilterPanelComponent 
         }
 
         // 정렬
-        this.sortCandidateValues(this.filter, 'ALPHNUMERIC', 'ASC');
+        this.sortCandidateValues(this.filter);
 
         // 위젯 화면 표시
         this.isShowFilter = true;

--- a/discovery-frontend/src/app/dashboard/util/filter.util.ts
+++ b/discovery-frontend/src/app/dashboard/util/filter.util.ts
@@ -14,7 +14,9 @@
 
 import {
   InclusionFilter,
-  InclusionSelectorType
+  InclusionItemSort,
+  InclusionSelectorType,
+  InclusionSortBy
 } from '../../domain/workbook/configurations/filter/inclusion-filter';
 import { BoundFilter } from '../../domain/workbook/configurations/filter/bound-filter';
 import {
@@ -43,8 +45,10 @@ import {
 import { DashboardUtil } from './dashboard.util';
 import {
   IntervalFilter,
-  IntervalRelativeTimeType, IntervalSelectorType
+  IntervalRelativeTimeType,
+  IntervalSelectorType
 } from '../../domain/workbook/configurations/filter/interval-filter';
+import { DIRECTION } from '../../domain/workbook/configurations/sort';
 
 declare let moment;
 
@@ -133,7 +137,6 @@ export class FilterUtil {
    * @return {InclusionFilter}
    */
   public static getBasicInclusionFilter(field: Field, importanceType?: string, preFilterData?: any): InclusionFilter {
-    // 시간 필터
     const inclusionFilter = new InclusionFilter(field.name);
     inclusionFilter.selector = InclusionSelectorType.SINGLE_COMBO;
     inclusionFilter.preFilters = [];
@@ -145,8 +148,8 @@ export class FilterUtil {
     inclusionFilter.preFilters.push(this.getBasicPositionFilter(preFilterData));
     inclusionFilter.preFilters.push(this.getBasicWildCardFilter(field.name, preFilterData));
 
-    // inclusionFilter.ui.masterDsId = field.uiMasterDsId;
-    // inclusionFilter.ui.dsId = field.dsId;
+    inclusionFilter.sort = new InclusionItemSort( InclusionSortBy.TEXT, DIRECTION.ASC );
+
     (importanceType) && (inclusionFilter.ui.importanceType = importanceType);
     (-1 < field.filteringSeq) && (inclusionFilter.ui.filteringSeq = field.filteringSeq + 1);
     if (field.filteringOptions) {
@@ -254,7 +257,7 @@ export class FilterUtil {
           'locale', 'format', 'rrule', 'relValue', 'timeUnit'];
         break;
       case 'include' :
-        keyMap = ['valueList', 'candidateValues'];
+        keyMap = ['valueList', 'candidateValues','sort'];
         break;
       case 'timestamp' :
         keyMap = ['selectedTimestamps', 'timeFormat'];
@@ -332,7 +335,7 @@ export class FilterUtil {
           'minTime', 'maxTime', 'valueList', 'candidateValues', 'discontinuous', 'granularity'];
         break;
       case 'include' :
-        keyMap = ['selector', 'preFilters', 'valueList', 'candidateValues', 'definedValues'];
+        keyMap = ['selector', 'preFilters', 'valueList', 'candidateValues', 'definedValues','sort'];
         break;
       case 'timestamp' :
         keyMap = ['selectedTimestamps', 'timeFormat'];

--- a/discovery-frontend/src/app/dashboard/widgets/filter-widget/filter-widget.component.ts
+++ b/discovery-frontend/src/app/dashboard/widgets/filter-widget/filter-widget.component.ts
@@ -21,8 +21,8 @@ import { FilterWidget, FilterWidgetConfiguration } from '../../../domain/dashboa
 import { Filter } from '../../../domain/workbook/configurations/filter/filter';
 import {
   Candidate,
-  InclusionFilter,
-  InclusionSelectorType
+  InclusionFilter, InclusionItemSort,
+  InclusionSelectorType, InclusionSortBy
 } from '../../../domain/workbook/configurations/filter/inclusion-filter';
 import { Alert } from '../../../common/util/alert.util';
 import { Dashboard } from '../../../domain/dashboard/dashboard';
@@ -42,6 +42,8 @@ import { StringUtil } from '../../../common/util/string.util';
 import { DashboardUtil } from '../../util/dashboard.util';
 import { FilterUtil } from '../../util/filter.util';
 import { TimeFilter } from '../../../domain/workbook/configurations/filter/time-filter';
+import { DIRECTION } from '../../../domain/workbook/configurations/sort';
+import { isNullOrUndefined } from 'util';
 
 @Component({
   selector: 'filter-widget',
@@ -503,6 +505,30 @@ export class FilterWidgetComponent extends AbstractWidgetComponent implements On
           } else {
             result.forEach(item => {
               this.candidateList.push(this._objToCandidate(item, this.field));
+            });
+          }
+
+          // Sort List
+          if( isNullOrUndefined( inclusionFilter.sort ) ) {
+            inclusionFilter.sort = new InclusionItemSort( InclusionSortBy.TEXT, DIRECTION.ASC );
+          }
+          if (InclusionSortBy.COUNT === inclusionFilter.sort.by ) {
+            // sort by count
+            this.candidateList.sort((val1: Candidate, val2: Candidate) => {
+              return ( DIRECTION.ASC === inclusionFilter.sort.direction ) ? val1.count - val2.count : val2.count - val1.count;
+            });
+          } else {
+            // sort by text
+            this.candidateList.sort((val1: Candidate, val2: Candidate) => {
+              const name1: string = (val1.name) ? val1.name.toUpperCase() : '';
+              const name2: string = (val2.name) ? val2.name.toUpperCase() : '';
+              if (name1 < name2) {
+                return (DIRECTION.ASC === inclusionFilter.sort.direction ) ? -1 : 1;
+              }
+              if (name1 > name2) {
+                return (DIRECTION.ASC === inclusionFilter.sort.direction ) ? 1 : -1;
+              }
+              return 0;
             });
           }
 

--- a/discovery-frontend/src/app/domain/workbook/configurations/filter/inclusion-filter.ts
+++ b/discovery-frontend/src/app/domain/workbook/configurations/filter/inclusion-filter.ts
@@ -14,23 +14,27 @@
 
 import { Filter } from './filter';
 import { AdvancedFilter } from './advanced-filter';
+import { DIRECTION } from '../sort';
 
 export class InclusionFilter extends Filter {
 
-  // 선택 값(목록) 정보
+  // Selected Item List
   public valueList: any[];
 
-  // 목록 값(목록) 정보
-  public candidateValues: any[];
-
-  // UI 에 표시될 선택표시 유형 추가 (Optional)
+  // Add the type to be displayed in the UI (Optional)
   public selector: InclusionSelectorType = InclusionSelectorType.SINGLE_LIST;
 
-  // User-Defined 타입인 경우 정의된 값 정보 (Optional)
+  // About list value (list)
+  public candidateValues: any[];
+
+  // Information defined for User-Defined type (Optional)
   public definedValues: string[];
 
-  // InclusionFilter 값을 선택하기전 수행 필터 정보 (Optional)
+  // Perform filter before selecting InclusionFilter value (Optional)
   public preFilters: AdvancedFilter[];
+
+  // Sort condition (Optional, for UI)
+  public sort:InclusionItemSort;
 
   constructor(field: string, valueList: string[] = []) {
     super();
@@ -47,12 +51,28 @@ export class InclusionFilter extends Filter {
   public pageNum: number = 0;
 }
 
+export class InclusionItemSort {
+  public by:InclusionSortBy;
+  public direction:DIRECTION;
+
+  constructor( by:InclusionSortBy, direction:DIRECTION ) {
+    this.by = by;
+    this.direction = direction;
+  }
+}
+
 export class Candidate {
   public name: string;
   public count: number;
   public isDefinedValue: boolean = false;
-  // 눈표시 여부
-  public isShow: boolean = false;
+  public isShow: boolean = false;   // Whether icon is displayed
+}
+
+export enum InclusionSortBy {
+  COUNT = <any>'COUNT',
+  TEXT = <any>'TEXT',
+  NUMERIC = <any>'NUMERIC',
+  DATE = <any>'DATE'
 }
 
 export enum InclusionSelectorType {

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/filter/InclusionFilter.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/filter/InclusionFilter.java
@@ -14,6 +14,8 @@
 
 package app.metatron.discovery.domain.workbook.configurations.filter;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -22,26 +24,32 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.List;
 import java.util.Map;
 
+import app.metatron.discovery.domain.workbook.configurations.Sort;
+import app.metatron.discovery.util.EnumUtils;
+
+/**
+ * In Filter
+ */
 @JsonTypeName("include")
 public class InclusionFilter extends Filter {
 
   /**
-   * 선택 값(목록) 정보
+   * Selected Item List
    */
   List<String> valueList;
 
   /**
-   * UI 에 표시될 선택표시 유형 추가 (Optional, for UI)
+   * Selection Type (Optional, for UI)
    */
   SelectorType selector;
 
   /**
-   * 보기 설정된 아이템 항목  (Optional, for UI)
+   * View set items  (Optional, for UI)
    */
   List<String> candidateValues;
 
   /**
-   * User-Defined 타입인 경우 정의된 값 정보 (Optional, for UI)
+   * User-Defined Item (Optional, for UI)
    */
   List<String> definedValues;
 
@@ -51,12 +59,44 @@ public class InclusionFilter extends Filter {
   List<AdvancedFilter> preFilters;
 
   /**
-   * Value Pair
+   * Sort condition (Optional, for UI)
+   */
+  ItemSort sort;
+
+  /**
+   * Value Pair (Optional, for Lookup)
    */
   Map<String, String> valuePair;
 
   public InclusionFilter() {
     // Empty Constructor
+  }
+
+  @JsonCreator
+  public InclusionFilter(@JsonProperty("dataSource") String dataSource,
+                         @JsonProperty("field") String field,
+                         @JsonProperty("ref") String ref,
+                         @JsonProperty("valueList") List<String> valueList,
+                         @JsonProperty("values") List<String> values,
+                         @JsonProperty("selector") String selector,
+                         @JsonProperty("candidateValues") List<String> candidateValues,
+                         @JsonProperty("definedValues") List<String> definedValues,
+                         @JsonProperty("preFilters") List<AdvancedFilter> preFilters,
+                         @JsonProperty("sort") ItemSort sort,
+                         @JsonProperty("valuePair") Map<String, String> valuePair) {
+    super(dataSource, field, ref);
+
+    this.valueList = valueList;
+    if(values != null) {
+      this.valueList = values;
+    }
+
+    this.selector = EnumUtils.getUpperCaseEnum(SelectorType.class, selector);
+    this.candidateValues = candidateValues;
+    this.definedValues = definedValues;
+    this.preFilters = preFilters;
+    this.sort = sort;
+    this.valuePair = valuePair;
   }
 
   public InclusionFilter(String field, List<String> valueList) {
@@ -138,6 +178,70 @@ public class InclusionFilter extends Filter {
 
   public void setValuePair(Map<String, String> valuePair) {
     this.valuePair = valuePair;
+  }
+
+  public ItemSort getSort() {
+    return sort;
+  }
+
+  public void setSort(ItemSort sort) {
+    this.sort = sort;
+  }
+
+  @Override
+  public String toString() {
+    return "InclusionFilter{" +
+        "valueList=" + valueList +
+        ", selector=" + selector +
+        ", candidateValues=" + candidateValues +
+        ", definedValues=" + definedValues +
+        ", preFilters=" + preFilters +
+        ", sort=" + sort +
+        ", valuePair=" + valuePair +
+        "} " + super.toString();
+  }
+
+  /**
+   * Define sort conditions
+   */
+  public static class ItemSort {
+
+    /**
+     * Sort By
+     */
+    SortBy by;
+
+    /**
+     * Sort Direction
+     */
+    Sort.Direction direction;
+
+    @JsonCreator
+    public ItemSort(@JsonProperty("by") String by,
+                    @JsonProperty("direction") String direction) {
+      this.by = EnumUtils.getUpperCaseEnum(SortBy.class, by);
+      this.direction = EnumUtils.getUpperCaseEnum(Sort.Direction.class, direction);
+    }
+
+    public SortBy getBy() {
+      return by;
+    }
+
+    public Sort.Direction getDirection() {
+      return direction;
+    }
+
+    @Override
+    public String toString() {
+      return "ItemSort{" +
+          "by=" + by +
+          ", direction=" + direction +
+          '}';
+    }
+  }
+
+  public enum  SortBy {
+    COUNT, TEXT, NUMERIC, DATE
   }
 
   public enum SelectorType {

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/workbook/configurations/filter/InclusionFilterTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/workbook/configurations/filter/InclusionFilterTest.java
@@ -1,0 +1,29 @@
+package app.metatron.discovery.domain.workbook.configurations.filter;
+
+import org.assertj.core.util.Lists;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import app.metatron.discovery.common.GlobalObjectMapper;
+
+public class InclusionFilterTest {
+
+  @Test
+  public void de_serialize() throws IOException {
+
+    InclusionFilter inFilter = new InclusionFilter();
+    inFilter.setDataSource("datasource1");
+    inFilter.setField("field1");
+    inFilter.setValueList(Lists.newArrayList("value"));
+    inFilter.setSort(new InclusionFilter.ItemSort("count", "desc"));
+
+    String specStr = GlobalObjectMapper.writeValueAsString(inFilter);
+    System.out.println(specStr);
+
+    InclusionFilter deserializedConfObj = GlobalObjectMapper.getDefaultMapper().readValue(specStr, InclusionFilter.class);
+
+    System.out.println(deserializedConfObj);
+  }
+
+}


### PR DESCRIPTION
### Description
* 필터 편집화면에서 지정된 정렬 정보가 필터 패널에 전달 되지 않고 초기화 됩니다.
* 대시보드내 Dimension 필터 항목에 대한 정렬정보가 저장이 되지 않고 초기화 됩니다.

**Related Issue** : #153 
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 대시보드 편집화면으로 이동합니다.
2. 신규 필터 추가 팝업을 오픈합니다.
3. Dimension 필드에 대해서 필터 추가를 선택하고, 필터 설정 화면에서 정렬 방식을 변경합니다.
4. 변경된 정렬 방식에 따라 필터 패널과 필터 위젯의 목록이 표시되는지 확인합니다.
5. 저장한 이후에 변경된 정렬 방식이 유지되는지 확인합니다.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
