### PR TITLE
#218 escape column name with regular expression character

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/AbstractQueryBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/AbstractQueryBuilder.java
@@ -515,7 +515,9 @@ public abstract class AbstractQueryBuilder {
    */
   public String checkColumnName(final String name) {
 
-    Pattern pattern = Pattern.compile(String.format(PATTERN_FIELD_NAME_STRING, name));
+    // to escape column name for regular expression
+    String escapedName = PolarisUtils.escapeSpecialRegexChars(name);
+    Pattern pattern = Pattern.compile(String.format(PATTERN_FIELD_NAME_STRING, escapedName));
 
     List<String> vailidColumn = validColumnNames.parallelStream()
                                                 .filter(colName -> pattern.matcher(colName).matches())

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/datasource/data/DataQueryRestIntegrationTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/datasource/data/DataQueryRestIntegrationTest.java
@@ -558,7 +558,7 @@ public class DataQueryRestIntegrationTest extends AbstractRestIntegrationTest {
     List<Filter> filters = Lists.newArrayList();
 
     List<UserDefinedField> userFields = Lists.newArrayList(
-        new ExpressionField("test", "AVGOF(\"Sales\")", "measure",true)
+        new ExpressionField("test(%)", "AVGOF(\"Sales\")", "measure",true)
         //        new ExpressionField("test", "countd(\"City\")", "measure", null,true)
         //        new ExpressionField("test", "Sales + 1", "measure", null,false)
     );
@@ -567,8 +567,8 @@ public class DataQueryRestIntegrationTest extends AbstractRestIntegrationTest {
     Pivot pivot = new Pivot();
     pivot.setColumns(Lists.newArrayList(new DimensionField("Category")));
     pivot.setAggregations(Lists.newArrayList(
-        new MeasureField("Sales", null, MeasureField.AggregationType.SUM)
-        //        new MeasureField("test", "user_defined", MeasureField.AggregationType.NONE)
+//        new MeasureField("Sales", null, MeasureField.AggregationType.SUM)
+                new MeasureField("test(%)", "user_defined", MeasureField.AggregationType.NONE)
     ));
 
     SearchQueryRequest request = new SearchQueryRequest(dataSource1, filters, pivot, limit);


### PR DESCRIPTION
### Description
검색 질의 처리시 유효한 컬럼인지 확인하는 과정에서 패턴 매칭을 수행합니다. 
이때 Regexp 에서 사용하는 문자 (ex . + * ? ( ) [ ] { } ^ $)  가 포함된 경우 정삭적으로 escape가 되지 않아 
컬럼유효성 체크에서 오류를 발생시킵니다.

**Related Issue** : #218 

### How Has This Been Tested?
1.  Workbook > Dashboard 를 생성합니다. 
2. Dashboard 생성 후 차트 위젯을 생성합니다. 
3. 데이터 소스 패널에서 사용자 정의 필드를 생성하는 (+) 버튼을 클릭합니다. 
4. 사용자 정의 필드 명에 위에서 언급한 문자를 포함한 필드명을 구성합니다. 
4-1. expression 은 간단히 기존 있는 필드 명을 기입합니다. (ex. Sales)
5. 사용자 정의 필드 를 사용하여 차트가 정상적으로 생성되는지 확인합니다.
   ex. BarChart , 행 : Category, 교차  : 사용자 정의 필드

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
