### PR TITLE
#227 fix animation bug when datasource is changed

### DIFF
--- a/discovery-frontend/src/app/page/page-pivot/page-pivot.component.ts
+++ b/discovery-frontend/src/app/page/page-pivot/page-pivot.component.ts
@@ -2326,6 +2326,33 @@ export class PagePivotComponent extends AbstractComponent implements OnInit, OnD
   }
 
   /**
+   * remove animation
+   */
+  public removeAnimation() {
+
+    const element = this.$element.find('.ddp-wrap-default');
+
+    let scope = this;
+
+    // 선반의 길이에따라 animation 설정
+    element.each(function () {
+
+      // animation total width 설정
+      let totalWidth = scope.getShelveTotalWidth($(this));
+
+      // total width 설정 (드래그시 아래로 떨어지는걸 방지하기위해서 drag item width인 150을 더해주기)
+      $(this).css('width', totalWidth + 150);
+
+      $(this).parent().parent().find('.ddp-btn-prev').hide();
+      $(this).parent().parent().find('.ddp-btn-next').hide();
+      $(this).css('padding', '0px');
+
+      // marginLeft 초기화 설정
+      $(this).css('marginLeft', 0);
+    });
+  }
+
+  /**
    * 아이템의 길이가 선반 길이보다 긴경우 prev / next 버튼 show설정
    */
   private onShelveAnimation(element: JQuery) {

--- a/discovery-frontend/src/app/page/page.component.ts
+++ b/discovery-frontend/src/app/page/page.component.ts
@@ -581,6 +581,8 @@ export class PageComponent extends AbstractPopupComponent implements OnInit, OnD
 
     // 데이터 필드 설정 (data panel의 pivot 설정)
     this.setDatasourceFields(true);
+
+    if (this.pagePivot) this.pagePivot.removeAnimation();
   } // function - selectDataSource
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/discovery-frontend/src/assets/css/polaris.v2.page.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.page.css
@@ -2924,7 +2924,7 @@ ul.ddp-list-layer-option li.ddp-hover {background:#f6f6f7 !important;}
 
 ul.ddp-list-layer-option li:hover .ddp-ui-2depth {display:block;}
 ul.ddp-list-layer-option li:hover {background-color:#f6f6f7}
-ul.ddp-list-layer-option li:first-of-type a {border-top:none;}
+ul.ddp-list-layer-option li:first-of-type > a {border-top:none;}
 ul.ddp-list-layer-option li a .ddp-label-toggle {margin:-10px -16px; padding:10px 16px; display:block; color:#4b515b; font-size:13px; cursor: pointer;}
 ul.ddp-list-layer-option li a .ddp-label-toggle input[type="checkbox"] {opacity:0;}
 ul.ddp-list-layer-option li a .ddp-label-toggle span.ddp-txt-toggle {position:absolute; top:50%; right:15px; margin-top:-9px;}


### PR DESCRIPTION
### Description
- 차트 편집화면에서 좌측의 데이터소스 변경시 기존 차트의 선반 animation이 남아있음
<!--- Describe your changes in detail -->

**Related Issue** : #227 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
- dashboard 생성시 여러개의 datasource를 선택하여 생성하고,
선반에 dimension / measure를 기존 길이보다 길어지게 생성후, 
datasource를 변경시 animation이 해제되는지 테스트합니다.
<!--- Please describe in detail how you tested your changes. -->


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
