### PR TITLE
#106 gauge chart gradient incorrect

### DIFF
--- a/discovery-frontend/src/app/common/component/chart/type/gauge-chart/gauge-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/gauge-chart/gauge-chart.component.ts
@@ -24,7 +24,7 @@ import {
   ChartColorList,
   ChartColorType,
   ChartSelectMode,
-  ChartType,
+  ChartType, ColorCustomMode,
   ColorRangeType,
   Position,
   SeriesType,
@@ -421,6 +421,62 @@ export class GaugeChartComponent extends BaseChart {
       }
 
     });
+
+    return this.chartOption;
+  }
+
+  /**
+   * 시리즈 정보를 변환한다.
+   * - 필요시 각 차트에서 Override
+   * @returns {BaseOption}
+   */
+  protected convertSeries(): BaseOption {
+
+    // Base Call
+    this.chartOption = super.convertSeries();
+
+    // Gradient Color Change
+    if (this.uiOption.color['customMode'] && ColorCustomMode.GRADIENT == this.uiOption.color['customMode']) {
+
+      _.each(this.data.columns, (column, columnIndex) => {
+
+        // Series Total Value
+        let totalValue: number = column.categoryValue;
+
+        _.each(this.chartOption.series, (series) => {
+
+          let data = series.data[columnIndex];
+
+          // Validate
+          if (!this.uiOption.color['ranges']) {
+            return false;
+          }
+
+          // Base Data
+          let value: number = null;
+          if (data && isNaN(data)) {
+            value = data.value;
+          }
+          else {
+            value = data;
+          }
+
+          let maxValue: number = this.data.info.maxValue;
+          let rangePercent: number = (maxValue / totalValue) * 100;
+          let codes: string[] = _.cloneDeep(this.chartOption.visualMap.color).reverse();
+          let index: number = Math.round(value / rangePercent * codes.length);
+          index = index == codes.length ? codes.length-1 : index;
+          series.data[columnIndex].itemStyle = {
+            normal: {
+              color: codes[index]
+            }
+          };
+        });
+      });
+
+      delete this.chartOption.visualMap;
+    }
+
 
     return this.chartOption;
   }

--- a/discovery-frontend/src/app/common/component/chart/type/gauge-chart/gauge-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/gauge-chart/gauge-chart.component.ts
@@ -39,7 +39,7 @@ import * as _ from 'lodash';
 import { Pivot } from '../../../../../domain/workbook/configurations/pivot';
 import { Alert } from '../../../../util/alert.util';
 import { BaseOption } from '../../option/base-option';
-import { UIChartColorByDimension, UIChartFormat, UIOption } from '../../option/ui-option';
+import {UIChartColorByDimension, UIChartColorByValue, UIChartFormat, UIOption} from '../../option/ui-option';
 import { FormatOptionConverter } from '../../option/converter/format-option-converter';
 import { ColorRange, UIChartColor, UIChartColorBySeries } from '../../option/ui-option/ui-color';
 import { UIScatterChart } from '../../option/ui-option/ui-scatter-chart';
@@ -436,7 +436,7 @@ export class GaugeChartComponent extends BaseChart {
     this.chartOption = super.convertSeries();
 
     // Gradient Color Change
-    if (this.uiOption.color['customMode'] && ColorCustomMode.GRADIENT == this.uiOption.color['customMode']) {
+    if (_.eq(this.uiOption.color.type, ChartColorType.MEASURE ) && this.uiOption.color['customMode'] && ColorCustomMode.GRADIENT == this.uiOption.color['customMode']) {
 
       _.each(this.data.columns, (column, columnIndex) => {
 
@@ -466,6 +466,53 @@ export class GaugeChartComponent extends BaseChart {
           let codes: string[] = _.cloneDeep(this.chartOption.visualMap.color).reverse();
           let index: number = Math.round(value / rangePercent * codes.length);
           index = index == codes.length ? codes.length-1 : index;
+          series.data[columnIndex].itemStyle = {
+            normal: {
+              color: codes[index]
+            }
+          };
+        });
+      });
+
+      delete this.chartOption.visualMap;
+    }
+    // Default Color Change
+    else if( _.eq(this.uiOption.color.type, ChartColorType.MEASURE ) ) {
+
+      _.each(this.data.columns, (column, columnIndex) => {
+
+        // Series Total Value
+        let totalValue: number = column.categoryValue;
+
+        _.each(this.chartOption.series, (series) => {
+
+          let data = series.data[columnIndex];
+
+          // Validate
+          if (!this.uiOption.color['ranges']) {
+            return false;
+          }
+
+          // Base Data
+          let value: number = null;
+          if (data && isNaN(data)) {
+            value = data.value;
+          }
+          else {
+            value = data;
+          }
+
+          let originalValue: number = totalValue * (value / 100);
+          let codes = _.cloneDeep(ChartColorList[(<UIChartColorByDimension>this.uiOption.color).schema]).reverse();
+          let index: number = 0;
+          _.each(this.uiOption.color['ranges'], (range, rangeIndex) => {
+            let min: number = range.fixMin != null ? range.fixMin : 0;
+            let max: number = range.fixMax != null ? range.fixMax : min;
+            if( originalValue >= min && originalValue <= max ) {
+              index = Number(rangeIndex);
+              return false;
+            }
+          });
           series.data[columnIndex].itemStyle = {
             normal: {
               color: codes[index]


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Gauge chart > Custom Color Setting > Default에서 색상이 제대로 표기안되는 문제를 수정합니다.

**Related Issue** : #106 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Gauge chart > Custom Color Setting > Default 설정 후 색상이 제대로 표기되는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
