### PR TITLE
#224 Problems with dashboard display reflecting multi-data source after data source deletion

### DIFF
--- a/discovery-frontend/src/app/dashboard/component/create-dashboard/create-board-ds-network.component.ts
+++ b/discovery-frontend/src/app/dashboard/component/create-dashboard/create-board-ds-network.component.ts
@@ -639,7 +639,6 @@ export class CreateBoardDsNetworkComponent extends AbstractComponent implements 
 
       // 네트워크 노드 추가
       const isKorean: boolean = this._checkKorean( ds.name );   // 한글 체크
-      console.info( '>>>>>> name : %s, isKorean : %s', ds.name, isKorean );
       if (360 < (isKorean ? 2 * ds.name.length : ds.name.length) * 14) {
         const nodeName: string = isKorean ? ds.name.substr(0, 11) + '...' : ds.name.substr(0, 22) + '...';
         this._nodes.add({ id: ds.id, label: nodeName, title: ds.name });

--- a/discovery-frontend/src/app/dashboard/component/dashboard-layout/dashboard.layout.component.ts
+++ b/discovery-frontend/src/app/dashboard/component/dashboard-layout/dashboard.layout.component.ts
@@ -75,7 +75,7 @@ export abstract class DashboardLayoutComponent extends AbstractComponent impleme
   private _widgetHeaderComps: ComponentRef<DashboardWidgetHeaderComponent>[] = [];  // 위젯 헤더 컴포넌트 목록
   private _widgetComps: ComponentRef<DashboardWidgetComponent>[] = [];              // 위젯 컴포넌트 목록
 
-  private _invalidLayoutWidgets:string[] = [];    // 유효하지 않은 Layout 위젯의 레이아웃 아이디 목록
+  private _invalidLayoutWidgets: string[] = [];    // 유효하지 않은 Layout 위젯의 레이아웃 아이디 목록
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Public Variables
@@ -114,7 +114,7 @@ export abstract class DashboardLayoutComponent extends AbstractComponent impleme
     // 위젯 실행
     this.subscriptions.push(
       this.broadCaster.on<any>('START_PROCESS').subscribe((data: { widgetId: string }) => {
-        DashboardUtil.getLayoutWidgetInfos( this.dashboard ).some(item => {
+        DashboardUtil.getLayoutWidgetInfos(this.dashboard).some(item => {
           if (item.ref === data.widgetId) {
             item.isLoaded = false;
           }
@@ -127,7 +127,7 @@ export abstract class DashboardLayoutComponent extends AbstractComponent impleme
     // 위젯 종료
     this.subscriptions.push(
       this.broadCaster.on<any>('STOP_PROCESS').subscribe((data: { widgetId: string }) => {
-        const layoutWidgets: LayoutWidgetInfo[] = DashboardUtil.getLayoutWidgetInfos( this.dashboard );
+        const layoutWidgets: LayoutWidgetInfo[] = DashboardUtil.getLayoutWidgetInfos(this.dashboard);
         let cntInLayout: number = 0;
         let cntLoaded: number = 0;
         layoutWidgets.forEach(item => {
@@ -610,6 +610,7 @@ export abstract class DashboardLayoutComponent extends AbstractComponent impleme
    * @private
    */
   private _bootstrapWidgetComponent(container, componentState) {
+
     let widgetInfo: Widget = DashboardUtil.getWidgetByLayoutComponentId(this.dashboard, componentState.id);
 
     if (widgetInfo) {
@@ -622,6 +623,7 @@ export abstract class DashboardLayoutComponent extends AbstractComponent impleme
       widgetInfo.dashBoard = this.dashboard;
 
       this.dashboard = DashboardUtil.setUseWidgetInLayout(this.dashboard, widgetInfo.id, true);
+
       widgetComp.instance.init(
         widgetInfo, DashboardUtil.getBoardWidgetOptions(this.dashboard),
         this._layoutMode, DashboardUtil.getLayoutWidgetInfoByWidgetId(this.dashboard, widgetInfo.id)
@@ -629,7 +631,7 @@ export abstract class DashboardLayoutComponent extends AbstractComponent impleme
 
       this._widgetComps.push(widgetComp);
     } else {
-      this._invalidLayoutWidgets.push( componentState.id );
+      this._invalidLayoutWidgets.push(componentState.id);
     }
   } // function - _bootstrapWidgetComponent
 
@@ -641,11 +643,11 @@ export abstract class DashboardLayoutComponent extends AbstractComponent impleme
    */
   private _bootstrapWidgetHeaderComponent(stack, globalOpts: BoardGlobalOptions) {
     let componentState: any = stack.config.content[0];
-    if( componentState ) {
+    if (componentState) {
       let widgetInfo: Widget = DashboardUtil.getWidgetByLayoutComponentId(this.dashboard, componentState.id);
 
-      if( widgetInfo ) {
-        const layoutWidgets: LayoutWidgetInfo[] = DashboardUtil.getLayoutWidgetInfos( this.dashboard );
+      if (widgetInfo) {
+        const layoutWidgets: LayoutWidgetInfo[] = DashboardUtil.getLayoutWidgetInfos(this.dashboard);
         let widgetHeaderCompFactory
           = this.componentFactoryResolver.resolveComponentFactory(DashboardWidgetHeaderComponent);
         let widgetHeaderComp = this.appRef.bootstrap(widgetHeaderCompFactory, stack.header.tabs[0].element.get(0));
@@ -784,7 +786,7 @@ export abstract class DashboardLayoutComponent extends AbstractComponent impleme
 
       const dashboard: Dashboard = this.dashboard;
       const objLayout: DashboardLayout = dashboard.configuration.layout;
-      const layoutWidgets: LayoutWidgetInfo[] = DashboardUtil.getLayoutWidgetInfos( dashboard );
+      const layoutWidgets: LayoutWidgetInfo[] = DashboardUtil.getLayoutWidgetInfos(dashboard);
       const globalOpts: BoardGlobalOptions = dashboard.configuration.options;
       const globalOptsLayout: BoardLayoutOptions = globalOpts.layout;
       let isInitialisedLayout: boolean = false;
@@ -839,8 +841,9 @@ export abstract class DashboardLayoutComponent extends AbstractComponent impleme
             this._updateLayoutFinished();
           }
 
-          this._invalidLayoutWidgets.forEach( item => {
-            this._layoutObj.root.getItemsById(item)[0].remove();
+          this._invalidLayoutWidgets.forEach(item => {
+            const tempData = this._layoutObj.root.getItemsById(item);
+            (tempData) && (tempData[0].remove());
           });
         });
 
@@ -988,7 +991,7 @@ export abstract class DashboardLayoutComponent extends AbstractComponent impleme
         if (ConnectionType.LINK !== dsInfo.connType) {
           promises.push(new Promise<any>((res2, rej2) => {
             // 데이터소스의 필터 목록
-            const dsFilters: Filter[] = boardFilters.filter(filter => filter.dataSource === dsInfo.id);
+            const dsFilters: Filter[] = boardFilters.filter(filter => filter.dataSource === dsInfo.engineName);
             // 최초 추천 필터
             const firstFilter: Filter = dsFilters.find(filter => {
               return 'recommended' === filter.ui.importanceType && 1 === filter.ui.filteringSeq;
@@ -1080,11 +1083,11 @@ export abstract class DashboardLayoutComponent extends AbstractComponent impleme
    * When in edit mode, display as full loading
    */
   public showBoardLoading() {
-    if (LayoutMode.EDIT === this._layoutMode ) {
+    if (LayoutMode.EDIT === this._layoutMode) {
       this.loadingShow();
     } else {
-      const isRealTimeBoard:boolean = this.dashboard && this.dashboard.configuration.options.sync && this.dashboard.configuration.options.sync.enabled;
-      ( isRealTimeBoard ) || ( this.isShowDashboardLoading = true );
+      const isRealTimeBoard: boolean = this.dashboard && this.dashboard.configuration.options.sync && this.dashboard.configuration.options.sync.enabled;
+      (isRealTimeBoard) || (this.isShowDashboardLoading = true);
     }
     this.safelyDetectChanges();
   } // function - showBoardLoading
@@ -1093,7 +1096,7 @@ export abstract class DashboardLayoutComponent extends AbstractComponent impleme
    * Hide Loading
    */
   public hideBoardLoading() {
-    if (LayoutMode.EDIT === this._layoutMode ) {
+    if (LayoutMode.EDIT === this._layoutMode) {
       this.loadingHide();
     } else {
       this.isShowDashboardLoading = false;
@@ -1205,19 +1208,28 @@ export abstract class DashboardLayoutComponent extends AbstractComponent impleme
       {
         const filters: Filter[] = DashboardUtil.getBoardFilters(boardInfo);
         if (filters && 0 < filters.length) {
-          filters.forEach((filter: Filter) => {
-            const filterDs: Datasource = boardInfo.dataSources.find(ds => ds.id === filter.dataSource);
-            (filterDs) && (filter.dataSource = filterDs.engineName);
-
-            if (isNullOrUndefined(filter.dataSource)) {
-              const fieldDs: Datasource = boardInfo.dataSources.find(ds => ds.fields.some(item => item.name === filter.field));
-              (fieldDs) && (filter.dataSource = fieldDs.engineName);
+          // Change data source information from id to engine name
+          const uniqFilterKeyList: string[] = [];
+          boardInfo.configuration.filters
+            = filters.filter((filter: Filter) => {
+            const uniqFilterKey: string = filter.dataSource + '_' + filter.field;
+            if (-1 === uniqFilterKeyList.indexOf(uniqFilterKey)) {
+              const filterDs: Datasource = boardInfo.dataSources.find(ds => ds.id === filter.dataSource);
+              (filterDs) && (filter.dataSource = filterDs.engineName);
+              if (isNullOrUndefined(filter.dataSource)) {
+                const fieldDs: Datasource = boardInfo.dataSources.find(ds => ds.fields.some(item => item.name === filter.field));
+                (fieldDs) && (filter.dataSource = fieldDs.engineName);
+              }
+              uniqFilterKeyList.push(uniqFilterKey);
+              return true;
+            } else {
+              return false;
             }
-
           });
         }
         const widgets: Widget[] = boardInfo.widgets;
         if (widgets && 0 < widgets.length) {
+          // Change data source information from id to engine name
           widgets.forEach((widget: Widget) => {
             if ('filter' === widget.type) {
               const filter: Filter = (<FilterWidget>widget).configuration.filter;
@@ -1241,19 +1253,17 @@ export abstract class DashboardLayoutComponent extends AbstractComponent impleme
         const promises = [];
         if (boardInfo.configuration.filters) {
 
-          // 등록되지 않은 필터 위젯 사전 등록
+          // Adjust filter widget information error
           boardInfo.configuration.filters.forEach((filter: Filter) => {
-            // const filterId: string = filter.dataSource + '_' + filter.type + '_' + filter.field;
             const filterId: string = filter.dataSource + '_' + filter.field;
-            const isExistWidget: boolean = boardInfo.widgets.some(widget => {
+            const filterWidgets: Widget[] = boardInfo.widgets.filter(widget => {
               if ('filter' === widget.type) {
                 const filterInWidget: Filter = (<FilterWidgetConfiguration>widget.configuration).filter;
-                // return (filterInWidget.dataSource + '_' + filterInWidget.type + '_' + filterInWidget.field === filterId);
                 return (filterInWidget.dataSource + '_' + filterInWidget.field === filterId);
               }
             });
 
-            if (!isExistWidget) {
+            if (0 === filterWidgets.length) {
               // 필터위젯 정보가 없는 필터의 경우 - 필터 위젯 정보 생성
               promises.push(new Promise((res) => {
                 this.widgetService.createWidget(new FilterWidget(filter, boardInfo), boardInfo.id)
@@ -1262,6 +1272,19 @@ export abstract class DashboardLayoutComponent extends AbstractComponent impleme
                     res();
                   });
               }));
+            } else {
+              filterWidgets.forEach((item, index) => {
+                if (0 < index) {
+                  promises.push(new Promise((res) => {
+                    console.info('>>>>> remove widget', item.id);
+                    this.widgetService.deleteWidget(item.id)
+                      .then(() => {
+                        boardInfo.widgets = boardInfo.widgets.filter(widgetItem => widgetItem.id !== item.id);
+                        res();
+                      });
+                  }));
+                }
+              });
             }
           });
         } // end if - filters

--- a/discovery-frontend/src/app/dashboard/component/dashboard-layout/dashboard.widget.header.component.ts
+++ b/discovery-frontend/src/app/dashboard/component/dashboard-layout/dashboard.widget.header.component.ts
@@ -32,6 +32,7 @@ import {
   InclusionSelectorType
 } from '../../../domain/workbook/configurations/filter/inclusion-filter';
 import { DashboardUtil } from '../../util/dashboard.util';
+import { Datasource } from '../../../domain/datasource/datasource';
 
 @Component({
   selector: 'dashboard-widget-header',
@@ -75,6 +76,7 @@ export class DashboardWidgetHeaderComponent extends AbstractComponent implements
 
   public isMiniHeader: boolean = false;  // 미니 헤더 적용 여부
   public isShowMore: boolean = false;    // 미니 헤더 More 적용 여부
+  public isValidWidget: boolean = false;
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Constructor
@@ -104,6 +106,16 @@ export class DashboardWidgetHeaderComponent extends AbstractComponent implements
   public ngAfterViewInit() {
     // Header 내 아이콘이 그러지지 않는 상황에 대한 임시 해결
     setTimeout(() => {
+
+      if (this.isPageWidget && this.widget && (<PageWidgetConfiguration>this.widget.configuration).dataSource) {
+        const widgetDataSource: Datasource
+          = DashboardUtil.getDataSourceFromBoardDataSource(
+          this.widget.dashBoard, (<PageWidgetConfiguration>this.widget.configuration).dataSource
+        );
+
+        (widgetDataSource) && ( this.isValidWidget = true );
+      }
+
       this.changeDetect.detectChanges();
     }, 200);
   }
@@ -130,12 +142,15 @@ export class DashboardWidgetHeaderComponent extends AbstractComponent implements
    * 데이터소스 이름 조회
    * @return {string}
    */
-  public getDataSourceName():string {
+  public getDataSourceName(): string {
     let strName: string = '';
-    if( this.isPageWidget && this.widget && (<PageWidgetConfiguration>this.widget.configuration).dataSource ) {
-      strName = DashboardUtil.getDataSourceFromBoardDataSource(
+    if (this.isPageWidget && this.widget && (<PageWidgetConfiguration>this.widget.configuration).dataSource) {
+      const widgetDataSource: Datasource
+        = DashboardUtil.getDataSourceFromBoardDataSource(
         this.widget.dashBoard, (<PageWidgetConfiguration>this.widget.configuration).dataSource
-      ).name;
+      );
+
+      (widgetDataSource) && (strName = widgetDataSource.name);
     }
     return strName;
   } // function - getDataSourceName
@@ -185,7 +200,7 @@ export class DashboardWidgetHeaderComponent extends AbstractComponent implements
    * 차트 필터 존재 여부
    * @return {boolean}
    */
-  public existChartFilter():boolean {
+  public existChartFilter(): boolean {
     return (this.isPageWidget && this.widget
       && (<PageWidgetConfiguration>this.widget.configuration).filters
       && 0 < (<PageWidgetConfiguration>this.widget.configuration).filters.length);
@@ -195,7 +210,7 @@ export class DashboardWidgetHeaderComponent extends AbstractComponent implements
    * 차트 필터 필드 목록 반환
    * @return {string}
    */
-  public getChartFilterStr():string {
+  public getChartFilterStr(): string {
     let strFields: string = '';
     if (this.isPageWidget && this.widget && (<PageWidgetConfiguration>this.widget.configuration).filters) {
       strFields = (<PageWidgetConfiguration>this.widget.configuration).filters.map(item => item.field).join(',');
@@ -376,14 +391,18 @@ export class DashboardWidgetHeaderComponent extends AbstractComponent implements
    * 위젯 수정
    */
   public editWidget() {
-  this.broadCaster.broadcast('EDIT_WIDGET', { widgetId: this.widget.id, widgetType: this.widget.type });
+    if (this.isValidWidget) {
+      this.broadCaster.broadcast('EDIT_WIDGET', { widgetId: this.widget.id, widgetType: this.widget.type });
+    }
   } // function - editWidget
 
   /**
    * 위젯 복제
    */
   public copyPageWidget() {
-  this.broadCaster.broadcast('COPY_WIDGET', { widgetId: this.widget.id });
+    if (this.isValidWidget) {
+      this.broadCaster.broadcast('COPY_WIDGET', { widgetId: this.widget.id });
+    }
   } // function - copyPageWidget
 
   /**
@@ -401,7 +420,7 @@ export class DashboardWidgetHeaderComponent extends AbstractComponent implements
    * 위젯 삭제
    */
   public removeWidget() {
-  this.broadCaster.broadcast('REMOVE', { widgetId: this.widget.id, widgetType: this.widget.type });
+    this.broadCaster.broadcast('REMOVE', { widgetId: this.widget.id, widgetType: this.widget.type });
   } // function - removeWidget
 
   /**

--- a/discovery-frontend/src/app/dashboard/filters/abstract-filter-panel.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/abstract-filter-panel.component.ts
@@ -28,6 +28,7 @@ import { Filter } from '../../domain/workbook/configurations/filter/filter';
 import { Dashboard } from '../../domain/dashboard/dashboard';
 import { Datasource, Field } from '../../domain/datasource/datasource';
 import { DashboardUtil } from '../util/dashboard.util';
+import { FilterUtil } from '../util/filter.util';
 
 export class AbstractFilterPanelComponent extends AbstractComponent implements OnInit, OnDestroy {
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
@@ -201,20 +202,27 @@ export class AbstractFilterPanelComponent extends AbstractComponent implements O
    */
   protected setPanelData(filter: Filter) {
 
-    // 대시보드 필터 여부
-    this.isBoardFilter = !filter.ui.widgetId;
+    this.dataSource = FilterUtil.getDataSourceForFilter(filter, this.dashboard);
 
-    // 필드
-    this.field = DashboardUtil.getFieldByName(this.dashboard, filter.dataSource, filter.field, filter.ref);
+    if( this.dataSource ) {
+      // 대시보드 필터 여부
+      this.isBoardFilter = !filter.ui.widgetId;
 
-    // 타임스탬프, 필수필터, 추천필터일 경우에도 변경 불가능
-    if ( 'recommended' === filter.ui.importanceType || 'timestamp' === filter.ui.importanceType  ) {
-      this.isChangeable = false;
+      // 필드
+      this.field = DashboardUtil.getFieldByName(this.dashboard, filter.dataSource, filter.field, filter.ref);
+
+      // 타임스탬프, 필수필터, 추천필터일 경우에도 변경 불가능
+      if ( 'recommended' === filter.ui.importanceType || 'timestamp' === filter.ui.importanceType  ) {
+        this.isChangeable = false;
+      }
+
+      // 기능 버튼 활성 여부
+      this.isDeletable = this.isChangeable && (this.isDashboardMode === this.isBoardFilter);
+      this.isEditable = (this.isDashboardMode === this.isBoardFilter);
+    } else {
+      this.isDeletable = true;
     }
 
-    // 기능 버튼 활성 여부
-    this.isDeletable = this.isChangeable && (this.isDashboardMode === this.isBoardFilter);
-    this.isEditable = (this.isDashboardMode === this.isBoardFilter);
   } // function - setPanelData
 
   /**

--- a/discovery-frontend/src/app/dashboard/filters/bound-filter/bound-filter-panel.component.html
+++ b/discovery-frontend/src/app/dashboard/filters/bound-filter/bound-filter-panel.component.html
@@ -78,7 +78,7 @@
     <div *ngIf="filter" class="ddp-itemtype-title">
       <div class="ddp-data-itemtype ddp-type">
         <span class="ddp-icon-box ddp-measure">
-          <em class="{{getMeasureTypeIconClass(field)}}" ></em>
+          <em *ngIf="field" class="{{getMeasureTypeIconClass(field)}}" ></em>
           <em class="ddp-icon-use3" *ngIf="isWidgetInLayout"></em>
         </span>
         <span class="ddp-txt-itemtype">

--- a/discovery-frontend/src/app/dashboard/filters/bound-filter/bound-filter-panel.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/bound-filter/bound-filter-panel.component.ts
@@ -92,13 +92,10 @@ export class BoundFilterPanelComponent extends AbstractFilterPanelComponent impl
     if (filterChanges) {
       const currFilter: BoundFilter = _.cloneDeep(filterChanges.currentValue);
 
-      this.dataSource = FilterUtil.getDataSourceForFilter(currFilter, this.dashboard);
+      this.setPanelData(currFilter);    // 패널에서 사용하는 데이터 설정
 
-      // 패널에서 사용하는 데이터 설정
-      this.setPanelData(currFilter);
+      (this.dataSource) && (this._candidate(currFilter)); // 후보값 조회
 
-      // 후보값 조회
-      this._candidate(currFilter);
     }
   } // function - ngOnChanges
 

--- a/discovery-frontend/src/app/dashboard/filters/inclusion-filter/configure-filters-inclusion.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/inclusion-filter/configure-filters-inclusion.component.ts
@@ -483,8 +483,6 @@ export class ConfigureFiltersInclusionComponent extends AbstractFilterPopupCompo
     ( sortBy ) && ( filter.sort.by = sortBy );
     ( direction ) && ( filter.sort.direction = direction );
 
-    console.info( '>>>>>> filter.sort', filter.sort );
-
     // 데이터 정렬
     const allCandidates: Candidate[] = _.cloneDeep(this._candidateList);
     if (InclusionSortBy.COUNT === filter.sort.by ) {

--- a/discovery-frontend/src/app/dashboard/filters/inclusion-filter/inclusion-filter-panel.component.html
+++ b/discovery-frontend/src/app/dashboard/filters/inclusion-filter/inclusion-filter-panel.component.html
@@ -103,7 +103,7 @@
     <div *ngIf="filter" class="ddp-itemtype-title">
       <div class="ddp-data-itemtype ddp-type">
         <span class="ddp-icon-box">
-          <em class="{{getDimensionTypeIconClass(field)}}" ></em>
+          <em *ngIf="field" class="{{getDimensionTypeIconClass(field)}}" ></em>
           <em class="ddp-icon-use3" *ngIf="isWidgetInLayout"></em>
         </span>
         <span class="ddp-txt-itemtype">

--- a/discovery-frontend/src/app/dashboard/filters/inclusion-filter/inclusion-filter-panel.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/inclusion-filter/inclusion-filter-panel.component.ts
@@ -125,7 +125,7 @@ export class InclusionFilterPanelComponent extends AbstractFilterPanelComponent 
       if (data.type === 'page' && this.isDashboardMode) return;
 
       // 필터 위젯에서 값이 변경될 경우
-      if ('change-filter' === data.name && this.filter.field === data.data.field && this.filter.dataSource === data.data.dataSource ) {
+      if ('change-filter' === data.name && this.filter.field === data.data.field && this.filter.dataSource === data.data.dataSource) {
         this._initComponent(data.data);
       } else if ('remove-filter' === data.name && this.filter.ui.importanceType === 'general') {
         this._resetList(data.data);
@@ -245,15 +245,15 @@ export class InclusionFilterPanelComponent extends AbstractFilterPanelComponent 
    */
   public sortCandidateValues(filter: InclusionFilter, sortBy?: InclusionSortBy, direction?: DIRECTION) {
     // 정렬 정보 저장
-    ( sortBy ) && ( filter.sort.by = sortBy );
-    ( direction ) && ( filter.sort.direction = direction );
+    (sortBy) && (filter.sort.by = sortBy);
+    (direction) && (filter.sort.direction = direction);
 
     // 데이터 정렬
     const allCandidates: Candidate[] = _.cloneDeep(this._candidateList);
-    if (InclusionSortBy.COUNT === filter.sort.by ) {
+    if (InclusionSortBy.COUNT === filter.sort.by) {
       // value 기준으로 정렬
       allCandidates.sort((val1: Candidate, val2: Candidate) => {
-        return ( DIRECTION.ASC === filter.sort.direction ) ? val1.count - val2.count : val2.count - val1.count;
+        return (DIRECTION.ASC === filter.sort.direction) ? val1.count - val2.count : val2.count - val1.count;
       });
     } else {
       // name 기준으로 정렬
@@ -261,10 +261,10 @@ export class InclusionFilterPanelComponent extends AbstractFilterPanelComponent 
         const name1: string = (val1.name) ? val1.name.toUpperCase() : '';
         const name2: string = (val2.name) ? val2.name.toUpperCase() : '';
         if (name1 < name2) {
-          return (DIRECTION.ASC === filter.sort.direction ) ? -1 : 1;
+          return (DIRECTION.ASC === filter.sort.direction) ? -1 : 1;
         }
         if (name1 > name2) {
-          return (DIRECTION.ASC === filter.sort.direction ) ? 1 : -1;
+          return (DIRECTION.ASC === filter.sort.direction) ? 1 : -1;
         }
         return 0;
       });
@@ -350,17 +350,15 @@ export class InclusionFilterPanelComponent extends AbstractFilterPanelComponent 
   private _initComponent(filter: InclusionFilter) {
     const currFilter: InclusionFilter = _.cloneDeep(filter);
 
-    // 패널에서 사용하는 데이터 설정
-    this.setPanelData(currFilter);
-
     // Selector 설정
     this.isMultiSelector = (currFilter.selector === InclusionSelectorType.MULTI_COMBO || currFilter.selector === InclusionSelectorType.MULTI_LIST);
 
     this.filter = currFilter;
 
-    this.dataSource = FilterUtil.getDataSourceForFilter(currFilter, this.dashboard);
+    this.setPanelData(currFilter);  // 패널에서 사용하는 데이터 설정
 
-    this._candidate();    // 데이터 목록 조회
+    (this.dataSource) && (this._candidate()); // 데이터 목록 조회
+
   } // function - _initComponent
 
   /**

--- a/discovery-frontend/src/app/dashboard/filters/time-filter/time-filter-panel.component.html
+++ b/discovery-frontend/src/app/dashboard/filters/time-filter/time-filter-panel.component.html
@@ -78,7 +78,7 @@
     <div *ngIf="filter" class="ddp-itemtype-title">
       <div class="ddp-data-itemtype ddp-type">
         <span class="ddp-icon-box">
-          <em class="{{getDimensionTypeIconClass(field)}}" ></em>
+          <em *ngIf="field" class="{{getDimensionTypeIconClass(field)}}" ></em>
           <em class="ddp-icon-use3" *ngIf="isWidgetInLayout"></em>
         </span>
         <span class="ddp-txt-itemtype">

--- a/discovery-frontend/src/app/dashboard/filters/time-filter/time-filter-panel.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/time-filter/time-filter-panel.component.ts
@@ -303,36 +303,36 @@ export class TimeFilterPanelComponent extends AbstractFilterPanelComponent imple
     this._tempRangeFilter = null;
     this._tempListFilter = null;
 
-    // 패널에서 사용하는 데이터 설정
-    this.setPanelData(filter);
-
-    // 타임스탬프인지 판단
-    if (this.field && this.field.biType === BIType.TIMESTAMP
-      && this.field.role === FieldRole.TIMESTAMP) {
-      this.isTimeStamp = true;
-    } else if (this.field == null && filter.field === 'current_datetime') {
-      this.isTimeStamp = true;
-    }
-
     this.filter = filter;
 
-    this.dataSource = FilterUtil.getDataSourceForFilter(filter, this.dashboard);
+    this.setPanelData(filter);    // 패널에서 사용하는 데이터 설정
 
-    this._setStatus();
+    if( this.dataSource )  {
 
-    // TimeUnit 선택 방지 코드
-    if (!this.isLiveStatus) {
-      if (this.isRelativeType) {
-        delete filter.timeUnit;
-        this.setTimeAllFilter();
+      // 타임스탬프인지 판단
+      if (this.field && this.field.biType === BIType.TIMESTAMP
+        && this.field.role === FieldRole.TIMESTAMP) {
+        this.isTimeStamp = true;
+      } else if (this.field == null && filter.field === 'current_datetime') {
+        this.isTimeStamp = true;
       }
-    }
 
-    // 위젯 화면 표시
-    this.isShowFilter = true;
+      this._setStatus();
 
-    if (isTriggerUpdateEvent) {
-      this.updateFilterEvent.emit(filter);
+      // TimeUnit 선택 방지 코드
+      if (!this.isLiveStatus) {
+        if (this.isRelativeType) {
+          delete filter.timeUnit;
+          this.setTimeAllFilter();
+        }
+      }
+
+      // 위젯 화면 표시
+      this.isShowFilter = true;
+
+      if (isTriggerUpdateEvent) {
+        this.updateFilterEvent.emit(filter);
+      }
     }
 
     this.safelyDetectChanges();

--- a/discovery-frontend/src/app/dashboard/filters/time-filter/time-filter-panel.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/time-filter/time-filter-panel.component.ts
@@ -319,14 +319,6 @@ export class TimeFilterPanelComponent extends AbstractFilterPanelComponent imple
 
       this._setStatus();
 
-      // TimeUnit 선택 방지 코드
-      if (!this.isLiveStatus) {
-        if (this.isRelativeType) {
-          delete filter.timeUnit;
-          this.setTimeAllFilter();
-        }
-      }
-
       // 위젯 화면 표시
       this.isShowFilter = true;
 

--- a/discovery-frontend/src/app/dashboard/util/dashboard.util.ts
+++ b/discovery-frontend/src/app/dashboard/util/dashboard.util.ts
@@ -244,11 +244,11 @@ export class DashboardUtil {
    * 연계된 데이터소스에 대한 전체 필터 목록 조회
    * @param {Dashboard} board
    * @param {string} engineName
-   * @param {Filter[]} totalFilters
+   * @param {Filter[]} paramFilters
    * @return {Filter[]}
    */
-  public static getAllFiltersDsRelations(board: Dashboard, engineName: string, totalFilters?: Filter[]): Filter[] {
-    (totalFilters) || (totalFilters = board.configuration.filters);
+  public static getAllFiltersDsRelations(board: Dashboard, engineName: string, paramFilters?: Filter[]): Filter[] {
+    const totalFilters:Filter[] = _.cloneDeep( ( paramFilters ) ? paramFilters : board.configuration.filters );
     // 대상 데이터소스의 필터 목록 - getFiltersForBoardDataSource
     let srcDsFilters: Filter[] = totalFilters.filter(filter => filter.dataSource === engineName);
     // 연계 데이터소스의 연계 필드에 대응하는 대상 데이터소스의 필드의 필터

--- a/discovery-frontend/src/app/dashboard/util/dashboard.util.ts
+++ b/discovery-frontend/src/app/dashboard/util/dashboard.util.ts
@@ -851,15 +851,22 @@ export class DashboardUtil {
       // Filter ( dataSource ( id -> engineName ) )
       const filters: Filter[] = DashboardUtil.getBoardFilters(boardInfo);
       if (filters && 0 < filters.length) {
-        filters.forEach((filter: Filter) => {
-          const filterDs: Datasource = boardInfo.dataSources.find(ds => ds.id === filter.dataSource);
-          (filterDs) && (filter.dataSource = filterDs.engineName);
-
-          if (isNullOrUndefined(filter.dataSource)) {
-            const fieldDs: Datasource = boardInfo.dataSources.find(ds => ds.fields.some(item => item.name === filter.field));
-            (fieldDs) && (filter.dataSource = fieldDs.engineName);
+        const uniqFilterKeyList: string[] = [];
+        boardInfo.configuration.filters
+          = filters.filter((filter: Filter) => {
+          const uniqFilterKey: string = filter.dataSource + '_' + filter.field;
+          if (-1 === uniqFilterKeyList.indexOf(uniqFilterKey)) {
+            const filterDs: Datasource = boardInfo.dataSources.find(ds => ds.id === filter.dataSource);
+            (filterDs) && (filter.dataSource = filterDs.engineName);
+            if (isNullOrUndefined(filter.dataSource)) {
+              const fieldDs: Datasource = boardInfo.dataSources.find(ds => ds.fields.some(item => item.name === filter.field));
+              (fieldDs) && (filter.dataSource = fieldDs.engineName);
+            }
+            uniqFilterKeyList.push(uniqFilterKey);
+            return true;
+          } else {
+            return false;
           }
-
         });
       }
       // Widget

--- a/discovery-frontend/src/app/dashboard/widgets/abstract-widget.component.ts
+++ b/discovery-frontend/src/app/dashboard/widgets/abstract-widget.component.ts
@@ -33,6 +33,7 @@ export abstract class AbstractWidgetComponent extends AbstractComponent implemen
   public isEditMode: boolean = false;
   public isViewMode: boolean = false;
   public isAuthMgmtViewMode: boolean = false;
+  public isValidWidget:boolean = false;
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Public Variables - Input & Output
@@ -89,15 +90,17 @@ export abstract class AbstractWidgetComponent extends AbstractComponent implemen
    * 위젯 수정
    */
   public editWidget() {
-    // workbook.component 로 이벤트 전달 -> 워크북에서 대시보드 편집 화면으로 이동시킴
-    this.broadCaster.broadcast(
-      'MOVE_EDIT_WIDGET',
-      {
-        cmd: 'MODIFY',
-        id: this.widget.id,
-        type: this.widget.type.toUpperCase()
-      }
-    );
+    if( this.isValidWidget ) {
+      // workbook.component 로 이벤트 전달 -> 워크북에서 대시보드 편집 화면으로 이동시킴
+      this.broadCaster.broadcast(
+        'MOVE_EDIT_WIDGET',
+        {
+          cmd: 'MODIFY',
+          id: this.widget.id,
+          type: this.widget.type.toUpperCase()
+        }
+      );
+    }
   } // function - editWidget
 
   /**

--- a/discovery-frontend/src/app/dashboard/widgets/filter-widget/filter-widget.component.ts
+++ b/discovery-frontend/src/app/dashboard/widgets/filter-widget/filter-widget.component.ts
@@ -193,12 +193,6 @@ export class FilterWidgetComponent extends AbstractWidgetComponent implements On
       this.field = DashboardUtil.getFieldByName( this.widget.dashBoard, filter.dataSource, filter.field, filter.ref );
 
       if( this.field ) {
-
-        // 글로벌 필터 셋팅
-        if (widget.dashBoard.configuration.filters) {
-          this.globalFilters = widget.dashBoard.configuration.filters;
-        }
-
         // 필터 후보값 조회
         this._candidate( filter );
       } else {

--- a/discovery-frontend/src/app/dashboard/widgets/filter-widget/filter-widget.component.ts
+++ b/discovery-frontend/src/app/dashboard/widgets/filter-widget/filter-widget.component.ts
@@ -201,13 +201,21 @@ export class FilterWidgetComponent extends AbstractWidgetComponent implements On
       this.dashboard = this.widget.dashBoard;
       this.field = DashboardUtil.getFieldByName( this.widget.dashBoard, filter.dataSource, filter.field, filter.ref );
 
-      // 글로벌 필터 셋팅
-      if (widget.dashBoard.configuration.filters) {
-        this.globalFilters = widget.dashBoard.configuration.filters;
+      if( this.field ) {
+
+        // 글로벌 필터 셋팅
+        if (widget.dashBoard.configuration.filters) {
+          this.globalFilters = widget.dashBoard.configuration.filters;
+        }
+
+        // 필터 후보값 조회
+        this._candidate( filter );
+      } else {
+        this.processStart();
+        this.isValidWidget = false;
+        this.processEnd();
       }
 
-      // 필터 후보값 조회
-      this._candidate( filter );
     }
 
   } // function - ngOnChanges
@@ -231,8 +239,10 @@ export class FilterWidgetComponent extends AbstractWidgetComponent implements On
    * @param {FilterWidgetConfiguration} objConfig
    */
   public setConfiguration(objConfig: FilterWidgetConfiguration) {
-    this.widget.configuration = objConfig;
-    this._candidate( this.getFilter() );
+    if( this.isValidWidget ) {
+      this.widget.configuration = objConfig;
+      this._candidate( this.getFilter() );
+    }
   } // function - setConfiguration
 
   /**
@@ -431,6 +441,7 @@ export class FilterWidgetComponent extends AbstractWidgetComponent implements On
    * @private
    */
   private _initialContainer() {
+    this.isValidWidget = true;
     // 콤보박스 관련된 필터 뷰 설정
     this.safelyDetectChanges();
     if (!this.isEditMode ) {
@@ -556,6 +567,8 @@ export class FilterWidgetComponent extends AbstractWidgetComponent implements On
 
         this.processEnd();
       }).catch((error) => {
+        this.isValidWidget = false;
+
         this.commonExceptionHandler(error);
         // 목록 비움
         this.candidateList = [];

--- a/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
+++ b/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
@@ -769,9 +769,9 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
   public getDataSourceName(): string {
     let strName: string = '';
     if (this.widget && this.widget.configuration.dataSource) {
-      strName = DashboardUtil.getDataSourceFromBoardDataSource(
-        this.widget.dashBoard, this.widget.configuration.dataSource
-      ).name;
+      const widgetDataSource: Datasource
+        = DashboardUtil.getDataSourceFromBoardDataSource( this.widget.dashBoard, this.widget.configuration.dataSource );
+      ( widgetDataSource ) && ( strName = widgetDataSource.name );
     }
     return strName;
   } // function - getDataSourceName
@@ -968,6 +968,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
    * @private
    */
   private _setWidget(widget: PageWidget) {
+
     this.widget = <PageWidget>_.extend(new PageWidget(), widget);
     this.widgetConfiguration = <PageWidgetConfiguration>this.widget.configuration;
     this.chartType = this.widgetConfiguration.chart.type.toString();
@@ -978,68 +979,83 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
       // Pivot 내 누락된 필드 정보 설정
       const widgetDataSource: Datasource
         = DashboardUtil.getDataSourceFromBoardDataSource(this.widget.dashBoard, this.widgetConfiguration.dataSource);
-      const fields: Field[] = DashboardUtil.getFieldsForMainDataSource(this.widget.dashBoard.configuration, widgetDataSource.engineName);
-      fields.forEach((field) => {
-        this.widgetConfiguration.pivot.rows
-          .forEach((abstractField) => {
-            if (isNullOrUndefined(abstractField.field)
-              && String(field.biType) == abstractField.type.toUpperCase() && field.name == abstractField.name) {
-              abstractField.field = field;
-            }
-          });
 
-        this.widgetConfiguration.pivot.columns
-          .forEach((abstractField) => {
-            if (isNullOrUndefined(abstractField.field)
-              && String(field.biType) == abstractField.type.toUpperCase() && field.name == abstractField.name) {
-              abstractField.field = field;
-            }
-          });
-
-        this.widgetConfiguration.pivot.aggregations
-          .forEach((abstractField) => {
-            if (isNullOrUndefined(abstractField.field)
-              && String(field.biType) == abstractField.type.toUpperCase() && field.name == abstractField.name) {
-              abstractField.field = field;
-            }
-          });
-      });
-
-      // Hierarchy 설정
-      if (boardConf.relations) {
-        const relations: DashboardPageRelation[] = boardConf.relations;
-        const parentWidgetId: string = this._findParentWidgetId(this.widget.id, relations);
-        if (parentWidgetId) {
-          this.parentWidget = widget.dashBoard.widgets.find(item => item.id === parentWidgetId);
-          this.isShowHierarchyView = true;
-        }
-      }
-      // RealTime 데이터갱신 설정
-      if (this.layoutMode !== LayoutMode.EDIT && boardConf.options.sync && boardConf.options.sync.enabled) {
-        const syncOpts: BoardSyncOptions = boardConf.options.sync;
-        this._interval = setInterval(() => {
-          this.safelyDetectChanges();
-          if(this.parentWidget) {
-            // 차트에 대한 프로세스가 진행되었다는 것을 전파하기 위해 추가
-            this.processStart();
-            this._isDuringProcess = true;
-            this.updateComplete();
-          } else {
-            this._search();
-          }
-        }, syncOpts.interval * 1000);
-      }
-
-      this.safelyDetectChanges();
-
-      if(this.parentWidget) {
-        // 차트에 대한 프로세스가 진행되었다는 것을 전파하기 위해 추가
+      if( isNullOrUndefined( widgetDataSource ) ) {
+        // If the widget does not have a data source
         this.processStart();
         this._isDuringProcess = true;
-        this.updateComplete();
+        this.isValidWidget = false;
+        this.showError();
       } else {
-        this._search();
-      }
+        // If the widget has a data source
+
+        this.isValidWidget = true;
+
+        const fields: Field[] = DashboardUtil.getFieldsForMainDataSource(this.widget.dashBoard.configuration, widgetDataSource.engineName);
+        fields.forEach((field) => {
+          this.widgetConfiguration.pivot.rows
+            .forEach((abstractField) => {
+              if (isNullOrUndefined(abstractField.field)
+                && String(field.biType) == abstractField.type.toUpperCase() && field.name == abstractField.name) {
+                abstractField.field = field;
+              }
+            });
+
+          this.widgetConfiguration.pivot.columns
+            .forEach((abstractField) => {
+              if (isNullOrUndefined(abstractField.field)
+                && String(field.biType) == abstractField.type.toUpperCase() && field.name == abstractField.name) {
+                abstractField.field = field;
+              }
+            });
+
+          this.widgetConfiguration.pivot.aggregations
+            .forEach((abstractField) => {
+              if (isNullOrUndefined(abstractField.field)
+                && String(field.biType) == abstractField.type.toUpperCase() && field.name == abstractField.name) {
+                abstractField.field = field;
+              }
+            });
+        });
+
+        // Hierarchy 설정
+        if (boardConf.relations) {
+          const relations: DashboardPageRelation[] = boardConf.relations;
+          const parentWidgetId: string = this._findParentWidgetId(this.widget.id, relations);
+          if (parentWidgetId) {
+            this.parentWidget = widget.dashBoard.widgets.find(item => item.id === parentWidgetId);
+            this.isShowHierarchyView = true;
+          }
+        }
+
+        // RealTime 데이터갱신 설정
+        if (this.layoutMode !== LayoutMode.EDIT && boardConf.options.sync && boardConf.options.sync.enabled) {
+          const syncOpts: BoardSyncOptions = boardConf.options.sync;
+          this._interval = setInterval(() => {
+            this.safelyDetectChanges();
+            if(this.parentWidget) {
+              // 차트에 대한 프로세스가 진행되었다는 것을 전파하기 위해 추가
+              this.processStart();
+              this._isDuringProcess = true;
+              this.updateComplete();
+            } else {
+              this._search();
+            }
+          }, syncOpts.interval * 1000);
+        }
+
+        this.safelyDetectChanges();
+
+        if(this.parentWidget) {
+          // 차트에 대한 프로세스가 진행되었다는 것을 전파하기 위해 추가
+          this.processStart();
+          this._isDuringProcess = true;
+          this.updateComplete();
+        } else {
+          this._search();
+        }
+      } // end of - widgetDataSource
+
     } // end if - dashboard.configuration
 
     this.safelyDetectChanges();
@@ -1126,6 +1142,13 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
 
     // 필터 설정
     const widgetDataSource: Datasource = DashboardUtil.getDataSourceFromBoardDataSource(this.widget.dashBoard, this.widgetConfiguration.dataSource);
+
+    if( isNullOrUndefined( widgetDataSource ) ) {
+      this.isValidWidget = false;
+      this.showError();
+      return;
+    }
+
     if (isNullOrUndefined(externalFilters)) {
       // 외부필터가 없고 글로벌 필터가 있을 경우 추가 (초기 진입시)
       const boardFilter: Filter[] = DashboardUtil.getAllFiltersDsRelations(this.widget.dashBoard, widgetDataSource.engineName);
@@ -1202,11 +1225,14 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
         this.chart.resultData = this.resultData;
       }
 
+      this.isValidWidget = true;
+
       // 변경 적용
       this.safelyDetectChanges();
     }).catch((error) => {
       console.error(error);
       // 프로세스 종료 등록 및 No Data 표시
+      this.isValidWidget = false;
       this.showError();
       // 변경 적용
       this.safelyDetectChanges();

--- a/discovery-frontend/src/app/workbook/workbook.component.ts
+++ b/discovery-frontend/src/app/workbook/workbook.component.ts
@@ -724,10 +724,12 @@ export class WorkbookComponent extends AbstractComponent implements OnInit, OnDe
         } else {
           this.loadAndSelectDashboard(this.dashboards[0]);
         }
+      } else {
+        this.selectedDashboard = null;
       }
 
-      // 변경 확인
-      this.changeDetect.detectChanges();
+      // detect changes
+      this.safelyDetectChanges();
 
     }).catch(() => {
       Alert.error(this.translateService.instant('msg.comm.alert.del.fail'));


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
멀티데이터소스로 대시보드를 구현한 후, 사용했던 데이터소스를 삭제하고 해당 대시보드를 확인하면, 다른 데이터소스로 구현한 차트까지 나오지 않은 현상

**Related Issue** : #224 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. A 데이터소스와 B 데이터소스를 이용하여 대시보드를 생성합니다. 
2. 대시보드 편집화면에서 각각 데이터소스를 이용하여 차트를 그리고 저장합니다.
3. 데이터소스 관리 화면에서 A 데이터소스를 삭제 합니다.
4. 대시보드 화면으로 돌아가서 B 데이터소스로 그린 차트는 정상적으로 표시되고, A 데이터소스로 그린 차트에 대해서는 차트 오류 표현 화면으로 변경되었는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
