### PR TITLE
#166 metadata information is incorrect on data source when creating dashboard

### DIFF
--- a/discovery-frontend/src/app/datasource/component/datasource-summary/datasource-summary.component.ts
+++ b/discovery-frontend/src/app/datasource/component/datasource-summary/datasource-summary.component.ts
@@ -100,6 +100,8 @@ export class DatasourceSummaryComponent extends AbstractComponent implements OnI
       this.datasourceId = datasourceId;
 
       this.loadingShow();
+      this.datasource = undefined;
+      this.metadata = undefined;
       this.datasourceService.getDatasourceSummary(this.datasourceId).then((datasource) => {
         this.datasource = datasource;
         this.metadataService.getMetadataForDataSource( datasource.id ).then( result => {


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
* 대시보드 생성시 데이터소스를 선택하는 리스트에서 상세 정보에 뜨는 메타데이터 내용이 잘못 표시 됩니다.

**Related Issue** : #166 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 워크북으로 이동합니다.
2. 좌측 하단의 대시보드 생성 버튼을 클릭합니다.
3. 대시보드 생성 화면에서 데이터소스 추가 버튼을 클릭합니다.
4. 데이터소스 목록 중 하나를 클릭했을 때, 우측에 표시되는 데이터소스 상세 정보에서 메타데이터 정보가 정확히 표시되는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
