### PR TITLE
#280 fix datalabel, tooltip error in gauge chart

### DIFF
--- a/discovery-frontend/src/app/common/component/chart/type/gauge-chart/gauge-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/gauge-chart/gauge-chart.component.ts
@@ -409,7 +409,7 @@ export class GaugeChartComponent extends BaseChart {
           // uiData가 없는경우
           if (!item['uiData']) {
 
-            item['uiData'] = this.data.columns[dataIndex][index];
+            item['uiData'] = _.find(this.data.columns[dataIndex], {'name' : item.name});
           }
         });
       }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
- 게이지차트에서 2개이상의 dimension을 설정시 series에 맞게 datalabel, tooltip이 구성되지 않습니다.

**Related Issue** : #280 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
- dimension의 데이터 개수가 서로 다른 dimension을 두개올리고 datalabel, tooltip을 확인시 series에 맞게
구성되는것을 확인하였습니다.
<!--- Please describe in detail how you tested your changes. -->


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
