### PR TITLE
#349 Remove unnecessary undo code and change condition of header rule…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,4 @@ discovery-server/src/main/resources/hive-site.xml
 discovery-frontend/src/environments/build.env.ts
 
 # dataprep local base dir
-dataprep/uploads
-dataprep/snapshots
-dataprep/previews
+dataprep/

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
@@ -311,7 +311,6 @@ public class PrepTransformService {
           isNotORC = false;
       }
 
-      // FIXME: reconsider whether UNDO is necessary.
       if (prepProperties.isAutoTyping() && isNotORC) {
         setTypeRules = autoTypeDetection(gridResponse);
         //반환 받은 setType Rule 들을 적용
@@ -321,9 +320,7 @@ public class PrepTransformService {
             // 주의: response를 갱신하면 안됨. 기존의 create()에 대한 response를 그대로 주어야 함.
             transform(wrangledDsId, PrepDataset.OP_TYPE.APPEND, i, setTypeRule);
           } catch (Exception e) {
-            LOGGER.info("create(): caught an exception: this setType rule might be wrong [" + setTypeRule + "]", e);
-            transform(wrangledDsId, PrepDataset.OP_TYPE.UNDO, null, setTypeRule);
-            continue;
+            LOGGER.error("create(): caught an exception: this setType rule might be wrong [" + setTypeRule + "]", e);
           }
         }
       }
@@ -440,8 +437,10 @@ public class PrepTransformService {
       doTypeCheck_100(df, i, columnTypes, columnTypesRow0, timestampStyles);
     }
 
-    //0번 Row의 예상 Type이 모두 String인 경우 header 룰을 추가하고 columnNames를 변경.
-    if(Collections.frequency(columnTypesRow0, ColumnType.STRING) == df.colCnt) {
+    //If all column types of row 0 elements is String and predicted column types is not all String.
+    //Then add Header rule and change column name.
+    if(Collections.frequency(columnTypesRow0, ColumnType.STRING) == df.colCnt &&
+            Collections.frequency(columnTypes, ColumnType.STRING) != df.colCnt) {
       setTypeRules.add("header rownum: 1");
       columnNames.clear();
 


### PR DESCRIPTION
… from AutoTyping

### Description
Mismatched 추가로 SetType 룰이 실패하는 경우가 사라졌기 때문에, AutoTyping 기능 중에 룰 적용 실패 시 Undo 처리하는 코드를 제거합니다.
After adding concept of "Mismatched", now SetType rules never fail. So remove Undo code for SetType failure case from AutoTyping feature.

**Related Issue** : <!--- Please link to the issue here. -->
https://github.com/metatron-app/metatron-discovery/issues/349


### How Has This Been Tested?
Imported Dataset에서 Wrangled Data Set을 생성한다. Mismatched 되는 경우가 있더라도 Data Set 생성이 실패하지 않는다.
Make Wrangled Data Set from Imported Data Set. Data Set creation never fails even if there are some mismatched values.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
