### PR TITLE
#347 Change logics related with Timestamp Style in DataFrame and Rules

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DfSetType.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DfSetType.java
@@ -17,6 +17,7 @@ package app.metatron.discovery.domain.dataprep.teddy;
 import app.metatron.discovery.domain.dataprep.teddy.exceptions.ColumnNotFoundException;
 import app.metatron.discovery.domain.dataprep.teddy.exceptions.TeddyException;
 import app.metatron.discovery.domain.dataprep.teddy.exceptions.WrongTargetColumnExpressionException;
+import app.metatron.discovery.domain.dataprep.transform.TimestampTemplate;
 import app.metatron.discovery.prep.parser.preparation.rule.Rule;
 import app.metatron.discovery.prep.parser.preparation.rule.SetType;
 import app.metatron.discovery.prep.parser.preparation.rule.expr.ExprType;
@@ -70,7 +71,11 @@ public class DfSetType extends DataFrame {
 
     for (int colno = 0; colno < prevDf.getColCnt(); colno++) {
       if (targetColnos.contains(colno)) {
-        addColumnWithTimestampStyle(prevDf.getColName(colno), toType, timestampFormat);
+        if(toType == ColumnType.TIMESTAMP) {
+          addColumnWithTimestampStyle(prevDf.getColName(colno), toType, timestampFormat);
+        } else {
+          addColumnWithTimestampStyle(prevDf.getColName(colno), toType, null);
+        }
       } else {
         addColumn(prevDf.getColName(colno), prevDf.getColDesc(colno));
       }


### PR DESCRIPTION
### Description
Timestamp 타입의 컬럼은 항상 Timestamp Style 값을 갖도록 수정(기본 값 "yyyy-MM-dd hh:mm:ss").
Timestamp 타입이 아닌 컬럼은 Timestamp Style 값을 갖지 않도록 수정.
DataFrame의 decideType 함수에서 ruleColumns를 초기화 하도록 수정.

Timestamp type columns always have Timestamp Style value.(Default: "yyyy-MM-dd hh:mm:ss")
Non-Timestamp type columns always have no Timestamp style value.
When decideType function is called, ruleColumns value are cleared at start.

**Related Issue** : <!--- Please link to the issue here. -->
https://github.com/metatron-app/metatron-discovery/issues/347


### How Has This Been Tested?
set col: date value: now()
derive value: date as: 'col_1'
derive value: now() as: 'col_2'
settype col: date type: String format: 'yyyy.MM.dd.
settype col: date type: Timestamp format: 'yyyy.MM.dd.'
settype col: date type: Long

check Timestamp Style values in result.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
