### PR TITLE
#190 fix parameter when row condition is blank

### DIFF
--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-set.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-set.component.ts
@@ -21,7 +21,7 @@ import { EditRuleComponent } from './edit-rule.component';
 import { Alert } from '../../../../../../common/util/alert.util';
 import { RuleConditionInputComponent } from './rule-condition-input.component';
 import * as _ from 'lodash';
-import { isUndefined } from 'util';
+import {isNullOrUndefined, isUndefined} from 'util';
 import { StringUtil } from '../../../../../../common/util/string.util';
 
 @Component({
@@ -112,7 +112,7 @@ export class EditRuleSetComponent extends EditRuleComponent implements OnInit, A
         ruleString: `set col: ${columnsStr} value: ${val}`
       };
 
-      if ('' !== this.condition) {
+      if ('' !== this.condition && !isNullOrUndefined(this.condition)) {
         rules.ruleString += ` row: ${this.condition}`;
       }
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Fixed parameter when row condition (Use only under the following conditions) is blank.
Originally `row:undefined` to not sending `row:` at all

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#190 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
'SET'룰을 적용할 때 컨디션(다음 조건에서만 수행) 이 입력되지 않았을 때 `row: undefined`를 보내고 있지 않은지 확인,
편집 후 적용 시 undefined error 가 나는지 확인

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
