### PR TITLE
#196 Improve usability of the dashboard's time filter widget

### DIFF
--- a/discovery-frontend/src/app/dashboard/filters/component/time-range.component.html
+++ b/discovery-frontend/src/app/dashboard/filters/component/time-range.component.html
@@ -12,10 +12,10 @@
   ~ limitations under the License.
   -->
 
-<div class="ddp-wrap-dateinfo ddp-filter-dateinfo" [ngStyle]="{'width' : 'WIDGET' === mode ? '90%' : '' }">
+<div class="ddp-wrap-dateinfo ddp-filter-dateinfo" >
   <!-- 날짜 -->
-  <div class="ddp-ui-dateinfo ddp-from">
-    <div class="ddp-dateinfo-in">
+  <div [ngStyle]="{'width' : ('WIDGET' === mode) ? '200px' : ''}" class="ddp-ui-dateinfo ddp-from" >
+    <div class="ddp-dateinfo-in" >
       <span class="ddp-txt-date">From</span>
 
       <div class="ddp-box-rome" *ngIf="isEarliestDateTime" >
@@ -42,8 +42,8 @@
   <!-- //날짜 -->
 
   <!-- 날짜 -->
-  <div class="ddp-ui-dateinfo ddp-to">
-    <div class="ddp-dateinfo-in">
+  <div [ngStyle]="{'width' : ('WIDGET' === mode) ? '200px' : ''}" class="ddp-ui-dateinfo ddp-to">
+    <div class="ddp-dateinfo-in" >
       <span class="ddp-txt-date">To</span>
 
       <div class="ddp-box-rome" *ngIf="isLatestDateTime" >

--- a/discovery-frontend/src/app/dashboard/filters/component/time-range.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/component/time-range.component.ts
@@ -380,6 +380,7 @@ export class TimeRangeComponent extends AbstractComponent implements OnInit, OnD
     return this._getRangeFromMoment(moment().year(sYear).week(sWeek), moment().year(eYear).week(eWeek), 'week');
   } // function - _getRangeFromWeek
 
+  // noinspection JSMethodCanBeStatic
   /**
    * Moment 로 부터 Range 정보를 얻는다.
    * @param fromMoment

--- a/discovery-frontend/src/app/dashboard/filters/time-filter/time-range-filter.component.html
+++ b/discovery-frontend/src/app/dashboard/filters/time-filter/time-range-filter.component.html
@@ -12,7 +12,7 @@
   ~ limitations under the License.
   -->
 
-<div *ngIf="targetFilter" class="ddp-dateinfo-view">
+<div *ngIf="targetFilter" class="ddp-dateinfo-view" [class.ddp-inline]="'WIDGET' === mode">
   <div class="ddp-filter-calen">
     <div *ngFor="let item of timeRangeList;let idx = index;" class="ddp-filter-calen-in">
       <!-- wrap dateinfo -->

--- a/discovery-frontend/src/app/dashboard/filters/time-filter/time-range-filter.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/time-filter/time-range-filter.component.ts
@@ -71,6 +71,7 @@ export class TimeRangeFilterComponent extends AbstractFilterPopupComponent imple
   // 필터 변경 이벤트
   @Output('change')
   public changeEvent: EventEmitter<TimeRangeFilter> = new EventEmitter();
+
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
   | Constructor
   |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/

--- a/discovery-frontend/src/app/dashboard/filters/time-filter/time-relative-filter.component.html
+++ b/discovery-frontend/src/app/dashboard/filters/time-filter/time-relative-filter.component.html
@@ -14,22 +14,27 @@
 
 <span *ngIf="targetFilter" class="ddp-txt-preview">{{getPreview()}}</span>
 <!-- filter area -->
-<div *ngIf="targetFilter" class="ddp-filter-area" >
+<div *ngIf="targetFilter" class="ddp-filter-area"
+     #filterArea
+     [ngStyle]="{'overflow-y' : ('WIDGET' === mode) ? 'initial !important' : ''}">
   <!-- 과거 선택 -->
   <div class="ddp-filter-type">
     <span class="ddp-label-name">Previous</span>
     <ul class="ddp-list-buttons">
       <li (click)="setRelative( 'PREVIOUS', 'DAY', 1 )"
-          [class.ddp-selected]="isSelectedRelative('BUTTON', 'PREVIOUS', 'DAY')" style="width: 25%;">
-        {{ 'CHANGE' === mode ? 'Yesterday' : 'D'  }}
+          [class.ddp-selected]="isSelectedRelative('BUTTON', 'PREVIOUS', 'DAY')" style="width: 25%;"
+          title="Yesterday">
+        {{ isShortLabel ? 'D' : 'Yesterday' }}
       </li>
       <li (click)="setRelative( 'PREVIOUS', 'WEEK', 1 )"
-          [class.ddp-selected]="isSelectedRelative('BUTTON', 'PREVIOUS', 'WEEK')" style="width: 25%;">
-        {{ 'CHANGE' === mode ? 'Last Week' : 'W' }}
+          [class.ddp-selected]="isSelectedRelative('BUTTON', 'PREVIOUS', 'WEEK')" style="width: 25%;"
+          title="Last Week">
+        {{ isShortLabel ? 'W' : 'Last Week' }}
       </li>
       <li (click)="setRelative( 'PREVIOUS', 'MONTH', 1 )"
-          [class.ddp-selected]="isSelectedRelative('BUTTON', 'PREVIOUS', 'MONTH')" style="width: 25%;">
-        {{ 'CHANGE' === mode ? 'Last Month' : 'M' }}
+          [class.ddp-selected]="isSelectedRelative('BUTTON', 'PREVIOUS', 'MONTH')" style="width: 25%;"
+          title="Last Month">
+        {{ isShortLabel ? 'M' : 'Last Month' }}
       </li>
       <!--
       <li (click)="setRelative( 'PREVIOUS', 'QUARTER', 1 )"
@@ -38,13 +43,14 @@
       </li>
       -->
       <li (click)="setRelative( 'PREVIOUS', 'YEAR', 1 )"
-          [class.ddp-selected]="isSelectedRelative('BUTTON', 'PREVIOUS', 'YEAR')" style="width: 25%;">
-        {{ 'CHANGE' === mode ? 'Last Year' : 'Y' }}
+          [class.ddp-selected]="isSelectedRelative('BUTTON', 'PREVIOUS', 'YEAR')" style="width: 25%;"
+          title="Last Year">
+        {{ isShortLabel ? 'Y' : 'Last Year' }}
       </li>
     </ul>
     <div [class.ddp-selected]="isSelectedRelative('INPUT', 'PREVIOUS')" class="ddp-btn-time">
       <div class="ddp-form-multy">
-        <span class="ddp-txt-label">Last</span>
+        <span class="ddp-txt-label" style="top:10px;">Last</span>
         <div class="ddp-box-multy ddp-clear ddp-form-time">
           <input #inputLastValue [ngModel]="targetFilter.value"
                  (keypress)="setLastValue($event)" (blur)="resetLastValue()"
@@ -73,16 +79,19 @@
     <span class="ddp-label-name">Current</span>
     <ul class="ddp-list-buttons">
       <li (click)="setRelative( 'CURRENT', 'DAY', 1 )"
-          [class.ddp-selected]="isSelectedRelative('BUTTON', 'CURRENT', 'DAY')" style="width: 25%;">
-        {{ 'CHANGE' === mode ? 'Today' : 'D' }}
+          [class.ddp-selected]="isSelectedRelative('BUTTON', 'CURRENT', 'DAY')" style="width: 25%;"
+          title="Today">
+        {{ isShortLabel ? 'D' : 'Today' }}
       </li>
       <li (click)="setRelative( 'CURRENT', 'WEEK', 1 )"
-          [class.ddp-selected]="isSelectedRelative('BUTTON', 'CURRENT', 'WEEK')" style="width: 25%;">
-        {{ 'CHANGE' === mode ? 'This Week' : 'W' }}
+          [class.ddp-selected]="isSelectedRelative('BUTTON', 'CURRENT', 'WEEK')" style="width: 25%;"
+          title="This Week">
+        {{ isShortLabel ? 'W' : 'This Week' }}
       </li>
       <li (click)="setRelative( 'CURRENT', 'MONTH', 1 )"
-          [class.ddp-selected]="isSelectedRelative('BUTTON', 'CURRENT', 'MONTH')" style="width: 25%;">
-        {{ 'CHANGE' === mode ? 'This Month' : 'M' }}
+          [class.ddp-selected]="isSelectedRelative('BUTTON', 'CURRENT', 'MONTH')" style="width: 25%;"
+          title="This Month">
+        {{ isShortLabel ? 'M' : 'This Month' }}
       </li>
       <!--
       <li (click)="setRelative( 'CURRENT', 'QUARTER', 1 )"
@@ -91,8 +100,9 @@
       </li>
       -->
       <li (click)="setRelative( 'CURRENT', 'YEAR', 1 )"
-          [class.ddp-selected]="isSelectedRelative('BUTTON', 'CURRENT', 'YEAR')" style="width: 25%;">
-        {{ 'CHANGE' === mode ? 'This Year' : 'Y' }}
+          [class.ddp-selected]="isSelectedRelative('BUTTON', 'CURRENT', 'YEAR')" style="width: 25%;"
+          title="This Year" >
+        {{ isShortLabel ? 'Y' : 'This Year' }}
       </li>
     </ul>
   </div>
@@ -102,16 +112,19 @@
     <span class="ddp-label-name">Next</span>
     <ul class="ddp-list-buttons">
       <li (click)="setRelative( 'NEXT', 'DAY', 1 )"
-          [class.ddp-selected]="isSelectedRelative('BUTTON', 'NEXT', 'DAY')" style="width: 25%;">
-        {{ 'CHANGE' === mode ? 'Tomorrow' : 'D' }}
+          [class.ddp-selected]="isSelectedRelative('BUTTON', 'NEXT', 'DAY')" style="width: 25%;"
+          title="Tomorrow">
+        {{ isShortLabel ? 'D' : 'Tomorrow' }}
       </li>
       <li (click)="setRelative( 'NEXT', 'WEEK', 1 )"
-          [class.ddp-selected]="isSelectedRelative('BUTTON', 'NEXT', 'WEEK')" style="width: 25%;">
-        {{ 'CHANGE' === mode ? 'Next Week' : 'W' }}
+          [class.ddp-selected]="isSelectedRelative('BUTTON', 'NEXT', 'WEEK')" style="width: 25%;"
+          title="Next Week">
+        {{ isShortLabel ? 'W' : 'Next Week' }}
       </li>
       <li (click)="setRelative( 'NEXT', 'MONTH', 1 )"
-          [class.ddp-selected]="isSelectedRelative('BUTTON', 'NEXT', 'MONTH')" style="width: 25%;">
-        {{ 'CHANGE' === mode ? 'Next Month' : 'M' }}
+          [class.ddp-selected]="isSelectedRelative('BUTTON', 'NEXT', 'MONTH')" style="width: 25%;"
+          title="Next Month">
+        {{ isShortLabel ? 'M' : 'Next Month' }}
       </li>
       <!--
       <li (click)="setRelative( 'NEXT', 'QUARTER', 1 )"
@@ -120,13 +133,14 @@
       </li>
       -->
       <li (click)="setRelative( 'NEXT', 'YEAR', 1 )"
-          [class.ddp-selected]="isSelectedRelative('BUTTON', 'NEXT', 'YEAR')" style="width: 25%;">
-        {{ 'CHANGE' === mode ? 'Next Year' : 'Y' }}
+          [class.ddp-selected]="isSelectedRelative('BUTTON', 'NEXT', 'YEAR')" style="width: 25%;"
+          title="Next Year">
+        {{ isShortLabel ? 'Y' : 'Next Year' }}
       </li>
     </ul>
     <div [class.ddp-selected]="isSelectedRelative('INPUT', 'NEXT')" class="ddp-btn-time">
       <div class="ddp-form-multy">
-        <span class="ddp-txt-label">Next</span>
+        <span class="ddp-txt-label" style="top:10px;">Next</span>
         <div class="ddp-box-multy ddp-clear ddp-form-time">
           <input #inputNextValue [ngModel]="targetFilter.value"
                  (keypress)="setNextValue($event)" (blur)="resetNextValue()"

--- a/discovery-frontend/src/app/dashboard/filters/time-filter/time-relative-filter.component.html
+++ b/discovery-frontend/src/app/dashboard/filters/time-filter/time-relative-filter.component.html
@@ -48,9 +48,9 @@
         {{ isShortLabel ? 'Y' : 'Last Year' }}
       </li>
     </ul>
-    <div [class.ddp-selected]="isSelectedRelative('INPUT', 'PREVIOUS')" class="ddp-btn-time">
+    <div [class.ddp-selected]="isSelectedRelative('INPUT', 'PREVIOUS')" class="ddp-btn-time" style="height:30px;">
       <div class="ddp-form-multy">
-        <span class="ddp-txt-label" style="top:10px;">Last</span>
+        <span class="ddp-txt-label" >Last</span>
         <div class="ddp-box-multy ddp-clear ddp-form-time">
           <input #inputLastValue [ngModel]="targetFilter.value"
                  (keypress)="setLastValue($event)" (blur)="resetLastValue()"
@@ -138,9 +138,9 @@
         {{ isShortLabel ? 'Y' : 'Next Year' }}
       </li>
     </ul>
-    <div [class.ddp-selected]="isSelectedRelative('INPUT', 'NEXT')" class="ddp-btn-time">
+    <div [class.ddp-selected]="isSelectedRelative('INPUT', 'NEXT')" class="ddp-btn-time" style="height:30px;">
       <div class="ddp-form-multy">
-        <span class="ddp-txt-label" style="top:10px;">Next</span>
+        <span class="ddp-txt-label" >Next</span>
         <div class="ddp-box-multy ddp-clear ddp-form-time">
           <input #inputNextValue [ngModel]="targetFilter.value"
                  (keypress)="setNextValue($event)" (blur)="resetNextValue()"

--- a/discovery-frontend/src/app/dashboard/widgets/filter-widget/filter-widget.component.html
+++ b/discovery-frontend/src/app/dashboard/widgets/filter-widget/filter-widget.component.html
@@ -39,7 +39,7 @@
     <!-- //title -->
 
     <!-- 차원값 필터 -->
-    <div class="ddp-ui-widget-contents" *ngIf="filter.type === 'include'">
+    <div *ngIf="filter.type === 'include'" class="ddp-ui-widget-contents" >
       <!-- 복수 선택 콤보 박스 -->
       <component-filter-multi-select *ngIf="convertToIncludeFilter(filter).selector === inclusionSelectorType.MULTI_COMBO"
                                      [array]="candidateList"
@@ -115,7 +115,7 @@
     </div>
     <!-- // 차원값 필터 -->
     <!-- 측정값 필터 -->
-    <div class="ddp-ui-widget-contents" *ngIf="filter.type === 'bound'">
+    <div *ngIf="filter.type === 'bound'" class="ddp-ui-widget-contents" >
       <div class="ddp-display-table" >
         <div class="ddp-table-in" >
           <bound-filter [filter]="filter" (change)="applyValue()"></bound-filter>
@@ -124,7 +124,7 @@
     </div>
     <!-- // 측정값 필터 -->
     <!-- Timestamp Filter -->
-    <div class="ddp-ui-widget-contents" *ngIf="isTimeFilter">
+    <div *ngIf="isTimeFilter" class="ddp-ui-widget-contents" >
 
       <!-- 전체 기간 선택 탭 영역 -->
       <div class="ddp-filter-view ddp-full" >

--- a/discovery-frontend/src/app/dashboard/widgets/filter-widget/filter-widget.component.html
+++ b/discovery-frontend/src/app/dashboard/widgets/filter-widget/filter-widget.component.html
@@ -123,76 +123,43 @@
       </div>
     </div>
     <!-- // 측정값 필터 -->
-    <!-- 타임스탬프 필터 -->
+    <!-- Timestamp Filter -->
     <div class="ddp-ui-widget-contents" *ngIf="isTimeFilter">
-      <!-- 연속 형식 - None Granularity -->
-      <div *ngIf="!isDiscontinuousFilter && isContinuousByAll" class="ddp-ui-divide">
-        <!-- 탭별 내용 영역 -->
-        <div class="ddp-wrap-toggle-contents">
-          <!-- 전체 기간 선택 탭 영역 -->
-          <div *ngIf="isAllTypeTimeFilter" class="ddp-ui-toggle-contents">
-            <span class="ddp-txt-preview">(No time filtering)</span>
-          </div>
-          <!-- // 전체 기간 선택 탭 영역 -->
-          <!-- 상대적인 기간 선택 탭 영역 -->
-          <div *ngIf="isRelativeTypeTimeFilter" class="ddp-ui-toggle-contents">
-            <app-time-relative-filter
-              [mode]="'WIDGET'" [filter]="filter"
-              (change)="changeFilterEvent($event)">
-            </app-time-relative-filter>
-          </div>
-          <!-- // 상대적인 기간 선택 탭 영역 -->
-          <!-- 특정 기간 선택 탭 영역 -->
-          <div *ngIf="isRangeTypeTimeFilter" class="ddp-ui-toggle-contents">
-            <app-time-range-filter
-              [mode]="'WIDGET'" [filter]="filter" [dashboard]="widget.dashBoard"
-              (change)="changeFilterEvent($event)">
-            </app-time-range-filter>
-          </div>
-          <!-- // 특정 기간 선택 탭 영역 -->
-        </div>
-        <!-- // 탭별 내용 영역 -->
+
+      <!-- 전체 기간 선택 탭 영역 -->
+      <div class="ddp-filter-view ddp-full" >
+        <span *ngIf="isAllTypeTimeFilter" class="ddp-txt-preview">(No time filtering)</span>
       </div>
-      <!-- // 연속 형식 - None Granularity -->
-      <!-- 연속 형식 - Granularity -->
-      <div *ngIf="!isDiscontinuousFilter && !isContinuousByAll" class="ddp-ui-divide" >
-        <!-- 탭별 내용 영역 -->
-        <div class="ddp-wrap-toggle-contents">
-          <!-- 전체 기간 선택 탭 영역 -->
-          <div *ngIf="isListTypeTimeFilter" class="ddp-ui-toggle-contents">
-            <app-time-list-filter
-              [mode]="'WIDGET'" [filter]="filter"
-              [dashboard]="widget.dashBoard" [field]="field"
-              (change)="changeFilterEvent($event)">
-            </app-time-list-filter>
-          </div>
-          <!-- // 전체 기간 선택 탭 영역 -->
-          <!-- 특정 기간 선택 탭 영역 -->
-          <div *ngIf="isRangeTypeTimeFilter" class="ddp-ui-toggle-contents">
-            <app-time-range-filter
-              [mode]="'WIDGET'" [filter]="filter" [dashboard]="widget.dashBoard"
-              (change)="changeFilterEvent($event)">
-            </app-time-range-filter>
-          </div>
-          <!-- // 특정 기간 선택 탭 영역 -->
-        </div>
-        <!-- // 탭별 내용 영역 -->
+      <!-- // 전체 기간 선택 탭 영역 -->
+
+      <!-- Relative Time Filter -->
+      <div *ngIf="isRelativeTypeTimeFilter" class="ddp-filter-view ddp-full">
+        <app-time-relative-filter
+          [mode]="'WIDGET'" [filter]="filter"
+          (change)="changeFilterEvent($event)">
+        </app-time-relative-filter>
       </div>
-      <!-- // 연속 형식 - Granularity -->
-      <!-- 불연속 형식 -->
-      <div *ngIf="isDiscontinuousFilter" class="ddp-ui-divide" >
-        <!-- //summary -->
-        <div class="ddp-filter-form">
-          <app-time-list-filter
-            [mode]="'WIDGET'" [filter]="filter"
-            [dashboard]="widget.dashBoard" [field]="field"
-            (change)="changeFilterEvent($event)">
-          </app-time-list-filter>
-        </div>
-      </div>
-      <!-- // 불연속 형식 -->
+      <!-- // Relative Time Filter -->
+
+      <!-- Range Time Filter -->
+      <app-time-range-filter
+        *ngIf="isRangeTypeTimeFilter"
+        [mode]="'WIDGET'" [filter]="filter" [dashboard]="widget.dashBoard"
+        (change)="changeFilterEvent($event)">
+      </app-time-range-filter>
+      <!-- // Range Time Filter -->
+
+      <!-- List Time Filter -->
+      <app-time-list-filter
+        *ngIf="isListTypeTimeFilter || isDiscontinuousFilter"
+        [mode]="'WIDGET'" [filter]="filter"
+        [dashboard]="widget.dashBoard" [field]="field"
+        (change)="changeFilterEvent($event)">
+      </app-time-list-filter>
+      <!-- // List Time Filter -->
+
     </div>
-    <!-- // 타임스탬프 필터 -->
+    <!-- // Timestamp Filter -->
   </div>
 
   <!-- 수정 버튼 레이어 -->

--- a/discovery-frontend/src/app/dashboard/widgets/filter-widget/filter-widget.component.ts
+++ b/discovery-frontend/src/app/dashboard/widgets/filter-widget/filter-widget.component.ts
@@ -94,11 +94,9 @@ export class FilterWidgetComponent extends AbstractWidgetComponent implements On
   public field: Field;
   public dashboard: Dashboard;
 
-  public globalFilters: Filter[] = [];
-
   // T/F
   public isVisibleScrollbar: boolean = false;   // 스크롤바 표시 여부 체크
-  public isTimeFilter:boolean = false;              // TimeFilter 여부
+  public isTimeFilter: boolean = false;              // TimeFilter 여부
   public isContinuousByAll: boolean = false;        // Granularity 가 지정되지 않은 연속성 여부 판단
   public isDiscontinuousFilter: boolean = false;    // 불연속 필터 여부
   public isAllTypeTimeFilter: boolean = false;      // All Time Filter
@@ -140,7 +138,7 @@ export class FilterWidgetComponent extends AbstractWidgetComponent implements On
     const popupSubscribe = this.popupService.filterView$.subscribe((data: SubscribeArg) => {
       if ('reset-general-filter' === data.name) {
         if (this.filter.ui.importanceType === 'general') {
-          const inclusionFilter:InclusionFilter = (<InclusionFilter>this.filter);
+          const inclusionFilter: InclusionFilter = (<InclusionFilter>this.filter);
           inclusionFilter.valueList = [];
           switch (inclusionFilter.selector) {
             case InclusionSelectorType.SINGLE_COMBO:
@@ -150,11 +148,11 @@ export class FilterWidgetComponent extends AbstractWidgetComponent implements On
               this.filterMultiSelectComponent.updateView(this.selectedItems);
               break;
             default :
-              this._candidate( inclusionFilter );
+              this._candidate(inclusionFilter);
           }
         }
       }
-      this.changeDetect.detectChanges();
+      this.safelyDetectChanges();
     });
     this.subscriptions.push(popupSubscribe);
 
@@ -163,14 +161,8 @@ export class FilterWidgetComponent extends AbstractWidgetComponent implements On
       this.broadCaster.on<any>('CHANGE_FILTER_SELECTOR').subscribe(data => {
         if (this.widget.id === data.widget.id) {
           this.setConfiguration(data.widget.configuration);
+          this.safelyDetectChanges();
         }
-      })
-    );
-
-    // 외부 필터 설정
-    this.subscriptions.push(
-      this.broadCaster.on<any>('SET_EXTERNAL_FILTER').subscribe(data => {
-        this.globalFilters = data.filters;
       })
     );
 
@@ -180,6 +172,7 @@ export class FilterWidgetComponent extends AbstractWidgetComponent implements On
       this.broadCaster.on<any>('SET_WIDGET_CONFIG').subscribe(data => {
         if (data.widgetId === this.widget.id) {
           this.setConfiguration(data.config);
+          this.safelyDetectChanges();
         }
       })
     );
@@ -193,21 +186,14 @@ export class FilterWidgetComponent extends AbstractWidgetComponent implements On
   public ngOnChanges(changes: SimpleChanges) {
     const widgetChanges: SimpleChange = changes.inputWidget;
     if (widgetChanges && widgetChanges.currentValue) {
-      const widget: FilterWidget = widgetChanges.currentValue;
-
-      this.widget = widget;
-      const filter:Filter = this.getFilter();
+      this.widget = widgetChanges.currentValue;
+      const filter: Filter = this.getFilter();
 
       this.dashboard = this.widget.dashBoard;
-      this.field = DashboardUtil.getFieldByName( this.widget.dashBoard, filter.dataSource, filter.field, filter.ref );
-
-      // 글로벌 필터 셋팅
-      if (widget.dashBoard.configuration.filters) {
-        this.globalFilters = widget.dashBoard.configuration.filters;
-      }
+      this.field = DashboardUtil.getFieldByName(this.widget.dashBoard, filter.dataSource, filter.field, filter.ref);
 
       // 필터 후보값 조회
-      this._candidate( filter );
+      this._candidate(filter);
     }
 
   } // function - ngOnChanges
@@ -232,7 +218,7 @@ export class FilterWidgetComponent extends AbstractWidgetComponent implements On
    */
   public setConfiguration(objConfig: FilterWidgetConfiguration) {
     this.widget.configuration = objConfig;
-    this._candidate( this.getFilter() );
+    this._candidate(this.getFilter());
   } // function - setConfiguration
 
   /**
@@ -242,7 +228,7 @@ export class FilterWidgetComponent extends AbstractWidgetComponent implements On
   public getFilter(): Filter {
     const conf: FilterWidgetConfiguration = <FilterWidgetConfiguration>this.widget.configuration;
     const filter: Filter = _.cloneDeep(conf.filter);
-    if (FilterUtil.isTimeFilter(filter) ) {
+    if (FilterUtil.isTimeFilter(filter)) {
       this._setTimeFilterStatus(<TimeFilter>filter);
     }
     return filter;
@@ -282,7 +268,7 @@ export class FilterWidgetComponent extends AbstractWidgetComponent implements On
    * 목록에 사용자 정의값 추가
    * @param {InclusionFilter} filter
    */
-  public addDefineValues(filter:InclusionFilter) {
+  public addDefineValues(filter: InclusionFilter) {
     if (filter.definedValues && filter.definedValues.length > 0) {
       this.candidateList = filter.definedValues.map(item => this._stringToCandidate(item)).concat(this.candidateList);
     }
@@ -433,13 +419,13 @@ export class FilterWidgetComponent extends AbstractWidgetComponent implements On
   private _initialContainer() {
     // 콤보박스 관련된 필터 뷰 설정
     this.safelyDetectChanges();
-    if (!this.isEditMode ) {
-      const filter:Filter = this.filter;
-      const isInterval:boolean = ( 'interval' === filter.type );
-      const isIncludeCombo:boolean = ( 'include' === filter.type
-        && ( (<InclusionFilter>filter).selector === InclusionSelectorType.SINGLE_COMBO
-          || (<InclusionFilter>filter).selector === InclusionSelectorType.MULTI_COMBO ));
-      if( isInterval || isIncludeCombo ) {
+    if (!this.isEditMode) {
+      const filter: Filter = this.filter;
+      const isInterval: boolean = ('interval' === filter.type);
+      const isIncludeCombo: boolean = ('include' === filter.type
+        && ((<InclusionFilter>filter).selector === InclusionSelectorType.SINGLE_COMBO
+          || (<InclusionFilter>filter).selector === InclusionSelectorType.MULTI_COMBO));
+      if (isInterval || isIncludeCombo) {
         // 필터 z-index 최상으로 처리
         const $filterWidgetEl = $(this.filterWidget.nativeElement);
         $filterWidgetEl.closest('.lm_item .lm_stack').css({ 'z-index': 100, 'position': 'relative' });
@@ -467,7 +453,7 @@ export class FilterWidgetComponent extends AbstractWidgetComponent implements On
    * Inclusion 및 Bound 필터에 대한 후보값 조회
    * @param {Filter} filter
    */
-  private _candidate(filter:Filter) {
+  private _candidate(filter: Filter) {
 
     // 프로세스 실행 등록
     this.processStart();
@@ -477,12 +463,12 @@ export class FilterWidgetComponent extends AbstractWidgetComponent implements On
       // 필터 데이터 후보 조회
       // this.datasourceService.getCandidateForFilter(
       //   this.filter, this.dashboard, this.getFiltersParam(this.filter), this.field).then((result) => {
-      this.datasourceService.getCandidateForFilter( filter, this.dashboard, [], this.field).then((result) => {
+      this.datasourceService.getCandidateForFilter(filter, this.dashboard, [], this.field).then((result) => {
 
         if ('include' === filter.type) {
 
           // 기본값 설정
-          const inclusionFilter:InclusionFilter = <InclusionFilter>filter;
+          const inclusionFilter: InclusionFilter = <InclusionFilter>filter;
           if (inclusionFilter.hasOwnProperty('valueList') && inclusionFilter.valueList.length > 0) {
             this.selectedItems = inclusionFilter.valueList.map(item => this._stringToCandidate(item));
           }
@@ -490,7 +476,7 @@ export class FilterWidgetComponent extends AbstractWidgetComponent implements On
           this.candidateList = [];
 
           // 사용자 정의 값 추가
-          this.addDefineValues( inclusionFilter );
+          this.addDefineValues(inclusionFilter);
 
           // 선택된 후보값 목록
           const selectedCandidateValues: string[] = inclusionFilter.candidateValues;
@@ -509,13 +495,13 @@ export class FilterWidgetComponent extends AbstractWidgetComponent implements On
           }
 
           // Sort List
-          if( isNullOrUndefined( inclusionFilter.sort ) ) {
-            inclusionFilter.sort = new InclusionItemSort( InclusionSortBy.TEXT, DIRECTION.ASC );
+          if (isNullOrUndefined(inclusionFilter.sort)) {
+            inclusionFilter.sort = new InclusionItemSort(InclusionSortBy.TEXT, DIRECTION.ASC);
           }
-          if (InclusionSortBy.COUNT === inclusionFilter.sort.by ) {
+          if (InclusionSortBy.COUNT === inclusionFilter.sort.by) {
             // sort by count
             this.candidateList.sort((val1: Candidate, val2: Candidate) => {
-              return ( DIRECTION.ASC === inclusionFilter.sort.direction ) ? val1.count - val2.count : val2.count - val1.count;
+              return (DIRECTION.ASC === inclusionFilter.sort.direction) ? val1.count - val2.count : val2.count - val1.count;
             });
           } else {
             // sort by text
@@ -523,10 +509,10 @@ export class FilterWidgetComponent extends AbstractWidgetComponent implements On
               const name1: string = (val1.name) ? val1.name.toUpperCase() : '';
               const name2: string = (val2.name) ? val2.name.toUpperCase() : '';
               if (name1 < name2) {
-                return (DIRECTION.ASC === inclusionFilter.sort.direction ) ? -1 : 1;
+                return (DIRECTION.ASC === inclusionFilter.sort.direction) ? -1 : 1;
               }
               if (name1 > name2) {
-                return (DIRECTION.ASC === inclusionFilter.sort.direction ) ? 1 : -1;
+                return (DIRECTION.ASC === inclusionFilter.sort.direction) ? 1 : -1;
               }
               return 0;
             });
@@ -534,7 +520,7 @@ export class FilterWidgetComponent extends AbstractWidgetComponent implements On
 
           this.filter = inclusionFilter;
         } else if ('bound' === filter.type) {
-          const boundFilter:BoundFilter = <BoundFilter>filter;
+          const boundFilter: BoundFilter = <BoundFilter>filter;
           if (result && result.hasOwnProperty('maxValue')) {
             if (boundFilter.min === 0 && boundFilter.max === 0) {
               boundFilter.min = result.minValue;
@@ -626,7 +612,7 @@ export class FilterWidgetComponent extends AbstractWidgetComponent implements On
    * @param {TimeFilter} timeFilter
    * @private
    */
-  private _setTimeFilterStatus(timeFilter:TimeFilter) {
+  private _setTimeFilterStatus(timeFilter: TimeFilter) {
     this.isTimeFilter = true;
     this.isContinuousByAll = FilterUtil.isContinuousByAll(timeFilter);
     this.isDiscontinuousFilter = FilterUtil.isDiscontinuousTimeFilter(timeFilter);

--- a/discovery-frontend/src/assets/css/polaris.v2.page.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.page.css
@@ -897,6 +897,11 @@ ul.ddp-list-board-thumbview li.ddp-selected a span.ddp-data-name {color:#4b515b;
 .ddp-ui-widget-contents .ddp-dateinfo-view .ddp-list-buttons {width:100%;}
 .ddp-ui-widget-contents .ddp-dateinfo-view .ddp-list-buttons li {margin-bottom:11px;}
 .ddp-ui-widget-contents .ddp-filter-calen-in {padding-bottom:20px;}
+.ddp-dateinfo-view.ddp-inline {width:auto;}
+.ddp-dateinfo-view.ddp-inline .ddp-filter-calen {}
+.ddp-dateinfo-view.ddp-inline .ddp-filter-calen .ddp-ui-dateinfo {display:inline-block; width:280px; margin-top:5px;}
+
+.ddp-dateinfo-view.ddp-inline .ddp-filter-calen .ddp-ui-dateinfo.ddp-to {}
 .ddp-ui-widget-contents .ddp-filter-dateinfo .ddp-ui-dateinfo .ddp-box-rome {width:100%;}
 .ddp-ui-widget-contents .ddp-filter-dateinfo .ddp-ui-dateinfo {width:100%; text-align:left;}
 .ddp-ui-widget-contents .ddp-filter-dateinfo .ddp-ui-dateinfo:last-of-type {margin-top:4px;text-align:left;}
@@ -1445,10 +1450,11 @@ ul.ddp-list-text li a .ddp-data-info span {display:block; color:#4b515b; font-si
 .ddp-filter-dateinfo .ddp-ui-dateinfo .ddp-box-dateinfo {display:inline-block; text-align:left; width:100%; box-sizing:border-box;}
 .ddp-filter-dateinfo .ddp-ui-dateinfo .ddp-box-dateinfo .ddp-type-selectbox {float:left; width:45%; border:none; border-left:1px solid #d0d1d8; box-sizing:border-box; z-index:inherit;}
 .ddp-filter-view {max-width:400px; min-width:300px; box-sizing:border-box;}
+.ddp-filter-view.ddp-full {max-width:100%;}
+.ddp-filter-view.ddp-full .ddp-wrap-buttons {width:100%;}
+.ddp-filter-view.ddp-full .ddp-wrap-buttons.ddp-size ul.ddp-list-buttons li em {display:none;}
 .ddp-filter-view .ddp-filter-area {position:relative; top:0; left:0; padding:0px;border-top:none; overflow:inherit;}
-
 .ddp-filter-view .ddp-txt-preview {display:block; color:#4c515a; font-size:14px; text-align:center;}
-
 .ddp-filter-view .ddp-filter-area .ddp-filter-type {padding-top:10px;}
 
 .ddp-filter-area {position:absolute; top:45px; left:0; right:0; bottom:0; padding:0 25px; border-top:1px solid #e7e7ea; overflow-y:auto;}
@@ -1476,6 +1482,7 @@ ul.ddp-list-text li a .ddp-data-info span {display:block; color:#4b515b; font-si
 
 .ddp-filter-area .ddp-filter-type .ddp-btn-time.ddp-selected .ddp-form-multy  span.ddp-txt-label:before  {display:inline-block; position:relative; margin-right:7px; width:14px; height:10px; background:url(../images/icon_select2.png) no-repeat; background-position-y:-11px; vertical-align: middle; content:'';}
 .ddp-filter-area .ddp-filter-type .ddp-btn-time.ddp-selected:before {position:absolute; top:0; left:0; right:0; bottom:0; border-radius:2px; border:1px solid #90969f; content:'';}
+.ddp-filter-area .ddp-filter-type .ddp-btn-time .ddp-form-multy .ddp-box-multy { top:2px;}
 
 .ddp-filter-form .ddp-option {padding:25px 0 10px 0;}
 .ddp-filter1 .ddp-filter-form .ddp-box-item-search {top:135px;}

--- a/discovery-frontend/src/assets/css/polaris.v2.page.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.page.css
@@ -876,13 +876,17 @@ ul.ddp-list-board-thumbview li.ddp-selected a span.ddp-data-name {color:#4b515b;
 .ddp-box-widget .ddp-top-control .ddp-ui-buttons em.ddp-icon-widget-graph {width:10px; height:11px; background-position:left -80px;}
 .ddp-ui-btnview .ddp-box-btn.ddp-selected {background-color:#4b515b;}
 
-.ddp-view-widget.ddp-view-widget-filter {overflow-y:auto;}
+.ddp-wrap-editboard .ddp-view-widget.ddp-view-widget-filter {overflow-y:auto;}
 .ddp-view-widget .ddp-ui-slider-type {margin:0;}
 .ddp-view-widget.ddp-view-name {top:25px;}
 .ddp-view-widget {position:absolute; top:0px; left:0; right:0; bottom:0; padding:5px 10px; z-index:1;}
+.ddp-view-widget .ddp-ui-widget-contents {position:absolute; top:43px; left:0; right:0; bottom:0; padding:10px; overflow:auto;}
+.ddp-box-boardedit .ddp-view-widget .ddp-ui-widget-contents {position:relative; top:0; padding:0; overflow:initial;}
+.ddp-ui-widget-contents .ddp-form-multy .ddp-box-multy.ddp-form-time .ddp-input-typebasic {width:45%;}
+.ddp-ui-widget-contents .ddp-form-multy .ddp-box-multy.ddp-form-time .ddp-type-selectbox {width:55%;}
 
 .ddp-view-widget-text {color:#4b515b; font-size:24px;overflow-y: auto;}
-.ddp-view-widget .ddp-ui-title {margin:0 0 10px 0; color:#4b515b; font-size:14px;}
+.ddp-view-widget .ddp-ui-title {padding:10px 0 9px 0;color:#4b515b; font-size:14px;}
 .ddp-view-widget .ddp-ui-title .ddp-icon-filter,
 .ddp-view-widget .ddp-ui-title .ddp-icon-parameter {display:inline-block; margin-right:5px; background:url(../images/icon_title.png) no-repeat; vertical-align: middle;}
 .ddp-view-widget .ddp-ui-title .ddp-icon-filter {width:15px; height:13px;}
@@ -892,7 +896,7 @@ ul.ddp-list-board-thumbview li.ddp-selected a span.ddp-data-name {color:#4b515b;
 .ddp-view-widget-parameter .ddp-ui-widget-contents
 .ddp-ui-dash-contents .ddp-view-widget .ddp-box-data-none {position:absolute; top:0; left:0; right:0; bottom:0; background-color:#fff; z-index:1;}
 .ddp-view-widget-parameter .ddp-ui-widget-contents .ddp-ui-slider-type {clear:both; margin-top:-10px;}
-.ddp-ui-widget-contents .ddp-dateinfo-view {position:relative; padding:10px 0 0 0; width:280px; overflow:inherit;}
+.ddp-ui-widget-contents .ddp-dateinfo-view {position:relative; padding:10px 0 0 0; width:280px; }
 .ddp-ui-widget-contents .ddp-dateinfo-view .ddp-box-preview {padding:6px 0; margin-bottom:10px; border-radius:2px; background-color:#f6f6f7; text-align:center; color:#4c515a; font-size:14px;}
 .ddp-ui-widget-contents .ddp-dateinfo-view .ddp-list-buttons {width:100%;}
 .ddp-ui-widget-contents .ddp-dateinfo-view .ddp-list-buttons li {margin-bottom:11px;}
@@ -1449,12 +1453,12 @@ ul.ddp-list-text li a .ddp-data-info span {display:block; color:#4b515b; font-si
 .ddp-filter-dateinfo .ddp-ui-dateinfo:last-of-type {text-align:right;}
 .ddp-filter-dateinfo .ddp-ui-dateinfo .ddp-box-dateinfo {display:inline-block; text-align:left; width:100%; box-sizing:border-box;}
 .ddp-filter-dateinfo .ddp-ui-dateinfo .ddp-box-dateinfo .ddp-type-selectbox {float:left; width:45%; border:none; border-left:1px solid #d0d1d8; box-sizing:border-box; z-index:inherit;}
-.ddp-filter-view {max-width:400px; min-width:300px; box-sizing:border-box;}
+.ddp-filter-view {max-width:400px; box-sizing:border-box;}
 .ddp-filter-view.ddp-full {max-width:100%;}
 .ddp-filter-view.ddp-full .ddp-wrap-buttons {width:100%;}
 .ddp-filter-view.ddp-full .ddp-wrap-buttons.ddp-size ul.ddp-list-buttons li em {display:none;}
-.ddp-filter-view .ddp-filter-area {position:relative; top:0; left:0; padding:0px;border-top:none; overflow:inherit;}
-.ddp-filter-view .ddp-txt-preview {display:block; color:#4c515a; font-size:14px; text-align:center;}
+.ddp-filter-view .ddp-filter-area {position:relative; top:0; left:0; padding:0px; min-width:150px; border-top:none; overflow:inherit;}
+.ddp-filter-view .ddp-txt-preview {display:block; padding:5px 0; color:#4c515a; font-size:16px; text-align:center; background-color:#f5f5f780;}
 .ddp-filter-view .ddp-filter-area .ddp-filter-type {padding-top:10px;}
 
 .ddp-filter-area {position:absolute; top:45px; left:0; right:0; bottom:0; padding:0 25px; border-top:1px solid #e7e7ea; overflow-y:auto;}
@@ -1466,14 +1470,13 @@ ul.ddp-list-text li a .ddp-data-info span {display:block; color:#4b515b; font-si
 .ddp-ui-widget-contents .ddp-filter-area .ddp-list-buttons li,
 .ddp-ui-widget-contents .ddp-filter-area .ddp-filter-type .ddp-btn-time {background-color:#f6f6f7;}
 
-.ddp-filter-area .ddp-list-buttons li {width:20%; border-radius:2px; white-space:nowrap; text-overflow:ellipsis; overflow:hidden; word-wrap:normal; background-color:#efeff1;}
+.ddp-filter-area .ddp-list-buttons li {width:20%; min-width:30px; border-radius:2px; white-space:nowrap; text-overflow:ellipsis; overflow:hidden; word-wrap:normal; background-color:#efeff1;}
 .ddp-filter-area .ddp-list-buttons li.ddp-selected {background:#fff; color:#4b515b; font-size:12px;}
 .ddp-filter-area .ddp-list-buttons li.ddp-selected:before {background-position-y:-11px;}
 .ddp-filter-area .ddp-list-buttons li.ddp-selected:after {position:absolute; top:0; left:0; right:0; bottom:0; border-radius:2px; border:1px solid #90969f; content:'';}
 
 .ddp-filter-area .ddp-filter-type {padding:49px 0 0 0;}
 
-.ddp-filter-area .ddp-filter-type:first-of-type {padding:25px 0 0 0;}
 .ddp-filter-area .ddp-filter-type .ddp-label-name {display:block; padding-bottom:5px; color:#90969f; font-size:13px;}
 .ddp-filter-area .ddp-filter-type .ddp-btn-time {display:inline-block; position:relative; padding:2px 3px 2px 10px; margin-top:6px; border-radius:2px; background-color:#f6f6f7; cursor:pointer;}
 .ddp-filter-area .ddp-filter-type .ddp-btn-time .ddp-form-multy {margin-top:0px; }
@@ -1482,7 +1485,7 @@ ul.ddp-list-text li a .ddp-data-info span {display:block; color:#4b515b; font-si
 
 .ddp-filter-area .ddp-filter-type .ddp-btn-time.ddp-selected .ddp-form-multy  span.ddp-txt-label:before  {display:inline-block; position:relative; margin-right:7px; width:14px; height:10px; background:url(../images/icon_select2.png) no-repeat; background-position-y:-11px; vertical-align: middle; content:'';}
 .ddp-filter-area .ddp-filter-type .ddp-btn-time.ddp-selected:before {position:absolute; top:0; left:0; right:0; bottom:0; border-radius:2px; border:1px solid #90969f; content:'';}
-.ddp-filter-area .ddp-filter-type .ddp-btn-time .ddp-form-multy .ddp-box-multy { top:2px;}
+.ddp-filter-area .ddp-filter-type .ddp-btn-time .ddp-form-multy .ddp-box-multy { top:0px;}
 
 .ddp-filter-form .ddp-option {padding:25px 0 10px 0;}
 .ddp-filter1 .ddp-filter-form .ddp-box-item-search {top:135px;}


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
* 대시보드에 타임 필터에 대한 필터 위젯의 표현 방식이 개선되어야 함
** 타임 필터의 버튼 방식일 경우 너비에 따라 라벨이 달라져야 함
** 시간 범위 선택 방식일 경우 상/하 배치가 아닌 좌/우 배치도 필요함
* 필터 위젯의 스크롤 영역이 필터에 따라 상이하게 표현됨

**Related Issue** : #196 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 대시보드 편집 화면에서 타임스탬프 타입의 필드에 대한 필터를 추가합니다.
2. 해당 필터를 대시보드에 배치합니다.
3. 우측 필터 패널에서 relative 타입으로 변경한 후, 위젯의 너비를 변경하였을 때 너비에 따라 라벨이 변경되는지 확인합니다.
4. 우측 필터 패널에서 specific 타입으로 변경한 후, 위젯의 너비를 변경하였을 때 너비에 따라 입력바의 배치가 변경되는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
