### PR TITLE
#252 async api to upload file dataset

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetController.java
@@ -365,6 +365,30 @@ public class PrepDatasetController {
         return ResponseEntity.status(HttpStatus.SC_CREATED).body(response);
     }
 
+    @RequestMapping(value = "/upload_async", method = RequestMethod.POST, produces = "application/json")
+    public @ResponseBody ResponseEntity<?> upload_async(@RequestParam("file") MultipartFile file) {
+        Map<String, Object> response = null;
+        try {
+            response = this.datasetFileService.uploadFile(file);
+        } catch (Exception e) {
+            LOGGER.error("upload_async(): caught an exception: ", e);
+            throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE,e);
+        }
+        return ResponseEntity.status(HttpStatus.SC_CREATED).body(response);
+    }
+
+    @RequestMapping(value = "/upload_async_poll", method = RequestMethod.POST, produces = "application/json")
+    public @ResponseBody ResponseEntity<?> upload_async_poll(@RequestBody String fileKey) {
+        Map<String, Object> response = null;
+        try {
+            response = this.datasetFileService.pollUploadFile(fileKey);
+        } catch (Exception e) {
+            LOGGER.error("upload_async_poll(): caught an exception: ", e);
+            throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE,e);
+        }
+        return ResponseEntity.status(HttpStatus.SC_CREATED).body(response);
+    }
+
     @RequestMapping(value = "/check_hdfs", method = RequestMethod.GET, produces = "application/json")
     public @ResponseBody ResponseEntity<?> checkHdfs() {
         Map<String, Object> response = new HashMap();

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetFileUploadAsyncConfig.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetFileUploadAsyncConfig.java
@@ -1,0 +1,90 @@
+package app.metatron.discovery.domain.dataprep;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
+
+@Configuration
+@EnableAsync
+public class PrepDatasetFileUploadAsyncConfig {
+    private static Logger LOGGER = LoggerFactory.getLogger(PrepDatasetFileUploadAsyncConfig.class);
+
+    @Bean(name = "prepFileUploadExecutor")
+    public Executor threadPoolTaskExecutor() {
+        ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
+        taskExecutor.setCorePoolSize(3);
+        taskExecutor.setMaxPoolSize(30);
+        taskExecutor.setQueueCapacity(10);
+        taskExecutor.setThreadNamePrefix("prepFileUpload-");
+        taskExecutor.initialize();
+        return taskExecutor;
+    }
+
+    public class HandlingExecutor implements AsyncTaskExecutor {
+        private AsyncTaskExecutor executor;
+
+        public HandlingExecutor(AsyncTaskExecutor executor) {
+            this.executor = executor;
+        }
+
+        @Override
+        public void execute(Runnable task) {
+            executor.execute(task);
+        }
+
+        @Override
+        public void execute(Runnable task, long startTimeout) {
+            executor.execute(createWrappedRunnable(task), startTimeout);
+        }
+
+        @Override
+        public Future<?> submit(Runnable task) {
+            return executor.submit(createWrappedRunnable(task));
+        }
+
+        @Override
+        public <T> Future<T> submit(final Callable<T> task) {
+            return executor.submit(createCallable(task));
+        }
+
+        private <T> Callable<T> createCallable(final Callable<T> task) {
+            return new Callable<T>() {
+                @Override
+                public T call() throws Exception {
+                    try {
+                        return task.call();
+                    } catch (Exception ex) {
+                        handle(ex);
+                        throw ex;
+                    }
+                }
+            };
+        }
+
+        private Runnable createWrappedRunnable(final Runnable task) {
+            return new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        task.run();
+                    } catch (Exception ex) {
+                        handle(ex);
+                    }
+                }
+            };
+        }
+
+        private void handle(Exception ex) {
+            LOGGER.error( "prepFileUploadExecutor : {}", ex.getMessage() );
+        }
+    }
+}
+

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetFileUploadService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetFileUploadService.java
@@ -1,0 +1,145 @@
+package app.metatron.discovery.domain.dataprep;
+
+import com.google.common.collect.Lists;
+import com.monitorjbl.xlsx.StreamingReader;
+import org.apache.commons.codec.binary.StringUtils;
+import org.apache.commons.io.ByteOrderMark;
+import org.apache.commons.io.input.BOMInputStream;
+import org.apache.poi.ss.usermodel.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.AsyncResult;
+import org.springframework.stereotype.Service;
+
+import java.io.*;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Future;
+
+@Service
+public class PrepDatasetFileUploadService {
+    private static Logger LOGGER = LoggerFactory.getLogger(PrepDatasetFileUploadService.class);
+
+    @Async("prepFileUploadExecutor")
+    public Future<Map<String,Object>> postUpload(String extensionType, Map<String,Object> responseMap) throws Exception {
+        String fileName = (String)responseMap.get("filename");
+        String filePath = (String)responseMap.get("filepath");
+        String fileKey = (String)responseMap.get("filekey");
+
+        List<String> sheets = Lists.newArrayList();
+        responseMap.put("sheets", sheets);
+
+        FileInputStream fis = null;
+        FileOutputStream fos = null;
+        try {
+            if(extensionType.equals("csv")) {
+                boolean convert = true;
+                fis = new FileInputStream(filePath);
+                ByteOrderMark byteOrderMark = ByteOrderMark.UTF_8;
+                Charset charSet = Charset.defaultCharset();
+                BOMInputStream bomInputStream = new BOMInputStream(fis,
+                        ByteOrderMark.UTF_8, ByteOrderMark.UTF_16BE, ByteOrderMark.UTF_16LE, ByteOrderMark.UTF_32BE, ByteOrderMark.UTF_32LE);
+                if (bomInputStream.hasBOM() == false) {
+                    charSet = Charset.forName("UTF-8");
+                    byteOrderMark = ByteOrderMark.UTF_8;
+                    convert = false;
+                } else if (bomInputStream.hasBOM(ByteOrderMark.UTF_8)) {
+                    charSet = Charset.forName("UTF-8");
+                    byteOrderMark = bomInputStream.getBOM();
+                } else if (bomInputStream.hasBOM(ByteOrderMark.UTF_16LE)) {
+                    charSet = Charset.forName("UTF-16LE");
+                    byteOrderMark = bomInputStream.getBOM();
+                } else if (bomInputStream.hasBOM(ByteOrderMark.UTF_16BE)) {
+                    charSet = Charset.forName("UTF-16BE");
+                    byteOrderMark = bomInputStream.getBOM();
+                } else if (bomInputStream.hasBOM(ByteOrderMark.UTF_32LE)) {
+                    charSet = Charset.forName("UTF-32LE");
+                    byteOrderMark = bomInputStream.getBOM();
+                } else if (bomInputStream.hasBOM(ByteOrderMark.UTF_32BE)) {
+                    charSet = Charset.forName("UTF-32BE");
+                    byteOrderMark = bomInputStream.getBOM();
+                }
+
+                if(true==convert) {
+                    String newFilePath = filePath + ".new";
+                    fos = new FileOutputStream(filePath);
+
+                    InputStreamReader isr = new InputStreamReader(bomInputStream, charSet);
+                    BufferedReader br = new BufferedReader(isr);
+                    String line;
+                    while ((line = br.readLine()) != null) {
+                        if (bomInputStream.hasBOM() && byteOrderMark != ByteOrderMark.UTF_8) {
+                            byte[] utf8 = StringUtils.getBytesUtf8(line);
+                            fos.write(utf8);
+                        } else {
+                            fos.write(line.getBytes(charSet));
+                        }
+                        fos.write('\n');
+                    }
+
+                    File origFile = new File(filePath);
+                    File newFile = new File(newFilePath);
+                    origFile.delete();
+                    newFile.renameTo(origFile);
+                }
+            } else if ("xlsx".equals(extensionType) || "xls".equals(extensionType)) {
+                /*
+                Workbook wb = null;
+                wb = WorkbookFactory.create(new File(filePath));
+                if (null != wb) {
+                    int sheetsCount = wb.getNumberOfSheets();
+                    for (int j = 0; j < sheetsCount; j++) {
+                        sheets.add(wb.getSheetAt(j).getSheetName());
+                    }
+                }
+                */
+
+                File origFile = new File(filePath);
+                InputStream is = new FileInputStream(origFile);
+                Workbook workbook = StreamingReader.builder()
+                        .rowCacheSize(100)
+                        .bufferSize(4096)
+                        .open(is);
+                for (Sheet sheet : workbook) {
+                    sheets.add(sheet.getSheetName());
+                    /*
+                    for (Row r : sheet) {
+                        for (Cell c : r) {
+                            System.out.println(c.getStringCellValue());
+                        }
+                    }
+                    */
+                }
+            }
+
+            responseMap.put("success", true);
+            responseMap.put("filekey", fileKey);
+            responseMap.put("filepath", filePath);
+            responseMap.put("filename", fileName);
+        } catch (Exception e) {
+            LOGGER.error("Failed to upload file : {}", e.getMessage());
+            responseMap.put("success", false);
+            responseMap.put("message", e.getMessage());
+        } finally {
+            if(null!=fis) {
+                try {
+                    fis.close();
+                } catch(IOException e) {
+                    LOGGER.error("fos.close()", e.getMessage());
+                }
+            }
+            if(null!=fos) {
+                try {
+                    fos.close();
+                } catch(IOException e) {
+                    LOGGER.error("fos.close()", e.getMessage());
+                }
+            }
+        }
+
+        responseMap.put("state","done");
+        return new AsyncResult<Map<String,Object>>(responseMap);
+    }
+}

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetSparkHiveService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetSparkHiveService.java
@@ -67,7 +67,6 @@ public class PrepDatasetSparkHiveService {
     private static Logger LOGGER = LoggerFactory.getLogger(PrepDatasetSparkHiveService.class);
 
     private String hiveDefaultHDFSPath=null;
-    private String snapshotDirectory="snapshots";
 
     @Autowired(required = false)
     PrepProperties prepProperties;
@@ -183,13 +182,8 @@ public class PrepDatasetSparkHiveService {
     }
 
     public String getHiveDefaultHDFSPath() {
-        String stagingBaseDir = prepProperties.getStagingBaseDir();
-        if(null==hiveDefaultHDFSPath) {
-            if (true == stagingBaseDir.endsWith(File.separator)) {
-                hiveDefaultHDFSPath = stagingBaseDir + snapshotDirectory;
-            } else {
-                hiveDefaultHDFSPath = stagingBaseDir + File.separator + snapshotDirectory;
-            }
+        if(null==hiveDefaultHDFSPath && null!=prepProperties.getStagingBaseDir()) {
+            hiveDefaultHDFSPath = prepProperties.getStagingBaseDir() + File.separator + PrepProperties.dirSnapshot;
         }
         return hiveDefaultHDFSPath;
     }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepHdfsService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepHdfsService.java
@@ -37,47 +37,31 @@ public class PrepHdfsService {
     private String snapshotHdfsPath = null;
     private String previewHdfsPath = null;
 
-    private String uploadDirectory = "uploads";
-    private String snapshotDirectory = "snapshots";
-    private String previewDirectory = "previews";
-
     private Configuration hadoopConf = null;
 
     private String getUploadPath() {
-        if(null==uploadHdfsPath) {
+        if(null==uploadHdfsPath && null!=prepProperties.getStagingBaseDir()) {
             String stagingBaseDir = prepProperties.getStagingBaseDir();
-            if (true == stagingBaseDir.endsWith(File.separator)) {
-                uploadHdfsPath = stagingBaseDir + uploadDirectory;
-            } else {
-                uploadHdfsPath = stagingBaseDir + File.separator + uploadDirectory;
-            }
+            uploadHdfsPath = stagingBaseDir + File.separator + PrepProperties.dirUpload;
         }
         return uploadHdfsPath;
     }
 
+    /*
     private String getSnapshotPath() {
-        if(null==snapshotHdfsPath) {
-            String stagingBaseDir = prepProperties.getStagingBaseDir();
-            if (true == stagingBaseDir.endsWith(File.separator)) {
-                snapshotHdfsPath = stagingBaseDir + snapshotDirectory;
-            } else {
-                snapshotHdfsPath = stagingBaseDir + File.separator + snapshotDirectory;
-            }
+        if(null==snapshotHdfsPath && null!=prepProperties.getStagingBaseDir()) {
+            snapshotHdfsPath = prepProperties.getStagingBaseDir() + File.separator + PrepProperties.dirSnapshot;
         }
         return snapshotHdfsPath;
     }
 
     private String getPreviewPath() {
-        if(null==previewHdfsPath) {
-            String stagingBaseDir = prepProperties.getStagingBaseDir();
-            if (true == stagingBaseDir.endsWith(File.separator)) {
-                previewHdfsPath = stagingBaseDir + previewDirectory;
-            } else {
-                previewHdfsPath = stagingBaseDir + File.separator + previewDirectory;
-            }
+        if(null==previewHdfsPath && null!=prepProperties.getStagingBaseDir()) {
+            previewHdfsPath = prepProperties.getStagingBaseDir() + File.separator + PrepProperties.dirPreview ;
         }
         return previewHdfsPath;
     }
+    */
 
     public Configuration getConf() {
         if(null==hadoopConf) {

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepPreviewLineService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepPreviewLineService.java
@@ -42,13 +42,7 @@ public class PrepPreviewLineService {
     }
 
     private String getPreviewPath() {
-        String tempDirPath = prepProperties.getLocalBaseDir();
-
-        if(true==tempDirPath.endsWith(File.separator)) {
-            tempDirPath += "previews";
-        } else {
-            tempDirPath += File.separator + "previews";
-        }
+        String tempDirPath = prepProperties.getLocalBaseDir() + File.separator + PrepProperties.dirDataprep;
 
         File tempPath = new File(tempDirPath);
         if(!tempPath.exists()){

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepProperties.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepProperties.java
@@ -47,6 +47,11 @@ public class PrepProperties {
   public static final String ETL_JAR              = "polaris.dataprep.etl.jar";
   public static final String ETL_JVM_OPTIONS      = "polaris.dataprep.etl.jvmOptions";
 
+  public static String dirDataprep = "dataprep";
+  public static String dirPreview = "previews";
+  public static String dirUpload = "uploads";
+  public static String dirSnapshot = "snapshots";
+
   public String localBaseDir;
   public String stagingBaseDir;
   public String hadoopConfDir;
@@ -277,7 +282,7 @@ public class PrepProperties {
 
   public String getLocalBaseDir() {
     if (localBaseDir == null) {
-      localBaseDir = System.getProperty("user.home") + File.separator + "dataprep";
+      localBaseDir = System.getProperty("user.home") + File.separator + dirDataprep;
     }
     return localBaseDir;
   }
@@ -303,11 +308,19 @@ public class PrepProperties {
   }
 
   public void setLocalBaseDir(String localBaseDir) {
-    this.localBaseDir = localBaseDir;
+    if(null!=localBaseDir && 1<localBaseDir.length() && true==localBaseDir.endsWith(File.separator)) {
+      this.localBaseDir = localBaseDir.substring(0,localBaseDir.length());
+    } else {
+      this.localBaseDir = localBaseDir;
+    }
   }
 
   public void setStagingBaseDir(String stagingBaseDir) {
-    this.stagingBaseDir = stagingBaseDir;
+    if(null!=stagingBaseDir && 1<stagingBaseDir.length() && true==stagingBaseDir.endsWith(File.separator)) {
+      this.stagingBaseDir = stagingBaseDir.substring(0,stagingBaseDir.length());
+    } else {
+      this.stagingBaseDir = stagingBaseDir;
+    }
   }
 
   public void setHadoopConfDir(String hadoopConfDir) {

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepSnapshotService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepSnapshotService.java
@@ -49,8 +49,6 @@ public class PrepSnapshotService {
     @Autowired
     private PrepDatasetSparkHiveService datasetSparkHiveService;
 
-    private String snapshotDirectory = "snapshots";
-
     public String makeSnapshotName(String dsName, DateTime launchTime) {
         String ssName;
 
@@ -77,7 +75,7 @@ public class PrepSnapshotService {
     }
 
     public String getSnapshotDir(String baseDir, String ssName) {
-        String ssDir = Paths.get(this.snapshotDirectory, ssName).toString();
+        String ssDir = Paths.get(PrepProperties.dirSnapshot, ssName).toString();
         if(baseDir.endsWith(File.separator)) {
             ssDir = baseDir + ssDir;
         } else {

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/exceptions/PrepMessageKey.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/exceptions/PrepMessageKey.java
@@ -19,6 +19,7 @@ public enum PrepMessageKey {
     MSG_DP_ALERT_REQUIRED_PROPERTY_MISSING(                     "msg.dp.alert.required.property.missing"),
 
     MSG_DP_ALERT_DATASET_FAILED_AFTERCREATE(                     "msg.dp.alert.dataset.failed.aftercreate"),
+    MSG_DP_ALERT_DATASET_UPLOAD_NO_KEY(                          "msg.dp.alert.dataset.upload.no.key"),
     MSG_DP_ALERT_JDBC_CONNECTION_ERROR(                          "msg.dp.alert.jdbc.connection.error"),
     MSG_DP_ALERT_STAGINGDB_CONNECTION_ERROR(                     "msg.dp.alert.stagingdb.connection.error"),
     MSG_DP_ALERT_NO_DATAFLOW(                                    "msg.dp.alert.no.dataflow"),


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
데이터셋 파일 업로드시 비동기 API 제공함.
스프링의 잔여파일 남기지 않음. (HDFS 복사 후 잔여파일 제거는 #264 이슈에 맞추기 위해 다음 이슈로 넘겨짐)
디렉토리 없는 경우 생성하는 것 확인. (부모 디렉토리에 권한이 없는 경우는 예외)

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
[#252](https://github.com/metatron-app/metatron-discovery/issues/252)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
POST /api/preparationdatasets/upload_async {MULTIPART}
POST /api/preparationdatasets/upload_async_poll {filekey}
에 Json {filepath,filekey,filename} 응답하면 성공.
UI에서 테스트 호출 발생시키고 응답확인후 테스트 API 제거함.
- 임시 디렉토리에 생성되는 upload*.tmp 파일은 사용후 삭제되는 것 확인함.
- 설정경로/uploads 디렉토리 없을때 생성되는 것 확인 함. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
