### PR TITLE
#149 fix incorrect gradient color in grid

### DIFF
--- a/discovery-frontend/src/app/common/component/chart/option/converter/color-option-converter.ts
+++ b/discovery-frontend/src/app/common/component/chart/option/converter/color-option-converter.ts
@@ -245,7 +245,7 @@ export class ColorOptionConverter {
     if (_.isUndefined(option.visualMap)) option.visualMap = OptionGenerator.VisualMap.continuousVisualMap();
 
     // get axis baseline
-    const valueAxis = AxisLabelType.COLUMN == uiOption.yAxis.mode ? uiOption.yAxis : uiOption.xAxis;
+    const valueAxis = !uiOption.yAxis ? null : AxisLabelType.COLUMN == uiOption.yAxis.mode ? uiOption.yAxis : uiOption.xAxis;
 
     // 색상 리스트 적용
     option.visualMap.color = <any>codes;
@@ -268,7 +268,7 @@ export class ColorOptionConverter {
         }
 
         // deduct baseline value in range
-        if (null !== valueAxis.baseline && undefined !== valueAxis.baseline) {
+        if (valueAxis && null !== valueAxis.baseline && undefined !== valueAxis.baseline) {
           item.fixMin = null == item.fixMin ? null : item.fixMin - valueAxis.baseline;
           item.fixMax = null == item.fixMax ? null : item.fixMax - valueAxis.baseline;
           item.gt = null == item.gt ? null : item.gt - valueAxis.baseline;

--- a/discovery-frontend/src/app/common/component/chart/option/define/common.ts
+++ b/discovery-frontend/src/app/common/component/chart/option/define/common.ts
@@ -496,6 +496,8 @@ export enum EventType {
   GRANULARITY = <any>'onChangeGranularity',
   // aggregation 변경시
   AGGREGATION = <any>'onChangeAggregationType',
+  // change chart type
+  CHART_TYPE = <any>'chartType',
   // filter changed
   FILTER = <any>'filter'
 }

--- a/discovery-frontend/src/app/common/component/chart/type/grid-chart/grid-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/grid-chart/grid-chart.component.ts
@@ -562,7 +562,7 @@ export class GridChartComponent extends BaseChart implements OnInit, OnDestroy, 
    */
   private setGradationRangeColor(cellColor: UIChartColorGradationByCell, gridModel: any) {
 
-    const codes = cellColor.visualGradations.map((item) => {return item['color']}).reverse();
+    const codes = cellColor.visualGradations.map((item) => {return item['color']});
 
     if (CellColorTarget.BACKGROUND == (<UIChartColorByCell>this.uiOption.color).colorTarget) {
       gridModel.body.color.stepColors = codes;

--- a/discovery-frontend/src/app/page/chart-style/color-option.component.ts
+++ b/discovery-frontend/src/app/page/chart-style/color-option.component.ts
@@ -235,8 +235,9 @@ export class ColorOptionComponent extends BaseOptionComponent implements OnInit,
 
     // set min / max by decimal format
     if (this.uiOption.valueFormat && undefined !== this.uiOption.valueFormat.decimal) {
-      this.minValue = FormatOptionConverter.getDecimalValue(this.uiOption.minValue, this.uiOption.valueFormat.decimal, this.uiOption.valueFormat.useThousandsSep);
-      this.minValue = parseInt(this.minValue) >= 0 ? FormatOptionConverter.getDecimalValue(0, this.uiOption.valueFormat.decimal, this.uiOption.valueFormat.useThousandsSep) : this.minValue;
+      const minValue = this.checkMinZero(this.uiOption.minValue, this.uiOption.minValue);
+
+      this.minValue = FormatOptionConverter.getDecimalValue(minValue, this.uiOption.valueFormat.decimal, this.uiOption.valueFormat.useThousandsSep);
       this.maxValue = FormatOptionConverter.getDecimalValue(this.uiOption.maxValue, this.uiOption.valueFormat.decimal, this.uiOption.valueFormat.useThousandsSep);
     }
 
@@ -778,7 +779,7 @@ export class ColorOptionComponent extends BaseOptionComponent implements OnInit,
 
     let colorList = ChartColorList[this.uiOption.color['schema']];
 
-    const minValue = this.uiOption.minValue >= 0 ? 0 : parseInt(this.uiOption.minValue.toFixed(0));
+    const minValue = this.checkMinZero(this.uiOption.minValue, parseInt(this.uiOption.minValue.toFixed(0)));
     const maxValue = parseInt(this.uiOption.maxValue.toFixed(0));
 
     if (!gradations || gradations.length == 0) {
@@ -831,7 +832,7 @@ export class ColorOptionComponent extends BaseOptionComponent implements OnInit,
     let decimalValue = this.uiOption.minValue;
 
     // uiOption minValue의 range에 설정할값 양수일때에는 0, 음수일때에는 minValue로 설정
-    const uiMinValue = this.uiOption.minValue >= 0 ? 0 : decimalValue;
+    const uiMinValue = this.checkMinZero(this.uiOption.minValue, decimalValue);
 
     // 입력가능 최소 / 최대범위 구하기
     let minValue = rangeList[index + 1] ? rangeList[index + 1].gt ? rangeList[index + 1].gt : uiMinValue :
@@ -893,7 +894,7 @@ export class ColorOptionComponent extends BaseOptionComponent implements OnInit,
     range = this.parseStrFloat(range);
 
     // uiOption minValue의 range에 설정할값 양수일때에는 0, 음수일때에는 minValue로 설정
-    const uiMinValue = this.uiOption.minValue >= 0 ? 0 : this.uiOption.minValue;
+    const uiMinValue = this.checkMinZero(this.uiOption.minValue, this.uiOption.minValue);
 
     // 하위 fixMin값
     const lowerfixMin = rangeList[index + 1] ?(rangeList[index + 1].fixMin) ? rangeList[index + 1].fixMin : rangeList[index + 1].fixMax : null;
@@ -928,7 +929,7 @@ export class ColorOptionComponent extends BaseOptionComponent implements OnInit,
     }
 
     // 최소값이 현재 최대값보다 큰경우 최소값과 하위 최대값 변경
-    if (range.fixMin > range.fixMax) {
+    if (null != range.fixMin && rangeList[index + 1] && range.fixMin > range.fixMax) {
 
       range.gt = range.fixMax;
       rangeList[index + 1].lte = range.fixMax;
@@ -1356,5 +1357,28 @@ export class ColorOptionComponent extends BaseOptionComponent implements OnInit,
     range.gt     = null == range.gt ? null : FormatOptionConverter.getNumberValue(range.gt);
     range.lte    = null == range.lte ? null : FormatOptionConverter.getNumberValue(range.lte);
     return range;
+  }
+
+  /**
+   * set minvalue zero by chart types
+   * @param {number} minValue
+   * @param {number} elseValue
+   */
+  private checkMinZero(minValue: number, elseValue: number) {
+
+    let returnValue: number = elseValue;
+
+    switch(this.uiOption.type) {
+
+      // charts minvalue is zero
+      case ChartType.BAR:
+      case ChartType.LINE:
+      case ChartType.SCATTER:
+      case ChartType.BOXPLOT:
+      case ChartType.COMBINE:
+        if (minValue >= 0) returnValue = 0;
+    }
+
+    return returnValue;
   }
 }

--- a/discovery-frontend/src/app/page/page.component.ts
+++ b/discovery-frontend/src/app/page/page.component.ts
@@ -172,7 +172,7 @@ export class PageComponent extends AbstractPopupComponent implements OnInit, OnD
   @ViewChild(LineChartComponent)
   private lineChartComponent: LineChartComponent;
 
-  private selectChartSource: Subject<string> = new Subject<string>();
+  private selectChartSource: Subject<Object> = new Subject<Object>();
   private selectChart$ = this.selectChartSource.asObservable().debounceTime(100);
 
   // page data 하위의 context menu
@@ -385,7 +385,7 @@ export class PageComponent extends AbstractPopupComponent implements OnInit, OnD
       this.recommendChart();
     }
 
-    this.selectChartSource.next(chartType);
+    this.selectChartSource.next({chartType : chartType, type : EventType.CHART_TYPE});
 
   }
 
@@ -492,11 +492,9 @@ export class PageComponent extends AbstractPopupComponent implements OnInit, OnD
 
     this.subscriptions.push(windowResizeSubscribe);
 
-    const changeChartSubs = this.selectChart$.subscribe((chartType) => {
-      if (chartType !== '') {
-        this.drawChart(() => {
-          this.chartResize();
-        });
+    const changeChartSubs = this.selectChart$.subscribe((param) => {
+      if (param['chartType'] !== '') {
+        this.drawChart({type : param['type']});
       }
     });
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
- 그리드차트에서 색범위가 반대로 편성됨
- 그리드차트의 최소값설정이 0으로 설정됨
**Related Issue** : #149 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
- 그리드차트의 색상 그라데이션 표현시 색표현이 설정한 범위대로 적용되는지 확인
- 그라데이션에서 그리드차트의 최소값이 제대로 적용되는지 확인
<!--- Please describe in detail how you tested your changes. -->


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
