### PR TITLE
#143 fix db type in connection

### DIFF
--- a/discovery-frontend/src/app/data-storage/data-connection/data-connection.component.html
+++ b/discovery-frontend/src/app/data-storage/data-connection/data-connection.component.html
@@ -126,7 +126,7 @@
           {{connection.name}}
         </td>
         <td>
-          {{connection.implementor}}
+          {{getConnectionType(connection.implementor)}}
         </td>
         <td>
           <span *ngIf="isDefaultType(connection)">{{connection.hostname}} / {{connection.port}}</span>

--- a/discovery-frontend/src/app/data-storage/data-connection/data-connection.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-connection/data-connection.component.ts
@@ -324,6 +324,15 @@ export class DataConnectionComponent extends AbstractComponent implements OnInit
     return this.pageResult.totalElements;
   }
 
+  /**
+   * Get connection type
+   * @param {string} implementor
+   * @returns {string}
+   */
+  public getConnectionType(implementor: string): string {
+    return (this.dbTypes.find((type) => type.value === implementor) || {label: implementor}).label;
+  }
+
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Protected Method
    |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
데이터 커넥션 목록의 커넥션 타입이 커넥션 타입 필터링 목록과 문구가 상이하게 나오는것 수정

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#143 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 데이터 커넥션 생성 > 생성
2. 데이터 커넥션 > 목록에서 1에서 생성한 커넥션 타입이 올바르게 출력되는지 확인

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project. _it will be added soon_
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
