### PR TITLE
F#330 hive timestamp mismatch

### DIFF
--- a/discovery-distribution/pom.xml
+++ b/discovery-distribution/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>metatron-discovery</artifactId>
         <groupId>app.metatron.discovery</groupId>
-        <version>3.0.3</version>
+        <version>3.0.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/discovery-frontend/pom.xml
+++ b/discovery-frontend/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>metatron-discovery</artifactId>
     <groupId>app.metatron.discovery</groupId>
-    <version>3.0.3</version>
+    <version>3.0.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/discovery-prep-parser/pom.xml
+++ b/discovery-prep-parser/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>metatron-discovery</artifactId>
         <groupId>app.metatron.discovery</groupId>
-        <version>3.0.3</version>
+        <version>3.0.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/discovery-server/pom.xml
+++ b/discovery-server/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>metatron-discovery</artifactId>
         <groupId>app.metatron.discovery</groupId>
-        <version>3.0.3</version>
+        <version>3.0.4</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/ColumnType.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/ColumnType.java
@@ -18,6 +18,7 @@ import app.metatron.discovery.domain.dataprep.teddy.exceptions.UnknownTypeExcept
 import org.joda.time.DateTime;
 
 import java.math.BigInteger;
+import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.List;
 import java.util.Map;
@@ -76,6 +77,9 @@ public enum ColumnType {
     }
     else if (obj instanceof Float) {
       return Double.valueOf(((Float) obj).doubleValue());
+    }
+    else if (obj instanceof Timestamp) {
+      return Util.sqlTimestampToJodaDateTime((Timestamp) obj);
     }
 
     return obj;

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/Util.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/Util.java
@@ -26,8 +26,11 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.joda.time.DateTime;
+import org.joda.time.LocalDateTime;
 
 import java.io.*;
+import java.sql.Timestamp;
 import java.util.*;
 
 import static app.metatron.discovery.domain.dataprep.PrepProperties.HADOOP_CONF_DIR;
@@ -295,6 +298,22 @@ public class Util {
     }
 
     return jsonRuleString;
+  }
+
+  public static Date jodatToSQLDate(LocalDateTime localDateTime) {
+    return new Date(localDateTime.toDateTime().getMillis());
+  }
+
+  public static Timestamp jodaToSQLTimestamp(LocalDateTime localDateTime) {
+    return new Timestamp(localDateTime.toDateTime().getMillis());
+  }
+
+  public static LocalDateTime sqlTimestampToJodaLocalDateTime(Timestamp timestamp) {
+    return LocalDateTime.fromDateFields(timestamp);
+  }
+
+  public static DateTime sqlTimestampToJodaDateTime(Timestamp timestamp) {
+    return sqlTimestampToJodaLocalDateTime(timestamp).toDateTime();
   }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <groupId>app.metatron.discovery</groupId>
     <artifactId>metatron-discovery</artifactId>
     <packaging>pom</packaging>
-    <version>3.0.3</version>
+    <version>3.0.4</version>
 
     <modules>
         <module>discovery-frontend</module>


### PR DESCRIPTION
### Description
Fixed a bug on JDBC timestamp type support, which made mismatched values on timestamp column of Hive datasets.

_JDBC 타임 스탬프 타입에 대한 버그 수정
Hive timestamp 타입 컬럼이 항상 mismatched로 나오던 문제 해결_

**Related Issue** : https://github.com/metatron-app/metatron-discovery/issues/330


### How Has This Been Tested?
Imported a Hive dataset with timestamp columns.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
