### PR TITLE
#48 fix error deleting sub tree

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workspace/BookTreeService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workspace/BookTreeService.java
@@ -20,7 +20,6 @@ import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -62,8 +61,8 @@ public class BookTreeService {
 
     List<Book> rootBooks = bookRepository.findRootBooksInWorkspace(workspaceId);
     rootBooks.sort(comparator);
-    for(Book book : rootBooks) {
-      if(book instanceof Folder) {
+    for (Book book : rootBooks) {
+      if (book instanceof Folder) {
         Folder folder = (Folder) book;
         List<Book> books = bookRepository.findOnlySubBooks(folder.getId());
         books.sort(comparator);
@@ -84,7 +83,7 @@ public class BookTreeService {
   public List<Book> findSubBooks(String bookId, boolean isRoot, String... type) {
 
     List<Book> books;
-    if(isRoot) {
+    if (isRoot) {
       books = bookRepository.findRootBooksInWorkspace(bookId, type);
     } else {
       books = bookRepository.findOnlySubBooks(bookId, type);
@@ -93,8 +92,8 @@ public class BookTreeService {
     books.sort(comparator);
 
     // 하위 Book 중 Folder Type 인 경우 하위 Book 들이 존재하는지 체크
-    for(Book book : books) {
-      if(book instanceof Folder) {
+    for (Book book : books) {
+      if (book instanceof Folder) {
         Folder folder = (Folder) book;
         folder.setHasSubBooks(
             bookRepository.countOnlySubBooks(folder.getId(), type) > 0 ? true : false
@@ -110,7 +109,7 @@ public class BookTreeService {
     List<Book> books = findSubBooks(bookId, isRoot, bookType);
 
     return books.stream().map(book -> {
-      if(type == LIST) {
+      if (type == LIST) {
         return book.listViewProjection();
       } else {
         return book.treeViewProjection();
@@ -143,19 +142,19 @@ public class BookTreeService {
     List<BookTree> bookTrees = Lists.newArrayList();
     bookTrees.add(new BookTree(book.getId(), book.getId(), 0));
 
-    if(Folder.ROOT.equals(book.getFolderId())) {
+    if (Folder.ROOT.equals(book.getFolderId())) {
       bookTreeRepository.save(bookTrees);
       return;
     }
 
     Folder folder = folderRepository.findOne(book.getFolderId());
-    if(folder == null) {
+    if (folder == null) {
       throw new IllegalArgumentException("Invalid Folder : " + book.getFolderId());
     }
 
     List<BookTree> ancestors = bookTreeRepository.findByIdDescendant(folder.getId());
 
-    for(BookTree ancestor : ancestors) {
+    for (BookTree ancestor : ancestors) {
       bookTrees.add(new BookTree(ancestor.getId().getAncestor(), book.getId(), ancestor.getDepth() + 1));
     }
 
@@ -167,7 +166,7 @@ public class BookTreeService {
     List<BookTree> bookTrees = Lists.newArrayList();
     List<String> deleteDescendants = Lists.newArrayList();
 
-    if("ROOT".equals(book.getFolderId())) {
+    if ("ROOT".equals(book.getFolderId())) {
 
       List<BookTree> descendants = bookTreeRepository.findDescendantNotAncenstor(book.getId());
       for (BookTree bookTree : descendants) {
@@ -195,7 +194,7 @@ public class BookTreeService {
       for (BookTree bookTree : descendants) {
         deleteDescendants.add(bookTree.getId().getDescendant());
         depthMap.forEach((ancestor, i) ->
-            bookTrees.add(new BookTree(ancestor, bookTree.getId().getDescendant(), i + bookTree.getDepth()))
+                             bookTrees.add(new BookTree(ancestor, bookTree.getId().getDescendant(), i + bookTree.getDepth()))
         );
       }
     }
@@ -209,21 +208,15 @@ public class BookTreeService {
 
   @Transactional
   public void deleteTree(Book book) {
-    // 하위 북 삭제
+    // delete sub-book
     List<BookTree> descendants = bookTreeRepository.findDescendantNotAncenstor(book.getId());
-    if(descendants.size() > 0) {
-      for(BookTree bookTree : descendants) {
-        try {
-          bookRepository.delete(bookTree.getId().getDescendant());
-          bookTreeRepository.delete(new BookTreeId(bookTree.getId().getDescendant(), bookTree.getId().getDescendant()));
-        } catch (EmptyResultDataAccessException e) {
-          LOGGER.warn("Fail to delete related book and tree from {}", book.getId(), e.getMessage());
-          continue;
-        }
+    if (descendants.size() > 0) {
+      for (BookTree bookTree : descendants) {
+        bookRepository.delete(bookTree.getId().getDescendant());
+        bookTreeRepository.deteleAllBookTree(book.getId());
       }
     }
 
-    // 트리 정보 삭제
     bookTreeRepository.deteleAllBookTree(book.getId());
   }
 
@@ -232,9 +225,9 @@ public class BookTreeService {
     @Override
     public int compare(Book book1, Book book2) {
 
-      if(book1 instanceof Folder && !(book2 instanceof Folder)) {
+      if (book1 instanceof Folder && !(book2 instanceof Folder)) {
         return -1;
-      } else if(!(book1 instanceof Folder) && book2 instanceof Folder) {
+      } else if (!(book1 instanceof Folder) && book2 instanceof Folder) {
         return 1;
       }
 

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/workspace/BookRestIntegrationTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/workspace/BookRestIntegrationTest.java
@@ -36,19 +36,19 @@ import static com.jayway.restassured.RestAssured.given;
 import static com.jayway.restassured.path.json.JsonPath.from;
 
 /**
- * Created by kyungtaak on 2016. 12. 20..
+ *
  */
 @TestExecutionListeners(value = OAuthTestExecutionListener.class, mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
 public class BookRestIntegrationTest extends AbstractRestIntegrationTest {
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     RestAssured.port = serverPort;
   }
 
   @Test
   @OAuthRequest(username = "polaris", value = {"SYSTEM_USER", "PERM_SYSTEM_WRITE_WORKBOOK"})
-  public void createWorkBookInWorkspaceShouldReturnWorkspaceInfo1() {
+  public void createWorkBookInWorkspaceShouldReturnWorkspaceInfo() {
 
     String workspaceId = "ws-02";
 
@@ -122,24 +122,6 @@ public class BookRestIntegrationTest extends AbstractRestIntegrationTest {
       .log().all();
     // @formatter:on
 
-    // Report 신규 생성
-    Map<String, Object> reportReq = Maps.newHashMap();
-    reportReq.put("type", "report");
-    reportReq.put("name", "report_test");
-    reportReq.put("workspace", "/api/workspaces/" + workspaceId);
-
-    // @formatter:off
-    given()
-      .auth().oauth2(oauth_token)
-      .body(reportReq)
-      .contentType(ContentType.JSON)
-    .when()
-      .post("/api/books")
-    .then()
-      .statusCode(HttpStatus.SC_CREATED)
-      .log().all();
-    // @formatter:on
-
     // Notebook 신규 생성
     Map<String, Object> notebookReq = Maps.newHashMap();
     notebookReq.put("type", "notebook");
@@ -167,13 +149,13 @@ public class BookRestIntegrationTest extends AbstractRestIntegrationTest {
     // @formatter:off
     given()
       .auth().oauth2(oauth_token)
-      .body(notebookReq)
       .contentType(ContentType.JSON)
+      .log().all()
     .when()
-      .post("/api/books/" + folder2Id + "/book/" + workbookId + "/move")
+      .post("/api/books/{bookId}/move/{folderId}", workbookId, folder2Id)
     .then()
-      .statusCode(HttpStatus.SC_NO_CONTENT)
-      .log().all();
+      .log().all()
+      .statusCode(HttpStatus.SC_NO_CONTENT);
     // @formatter:on
 
     // @formatter:off
@@ -184,7 +166,7 @@ public class BookRestIntegrationTest extends AbstractRestIntegrationTest {
     .when()
       .get("/api/workspaces/{workspace_id}", workspaceId)
     .then()
-//      .statusCode(HttpStatus.SC_OK)
+      .statusCode(HttpStatus.SC_OK)
       .log().all();
     // @formatter:on
 
@@ -213,7 +195,7 @@ public class BookRestIntegrationTest extends AbstractRestIntegrationTest {
     .when()
       .get("/api/workspaces/{workspace_id}", workspaceId)
     .then()
-//      .statusCode(HttpStatus.SC_OK)
+      .statusCode(HttpStatus.SC_OK)
       .log().all();
     // @formatter:on
   }


### PR DESCRIPTION
### Description
- 1-depth 이상의 폴더 삭제후 ROOT 내 폴더 삭제시 오류가 나는 현상을 수정합니다. 
- metadata 내 catalog 도 동일 로직을 활용하여 함께 점검합니다.

**Related Issue** : #48 

### How Has This Been Tested?
- 워크스페이스 내에서 ROOT 에 폴더 A를 생성합니다.
- 생성된 A 폴더 하위에 B 를 생성합니다. 
- B 폴더 하위에 워크북을 생성합니다.
- A 폴더에 돌아와서 B 폴더를 삭제합니다.
- ROOT 에 돌아와서 A 폴더를 삭제합니다.

※ metadata > catalog 도 동일한 depth 규칙으로 생성/삭제 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
