### PR TITLE
#106 modify gauge chart gradient

### DIFF
--- a/discovery-frontend/src/app/common/component/chart/type/gauge-chart/gauge-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/gauge-chart/gauge-chart.component.ts
@@ -24,7 +24,7 @@ import {
   ChartColorList,
   ChartColorType,
   ChartSelectMode,
-  ChartType,
+  ChartType, ColorCustomMode,
   ColorRangeType,
   Position,
   SeriesType,
@@ -421,6 +421,62 @@ export class GaugeChartComponent extends BaseChart {
       }
 
     });
+
+    return this.chartOption;
+  }
+
+  /**
+   * 시리즈 정보를 변환한다.
+   * - 필요시 각 차트에서 Override
+   * @returns {BaseOption}
+   */
+  protected convertSeries(): BaseOption {
+
+    // Base Call
+    this.chartOption = super.convertSeries();
+
+    // Gradient Color Change
+    if (this.uiOption.color['customMode'] && ColorCustomMode.GRADIENT == this.uiOption.color['customMode']) {
+
+      _.each(this.data.columns, (column, columnIndex) => {
+
+        // Series Total Value
+        let totalValue: number = column.categoryValue;
+
+        _.each(this.chartOption.series, (series) => {
+
+          let data = series.data[columnIndex];
+
+          // Validate
+          if (!this.uiOption.color['ranges']) {
+            return false;
+          }
+
+          // Base Data
+          let value: number = null;
+          if (data && isNaN(data)) {
+            value = data.value;
+          }
+          else {
+            value = data;
+          }
+
+          let maxValue: number = this.data.info.maxValue;
+          let rangePercent: number = (maxValue / totalValue) * 100;
+          let codes: string[] = _.cloneDeep(this.chartOption.visualMap.color).reverse();
+          let index: number = Math.round(value / rangePercent * codes.length);
+          index = index == codes.length ? codes.length-1 : index;
+          series.data[columnIndex].itemStyle = {
+            normal: {
+              color: codes[index]
+            }
+          };
+        });
+      });
+
+      delete this.chartOption.visualMap;
+    }
+
 
     return this.chartOption;
   }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Gauge chart 에서 Gradient mode 로 색을 선택하면 값에 따른 색 설정에 비해서 실제 부여된 색이 잘못됨을 수정합니다.

**Related Issue** : #106 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
- 차트 편집화면에서 게이지차트를 그린 후
- Color Setting > Measure > Custom Color Setting > Gradient 선택 후 표현되는 그라데이션이
게이지 시리즈의 크기만큼 표현되는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
