### PR TITLE
#227 Fix error chart name initialize

### DIFF
--- a/discovery-frontend/src/app/page/page.component.ts
+++ b/discovery-frontend/src/app/page/page.component.ts
@@ -556,7 +556,12 @@ export class PageComponent extends AbstractPopupComponent implements OnInit, OnD
    */
   public selectDataSource(dataSource: Datasource) {
     this.dataSource = dataSource;
+    let widgetName: string = null;
+    if( this.widget && this.widget.name ) {
+      widgetName = this.widget.name;
+    }
     this.widget = _.cloneDeep(this.originalWidget);
+    this.widget.name = !widgetName ? this.originalWidget.name : widgetName;
     const widgetDataSource:Datasource
       = DashboardUtil.getDataSourceFromBoardDataSource( this.widget.dashBoard, this.widget.configuration.dataSource );
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
멀티데이터소스 대시보드의 차트 편집 화면에서 차트의 대상 데이터소스를 변경할 경우 차트 이름이 초기화 되는 현상을 수정합니다.

**Related Issue** : #227 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 멀티데이터소스로 생성된 대시보드의 편집화면으로 이동합니다.
2. 신규 차트 생성 화면으로 이동합니다.
3. 상단의 차트 이름을 수정합니다.
4. 좌측 데이터소스 목록에서 다른 데이터소스로 선택합니다.
5. 작성했던 차트 이름이 초기화 되는지 확인합니다. (초기화가 안되어야 정상)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
