### PR TITLE
#151 Loading image error when saving after changing column of shelf in copied widget 

### DIFF
--- a/discovery-frontend/src/app/dashboard/component/dashboard-layout/dashboard.layout.component.ts
+++ b/discovery-frontend/src/app/dashboard/component/dashboard-layout/dashboard.layout.component.ts
@@ -636,16 +636,16 @@ export abstract class DashboardLayoutComponent extends AbstractComponent impleme
   /**
    * Dynamic Widget Header Component 등록
    * @param stack
-   * @param {LayoutWidgetInfo[]} layoutWidgets
    * @param {BoardGlobalOptions} globalOpts
    * @private
    */
-  private _bootstrapWidgetHeaderComponent(stack, layoutWidgets: LayoutWidgetInfo[], globalOpts: BoardGlobalOptions) {
+  private _bootstrapWidgetHeaderComponent(stack, globalOpts: BoardGlobalOptions) {
     let componentState: any = stack.config.content[0];
     if( componentState ) {
       let widgetInfo: Widget = DashboardUtil.getWidgetByLayoutComponentId(this.dashboard, componentState.id);
 
       if( widgetInfo ) {
+        const layoutWidgets: LayoutWidgetInfo[] = DashboardUtil.getLayoutWidgetInfos( this.dashboard );
         let widgetHeaderCompFactory
           = this.componentFactoryResolver.resolveComponentFactory(DashboardWidgetHeaderComponent);
         let widgetHeaderComp = this.appRef.bootstrap(widgetHeaderCompFactory, stack.header.tabs[0].element.get(0));
@@ -844,11 +844,11 @@ export abstract class DashboardLayoutComponent extends AbstractComponent impleme
           });
         });
 
-        // 레이아웃 스택이 생성되었을 때의 이벤트 처리 -> Header 기능 정의
+        // 레이아웃 스택이 생성되었을 때의 이벤트 처리 -> Header 기능 정의private _convertSpecToServer(param: any) {
         this._layoutObj.on('stackCreated', (stack) => {
           if (LayoutMode.EDIT === this._layoutMode) {
             setTimeout(() => {
-              this._bootstrapWidgetHeaderComponent(stack, layoutWidgets, globalOpts);
+              this._bootstrapWidgetHeaderComponent(stack, globalOpts);
             }, 200);
           }
         });

--- a/discovery-frontend/src/app/dashboard/service/widget.service.ts
+++ b/discovery-frontend/src/app/dashboard/service/widget.service.ts
@@ -212,7 +212,7 @@ export class WidgetService extends AbstractService {
       if (conf && conf.filters) {
         param.configuration.filters = conf.filters.map(item => FilterUtil.convertToServerSpecForDashboard( item ) );
       }
-      if (conf.pivot) {
+      if (conf && conf.pivot) {
         if (conf.pivot.columns) {
           conf.pivot.columns.forEach(item => {
             delete item.field.filter;

--- a/discovery-frontend/src/app/page/page.component.ts
+++ b/discovery-frontend/src/app/page/page.component.ts
@@ -3140,6 +3140,10 @@ export class PageComponent extends AbstractPopupComponent implements OnInit, OnD
       _.concat(this.dimensions, this.measures)
         .forEach((field) => {
 
+
+          // Remove Pivot
+          field.pivot = [];
+
           this.widgetConfiguration.pivot.rows
             .forEach((abstractField) => {
               if (String(field.biType) == abstractField.type.toUpperCase() && field.name == abstractField.name) {


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
* 차트 위젯 복사후 복사된 위젯에 선반의 컬럼을 변경하면 로딩이미지가 사라지지 않습니다.

**Related Issue** : #151 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 대시보드 편집 화면으로 이동합니다.
2. 신규 차트 생성 버튼을 클릭합니다.
3. 신규 차트를 생성합니다. (ex. 바차트 - Sub Category - Sales )
4. 대시보드 편집 화면에서 차트를 복제합니다.
5. 복제된 차트를 수정합니다. ( ex. LineChart, OrderDate )
6. 차트를 저장합니다.
7. 정상적으로 대시보드 편집 화면에 표시되는지 확인하고, 대시보드가 정상적으로 저장되는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
