### PR TITLE
#262 fix error setting of initial value of operating panel

### DIFF
--- a/discovery-frontend/src/app/page/chart-style/calrow-option.component.html
+++ b/discovery-frontend/src/app/page/chart-style/calrow-option.component.html
@@ -57,7 +57,7 @@
                 <component-select
                   [array]="operatorList"
                   [viewKey]="'name'"
-                  [defaultIndex]="0"
+                  [defaultIndex]="operatorDefaultIdx"
                   (onSelected)="changeOperator($event)"
                 ></component-select>
                 <!-- //selectbox -->
@@ -75,7 +75,7 @@
                 <component-select
                   [array]="hAlignList"
                   [viewKey]="'name'"
-                  [defaultIndex]="0"
+                  [defaultIndex]="hAlignDefaultIdx"
                   (onSelected)="changeHAlign($event)"
                 ></component-select>
                 <!-- //selectbox -->

--- a/discovery-frontend/src/app/page/chart-style/calrow-option.component.ts
+++ b/discovery-frontend/src/app/page/chart-style/calrow-option.component.ts
@@ -48,6 +48,7 @@ export class CalculatedRowOptionComponent extends BaseOptionComponent {
     {name: this.translateService.instant('msg.page.calrow.label.operator.min'), value: Operator.MIN},
     {name: this.translateService.instant('msg.page.calrow.label.operator.count'), value: Operator.COUNT},
   ];
+  public operatorDefaultIdx:number = 0;
 
   // 가로 align리스트
   public hAlignList: Object[] = [
@@ -56,6 +57,7 @@ export class CalculatedRowOptionComponent extends BaseOptionComponent {
     {name: this.translateService.instant('msg.page.chart.datalabel.text.align.center'), value: TextAlign.CENTER},
     {name: this.translateService.instant('msg.page.chart.datalabel.text.align.right'), value: TextAlign.RIGHT}
   ];
+  public hAlignDefaultIdx:number = 0;
 
   // 차트정보
   @Input('uiOption')
@@ -69,6 +71,13 @@ export class CalculatedRowOptionComponent extends BaseOptionComponent {
 
       this.uiOption = <UIOption>_.extend({}, this.uiOption, { totalValueStyle: null });
       this.update();
+    } else if( this.uiOption ) {
+      const gridUiOption = (<UIGridChart>this.uiOption);
+      if( gridUiOption.totalValueStyle ) {
+        this.operatorDefaultIdx = this.operatorList.findIndex( item => item['value'] === gridUiOption.totalValueStyle.aggregationType );
+        this.hAlignDefaultIdx = this.hAlignList.findIndex( item => item['value'] === gridUiOption.totalValueStyle.hAlign );
+        ( -1 === this.hAlignDefaultIdx ) && ( this.hAlignDefaultIdx = 0 );
+      }
     }
   }
 
@@ -124,6 +133,9 @@ export class CalculatedRowOptionComponent extends BaseOptionComponent {
       uiOption.totalValueStyle.hAlign = UIPosition.AUTO;
       uiOption.totalValueStyle.vAlign = UIPosition.MIDDLE;
       uiOption.totalValueStyle.aggregationType = Operator.SUM;
+
+      this.operatorDefaultIdx = 0;
+      this.hAlignDefaultIdx = 0;
 
     // annotation이 있을때
     } else {


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
* 연산행 설정 패널에서 '연산자 선택' 부분이 저장 후 다시 편집하려고 하면 초기화(합계) 되어 있는 현상

**Related Issue** : #262 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 그리드 차트를 생성합니다.
2. 오른쪽에 연산 행 설정 탭을 펼칩니다.
2. '연산자 선택'을 '평균'으로 변경합니다.
3. 차트와 대시보드를 저장 후 다시 차트를 편집합니다.
4. 연산행 설정 탭에서 '연산자 선택'이 이전에 설정한 값으로 표시되는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
