### PR TITLE
#48 Errors of disappearing summary areas and deletion errors in the workspace

### DIFF
--- a/discovery-frontend/src/app/workspace/workspace.component.ts
+++ b/discovery-frontend/src/app/workspace/workspace.component.ts
@@ -37,7 +37,7 @@ import { SharedMemberManageComponent } from './component/permission/shared-membe
 import { SubscribeArg } from '../common/domain/subscribe-arg';
 import { PopupService } from '../common/service/popup.service';
 import { SetNotebookServerComponent } from './component/etc/set-notebook-server.component';
-import { isUndefined } from 'util';
+import { isNullOrUndefined } from 'util';
 import { CookieConstant } from '../common/constant/cookie.constant';
 import { DashboardService } from '../dashboard/service/dashboard.service';
 import { EventBroadcaster } from '../common/event/event.broadcaster';
@@ -239,50 +239,7 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
 
     // Router에서 파라미터 전달 받기
     this.activatedRoute.params.subscribe((params) => {
-
-      // 쿠키 조회
-      this.getCookie();
-
-      // 외부에서 url에서 아이디 받아오기
-      this.workspaceId = params['id'];
-      this.currentFolderId = params['folderId'];
-      if (!isUndefined(this.workspaceId)) {
-        this.cookieWorkspace.workspaceId = this.workspaceId;
-      }
-      if (!isUndefined(this.currentFolderId)) {
-        this.cookieWorkspace.folderId = this.isRoot ? null : this.currentFolderId;
-      }
-
-      if (this.viewType === null) {
-        this.viewType = 'CARD';
-        this.cookieWorkspace.viewType = this.viewType;
-      }
-      this.cookieService.set(CookieConstant.KEY.CURRENT_WORKSPACE, JSON.stringify(this.cookieWorkspace), 0, '/');
-      // 로딩 show
-      this.loadingShow();
-      // 뷰
-      this.initViewPage();
-
-      // 워크스페이스 접속 통계 소켓
-      if ('my' !== this.workspaceId ) {
-        setTimeout(() => {
-          this.checkAndConnectWebSocket().then(() => {
-            try {
-              // 메세지 발신
-              const headers: any = { 'X-AUTH-TOKEN': this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN) };
-              const params = {
-                'type': 'View',
-                'object': { 'id': this.workspace.id, 'type': 'WORKSPACE' },
-                'generator': { 'type': 'WEBAPP', 'name': navigator.userAgent }
-              };
-              CommonConstant.stomp.send('/message/activities/add', params, headers);
-            } catch (err) {
-              console.error(err);
-            }
-          });
-        }, 500);
-      }
-
+      this._initViewPage( params['id'], params['folderId'] );
     });
 
     // 워크벤치 생성 step 구독
@@ -298,20 +255,19 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
     this.subscriptions.push(popupSubscription);
 
     // 글로벌 이벤트 리스너 - 워크스페이스 폴더 이동
-    this.broadCaster.on<string>('moveFromLnb').subscribe(() => {
-      // 쿠키 조회
-      this.getCookie();
-      // 로딩 show
-      this.loadingShow();
-      // 뷰
-      this.initViewPage();
-    });
+    this.subscriptions.push(
+      this.broadCaster.on<string>('moveFromLnb').subscribe( workspaceId => {
+        this._initViewPage( 'my' === workspaceId ? null : workspaceId );
+      })
+    );
     // 글로벌 이벤트 리스너 - 퍼미션 스키마 변경
-    this.broadCaster.on<string>('CHANGE_WORKSPACE_PERMS_SCHEMA').subscribe(() => {
-      this.loadWorkspace(true).then(() => {
-        this._wsPermSchemaSetComp.init(this.workspace);
-      });
-    });
+    this.subscriptions.push(
+      this.broadCaster.on<string>('CHANGE_WORKSPACE_PERMS_SCHEMA').subscribe(() => {
+        this.loadWorkspace(true).then(() => {
+          this._wsPermSchemaSetComp.init(this.workspace);
+        });
+      })
+    );
 
   } // function - ngOnInit
 
@@ -319,7 +275,6 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
   public ngOnDestroy() {
     super.ngOnDestroy();
   }
-
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Public Method
@@ -366,7 +321,7 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
           // 저장된 폴더 구조 추적
           this._traceFolderHierarchies();
           // 로딩 hide
-          ( this.initFolderHierarchies ) || ( this.loadingHide() );
+          (this.initFolderHierarchies) || (this.loadingHide());
           // 실행 종료 처리
           resolve();
         })
@@ -391,13 +346,13 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
           // 즐겨찾기 상태 제거
           this.workspace.favorite = false;
           // 로딩 hide
-          ( this.initFolderHierarchies ) || ( this.loadingHide() );
+          (this.initFolderHierarchies) || (this.loadingHide());
         })
         .catch(() => {
           // 실패 알림
           Alert.error(this.translateService.instant('msg.space.alert.del.favor'));
           // 로딩 hide
-          ( this.initFolderHierarchies ) || ( this.loadingHide() );
+          (this.initFolderHierarchies) || (this.loadingHide());
         });
     } else {
       this.workspaceService.setFavorite(this.workspaceId)
@@ -405,13 +360,13 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
           // 즐겨찾기 상태 추가
           this.workspace.favorite = true;
           // 로딩 hide
-          ( this.initFolderHierarchies ) || ( this.loadingHide() );
+          (this.initFolderHierarchies) || (this.loadingHide());
         })
         .catch(() => {
           // 실패 알림
           Alert.error(this.translateService.instant('msg.space.alert.add.favor'));
           // 로딩 hide
-          ( this.initFolderHierarchies ) || ( this.loadingHide() );
+          (this.initFolderHierarchies) || (this.loadingHide());
         });
     }
   }
@@ -424,7 +379,7 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
     event.stopPropagation();
 
     if (this.currentFolderId === this.moveTargetFolderId
-      || ( !this.currentFolderId && 'ROOT' === this.moveTargetFolderId && this.workspaceId === this.moveTargetWorkspaceId )) {
+      || (!this.currentFolderId && 'ROOT' === this.moveTargetFolderId && this.workspaceId === this.moveTargetWorkspaceId)) {
       Alert.warning(this.translateService.instant('msg.space.alert.mov.currentdisable'));
       return;
     }
@@ -445,7 +400,7 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
       const params = {
         'toWorkspace': this.moveTargetWorkspaceId
       };
-      const folderId: string = ( 'ROOT' !== this.moveTargetFolderId ) ? this.moveTargetFolderId : null;
+      const folderId: string = ('ROOT' !== this.moveTargetFolderId) ? this.moveTargetFolderId : null;
 
       // 워크북 이동
       this.workbookService.moveWorkbook(bookIds, folderId, params)
@@ -455,7 +410,7 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
           // 실패 알림
           Alert.error(this.translateService.instant('msg.space.alert.mov.fail'));
           // 로딩 hide
-          ( this.initFolderHierarchies ) || ( this.loadingHide() );
+          (this.initFolderHierarchies) || (this.loadingHide());
         });
     } else {
       // 다른 타입일 경우 이동
@@ -466,7 +421,7 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
           // 실패 알림
           Alert.error(this.translateService.instant('msg.space.alert.mov.fail'));
           // 로딩 hide
-          ( this.initFolderHierarchies ) || ( this.loadingHide() );
+          (this.initFolderHierarchies) || (this.loadingHide());
         });
     }
   } // function - moveContents
@@ -488,7 +443,7 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
         // 실패 알림
         Alert.error(this.translateService.instant('msg.space.alert.copy.workbook.fail'));
         // 로딩 hide
-        ( this.initFolderHierarchies ) || ( this.loadingHide() );
+        (this.initFolderHierarchies) || (this.loadingHide());
       });
     }
   } // function - cloneWorkbooks
@@ -499,7 +454,7 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
    * @param {Book} folder
    */
   public updateFolderNamePressEnter(event: KeyboardEvent, folder: Book) {
-    ( 13 === event.keyCode ) && ( this.updateFolderName(folder) );
+    (13 === event.keyCode) && (this.updateFolderName(folder));
   } // function - updateFolderNamePressEnter
 
   /**
@@ -532,7 +487,7 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
         // 실패 알림
         Alert.error(this.translateService.instant('msg.space.alert.edit.folder.fail'));
         // 로딩 hide
-        ( this.initFolderHierarchies ) || ( this.loadingHide() );
+        (this.initFolderHierarchies) || (this.loadingHide());
       });
   } // function - updateFolderName
 
@@ -583,7 +538,7 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
           this.folder = new Folder;
 
           // 해당 워크스페이스가 공유인지 개인인지 판단
-          this.isShareType = ( 'SHARED' === workspace.publicType );
+          this.isShareType = ('SHARED' === workspace.publicType);
 
           // 워크스페이스 데이터
           this._setWorkspaceData(workspace);
@@ -591,7 +546,7 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
           this._traceFolderHierarchies();
 
           // 로딩 hide
-          ( this.initFolderHierarchies ) || ( this.loadingHide() );
+          (this.initFolderHierarchies) || (this.loadingHide());
 
           this.workspace.books.some((book) => {
             if (book.id === result.id) {
@@ -605,7 +560,7 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
           // 실패 알림
           Alert.error(this.translateService.instant('msg.space.alert.retrieve'));
           // 로딩 hide
-          ( this.initFolderHierarchies ) || ( this.loadingHide() );
+          (this.initFolderHierarchies) || (this.loadingHide());
         });
       } else {
         // 내부 워크스페이스 폴더인 경우
@@ -615,7 +570,7 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
           // 저장된 폴더 구조 추적
           this._traceFolderHierarchies();
           // 로딩 hide
-          ( this.initFolderHierarchies ) || ( this.loadingHide() );
+          (this.initFolderHierarchies) || (this.loadingHide());
 
           this.folder.books.some((book) => {
             if (book.id === result.id) {
@@ -629,14 +584,14 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
           // 실패 알림
           Alert.error(this.translateService.instant('msg.space.alert.folder.retrieve'));
           // 로딩 hide
-          ( this.initFolderHierarchies ) || ( this.loadingHide() );
+          (this.initFolderHierarchies) || (this.loadingHide());
         });
       }
     }).catch(() => {
       // 실패 알림
       Alert.error(this.translateService.instant('msg.space.alert.add.folder.fail'));
       // 로딩 hide
-      ( this.initFolderHierarchies ) || ( this.loadingHide() );
+      (this.initFolderHierarchies) || (this.loadingHide());
     });
   } // function - createFoldeer
 
@@ -660,7 +615,7 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
   public getList(): Book[] {
     // 최상단 폴더라면 워크스페이스내 컨텐츠 보여주
     let list: Book[] = this.isRoot ? this.workspace.books : this.folder.books;
-    ( list ) || ( list = [] );
+    (list) || (list = []);
     if (this.permissionChecker && this.permissionChecker.isWorkspaceGuest()) {
       return list ? list.filter((item: Book) => 'folder' === item.type || 'workbook' === item.type) : [];
     } else {
@@ -818,8 +773,28 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
   public loadWorkspace(completeFl?: boolean): Promise<any> {
     // 업데이트 상태면 재조회
     if (completeFl) {
-      // 리스트 재조회
-      return this.isRoot ? this.getSharedWorkspace() : this.getWorkspaceFolder();
+      // reload workspace data
+      if( this.isRoot ) {
+        if (this.workspaceId == null) {
+          return this.getMyWorkspace();
+        } else {
+          return this.getSharedWorkspace();
+        }
+      } else {
+        if (this.workspaceId == null) {
+          return this.workspaceService.getMyWorkspace('forDetailView').then((workspace) => {
+            this.workspace = workspace;
+            this._setWorkspaceData(workspace);
+            return this.getWorkspaceFolder();
+          });
+        } else {
+          return this.workspaceService.getWorkSpace(this.workspaceId, 'forDetailView').then((workspace) => {
+            this.workspace = workspace;
+            this._setWorkspaceData(workspace);
+            return this.getWorkspaceFolder();
+          });
+        }
+      }
     } else {
       return Promise.resolve();
     }
@@ -851,8 +826,8 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
    */
   public createWorkbook() {
     if (this.permissionChecker
-      && ( this.permissionChecker.isManageWorkbook()
-        || this.permissionChecker.isEditWorkbook(this.loginUserId) )) {
+      && (this.permissionChecker.isManageWorkbook()
+        || this.permissionChecker.isEditWorkbook(this.loginUserId))) {
       if (this.isRoot) {
         this.createWorkbookComponent.init(this.workspaceId);
       } else {
@@ -866,8 +841,8 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
    */
   public createWorkbench() {
     if (this.permissionChecker
-      && ( this.permissionChecker.isManageWorkbench()
-        || this.permissionChecker.isEditWorkbench(this.loginUserId) )) {
+      && (this.permissionChecker.isManageWorkbench()
+        || this.permissionChecker.isEditWorkbench(this.loginUserId))) {
       this.workbenchStep = 'workbench-create-select';
     }
   } // function - createWorkbench
@@ -877,10 +852,10 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
    */
   public createNotebook() {
     if (this.permissionChecker
-      && ( this.permissionChecker.isManageNotebook()
+      && (this.permissionChecker.isManageNotebook()
         || this.permissionChecker.isEditNotebook(this.loginUserId))) {
       this.loadingShow();
-      this.getNotebookServer(this.workspaceId).then((result) => {
+      this.workspaceService.getNotebookServers(this.workspaceId).then((result) => {
         // 데이터가 없다면
         if (!result['_embedded'] || result['_embedded'].connectors.length === 0) {
           const modal = new Modal();
@@ -896,9 +871,9 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
             };
           } else {
             // 열람자
-            modal.name = this.translateService.instant( 'msg.space.ui.no.notebook.server' );
-            modal.description = this.translateService.instant( 'msg.space.ui.create.notebook.warning' );
-            modal.subDescription = this.translateService.instant( 'msg.space.ui.ask.space.admin' );
+            modal.name = this.translateService.instant('msg.space.ui.no.notebook.server');
+            modal.description = this.translateService.instant('msg.space.ui.create.notebook.warning');
+            modal.subDescription = this.translateService.instant('msg.space.ui.ask.space.admin');
             modal.isShowCancel = false;
             modal.data = { eventType: 'CREATE_NOTEBOOK' };
           }
@@ -927,16 +902,16 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
    */
   public checkEditAuth(book: Book): boolean {
     let isPossible: boolean = false;
-    const bookCreator: string = ( book.createdBy ) ? book.createdBy.username : '';
+    const bookCreator: string = (book.createdBy) ? book.createdBy.username : '';
     switch (book.type.toUpperCase()) {
       case 'WORKBOOK' :
-        isPossible = ( this.permissionChecker.isManageWorkbook() || this.permissionChecker.isEditWorkbook(bookCreator) );
+        isPossible = (this.permissionChecker.isManageWorkbook() || this.permissionChecker.isEditWorkbook(bookCreator));
         break;
       case 'WORKBENCH' :
-        isPossible = ( this.permissionChecker.isManageWorkbench() || this.permissionChecker.isEditWorkbench(bookCreator) );
+        isPossible = (this.permissionChecker.isManageWorkbench() || this.permissionChecker.isEditWorkbench(bookCreator));
         break;
       case 'NOTEBOOK' :
-        isPossible = ( this.permissionChecker.isManageNotebook() || this.permissionChecker.isEditNotebook(bookCreator) );
+        isPossible = (this.permissionChecker.isManageNotebook() || this.permissionChecker.isEditNotebook(bookCreator));
         break;
       case 'FOLDER' :
         isPossible = this.permissionChecker.isManageWsFolder();
@@ -1075,7 +1050,7 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
     };
     this.workspaceService.getWorkspaceImportAvailable(this.checkContents[0].id, params).then(items => {
       if (items) {
-        ( items['page'] ) && ( this.pageAvailableSpaces = items['page'] );
+        (items['page']) && (this.pageAvailableSpaces = items['page']);
         if (items['_embedded'] && items['_embedded']['workspaces']) {
           this.importAvailWorkspaces = this.importAvailWorkspaces.concat(items['_embedded']['workspaces']);
         }
@@ -1165,7 +1140,7 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
    * @returns {boolean}
    */
   public isDisableMove(targetId: string): boolean {
-    return ( -1 < this.checkContents.findIndex((item: Book) => item.id === targetId) );
+    return (-1 < this.checkContents.findIndex((item: Book) => item.id === targetId));
   } // function - isDisableMove
 
   /**
@@ -1238,7 +1213,7 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
         eventType: 'MULTI_DELETE',
         target: this.checkContents
       };
-      modal.afterConfirm = (confirmData:Modal) => {
+      modal.afterConfirm = (confirmData: Modal) => {
         this.deleteBooks(confirmData.data.target); // 여러건 삭제
       };
 
@@ -1259,28 +1234,14 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
    | Private Method
    |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
 
-  // 노트북 서버 조회 api
-  private getNotebookServer(workspaceId: string): Promise<any> {
-    return new Promise<any>((resolve, reject) => {
-
-      this.workspaceService.getNotebookServers(workspaceId)
-        .then((result) => {
-          resolve(result);
-        })
-        .catch((error) => {
-          reject(error);
-        });
-    });
-  }
-
   /**
    * 개인 워크스페이스 조회
    */
-  private getMyWorkspace() {
+  private getMyWorkspace():Promise<any> {
     // 로딩 show
     this.loadingShow();
     // 개인 워크스페이스 조회
-    this.workspaceService.getMyWorkspace('forDetailView').then((workspace) => {
+    return this.workspaceService.getMyWorkspace('forDetailView').then((workspace) => {
       if (PublicType.SHARED === workspace.publicType && workspace.published) {
         // 게스트 사용자의 경우 전체 공개 워크스페이스로 강제 이동
         this.router.navigate(['/workspace', workspace.id]).then();
@@ -1290,7 +1251,7 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
         // 저장된 폴더 구조 추적
         this._traceFolderHierarchies();
         // 로딩 hide
-        ( this.initFolderHierarchies ) || ( this.loadingHide() );
+        (this.initFolderHierarchies) || (this.loadingHide());
       }
 
     }).catch(() => {
@@ -1321,7 +1282,7 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
           this.folder = new Folder;
 
           // 해당 워크스페이스가 공유인지 개인인지 판단
-          this.isShareType = ( workspace.publicType === 'SHARED' );
+          this.isShareType = (workspace.publicType === 'SHARED');
 
           // 워크스페이스 데이터 설정
           this._setWorkspaceData(workspace);
@@ -1329,7 +1290,7 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
           this._traceFolderHierarchies();
 
           // 로딩 hide
-          ( this.initFolderHierarchies ) || ( this.loadingHide() );
+          (this.initFolderHierarchies) || (this.loadingHide());
 
           resolve();
         })
@@ -1337,7 +1298,7 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
           // 실패 알림
           Alert.error(this.translateService.instant('msg.space.alert.retrieve'));
           // 로딩 hide
-          ( this.initFolderHierarchies ) || ( this.loadingHide() );
+          (this.initFolderHierarchies) || (this.loadingHide());
         });
     });
   } // function - getSharedWorkspace
@@ -1376,7 +1337,7 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
       // 실패 알림
       Alert.error(this.translateService.instant('msg.comm.alert.del.fail'));
       // 로딩 hide
-      ( this.initFolderHierarchies ) || ( this.loadingHide() );
+      (this.initFolderHierarchies) || (this.loadingHide());
     });
   } // function - deleteBook
 
@@ -1420,7 +1381,7 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
         // 실패 알림
         Alert.error(this.translateService.instant('msg.alert.batch.del.fail'));
         // 로딩 hide
-        ( this.initFolderHierarchies ) || ( this.loadingHide() );
+        (this.initFolderHierarchies) || (this.loadingHide());
       });
     }
   } // function - deleteBooks
@@ -1508,7 +1469,7 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
         // 데이터소스 수
         this.countOfDataSources = workspace.countOfDataSources;
         // 퍼미션
-        ( this.isRoot ) && ( this.permissionChecker = new PermissionChecker(workspace) );
+        (this.isRoot) && (this.permissionChecker = new PermissionChecker(workspace));
       } else {
         // 워크스페이스 이름
         this.workspaceName = workspace.name;
@@ -1530,7 +1491,7 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
       this.loadingShow();
       setTimeout(() => {
         const tempId = this.initFolderHierarchies.shift().id;
-        ( 0 === this.initFolderHierarchies.length ) && ( this.initFolderHierarchies = null );
+        (0 === this.initFolderHierarchies.length) && (this.initFolderHierarchies = null);
         this.detailFolder(tempId);
       }, 200); // 로딩 표시를 위한 시간 지연
     } else {
@@ -1539,38 +1500,82 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
     }
   } //  function - _traceFolderHierarchies
 
-  // View초기화
-  private initViewPage() {
-    // UI 구성요소 초기화
-    this.isInfoType = null;
-    this.workspace = new Workspace();
-    this.workspace.books = [];
-    this.countByBookType = new CountByBookType();
-    this.owner = new UserProfile();
-    this.isRoot = true;
+  /**
+   * initialize View
+   * @param {string} workspaceId
+   * @param {string} folderId
+   * @private
+   */
+  private _initViewPage(workspaceId?: string, folderId?: string) {
 
-    this.contentFilter = [
-      { key: 'all', value: this.translateService.instant('msg.comm.ui.list.all') },
-      { key: 'workbook', value: this.translateService.instant('msg.comm.ui.list.workbook') },
-      { key: 'notebook', value: this.translateService.instant('msg.comm.ui.list.notebook') },
-      { key: 'workbench', value: this.translateService.instant('msg.comm.ui.list.workbench') },
-    ];
-    this.selectedContentFilter = this.contentFilter[0];
+    // 쿠키 조회
+    this.getCookie();
 
-    this.contentSort = [
-      { key: 'name', value: this.translateService.instant('msg.comm.ui.list.name.asc'), type: 'asc' },
-      { key: 'name', value: this.translateService.instant('msg.comm.ui.list.name.desc'), type: 'desc' },
-      { key: 'modifiedTime', value: this.translateService.instant('msg.comm.ui.list.update.asc'), type: 'asc' },
-      { key: 'modifiedTime', value: this.translateService.instant('msg.comm.ui.list.update.desc'), type: 'desc' },
-    ];
-    this.selectedContentSort = this.contentSort[3];
-    // this.isShowContentSort = false;
+    // initialize Data
+    this.workspaceId = (workspaceId) ? workspaceId : undefined;
+    this.currentFolderId = (folderId) ? folderId : undefined;
 
-    // this.dataSourceCnt = 0;
+    (isNullOrUndefined(this.workspaceId)) || (this.cookieWorkspace.workspaceId = this.workspaceId);
+    (isNullOrUndefined(this.currentFolderId)) || (this.cookieWorkspace.folderId = this.isRoot ? null : this.currentFolderId);
 
-    // 데이터 초기화
-    this.getWorkspaceData();
-  }
+    if (this.viewType === null) {
+      this.viewType = 'CARD';
+      this.cookieWorkspace.viewType = this.viewType;
+    }
+    this.cookieService.set(CookieConstant.KEY.CURRENT_WORKSPACE, JSON.stringify(this.cookieWorkspace), 0, '/');
+    // 로딩 show
+    this.loadingShow();
+
+    {
+      // initialize UI Component
+      this.isInfoType = null;
+      this.workspace = new Workspace();
+      this.workspace.books = [];
+      this.countByBookType = new CountByBookType();
+      this.owner = new UserProfile();
+      this.isRoot = true;
+
+      this.contentFilter = [
+        { key: 'all', value: this.translateService.instant('msg.comm.ui.list.all') },
+        { key: 'workbook', value: this.translateService.instant('msg.comm.ui.list.workbook') },
+        { key: 'notebook', value: this.translateService.instant('msg.comm.ui.list.notebook') },
+        { key: 'workbench', value: this.translateService.instant('msg.comm.ui.list.workbench') },
+      ];
+      this.selectedContentFilter = this.contentFilter[0];
+
+      this.contentSort = [
+        { key: 'name', value: this.translateService.instant('msg.comm.ui.list.name.asc'), type: 'asc' },
+        { key: 'name', value: this.translateService.instant('msg.comm.ui.list.name.desc'), type: 'desc' },
+        { key: 'modifiedTime', value: this.translateService.instant('msg.comm.ui.list.update.asc'), type: 'asc' },
+        { key: 'modifiedTime', value: this.translateService.instant('msg.comm.ui.list.update.desc'), type: 'desc' },
+      ];
+      this.selectedContentSort = this.contentSort[3];
+
+      // initialize data
+      this.getWorkspaceData();
+    }
+
+    // Workspace access statistics socket
+    if (this.workspaceId && 'my' !== this.workspaceId) {
+      setTimeout(() => {
+        this.checkAndConnectWebSocket().then(() => {
+          try {
+            // 메세지 발신
+            const headers: any = { 'X-AUTH-TOKEN': this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN) };
+            const params = {
+              'type': 'View',
+              'object': { 'id': this.workspace.id, 'type': 'WORKSPACE' },
+              'generator': { 'type': 'WEBAPP', 'name': navigator.userAgent }
+            };
+            CommonConstant.stomp.send('/message/activities/add', params, headers);
+          } catch (err) {
+            console.error(err);
+          }
+        });
+      }, 500);
+    }
+
+  } // function - _initViewPage
 
   /**
    * 컨텐츠 이동 후의 처리
@@ -1604,9 +1609,9 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
     // 워크북 타입이 체크되었는지 확인
     const cntContents = this.checkContents.length;
     if (0 < cntContents) {
-      this.isCheckedWorkbook = ( -1 < this.checkContents.findIndex(item => item.type === 'workbook') );
+      this.isCheckedWorkbook = (-1 < this.checkContents.findIndex(item => item.type === 'workbook'));
       // workbook 타입은 무조건 1개만 이동할 수 있고, workbook 이 아닌 경우 여러개 이동 가능
-      this.isDisableMoveContent = ( this.isCheckedWorkbook && 1 < cntContents );
+      this.isDisableMoveContent = (this.isCheckedWorkbook && 1 < cntContents);
     } else {
       this.isDisableMoveContent = true;
       this.isCheckedWorkbook = false;
@@ -1619,7 +1624,7 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
    */
   private _updateStateSelectAll() {
     let filteredList: Book[] = this._getDisplayItems();
-    this.isAllChecked = ( filteredList.length === filteredList.filter((item: Book) => item.checked).length );
+    this.isAllChecked = (filteredList.length === filteredList.filter((item: Book) => item.checked).length);
   } // function - _updateStateSelectAll
 
   /**

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/catalog/CatalogTreeService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/catalog/CatalogTreeService.java
@@ -124,8 +124,9 @@ public class CatalogTreeService {
     List<CatalogTree> descendants = catalogTreeRepository.findDescendantNotAncenstor(catalog.getId());
     if (descendants.size() > 0) {
       for (CatalogTree catalogTree : descendants) {
-        catalogRepository.delete(catalogTree.getId().getDescendant());
-        catalogTreeRepository.deteleAllTree(catalog.getId());
+        String descendantId = catalogTree.getId().getDescendant();
+        catalogRepository.delete(descendantId);
+        catalogTreeRepository.deteleAllTree(descendantId);
       }
     }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workspace/BookTreeService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workspace/BookTreeService.java
@@ -212,8 +212,9 @@ public class BookTreeService {
     List<BookTree> descendants = bookTreeRepository.findDescendantNotAncenstor(book.getId());
     if (descendants.size() > 0) {
       for (BookTree bookTree : descendants) {
-        bookRepository.delete(bookTree.getId().getDescendant());
-        bookTreeRepository.deteleAllBookTree(book.getId());
+        String descendantId = bookTree.getId().getDescendant();
+        bookRepository.delete(descendantId);
+        bookTreeRepository.deteleAllBookTree(descendantId);
       }
     }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workspace/BookTreeService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workspace/BookTreeService.java
@@ -20,7 +20,6 @@ import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -62,8 +61,8 @@ public class BookTreeService {
 
     List<Book> rootBooks = bookRepository.findRootBooksInWorkspace(workspaceId);
     rootBooks.sort(comparator);
-    for(Book book : rootBooks) {
-      if(book instanceof Folder) {
+    for (Book book : rootBooks) {
+      if (book instanceof Folder) {
         Folder folder = (Folder) book;
         List<Book> books = bookRepository.findOnlySubBooks(folder.getId());
         books.sort(comparator);
@@ -84,7 +83,7 @@ public class BookTreeService {
   public List<Book> findSubBooks(String bookId, boolean isRoot, String... type) {
 
     List<Book> books;
-    if(isRoot) {
+    if (isRoot) {
       books = bookRepository.findRootBooksInWorkspace(bookId, type);
     } else {
       books = bookRepository.findOnlySubBooks(bookId, type);
@@ -93,8 +92,8 @@ public class BookTreeService {
     books.sort(comparator);
 
     // 하위 Book 중 Folder Type 인 경우 하위 Book 들이 존재하는지 체크
-    for(Book book : books) {
-      if(book instanceof Folder) {
+    for (Book book : books) {
+      if (book instanceof Folder) {
         Folder folder = (Folder) book;
         folder.setHasSubBooks(
             bookRepository.countOnlySubBooks(folder.getId(), type) > 0 ? true : false
@@ -110,7 +109,7 @@ public class BookTreeService {
     List<Book> books = findSubBooks(bookId, isRoot, bookType);
 
     return books.stream().map(book -> {
-      if(type == LIST) {
+      if (type == LIST) {
         return book.listViewProjection();
       } else {
         return book.treeViewProjection();
@@ -143,19 +142,19 @@ public class BookTreeService {
     List<BookTree> bookTrees = Lists.newArrayList();
     bookTrees.add(new BookTree(book.getId(), book.getId(), 0));
 
-    if(Folder.ROOT.equals(book.getFolderId())) {
+    if (Folder.ROOT.equals(book.getFolderId())) {
       bookTreeRepository.save(bookTrees);
       return;
     }
 
     Folder folder = folderRepository.findOne(book.getFolderId());
-    if(folder == null) {
+    if (folder == null) {
       throw new IllegalArgumentException("Invalid Folder : " + book.getFolderId());
     }
 
     List<BookTree> ancestors = bookTreeRepository.findByIdDescendant(folder.getId());
 
-    for(BookTree ancestor : ancestors) {
+    for (BookTree ancestor : ancestors) {
       bookTrees.add(new BookTree(ancestor.getId().getAncestor(), book.getId(), ancestor.getDepth() + 1));
     }
 
@@ -167,7 +166,7 @@ public class BookTreeService {
     List<BookTree> bookTrees = Lists.newArrayList();
     List<String> deleteDescendants = Lists.newArrayList();
 
-    if("ROOT".equals(book.getFolderId())) {
+    if ("ROOT".equals(book.getFolderId())) {
 
       List<BookTree> descendants = bookTreeRepository.findDescendantNotAncenstor(book.getId());
       for (BookTree bookTree : descendants) {
@@ -195,7 +194,7 @@ public class BookTreeService {
       for (BookTree bookTree : descendants) {
         deleteDescendants.add(bookTree.getId().getDescendant());
         depthMap.forEach((ancestor, i) ->
-            bookTrees.add(new BookTree(ancestor, bookTree.getId().getDescendant(), i + bookTree.getDepth()))
+                             bookTrees.add(new BookTree(ancestor, bookTree.getId().getDescendant(), i + bookTree.getDepth()))
         );
       }
     }
@@ -209,21 +208,15 @@ public class BookTreeService {
 
   @Transactional
   public void deleteTree(Book book) {
-    // 하위 북 삭제
+    // delete sub-book
     List<BookTree> descendants = bookTreeRepository.findDescendantNotAncenstor(book.getId());
-    if(descendants.size() > 0) {
-      for(BookTree bookTree : descendants) {
-        try {
-          bookRepository.delete(bookTree.getId().getDescendant());
-          bookTreeRepository.delete(new BookTreeId(bookTree.getId().getDescendant(), bookTree.getId().getDescendant()));
-        } catch (EmptyResultDataAccessException e) {
-          LOGGER.warn("Fail to delete related book and tree from {}", book.getId(), e.getMessage());
-          continue;
-        }
+    if (descendants.size() > 0) {
+      for (BookTree bookTree : descendants) {
+        bookRepository.delete(bookTree.getId().getDescendant());
+        bookTreeRepository.deteleAllBookTree(book.getId());
       }
     }
 
-    // 트리 정보 삭제
     bookTreeRepository.deteleAllBookTree(book.getId());
   }
 
@@ -232,9 +225,9 @@ public class BookTreeService {
     @Override
     public int compare(Book book1, Book book2) {
 
-      if(book1 instanceof Folder && !(book2 instanceof Folder)) {
+      if (book1 instanceof Folder && !(book2 instanceof Folder)) {
         return -1;
-      } else if(!(book1 instanceof Folder) && book2 instanceof Folder) {
+      } else if (!(book1 instanceof Folder) && book2 instanceof Folder) {
         return 1;
       }
 

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/workspace/BookRestIntegrationTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/workspace/BookRestIntegrationTest.java
@@ -36,19 +36,19 @@ import static com.jayway.restassured.RestAssured.given;
 import static com.jayway.restassured.path.json.JsonPath.from;
 
 /**
- * Created by kyungtaak on 2016. 12. 20..
+ *
  */
 @TestExecutionListeners(value = OAuthTestExecutionListener.class, mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
 public class BookRestIntegrationTest extends AbstractRestIntegrationTest {
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     RestAssured.port = serverPort;
   }
 
   @Test
   @OAuthRequest(username = "polaris", value = {"SYSTEM_USER", "PERM_SYSTEM_WRITE_WORKBOOK"})
-  public void createWorkBookInWorkspaceShouldReturnWorkspaceInfo1() {
+  public void createWorkBookInWorkspaceShouldReturnWorkspaceInfo() {
 
     String workspaceId = "ws-02";
 
@@ -122,24 +122,6 @@ public class BookRestIntegrationTest extends AbstractRestIntegrationTest {
       .log().all();
     // @formatter:on
 
-    // Report 신규 생성
-    Map<String, Object> reportReq = Maps.newHashMap();
-    reportReq.put("type", "report");
-    reportReq.put("name", "report_test");
-    reportReq.put("workspace", "/api/workspaces/" + workspaceId);
-
-    // @formatter:off
-    given()
-      .auth().oauth2(oauth_token)
-      .body(reportReq)
-      .contentType(ContentType.JSON)
-    .when()
-      .post("/api/books")
-    .then()
-      .statusCode(HttpStatus.SC_CREATED)
-      .log().all();
-    // @formatter:on
-
     // Notebook 신규 생성
     Map<String, Object> notebookReq = Maps.newHashMap();
     notebookReq.put("type", "notebook");
@@ -167,13 +149,13 @@ public class BookRestIntegrationTest extends AbstractRestIntegrationTest {
     // @formatter:off
     given()
       .auth().oauth2(oauth_token)
-      .body(notebookReq)
       .contentType(ContentType.JSON)
+      .log().all()
     .when()
-      .post("/api/books/" + folder2Id + "/book/" + workbookId + "/move")
+      .post("/api/books/{bookId}/move/{folderId}", workbookId, folder2Id)
     .then()
-      .statusCode(HttpStatus.SC_NO_CONTENT)
-      .log().all();
+      .log().all()
+      .statusCode(HttpStatus.SC_NO_CONTENT);
     // @formatter:on
 
     // @formatter:off
@@ -184,7 +166,7 @@ public class BookRestIntegrationTest extends AbstractRestIntegrationTest {
     .when()
       .get("/api/workspaces/{workspace_id}", workspaceId)
     .then()
-//      .statusCode(HttpStatus.SC_OK)
+      .statusCode(HttpStatus.SC_OK)
       .log().all();
     // @formatter:on
 
@@ -213,7 +195,7 @@ public class BookRestIntegrationTest extends AbstractRestIntegrationTest {
     .when()
       .get("/api/workspaces/{workspace_id}", workspaceId)
     .then()
-//      .statusCode(HttpStatus.SC_OK)
+      .statusCode(HttpStatus.SC_OK)
       .log().all();
     // @formatter:on
   }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
* 워크스페이스에서 폴더 내 워크북을 삭제했을 때, 실제 워크북의 개수와 좌측 상단에 표시되는 개수가 다른 경우가 있습니다.
* 상단 로고를 클릭했을 떄 요약 정보 영역이 표시되지 않는 경우가 있습니다.

**Related Issue** : #48 #186 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 워크스페이스 내 폴더로 이동합니다. 
2. 폴더 내에 있는 워크북을 하나 삭제 합니다. 
3. 좌측 상단에 워크북 개수가 삭제된 것 만큼 변경되었는지 확인합니다.
4. 상단 로고를 클릭합니다.
5. 워크스페이스 화면이 정상적으로 표시되었는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
