### PR TITLE
#314 fix error where field list paging

### DIFF
--- a/discovery-frontend/src/app/dashboard/component/custom-field/custom-field.component.ts
+++ b/discovery-frontend/src/app/dashboard/component/custom-field/custom-field.component.ts
@@ -94,10 +94,7 @@ export class CustomFieldComponent extends AbstractComponent implements OnInit, O
   public columnType = ColumnType;
 
   // 필드 페이지 사이
-  public pageSize = 14;
-
-  // 필드 갯수
-  public totalFieldsSize = 0;
+  public pageSize = 13;
 
   // 현재 페이지
   public currentPage = 1;
@@ -191,6 +188,9 @@ export class CustomFieldComponent extends AbstractComponent implements OnInit, O
   // Init
   public ngOnInit() {
 
+    // Init
+    super.ngOnInit();
+
     this._$calculationInput = $('#calculationInput');
 
     // 초기
@@ -220,14 +220,10 @@ export class CustomFieldComponent extends AbstractComponent implements OnInit, O
     } else {
       this.setColumnName();
     }
-
-    // Init
-    super.ngOnInit();
   }
 
   // Destory
   public ngOnDestroy() {
-    this._$calculationInput.remove();
     // Destory
     super.ngOnDestroy();
   }
@@ -314,19 +310,16 @@ export class CustomFieldComponent extends AbstractComponent implements OnInit, O
     // 필드 페이징
     if (this.fields.hasOwnProperty('length')) {
       // 총사이즈
-      this.totalFieldsSize = this.fields.length;
+      const totalFieldsSize:number = this.fields.length;
       // 마지막 페이지 계산
-      this.lastPage = (this.totalFieldsSize % this.pageSize === 0) ? (this.totalFieldsSize / this.pageSize) : Math.floor(this.totalFieldsSize / this.pageSize) + 1;
+      this.lastPage = Math.ceil( totalFieldsSize / this.pageSize );
 
-      start = (page * this.pageSize) - this.pageSize;
-      end = (page * this.pageSize) - 1;
-      if (end > this.totalFieldsSize) {
-        end = this.totalFieldsSize;
-      }
-      // 현재 페이지에 맞게 데이터 자르기
-      this.pagedFields = this.fields.slice(start, end);
+      start = ( page - 1 ) * this.pageSize;
+      end = start + this.pageSize;
+
+      this.pagedFields = this.fields.slice(start, end);   // 현재 페이지에 맞게 데이터 자르기
     }
-  }
+  } // function - setFieldPage
 
   // 자동완성 필터리스트 셋팅
   public setFilters() {


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
계산식 필드 팝업에 '추천 컬럼' 영역에 모든 데이터소스 안 컬럼이 보이지 않고, 특정 컬럼은 빠져 있는 현상

**Related Issue** : #314 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 차트 생성 화면을 띄웁니다.
2. 필드 목록 상단의 계산식 필드 팝업 버튼을 눌러 팝업을 띄웁니다.
3. 팝업 내 필드 목록에서 필드 누락이 없는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
