### PR TITLE
#325 Remove infinite loading from page widget

### DIFF
--- a/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
+++ b/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
@@ -93,7 +93,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
   private _isDuringProcess: boolean = false;
 
   private _interval: any;   // 실시간 데이터소스 조회 타이머
-  private _timer:any;       // 차트 리사이즈 타이머
+  private _timer: any;       // 차트 리사이즈 타이머
 
   // 대시보드 영역 overflow 여부
   private _dashboardOverflow: string;
@@ -312,11 +312,11 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
   // Destroy
   public ngOnDestroy() {
     super.ngOnDestroy();
-    if( this._timer ) {
+    if (this._timer) {
       clearTimeout(this._timer);
       this._timer = null;
     }
-    if( this._interval ) {
+    if (this._interval) {
       clearInterval(this._interval);
       this._interval = null;
     }
@@ -397,7 +397,8 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
             try {
               if (this.chart && this.chart.chart) this.chart.chart.resize();
             }
-            catch(error) { }
+            catch (error) {
+            }
           }
           // 변경 적용
           this.safelyDetectChanges();
@@ -436,13 +437,13 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
 
       // 마지막 외부필터로 들어온 데이터는 선택불가
       let selectData = [];
-      if( data.data ) {
-        data.data.map( (field) => {
+      if (data.data) {
+        data.data.map((field) => {
           let isExternalFilter: boolean = false;
-          if( this._externalFilters ) {
-            this._externalFilters.map( (filter) => {
+          if (this._externalFilters) {
+            this._externalFilters.map((filter) => {
               // 동일한 필터가 있는지 찾는다.
-              if( _.eq(field.alias, filter.field) ) {
+              if (_.eq(field.alias, filter.field)) {
                 isExternalFilter = true;
               }
             });
@@ -456,12 +457,12 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
             }
           });
 
-          if( !isExternalFilter || isAlreadyFilter ) {
+          if (!isExternalFilter || isAlreadyFilter) {
             selectData.push(field);
           }
         });
       }
-      if( selectData.length == 0 && !_.eq(data.mode, ChartSelectMode.CLEAR) ) {
+      if (selectData.length == 0 && !_.eq(data.mode, ChartSelectMode.CLEAR)) {
         return;
       }
       else {
@@ -493,10 +494,10 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
   public changeSelectFilterList(data: ChartSelectInfo): void {
 
     // 추가
-    if( _.eq(data.mode, ChartSelectMode.ADD) ) {
+    if (_.eq(data.mode, ChartSelectMode.ADD)) {
 
       // 필터 목록 추가
-      data.data.map( (field) => {
+      data.data.map((field) => {
         // 이미 추가된 필터인지 체크
         let isAlreadyFilter: boolean = false;
         this._selectFilterList.map((filter) => {
@@ -528,16 +529,16 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
       });
     }
     // 삭제
-    else if( _.eq(data.mode, ChartSelectMode.SUBTRACT) ) {
+    else if (_.eq(data.mode, ChartSelectMode.SUBTRACT)) {
 
       // 필터 목록 제거
-      for( let num = (this._selectFilterList.length - 1) ; num >= 0 ; num-- ) {
+      for (let num = (this._selectFilterList.length - 1); num >= 0; num--) {
         let filter = this._selectFilterList[num];
-        data.data.map( (field) => {
+        data.data.map((field) => {
           // 동일한 필터를 찾은다음
-          if( _.eq(field.alias, filter.alias) ) {
+          if (_.eq(field.alias, filter.alias)) {
             // 동일한 데이터를 제거한다.
-            for( let num2 = (field.data.length - 1) ; num2 >= 0 ; num2-- ) {
+            for (let num2 = (field.data.length - 1); num2 >= 0; num2--) {
               let data1 = field.data[num2];
               filter.data.map((data2) => {
                 if (_.eq(data1, data2)) {
@@ -547,7 +548,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
             }
 
             // 데이터가 모두 제거되었다면 필터자체를 제거한다.
-            if( filter.data.length == 0 ) {
+            if (filter.data.length == 0) {
               this._selectFilterList.splice(num, 1);
             }
           }
@@ -555,7 +556,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
       }
     }
     // 초기화
-    else if( _.eq(data.mode, ChartSelectMode.CLEAR) ) {
+    else if (_.eq(data.mode, ChartSelectMode.CLEAR)) {
 
       // 셀력션 데이터 치환
       data.mode = ChartSelectMode.SUBTRACT;
@@ -574,15 +575,15 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
 
 
     // 대시보드에서 필터를 발생시킨경우 => 필터 목록 제거
-    for( let num = (this._selectFilterList.length - 1) ; num >= 0 ; num-- ) {
+    for (let num = (this._selectFilterList.length - 1); num >= 0; num--) {
       let filter = this._selectFilterList[num];
       let isNotFilter: boolean = true;
-      externalFilters.map( (externalFilter) => {
+      externalFilters.map((externalFilter) => {
         // 동일한 필터를 찾은다음
-        if( _.eq(externalFilter.field, filter.alias) ) {
+        if (_.eq(externalFilter.field, filter.alias)) {
           isNotFilter = false;
           // 필터에 없는 데이터를 제거한다.
-          for( let num2 = (filter.data.length - 1) ; num2 >= 0 ; num2-- ) {
+          for (let num2 = (filter.data.length - 1); num2 >= 0; num2--) {
             let data1 = filter.data[num2];
             let isNotData = true;
             externalFilter['valueList'].map((data2) => {
@@ -590,26 +591,26 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
                 isNotData = false;
               }
             });
-            if( isNotData ) {
+            if (isNotData) {
               filter.data.splice(num, 1);
             }
           }
 
           // 데이터가 모두 제거되었다면 필터자체를 제거한다.
-          if( filter.data.length == 0 ) {
+          if (filter.data.length == 0) {
             this._selectFilterList.splice(num, 1);
           }
         }
       });
 
       // 발생시켰던 필터가 없어졌다면 저장목록에서도 제거
-      if( isNotFilter ) {
+      if (isNotFilter) {
         this._selectFilterList.splice(num, 1);
       }
     }
 
     // 현재 차트에서 필터를 발생시킨경우
-    if( externalFilters ) {
+    if (externalFilters) {
 
       // 복사
       externalFilters = _.cloneDeep(externalFilters);
@@ -758,6 +759,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
     }
     return iconClass;
   } // function - getChartIconClass
+
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Public Method - for Header
    |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
@@ -769,8 +771,8 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
     let strName: string = '';
     if (this.widget && this.widget.configuration.dataSource) {
       const widgetDataSource: Datasource
-        = DashboardUtil.getDataSourceFromBoardDataSource( this.widget.dashBoard, this.widget.configuration.dataSource );
-      ( widgetDataSource ) && ( strName = widgetDataSource.name );
+        = DashboardUtil.getDataSourceFromBoardDataSource(this.widget.dashBoard, this.widget.configuration.dataSource);
+      (widgetDataSource) && (strName = widgetDataSource.name);
     }
     return strName;
   } // function - getDataSourceName
@@ -979,7 +981,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
       const widgetDataSource: Datasource
         = DashboardUtil.getDataSourceFromBoardDataSource(this.widget.dashBoard, this.widgetConfiguration.dataSource);
 
-      if( isNullOrUndefined( widgetDataSource ) ) {
+      if (isNullOrUndefined(widgetDataSource)) {
         // If the widget does not have a data source
         this.processStart();
         this._isDuringProcess = true;
@@ -1032,7 +1034,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
           const syncOpts: BoardSyncOptions = boardConf.options.sync;
           this._interval = setInterval(() => {
             this.safelyDetectChanges();
-            if(this.parentWidget) {
+            if (this.parentWidget) {
               // 차트에 대한 프로세스가 진행되었다는 것을 전파하기 위해 추가
               this.processStart();
               this._isDuringProcess = true;
@@ -1045,7 +1047,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
 
         this.safelyDetectChanges();
 
-        if(this.parentWidget) {
+        if (this.parentWidget) {
           // 차트에 대한 프로세스가 진행되었다는 것을 전파하기 위해 추가
           this.processStart();
           this._isDuringProcess = true;
@@ -1142,7 +1144,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
     // 필터 설정
     const widgetDataSource: Datasource = DashboardUtil.getDataSourceFromBoardDataSource(this.widget.dashBoard, this.widgetConfiguration.dataSource);
 
-    if( isNullOrUndefined( widgetDataSource ) ) {
+    if (isNullOrUndefined(widgetDataSource)) {
       this.isValidWidget = false;
       this.showError();
       return;
@@ -1267,7 +1269,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
         (FilterUtil.isTimeListFilter(item) && item['valueList'] && 0 < item['valueList'].length);
     });
 
-    cloneQuery.userFields = CommonUtil.objectToArray( cloneQuery.userFields );
+    cloneQuery.userFields = CommonUtil.objectToArray(cloneQuery.userFields);
 
     return cloneQuery;
   } // function - _makeSearchQueryParam
@@ -1342,11 +1344,14 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
         .resolve()
         .then(() => {
           if (this.isAnalysisPredictionEnabled()) {
-            this.analysisPredictionService.getAnalysisPredictionLineFromDashBoard(this.widgetConfiguration, this.widget, this.chart, this.resultData);
+            this.analysisPredictionService.getAnalysisPredictionLineFromDashBoard(this.widgetConfiguration, this.widget, this.chart, this.resultData)
+              .catch(() => {
+                this.showError();
+              });
           } else {
             this.predictionLineDisabled();
           }
-        });
+        })
     } else {
       this.predictionLineDisabled();
     }

--- a/discovery-frontend/src/app/embedded/page/embedded-page.component.html
+++ b/discovery-frontend/src/app/embedded/page/embedded-page.component.html
@@ -134,4 +134,20 @@
   </div>
   <!-- // No Data 영역 -->
 
+  <!-- Error 표시 영역 -->
+  <div *ngIf="isError" class="ddp-view-widget ddp-view-widget-grid">
+    <div class="ddp-box-data-none">
+      <div class="ddp-wrap-data-none">
+        <div class="ddp-ui-data-none">
+          <div class="ddp-txt-none">
+            <em class="{{getChartIconClass()}} ddp-error"></em>
+            <span class="ddp-data-name">{{widget.name}}</span>
+            <span class="ddp-txt-det">{{ 'msg.page.ui.no.data.error' | translate }}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <!-- // Error 표시 영역 -->
+
 </div>

--- a/discovery-frontend/src/app/embedded/page/embedded-page.component.ts
+++ b/discovery-frontend/src/app/embedded/page/embedded-page.component.ts
@@ -65,6 +65,7 @@ export class EmbeddedPageComponent extends AbstractComponent implements OnInit, 
   public widgetConfiguration: PageWidgetConfiguration = new PageWidgetConfiguration();
   public chartType: string;
   public isShowNoData: boolean = false;
+  public isError: boolean = false;                // 에러 상태 표시 여부
 
   // 데이터 조회 쿼리
   public query: SearchQueryRequest;
@@ -173,7 +174,87 @@ export class EmbeddedPageComponent extends AbstractComponent implements OnInit, 
    */
   public showNoData() {
     this.isShowNoData = true;
+    this.loadingHide();
   } // function - showNoData
+
+  /**
+   * 에러 표시
+   */
+  public showError() {
+    this.isError = true;
+    this.loadingHide();
+
+    // 변경 적용
+    this.safelyDetectChanges();
+  } // function - showError
+
+  /**
+   * 차트의 아이콘 클래스명 반환
+   * @return {string}
+   */
+  public getChartIconClass(): string {
+    let iconClass: string = '';
+    switch (this.widget.configuration.chart.type) {
+      case ChartType.BAR :
+        iconClass = 'ddp-chart-bar';
+        break;
+      case ChartType.LINE :
+        iconClass = 'ddp-chart-linegraph';
+        break;
+      case ChartType.GRID :
+        iconClass = 'ddp-chart-table';
+        break;
+      case ChartType.SCATTER :
+        iconClass = 'ddp-chart-scatter';
+        break;
+      case ChartType.HEATMAP :
+        iconClass = 'ddp-chart-heatmap';
+        break;
+      case ChartType.PIE :
+        iconClass = 'ddp-chart-pie';
+        break;
+      case ChartType.MAPVIEW :
+        iconClass = 'ddp-chart-map';
+        break;
+      case ChartType.CONTROL :
+        iconClass = 'ddp-chart-cont';
+        break;
+      case ChartType.LABEL :
+        iconClass = 'ddp-chart-kpi';
+        break;
+      case ChartType.LABEL2 :
+        iconClass = 'ddp-chart-kpi';
+        break;
+      case ChartType.BOXPLOT :
+        iconClass = 'ddp-chart-boxplot';
+        break;
+      case ChartType.WATERFALL :
+        iconClass = 'ddp-chart-waterfall';
+        break;
+      case ChartType.WORDCLOUD :
+        iconClass = 'ddp-chart-wordcloud';
+        break;
+      case ChartType.COMBINE :
+        iconClass = 'ddp-chart-combo';
+        break;
+      case ChartType.TREEMAP :
+        iconClass = 'ddp-chart-treemap';
+        break;
+      case ChartType.RADAR :
+        iconClass = 'ddp-chart-radar';
+        break;
+      case ChartType.NETWORK :
+        iconClass = 'ddp-chart-network';
+        break;
+      case ChartType.SANKEY :
+        iconClass = 'ddp-chart-sankey';
+        break;
+      case ChartType.GAUGE :
+        iconClass = 'ddp-chart-bar';
+        break;
+    }
+    return iconClass;
+  } // function - getChartIconClass
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
   | Protected Method
@@ -245,6 +326,8 @@ export class EmbeddedPageComponent extends AbstractComponent implements OnInit, 
       this.chart['setQuery'] = this.query;
     }
 
+    this.loadingShow();
+
     this.datasourceService.searchQuery(cloneQuery).then((data) => {
 
       this.resultData = {
@@ -270,13 +353,15 @@ export class EmbeddedPageComponent extends AbstractComponent implements OnInit, 
         this.chart.resultData = this.resultData;
       }
 
+      this.loadingHide();
+
       // 변경 적용
-      this.changeDetect.markForCheck();
+      this.safelyDetectChanges();
+
     }).catch((error) => {
       console.error(error);
-      if (error.hasOwnProperty('message')) {
-        Alert.error(error.message);
-      }
+      this.showError();
+      this.loadingHide();
     });
   } // function - _search
 
@@ -342,7 +427,10 @@ export class EmbeddedPageComponent extends AbstractComponent implements OnInit, 
         .resolve()
         .then(() => {
           if (this.isAnalysisPredictionEnabled()) {
-            this.analysisPredictionService.getAnalysisPredictionLineFromDashBoard(this.widgetConfiguration, this.widget, this.chart, this.resultData);
+            this.analysisPredictionService.getAnalysisPredictionLineFromDashBoard(this.widgetConfiguration, this.widget, this.chart, this.resultData)
+              .catch(() => {
+                this.showError();
+              });
           } else {
             this.predictionLineDisabled();
           }

--- a/discovery-frontend/src/app/page/component/analysis/service/analysis.prediction.service.ts
+++ b/discovery-frontend/src/app/page/component/analysis/service/analysis.prediction.service.ts
@@ -149,9 +149,9 @@ export class AnalysisPredictionService extends AbstractService implements OnInit
   public getAnalysisPredictionLineFromDashBoard(widgetConfiguration: PageWidgetConfiguration,
                                                 widget: PageWidget,
                                                 chart: any,
-                                                resultData?: { data: any; config: SearchQueryRequest; uiOption: UIOption }): void {
+                                                resultData?: { data: any; config: SearchQueryRequest; uiOption: UIOption }): Promise<any> {
 
-    this.getAnalysis(this.createGetAnalysisParameter(widgetConfiguration, widget))
+    return this.getAnalysis(this.createGetAnalysisParameter(widgetConfiguration, widget))
       .then((result) => {
         this.createPredictionLineSeriesList(result, widgetConfiguration);
         return result;
@@ -164,7 +164,7 @@ export class AnalysisPredictionService extends AbstractService implements OnInit
       })
       .catch((error) => {
         chart.analysis = null;
-        console.info('error', error);
+        throw error;
       });
   }
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
* 예측선이 포함된 라인차트가 있는 대시보드에서 로딩이 없어지지 않는 현상이 발생

**Related Issue** : #325 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 대시보드를 생성합니다. ( 테스트는 sales datasource를 이용하여 진행함 )
2. 라인 차트를 생성하고 예측선 기능을 추가합니다. 
    ( 테스트 예 > dimension : OrderDate ( Granularity : year ) / measure : sales / 예측선 추가 => 오류가 나는 상황을 만들기 위한 설정 )
3. 차트를 저장하고 대시보드를 저장합니다.
4. 로딩없어지고 해당 차트는 표시할 수 없음 표시가 나타나는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
