### PR TITLE
#221 Fix metadata tooltip error

### DIFF
--- a/discovery-frontend/src/app/datasource/component/datasource-summary/datasource-summary.component.ts
+++ b/discovery-frontend/src/app/datasource/component/datasource-summary/datasource-summary.component.ts
@@ -54,10 +54,10 @@ export class DatasourceSummaryComponent extends AbstractComponent implements OnI
   public closeEvent = new EventEmitter();
 
   public datasource: Datasource;
-  public metadata:Metadata;
+  public metadata: Metadata;
 
   public hasHeader: boolean = true;
-  public isShowDataPreview:boolean = false;
+  public isShowDataPreview: boolean = false;
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Constructor
@@ -65,7 +65,7 @@ export class DatasourceSummaryComponent extends AbstractComponent implements OnI
 
   // 생성자
   constructor(private datasourceService: DatasourceService,
-              private metadataService:MetadataService,
+              private metadataService: MetadataService,
               protected elementRef: ElementRef,
               protected injector: Injector) {
 
@@ -102,17 +102,21 @@ export class DatasourceSummaryComponent extends AbstractComponent implements OnI
       this.loadingShow();
       this.datasource = undefined;
       this.metadata = undefined;
-      this.datasourceService.getDatasourceSummary(this.datasourceId).then((datasource) => {
-        this.datasource = datasource;
-        this.metadataService.getMetadataForDataSource( datasource.id ).then( result => {
-          if (result && 0 < result.length) {
-            this.metadata = result[0];
-            this.datasource.uiMetaData = this.metadata;
-          }
-          this.loadingHide();
-          this.changeDetect.detectChanges();
-        });
-      });
+      this.datasourceService.getDatasourceSummary(this.datasourceId)
+        .then((datasource) => {
+          this.datasource = datasource;
+          this.metadataService.getMetadataForDataSource(datasource.id)
+            .then(result => {
+              if (result && 0 < result.length) {
+                this.metadata = result[0];
+                this.datasource.uiMetaData = this.metadata;
+              }
+              this.loadingHide();
+              this.changeDetect.detectChanges();
+            })
+            .catch(err => this.commonExceptionHandler(err));
+        })
+        .catch(err => this.commonExceptionHandler(err));
     }
   }
 

--- a/discovery-frontend/src/app/page/page-data/page-data-context.component.html
+++ b/discovery-frontend/src/app/page/page-data/page-data-context.component.html
@@ -25,7 +25,7 @@
     </dl>
     <dl class="ddp-dl-more">
       <dt>Logical type</dt>
-      <dd>{{selectedField.uiMetaData?.type}}</dd>
+      <dd>{{getMetaDataLogicalTypeName()}}</dd>
     </dl>
   </div>
   <!-- // MetaData -->

--- a/discovery-frontend/src/app/page/page-data/page-data-context.component.ts
+++ b/discovery-frontend/src/app/page/page-data/page-data-context.component.ts
@@ -335,6 +335,28 @@ export class PageDataContextComponent extends AbstractComponent {
     return field.type !== 'user_expr' && isString(this.selectedField.nameAlias.dashBoardId);
   } // function - isAllowNameAlias
 
+  /**
+   * Get metaData logical type name
+   * @return {string}
+   */
+  public getMetaDataLogicalTypeName():string {
+    let name:string = '';
+    let metaData = this.selectedField.uiMetaData;
+    if( metaData ) {
+      switch( metaData.type ) {
+        case LogicalType.LNT :
+          name = 'Latitude';
+          break;
+        case LogicalType.LNG :
+          name = 'Longitude';
+          break;
+        default :
+          name = metaData.type.toString();
+      }
+    }
+    return name;
+  } // function - getMetaDataLogicalTypeName
+
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Protected Method
    |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
* 위도/경도 타입에 대한 메타데이터 정보가 약어로 표시되고 있습니다.

**Related Issue** : #221 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 메타데이터 화면으로 이동합니다.
2. 데이터소스에 대한 메타데이터를 생성하고, 상세 화면으로 이동합니다.
3. 특정 필드에 대한 논리형식을 위도/경도로 설정합니다.
4. 대시보드 편집 화면으로 이동합니다.
5. 신규 차트 생성 버튼을 클릭하고 좌측의 필드 목록을 확인합니다.
6. 필드 중 메타데이터의 논리형식을 위도/경도로 지정한 필드의 툴팁을 확인하여 위도/경도가 정상적으로 표시되는지 확인합니다.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
