### PR TITLE
#162 fix table header

### DIFF
--- a/discovery-frontend/src/app/meta-data-management/metadata/metadata-detail-columnschema.component.html
+++ b/discovery-frontend/src/app/meta-data-management/metadata/metadata-detail-columnschema.component.html
@@ -35,10 +35,10 @@
     <!-- header -->
     <table class="ddp-table-form ddp-table-type2 ddp-table-details">
       <colgroup>
-        <col width="140px">
+        <col width="160px">
         <col width="100px">
-        <col width="140px">
-        <col width="120px">
+        <col width="180px">
+        <col width="180px">
         <col width="150px">
         <col width="150px">
         <col width="200px">

--- a/discovery-frontend/src/app/meta-data-management/metadata/metadata-detail-columnschema.component.html
+++ b/discovery-frontend/src/app/meta-data-management/metadata/metadata-detail-columnschema.component.html
@@ -52,70 +52,112 @@
       <thead>
       <tr>
         <th class="ddp-cursor" (click)="onClickSort('popularity')">
-          {{'msg.metadata.th.column.popularity' | translate}}
-          <div class="ddp-wrap-hover-info">
-            <em class="ddp-icon-info3"></em>
-            <!-- popup -->
-            <div class="ddp-box-layout4 ddp-popularity">
-              <div class="ddp-data-title">
-                {{'msg.metadata.th.column.popularity.tooltip.title' | translate}}
+          <div class="ddp-th-long">
+            <div class="ddp-th-icons">
+              <div class="ddp-wrap-hover-info">
+                <em class="ddp-icon-info3"></em>
+                <!-- popup -->
+                <div class="ddp-box-layout4 ddp-popularity">
+                  <div class="ddp-data-title">
+                    {{'msg.metadata.th.column.popularity.tooltip.title' | translate}}
+                  </div>
+                  <div class="ddp-data-det">
+                    {{'msg.metadata.th.column.popularity.tooltip.desc' | translate}}
+                    <ul>
+                      <li>• {{'msg.metadata.th.column.popularity.tooltip.dashboard.conn' | translate}}
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+                <!-- //popup -->
               </div>
-              <div class="ddp-data-det">
-                {{'msg.metadata.th.column.popularity.tooltip.desc' | translate}}
-                <ul>
-                  <li>• {{'msg.metadata.th.column.popularity.tooltip.dashboard.conn' | translate}}
-                  </li>
-                </ul>
-              </div>
+              <em class="ddp-icon-array-default2" *ngIf="selectedContentSort.key !== 'popularity' || selectedContentSort.sort === 'default'"></em>
+              <em class="ddp-icon-array-asc2" *ngIf="selectedContentSort.key === 'popularity' && selectedContentSort.sort === 'asc'"></em>
+              <em class="ddp-icon-array-des2" *ngIf="selectedContentSort.key === 'popularity' && selectedContentSort.sort === 'desc'"></em>
             </div>
-            <!-- //popup -->
+            <span class="ddp-th-txt" title="{{'msg.metadata.th.column.popularity' | translate}}">
+              {{'msg.metadata.th.column.popularity' | translate}}
+            </span>
           </div>
-          <em class="ddp-icon-array-default2" *ngIf="selectedContentSort.key !== 'popularity' || selectedContentSort.sort === 'default'"></em>
-          <em class="ddp-icon-array-asc2" *ngIf="selectedContentSort.key === 'popularity' && selectedContentSort.sort === 'asc'"></em>
-          <em class="ddp-icon-array-des2" *ngIf="selectedContentSort.key === 'popularity' && selectedContentSort.sort === 'desc'"></em>
         </th>
         <th>
-          {{'msg.metadata.th.physical.type' | translate}}
+          <div class="ddp-th-long">
+            <div class="ddp-th-txt" title="{{'msg.metadata.th.physical.type' | translate}}">
+              {{'msg.metadata.th.physical.type' | translate}}
+            </div>
+          </div>
         </th>
         <th class="ddp-cursor" (click)="onClickSort('physicalName')">
-          {{'msg.metadata.th.physical.name' | translate}}
-          <em class="ddp-icon-array-default2" *ngIf="selectedContentSort.key !== 'physicalName' || selectedContentSort.sort === 'default'"></em>
-          <em class="ddp-icon-array-asc2" *ngIf="selectedContentSort.key === 'physicalName' && selectedContentSort.sort === 'asc'"></em>
-          <em class="ddp-icon-array-des2" *ngIf="selectedContentSort.key === 'physicalName' && selectedContentSort.sort === 'desc'"></em>
+          <div class="ddp-th-long">
+            <div class="ddp-th-icons">
+              <em class="ddp-icon-array-default2" *ngIf="selectedContentSort.key !== 'physicalName' || selectedContentSort.sort === 'default'"></em>
+              <em class="ddp-icon-array-asc2" *ngIf="selectedContentSort.key === 'physicalName' && selectedContentSort.sort === 'asc'"></em>
+              <em class="ddp-icon-array-des2" *ngIf="selectedContentSort.key === 'physicalName' && selectedContentSort.sort === 'desc'"></em>
+            </div>
+            <span class="ddp-th-txt" title="{{'msg.metadata.th.physical.name' | translate}}">
+              {{'msg.metadata.th.physical.name' | translate}}
+            </span>
+          </div>
         </th>
         <th class="ddp-cursor" (click)="onClickSort('name')">
-          {{'msg.metadata.th.name' | translate}}
-          <div class="ddp-wrap-hover-info">
-            <em class="ddp-icon-info3"></em>
-            <!-- popup -->
-            <div class="ddp-box-layout4 ddp-popularity">
-              <div class="ddp-data-title">
-                {{'msg.metadata.th.column.popularity.tooltip.title' | translate}}
+          <div class="ddp-th-long">
+            <div class="ddp-th-icons">
+              <div class="ddp-wrap-hover-info">
+                <em class="ddp-icon-info3"></em>
+                <!-- popup -->
+                <div class="ddp-box-layout4 ddp-popularity">
+                  <div class="ddp-data-title">
+                    {{'msg.metadata.th.column.logical.tooltip.title' | translate}}
+                  </div>
+                  <div class="ddp-data-det">
+                    {{'msg.metadata.th.column.logical.tooltip.desc' | translate}}
+                  </div>
+                </div>
+                <!-- //popup -->
               </div>
-              <div class="ddp-data-det">
-                {{'msg.metadata.th.column.popularity.tooltip.desc' | translate}}
-              </div>
+              <em class="ddp-icon-array-default2" *ngIf="selectedContentSort.key !== 'name' || selectedContentSort.sort === 'default'"></em>
+              <em class="ddp-icon-array-asc2" *ngIf="selectedContentSort.key === 'name' && selectedContentSort.sort === 'asc'"></em>
+              <em class="ddp-icon-array-des2" *ngIf="selectedContentSort.key === 'name' && selectedContentSort.sort === 'desc'"></em>
             </div>
-            <!-- //popup -->
+            <span class="ddp-th-txt" title="{{'msg.metadata.th.name' | translate}}">
+              {{'msg.metadata.th.name' | translate}}
+            </span>
           </div>
-          <em class="ddp-icon-array-default2" *ngIf="selectedContentSort.key !== 'name' || selectedContentSort.sort === 'default'"></em>
-          <em class="ddp-icon-array-asc2" *ngIf="selectedContentSort.key === 'name' && selectedContentSort.sort === 'asc'"></em>
-          <em class="ddp-icon-array-des2" *ngIf="selectedContentSort.key === 'name' && selectedContentSort.sort === 'desc'"></em>
         </th>
         <th>
-          {{'msg.metadata.th.dictionary' | translate}}
+          <div class="ddp-th-long">
+            <span class="ddp-th-txt" title="{{'msg.metadata.th.dictionary' | translate}}">
+              {{'msg.metadata.th.dictionary' | translate}}
+            </span>
+          </div>
         </th>
         <th>
-          {{'msg.storage.ui.th.logical.type'| translate}}
+          <div class="ddp-th-long">
+            <span class="ddp-th-txt" title="{{'msg.storage.ui.th.logical.type'| translate}}">
+              {{'msg.storage.ui.th.logical.type'| translate}}
+            </span>
+          </div>
         </th>
         <th>
-          {{'msg.storage.ui.th.format' | translate}}
+          <div class="ddp-th-long">
+            <span class="ddp-th-txt" title="{{'msg.storage.ui.th.format' | translate}}">
+              {{'msg.storage.ui.th.format' | translate}}
+            </span>
+          </div>
         </th>
         <th>
-          {{'msg.storage.ui.th.code.table' | translate}}
+          <div class="ddp-th-long">
+            <span class="ddp-th-txt" title="{{'msg.storage.ui.th.code.table' | translate}}">
+              {{'msg.storage.ui.th.code.table' | translate}}
+            </span>
+          </div>
         </th>
         <th>
-          {{'msg.storage.ui.th.description' | translate}}
+          <div class="ddp-th-long">
+            <span class="ddp-th-txt" title="{{'msg.storage.ui.th.description' | translate}}">
+              {{'msg.storage.ui.th.description' | translate}}
+            </span>
+          </div>
         </th>
         <!--<th>-->
           <!--{{'msg.metadata.th.max.digit' | translate}}-->

--- a/discovery-frontend/src/assets/css/polaris.v2.component.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.component.css
@@ -1709,6 +1709,14 @@ table.ddp-table-type2 tbody tr td .ddp-input-form input.ddp-txt-input:focus + em
 table.ddp-table-type2 thead tr th {position:relative; padding:7px 10px; color:#90969f; font-size:12px; border-right:1px solid #eaeaed;}
 table.ddp-table-type2 thead tr th:first-of-type {}
 table.ddp-table-type2 thead tr th:last-of-type {border-right:1px solid transparent;}
+table.ddp-table-type2 thead tr th .ddp-th-long {display:inline-block;   position:relative; max-width:100%; box-sizing:border-box;}
+
+table.ddp-table-type2 thead tr th .ddp-th-long {}
+table.ddp-table-type2 thead tr th .ddp-th-long .ddp-th-icons {float:right;}
+table.ddp-table-type2 thead tr th .ddp-th-long .ddp-th-txt {display:block; overflow:hidden; white-space:nowrap;text-overflow:ellipsis; line-height:19px;}
+table.ddp-table-type2 thead tr th .ddp-th-long .ddp-th-icons .ddp-wrap-hover-info {float:left; padding:5px 0 0 0; font-size:0px;}
+table.ddp-table-type2 thead tr th .ddp-th-long .ddp-th-icons [class*="ddp-icon-array"] {top:0;}
+
 table.ddp-table-type3 thead tr th {color:#4b515b; font-size:12px; font-weight:normal; border-top:1px solid #d2d3d9; border-bottom:1px solid #d2d3d9; background-color:#f8f8f8;}
 table.ddp-table-type3 thead tr th:first-of-type {border-left:1px solid #d2d3d9;}
 table.ddp-table-type3 thead tr th:last-of-type {border-right:1px solid #d2d3d9;}

--- a/discovery-frontend/src/assets/i18n/en.json
+++ b/discovery-frontend/src/assets/i18n/en.json
@@ -1102,7 +1102,7 @@
   "msg.board.create.guide-msg2" : "to another datasource to connect them",
   "msg.board.download.title" : "Download original data",
   "msg.board.download.desc" : "Up to 1 million downloads, <br> Please contact your administrator for more than 1 million data.",
-  "msg.board.download.calc-size" : "Calculating data size ...",  
+  "msg.board.download.calc-size" : "Calculating data size ...",
   "msg.board.ui.no.widget": "No widgets",
   "msg.board.th.allowance": "Show open data only",
   "msg.board.btn.add.datasource.join": "Add datasource to join",
@@ -2707,7 +2707,7 @@
   "msg.metadata.dictionary.used.metadata" : "Used in Metadata",
   "msg.metadata.ui.info" : "Metadata information",
   "msg.metadata.ui.enter.tag" : "Enter tag",
-  "msg.metadata.th.column.popularity.tooltip.title" : "What is logical column name?",
-  "msg.metadata.th.column.popularity.tooltip.desc" : "The logical column name is the column name that is commonly used by the user in the Metatron. It is specified as a logical name when creating business terms or index for users. Logical column names are used in the Metatron when creating a chart or workbench."
+  "msg.metadata.th.column.logical.tooltip.title" : "What is logical column name?",
+  "msg.metadata.th.column.logical.tooltip.desc" : "The logical column name is the column name that is commonly used by the user in the Metatron. It is specified as a logical name when creating business terms or index for users. Logical column names are used in the Metatron when creating a chart or workbench."
 
 }

--- a/discovery-frontend/src/assets/i18n/ko.json
+++ b/discovery-frontend/src/assets/i18n/ko.json
@@ -1099,7 +1099,7 @@
   "msg.board.create.select-association" : "연결 키를 선택하세요.",
   "msg.board.create.association-key" : "연결 키",
   "msg.board.create.guide-msg1" : "데이터 소스의 가장자리에서 드래그하십시오.",
-  "msg.board.create.guide-msg2" : "다른 데이터소스로 연결합니다.",  
+  "msg.board.create.guide-msg2" : "다른 데이터소스로 연결합니다.",
   "msg.board.download.title" : "원본데이터 다운로드",
   "msg.board.download.desc" : "최대 100만 건까지 다운로드됩니다,<br>100만 건 이상의 데이터는 관리자에게 문의해 주세요.",
   "msg.board.download.calc-size" : "데이터 용량 계산중...",
@@ -2710,6 +2710,6 @@
   "msg.metadata.dictionary.used.metadata" : "연결된 메타데이터",
   "msg.metadata.ui.info" : "메타데이터 정보",
   "msg.metadata.ui.enter.tag" : "태그 입력",
-  "msg.metadata.th.column.popularity.tooltip.title" : "논리 컬럼 명이란?",
-  "msg.metadata.th.column.popularity.tooltip.desc" : "논리 컬럼 명은 메타트론에서 사용자가 일반적으로 사용하는 컬럼 명입니다. 사용자의 비즈니스 용어 또는 인덱스를 생성할 때 논리 명으로 지정됩니다 논리 컬럼 명은 차트 또는 워크벤치를 작성할 때 메타트론에서 사용됩니다."
+  "msg.metadata.th.column.logical.tooltip.title" : "논리 컬럼 명이란?",
+  "msg.metadata.th.column.logical.tooltip.desc" : "논리 컬럼 명은 메타트론에서 사용자가 일반적으로 사용하는 컬럼 명입니다. 사용자의 비즈니스 용어 또는 인덱스를 생성할 때 논리 명으로 지정됩니다 논리 컬럼 명은 차트 또는 워크벤치를 작성할 때 메타트론에서 사용됩니다."
 }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
메타데이터 상세화면의 컬럼 스키마 탭에서 글자가 길어질 경우 다른 컬럼을 침범하는 것을 수정함
![2018-09-13 2 31 50](https://user-images.githubusercontent.com/42233627/45468965-56753500-b762-11e8-81d6-3a2549465c94.png)
글자가 길 경우 말 줄임으로 변경하고 툴팁을 추가함



**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#162 


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
메타데이터 생성 > 데이터소스로 생성 > 메타데이터 상세화면 > 컬럼 스키마 탭 > 윈도우 가로넓이 줄여서 컬럼 확인


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project. _it will be added soon_
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
