### PR TITLE
#215 An error that caused the label to be incorrect when the filter value is uploaded to the widget

### DIFF
--- a/discovery-frontend/src/app/dashboard/filters/component/filter-multi-select/filter-multi-select.component.html
+++ b/discovery-frontend/src/app/dashboard/filters/component/filter-multi-select/filter-multi-select.component.html
@@ -34,14 +34,14 @@
           [infiniteScrollDistance]="5"
           [infiniteScrollThrottle]="150"
           (scrolled)="onScroll()">
-        <li  *ngIf="isShowAll">
+        <li *ngIf="isShowAll">
           <a href="javascript:" (click)="$event.stopPropagation();">
             <label class="ddp-label-checkbox">
               <input type="checkbox"
                      [disabled]="isMockup" (change)="checkAll($event)"
                      [checked]="selectedArray && selectedArray.length > 0 && selectedArray.length === array.length">
               <i class="ddp-icon-checkbox ddp-dark"></i>
-              <span class="ddp-txt-checkbox">All</span>
+              <span class="ddp-txt-checkbox">{{'msg.comm.ui.list.all'|translate}}</span>
             </label>
           </a>
         </li>
@@ -50,9 +50,9 @@
             <label class="ddp-label-checkbox">
               <input type="checkbox"
                      [disabled]="isMockup" (change)="selected(item, $event)"
-                     [checked]="selectedArray && selectedArray.indexOf(item) > -1 ? true : false">
+                     [checked]="isSelectedItem(item)">
               <i class="ddp-icon-checkbox ddp-dark"></i>
-              <span class="ddp-txt-checkbox">{{isStringArray ? item : item[viewKey]}}</span>
+              <span class="ddp-txt-checkbox">{{item[viewKey]}}</span>
             </label>
           </a>
         </li>

--- a/discovery-frontend/src/app/dashboard/filters/component/filter-multi-select/filter-multi-select.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/component/filter-multi-select/filter-multi-select.component.ts
@@ -53,7 +53,7 @@ export class FilterMultiSelectComponent extends AbstractComponent implements OnI
 
   // 기본 메시지
   @Input()
-  public unselectedMessage = 'All';
+  public unselectedMessage = this.translateService.instant( 'msg.comm.ui.list.all' );
 
   // 비활성화 여부
   @Input()
@@ -92,9 +92,6 @@ export class FilterMultiSelectComponent extends AbstractComponent implements OnI
   // 셀렉트 리스트 show/hide 플래그
   public isShowSelectList = false;
 
-  // 문자열
-  public isStringArray = false;
-
   // 검색어
   public searchText: string = '';
 
@@ -118,28 +115,29 @@ export class FilterMultiSelectComponent extends AbstractComponent implements OnI
 
   // Init
   public ngOnInit() {
-    // array check
-    if (this.selectedArray == null || this.selectedArray.length === 0)  {
-      this.selectedArray = [];
-      this.viewText = this.unselectedMessage;
-    } else {
-      this.viewText = this.selectedArray.join(',');
-    }
-
-    // Init
     super.ngOnInit();
+
+    // array check
+    ( null === this.selectedArray ) && ( this.selectedArray = [] );
+
+    this.updateView(this.selectedArray);
   }
 
-  // Destory
+  // Destroy
   public ngOnDestroy() {
-
-    // Destory
     super.ngOnDestroy();
   }
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Public Method
    |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
+  /**
+   * Returns whether Item is selected.
+   * @param targetItem
+   */
+  public isSelectedItem( targetItem:any ) {
+    return this.selectedArray && this.selectedArray.some(item => item.name === targetItem.name );
+  } // function - isSelectedItem
 
   /**
    * 아이템 선택
@@ -162,11 +160,7 @@ export class FilterMultiSelectComponent extends AbstractComponent implements OnI
 
     }
 
-    if (this.selectedArray == null || this.selectedArray.length === 0)  {
-      this.viewText = this.unselectedMessage;
-    } else {
-      this.viewText = this.selectedArray.map( item => item.name ).join(',');
-    }
+    this.updateView(this.selectedArray);
   } // function selected
 
   /**
@@ -189,12 +183,7 @@ export class FilterMultiSelectComponent extends AbstractComponent implements OnI
       this.selectedArray = [];
     }
 
-    if (this.selectedArray == null || this.selectedArray.length === 0)  {
-      this.viewText = this.unselectedMessage;
-    } else {
-      this.viewText = this.selectedArray.map( item => item.name ).join(',');
-    }
-
+    this.updateView(this.selectedArray);
   }
 
   /**
@@ -230,26 +219,23 @@ export class FilterMultiSelectComponent extends AbstractComponent implements OnI
    * @param valueList
    */
   public reset(valueList: any) {
-    if (valueList == null || valueList.length === 0) {
-      this.selectedArray = null;
-      this.viewText = this.unselectedMessage;
-    } else {
-      this.selectedArray = valueList;
-      this.viewText = this.selectedArray.join(',');
-    }
-  } // function reset
+    this.selectedArray = (valueList == null || valueList.length === 0) ? [] : valueList;
+    this.updateView(this.selectedArray);
+  } // function - reset
 
   /**
-   * 화면 갱신
-   * @param seleteArray
+   * update combo-box label
+   * @param selectedArray
    */
-  public updateView(seleteArray: any) {
-    if (seleteArray == null || seleteArray.length === 0)  {
+  public updateView(selectedArray: any) {
+    if (selectedArray == null || selectedArray.length === 0)  {
       this.viewText = this.unselectedMessage;
+    } else if ( selectedArray.length === this.array.length ) {
+      this.viewText = this.translateService.instant( 'msg.comm.ui.list.all' );
     } else {
-      this.viewText = seleteArray.join(',');
+      this.viewText = selectedArray.map( item => item.name ).join(',');
     }
-  } // function reset
+  } // function - updateView
 
   /**
    * 리스트 닫기
@@ -258,7 +244,7 @@ export class FilterMultiSelectComponent extends AbstractComponent implements OnI
     this.isShowSelectList = false;
     this.onSelected.emit(this.selectedArray);
     this.changeDisplayOptions.emit(this.isShowSelectList);
-  } // function closeList
+  } // function - closeList
 
   /**
    * 스크롤 시 이벤트 ( 다음페이지 조회 호출 )
@@ -287,6 +273,6 @@ export class FilterMultiSelectComponent extends AbstractComponent implements OnI
         width : $dropboxWidth
       });
     }
-  }// function - _setViewListPosition
+  } // function - _setViewListPosition
 
 }

--- a/discovery-frontend/src/app/dashboard/filters/component/filter-select/filter-select.component.html
+++ b/discovery-frontend/src/app/dashboard/filters/component/filter-select/filter-select.component.html
@@ -35,7 +35,7 @@
           [infiniteScrollThrottle]="150"
           (scrolled)="onScroll()" >
         <li *ngIf="isShowAll">
-          <a href="javascript:"  draggable="false" (click)="selectAllItem();">All</a>
+          <a href="javascript:"  draggable="false" (click)="selectAllItem();">{{'msg.comm.ui.list.all'|translate}}</a>
         </li>
         <li *ngFor="let item of array | baseFilter:['name', searchText]">
           <a href="javascript:" (click)="selectCandidateItem(item);">{{isStringArray ? item : item[viewKey]}}</a>

--- a/discovery-frontend/src/app/dashboard/filters/component/filter-select/filter-select.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/component/filter-select/filter-select.component.ts
@@ -54,7 +54,7 @@ export class FilterSelectComponent extends AbstractComponent implements OnInit {
 
   // 기본 메시지
   @Input()
-  public unselectedMessage = 'All';
+  public unselectedMessage = this.translateService.instant( 'msg.comm.ui.list.all' );
 
   // 비활성화 여부
   @Input()


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
* 다중, 모든 값을 다 선택한 필터 값을 위젯으로 올렸을때, Select box에 'object object...'라는 레이블이 찍히는 현상

**Related Issue** : #215 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 대시보드 편집화면에서 우측의 필터 패널 열어 필터 추가 버튼을 클릭합니다.
2. 문자 타입의 차원값 필드를 선택하고, 여러건 선택 타입으로 필터를 추가합니다.
3. 기본값을 All 로 선택합니다. 
4. 해당 필터를 대시보드에 배치하여 표시되는 라벨이 정상적인지 확인합니다. 
5. 대시보드를 저장하고, 열람화면에서 필터 위젯을 값을 변경하면서 필터 위젯의 라벨이 정상적으로 표시되는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
