### PR TITLE
#232 union css error

### DIFF
--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/rule-union-popup/rule-union-popup.component.html
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/rule-union-popup/rule-union-popup.component.html
@@ -31,7 +31,8 @@
 
     </div>
     <!-- //title -->
-    <div class="ddp-ui-popup-contents">
+    <div class="ddp-ui-popup-contents ddp-union">
+      <a (click)="openPopup()" href="javascript:" class="ddp-btn-line ddp-dataset"><em class="ddp-icon-link-plus"></em>{{'msg.dp.btn.add.ds' | translate}}</a>
       <!-- 유니온 -->
       <div class="ddp-wrap-union">
         <!-- output -->
@@ -68,7 +69,6 @@
           <!-- title -->
           <div class="ddp-ui-title">
             {{'msg.dp.ui.ds.to.union' | translate : {value : unionDatasets.length + 1} }}
-            <a href="javascript:" class="ddp-btn-line" (click)="openPopup()"><em class="ddp-icon-link-plus"></em>{{'msg.dp.btn.add.ds' | translate}}</a>
           </div>
           <!-- //title -->
           <div class="ddp-wrap-union-set">
@@ -77,7 +77,6 @@
                 1개 이상의 컬럼이 drop될 경우, 해당 라인에 BG 표시 : tr class="ddp-disabled " 추가
             -->
             <div class="ddp-ui-union-table">
-              <!-- Master dataset info -->
               <table class="ddp-table-union">
                 <thead>
                 <tr>
@@ -108,10 +107,7 @@
                 <!--<tr class="ddp-disabled"><td></td></tr>-->
                 </tbody>
               </table>
-              <!-- // Master dataset info -->
-              <!-- Union dataset info -->
               <table class="ddp-table-union">
-                <!-- Union datasets header -->
                 <thead>
                 <tr>
                   <th *ngFor="let dsItem of unionDatasets" >

--- a/discovery-frontend/src/assets/css/polaris.v2.page.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.page.css
@@ -5406,12 +5406,14 @@ ul.ddp-list-detail li .ddp-wrap-detailinfo .ddp-data-history .ddp-data-success {
 /************************************************************************
 	page : 데이터 프리퍼레이션 유니온
 **********************************************************************/
-.ddp-wrap-union {position:relative; width:100%; height:100%;}
-.ddp-wrap-union .ddp-ui-title {padding:20px 0; font-size:13px; color:#b7b9c2; font-weight:bold;}
-.ddp-ui-union-output {position:absolute; top:0; left:0; bottom:0; width:258px; border-right:1px solid #e7e7ea;}
-.ddp-ui-union-output .ddp-data-total {display:block; padding-bottom:10px; color:#444; font-size:13px;}
+.ddp-wrap-union {position:relative; width:100%; height:100%; overflow:auto; background-color:#fafafa;}
+.ddp-wrap-union .ddp-ui-title {padding:20px 0 19px 0; font-size:13px; color:#b7b9c2; font-weight:bold;}
+.ddp-ui-union-output {position:absolute; top:0; left:0; bottom:0; width:258px; border-right:1px solid #e7e7ea; background-color:#fff;}
+.ddp-ui-union-output .ddp-data-total {display:block; padding-bottom:8px; color:#444; font-size:13px;}
 .ddp-ui-union-output .ddp-data-total .ddp-data-num {color:#666eb2;}
-.ddp-wrap-union-list {position:absolute; top:76px; left:0; right:0; bottom:0; padding-right:20px; overflow-y:auto;}
+.ddp-wrap-union-list {position:relative; float:left; width:100%; padding-right:12px; box-sizing:border-box;}
+
+.ddp-wrap-union-list:before {display:inline-block; position:absolute; top:0; left:0; right:0; bottom:0; background-color:#fff; content:'';}
 .ddp-wrap-union-list ul.ddp-list-union li {padding-bottom:10px;}
 .ddp-wrap-union-list ul.ddp-list-union li .ddp-box-column {position:relative; padding:0 25px 0 51px; border-radius:2px; border:1px solid #d0d1d8; cursor: pointer;}
 .ddp-wrap-union-list ul.ddp-list-union li .ddp-box-column:hover {border:1px solid #b7b9c2;}
@@ -5424,13 +5426,17 @@ ul.ddp-list-detail li .ddp-wrap-detailinfo .ddp-data-history .ddp-data-success {
 .ddp-wrap-union-list ul.ddp-list-union li .ddp-box-column em.ddp-icon-control-edit {display:none; position:absolute; top:50%; right:5px; margin-top:-10px;}
 .ddp-wrap-union-list ul.ddp-list-union li .ddp-box-column:hover em.ddp-icon-control-edit {display:block;}
 
-.ddp-ui-union-set {position:absolute; left:259px; top:0; right:0; bottom:39px; background-color:#fafafa;}
+.ddp-ui-union-set {position:absolute; left:259px; top:0; right:0; bottom:0; background-color:#fafafa;}
 .ddp-ui-union-set .ddp-ui-title {padding:20px 20px 20px 20px;}
-.ddp-ui-union-set .ddp-ui-title a.ddp-btn-line {float:right; position:relative; top:-7px; font-weight:normal; cursor:pointer;}
-.ddp-ui-union-set .ddp-ui-title a.ddp-btn-line .ddp-icon-link-plus {margin-right:5px;}
+.ddp-ui-popup-contents a.ddp-dataset {position:absolute; top:93px; right:50px; font-weight:normal; cursor:pointer;}
+.ddp-ui-popup-contents a.ddp-dataset .ddp-icon-link-plus {margin-right:5px;}
+.ddp-ui-popup-contents.ddp-union {padding-top:140px;}
+
+
+
 
 .ddp-ui-union-set .ddp-ui-title a.ddp-btn-line:hover .ddp-icon-link-plus {background-position:-20px -2px; }
-.ddp-wrap-union-set {position:absolute; top:53px; left:0; right:0; bottom:0; overflow:auto;}
+.ddp-wrap-union-set {position:absolute; top:53px; left:0; right:0; bottom:0;}
 .ddp-ui-union-table {display:inline-block;  white-space:nowrap;}
 .ddp-ui-union-table table.ddp-table-union:first-of-type tr th,
 .ddp-ui-union-table table.ddp-table-union:first-of-type tr td {padding-left:23px;}

--- a/discovery-frontend/src/assets/css/polaris.v2.page.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.page.css
@@ -5443,7 +5443,7 @@ ul.ddp-list-detail li .ddp-wrap-detailinfo .ddp-data-history .ddp-data-success {
 table.ddp-table-union {display:inline-block; margin-left:-3px; white-space:nowrap; vertical-align: top;}
 table.ddp-table-union tr th {position:relative; padding:0 5px 5px 12px; text-align:left;}
 table.ddp-table-union tr th:first-of-type {padding-left:23px;}
-table.ddp-table-union tr th .ddp-wrap-top {padding:0 77px 0 0; width:234px; box-sizing:border-box;}
+table.ddp-table-union tr th .ddp-wrap-top {padding:0 77px 0 0; width:234px; font-size : 0px; box-sizing:border-box;}
 table.ddp-table-union tr th .ddp-data-name {display:inline-block; width:100%; font-size:13px; color:#4b515b; white-space:nowrap; text-overflow:ellipsis; overflow:hidden; word-wrap:normal;}
 table.ddp-table-union tr th .ddp-ui-value {position:absolute; top:0; right:0;}
 table.ddp-table-union tr th .ddp-ui-value .ddp-data-value {float:left; position:relative; top:2px; color:#b7b9c2; font-size:12px;}


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
유니온 팝업내 css 수정 
- 마스터 데이터 셋과 추가될 데이터 셋 영역에 두 개의 스크롤이 생기는 문제
- 마스터 데이터 셋과 추가될 데이터 셋을 높이가 다른 문제

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#232 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
한 페이지에 스크롤은 하나만 나올 수 있도록 마크업 수정,
마스터 데이터 셋과 추가될 데이터 셋 높이 수정

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
