### PR TITLE
F#65 When I change crossing point value of area-line chart, measure based color distribution doesn't work

### DIFF
--- a/discovery-frontend/src/app/common/component/chart/option/converter/color-option-converter.ts
+++ b/discovery-frontend/src/app/common/component/chart/option/converter/color-option-converter.ts
@@ -21,6 +21,7 @@ import {
 } from '../ui-option';
 import { PivotTableInfo } from '../../base-chart';
 import {
+  AxisLabelType,
   AxisType,
   CHART_STRING_DELIMITER,
   ChartColorList,
@@ -243,6 +244,9 @@ export class ColorOptionConverter {
     // 기존 스타일이 존재 하지 않을 경우 기본스타일 생성 후 적용
     if (_.isUndefined(option.visualMap)) option.visualMap = OptionGenerator.VisualMap.continuousVisualMap();
 
+    // get axis baseline
+    const valueAxis = AxisLabelType.COLUMN == uiOption.yAxis.mode ? uiOption.yAxis : uiOption.xAxis;
+
     // 색상 리스트 적용
     option.visualMap.color = <any>codes;
 
@@ -261,6 +265,14 @@ export class ColorOptionConverter {
         } else {
           item.label = FormatOptionConverter.getDecimalValue(item.gt, uiOption.valueFormat.decimal, uiOption.valueFormat.useThousandsSep) + ' - ' +
             FormatOptionConverter.getDecimalValue(item.lte, uiOption.valueFormat.decimal, uiOption.valueFormat.useThousandsSep);
+        }
+
+        // deduct baseline value in range
+        if (null !== valueAxis.baseline && undefined !== valueAxis.baseline) {
+          item.fixMin = null == item.fixMin ? null : item.fixMin - valueAxis.baseline;
+          item.fixMax = null == item.fixMax ? null : item.fixMax - valueAxis.baseline;
+          item.gt = null == item.gt ? null : item.gt - valueAxis.baseline;
+          item.lte = null == item.lte ? null : item.lte - valueAxis.baseline;
         }
       }
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
- 색상모드를 measure로 설정 후 crossing point를 설정하면 전체색상이 지정된 값 범위게 맞게 동작하지않음

**Related Issue** : #65 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
- color by measure로 설정시 crossing point에 값을 설정 후 범위에 맞게 색상이 설정되었는지 확인
- 저장 후 재조회시 설정된값에 맞게 색상이 설정되었는지 확인
<!--- Please describe in detail how you tested your changes. -->


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
