### PR TITLE
#355 KPI chart same pivot error

### DIFF
--- a/discovery-frontend/src/app/common/component/chart/type/label-chart/label-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/label-chart/label-chart.component.ts
@@ -456,8 +456,10 @@ export class LabelChartComponent extends BaseChart implements OnInit, OnDestroy,
       // Pivot의 순서가 변경되었을때 처리
       /////////////////////
 
+      let isPush: boolean = false;
       for( let num2: number = 0 ; num2 < this.pivot.aggregations.length ; num2++ ) {
         if( option.series.length >= (num2+1) && _.eq(alias, option.series[num2].name) ) {
+          isPush = true;
           series.push(option.series[num2]);
         }
         if( option.icons.length >= (num2+1) && _.eq(alias, option.icons[num2].seriesName) ) {
@@ -468,6 +470,32 @@ export class LabelChartComponent extends BaseChart implements OnInit, OnDestroy,
         }
         if( option.secondaryIndicators.length >= (num2+1) && _.eq(alias, option.secondaryIndicators[num2].seriesName) ) {
           secondaryIndicators.push(option.secondaryIndicators[num2]);
+        }
+      }
+
+      /////////////////////
+      // Change alias process
+      /////////////////////
+
+      if( !isPush ) {
+        option.series[num].name = alias;
+        option.icons[num].seriesName = alias;
+        option.annotations[num].seriesName = alias;
+        option.secondaryIndicators[num].seriesName = alias;
+
+        for( let num2: number = 0 ; num2 < this.pivot.aggregations.length ; num2++ ) {
+          if( option.series.length >= (num2+1) && _.eq(alias, option.series[num2].name) ) {
+            series.push(option.series[num2]);
+          }
+          if( option.icons.length >= (num2+1) && _.eq(alias, option.icons[num2].seriesName) ) {
+            icons.push(option.icons[num2]);
+          }
+          if( option.annotations.length >= (num2+1) && _.eq(alias, option.annotations[num2].seriesName) ) {
+            annotations.push(option.annotations[num2]);
+          }
+          if( option.secondaryIndicators.length >= (num2+1) && _.eq(alias, option.secondaryIndicators[num2].seriesName) ) {
+            secondaryIndicators.push(option.secondaryIndicators[num2]);
+          }
         }
       }
     }

--- a/discovery-frontend/src/app/common/component/chart/type/label-chart/label-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/label-chart/label-chart.component.ts
@@ -384,7 +384,13 @@ export class LabelChartComponent extends BaseChart implements OnInit, OnDestroy,
       //format = format ? format : this.uiOption.format;
 
       // 값이 없을경우 처리
-      const alias: any = this.pivot.aggregations[num]['field']['alias'];
+      const field: any = this.pivot.aggregations[num];
+      let alias: any = field['alias'] ? field['alias'] : field['fieldAlias'] ? field['fieldAlias'] : field['name'];
+      if( field.aggregationType
+          && field.aggregationType != ""
+          && alias.indexOf(field.aggregationType +"(") == -1 ) {
+        alias = this.pivot.aggregations[num].aggregationType +"("+ alias +")";
+      }
       //const alias: any = this.pivot.aggregations[num].alias;
 
       /////////////////////
@@ -593,6 +599,10 @@ export class LabelChartComponent extends BaseChart implements OnInit, OnDestroy,
           }
           // 소수점 자리수
           value = Math.floor(Number(value) * (Math.pow(10, 1))) / Math.pow(10, 1);
+
+          // NaN일 경우 처리
+          if( isNaN(value) ) { value = 0; }
+
           // 천단위 표시
           kpi.targetValue = value.toLocaleString();
           kpi.targetOriginalValue = (Math.floor(Number(targetValue) * (Math.pow(10, 1))) / Math.pow(10, 1)).toLocaleString();

--- a/discovery-frontend/src/app/common/component/chart/type/label-chart/label-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/label-chart/label-chart.component.ts
@@ -397,6 +397,7 @@ export class LabelChartComponent extends BaseChart implements OnInit, OnDestroy,
       // Pivot이 추가되었을때 처리
       /////////////////////
 
+      //if( option.series.length <= num || option.series.length != seriesLength ) {
       if( option.series.length <= num ) {
         if( num > 0 ) {
           option.series[num] = {
@@ -451,6 +452,46 @@ export class LabelChartComponent extends BaseChart implements OnInit, OnDestroy,
         option.series[num] = {};
       }
 
+      /////////////////////
+      // Pivot의 순서가 변경되었을때 처리
+      /////////////////////
+
+      for( let num2: number = 0 ; num2 < this.pivot.aggregations.length ; num2++ ) {
+        if( option.series.length >= (num2+1) && _.eq(alias, option.series[num2].name) ) {
+          series.push(option.series[num2]);
+        }
+        if( option.icons.length >= (num2+1) && _.eq(alias, option.icons[num2].seriesName) ) {
+          icons.push(option.icons[num2]);
+        }
+        if( option.annotations.length >= (num2+1) && _.eq(alias, option.annotations[num2].seriesName) ) {
+          annotations.push(option.annotations[num2]);
+        }
+        if( option.secondaryIndicators.length >= (num2+1) && _.eq(alias, option.secondaryIndicators[num2].seriesName) ) {
+          secondaryIndicators.push(option.secondaryIndicators[num2]);
+        }
+      }
+    }
+
+    // 변경된 순서 반영
+    option.series = series;
+    option.icons = icons;
+    option.annotations = annotations;
+    option.secondaryIndicators = secondaryIndicators;
+
+    if( seriesLength != option.series.length ) {
+      (option).series = (option).series.slice(0, seriesLength);
+      (option).icons = (option).icons.slice(0, seriesLength);
+      (option).annotations = (option).annotations.slice(0, seriesLength);
+      (option).secondaryIndicators = (option).secondaryIndicators.slice(0, seriesLength);
+    }
+
+    // Calculate secondary indicators
+    for( let num: number = 0 ; num < seriesLength ; num++ ) {
+
+      // 포맷정보
+      let format: UIChartFormatItem = !this.uiOption.valueFormat.isAll && this.uiOption.valueFormat.each.length > 0 ? this.uiOption.valueFormat.each[num] : this.uiOption.valueFormat;
+
+      // KPI Info
       let kpi: KPI = new KPI();
       let kpiValue: number = _.sum(this.data.columns[num].value);
 
@@ -480,9 +521,9 @@ export class LabelChartComponent extends BaseChart implements OnInit, OnDestroy,
 
       // 목표값
       if( option.secondaryIndicators[num].show
-          && !_.eq(option.secondaryIndicators[num].indicatorType, LabelSecondaryIndicatorType.PERIOD)
-          && option.secondaryIndicators[num].targetValue
-          && option.secondaryIndicators[num].targetValue != 0 ) {
+        && !_.eq(option.secondaryIndicators[num].indicatorType, LabelSecondaryIndicatorType.PERIOD)
+        && option.secondaryIndicators[num].targetValue
+        && option.secondaryIndicators[num].targetValue != 0 ) {
 
         let value: number = kpiValue - option.secondaryIndicators[num].targetValue;
         // 목표값 양수여부
@@ -633,41 +674,10 @@ export class LabelChartComponent extends BaseChart implements OnInit, OnDestroy,
         kpi.show = false;
       }
 
-      /////////////////////
-      // Pivot의 순서가 변경되었을때 처리
-      /////////////////////
-
-      for( let num2: number = 0 ; num2 < this.pivot.aggregations.length ; num2++ ) {
-        if( option.series.length >= (num2+1) && _.eq(alias, option.series[num2].name) ) {
-          series.push(option.series[num2]);
-        }
-        if( option.icons.length >= (num2+1) && _.eq(alias, option.icons[num2].seriesName) ) {
-          icons.push(option.icons[num2]);
-        }
-        if( option.annotations.length >= (num2+1) && _.eq(alias, option.annotations[num2].seriesName) ) {
-          annotations.push(option.annotations[num2]);
-        }
-        if( option.secondaryIndicators.length >= (num2+1) && _.eq(alias, option.secondaryIndicators[num2].seriesName) ) {
-          secondaryIndicators.push(option.secondaryIndicators[num2]);
-        }
-      }
-
       // 추가
       this.list.push(kpi);
     }
 
-    // 변경된 순서 반영
-    option.series = series;
-    option.icons = icons;
-    option.annotations = annotations;
-    option.secondaryIndicators = secondaryIndicators;
-
-    if( seriesLength != option.series.length ) {
-      (option).series = (option).series.slice(0, seriesLength);
-      (option).icons = (option).icons.slice(0, seriesLength);
-      (option).annotations = (option).annotations.slice(0, seriesLength);
-      (option).secondaryIndicators = (option).secondaryIndicators.slice(0, seriesLength);
-    }
 
     // KPI 차트는 엘리먼트로 구성되지 않기 때문에 chartOption을 쓰지 않지만 override를 위해 반환
     return this.chartOption;

--- a/discovery-frontend/src/app/page/chart-style/common-option.component.ts
+++ b/discovery-frontend/src/app/page/chart-style/common-option.component.ts
@@ -229,7 +229,10 @@ export class CommonOptionComponent extends BaseOptionComponent {
           // 아이콘 타겟
           //////////////////////////////////////////
           const field: any = this.pivot.aggregations[num];
-          const alias: string = field['alias'] ? field['alias'] : field['fieldAlias'] ? field['fieldAlias'] : field['name'];
+          let alias: string = field['alias'] ? field['alias'] : field['fieldAlias'] ? field['fieldAlias'] : field['name'];
+          if( field.aggregationType && field.aggregationType != "" ) {
+            alias = field.aggregationType +"("+ alias +")";
+          }
 
           /////////////////////
           // Pivot이 추가되었을때 처리

--- a/discovery-frontend/src/app/page/chart-style/common-option.component.ts
+++ b/discovery-frontend/src/app/page/chart-style/common-option.component.ts
@@ -238,7 +238,8 @@ export class CommonOptionComponent extends BaseOptionComponent {
           // Pivot이 추가되었을때 처리
           /////////////////////
 
-          if (option.series.length <= num) {
+          //if( option.series.length <= num || option.series.length != this.pivot.aggregations.length ) {
+          if( option.series.length <= num ) {
             if (num > 0) {
               option.series[num] = {
                 name: alias
@@ -304,19 +305,8 @@ export class CommonOptionComponent extends BaseOptionComponent {
             }
           }
 
-          // if (!isIconAll) {
-          //   this.kpiIconTarget = this.kpiIconTargetList.length > 1 ? this.kpiIconTargetList[1] : this.kpiIconTargetList[0];
-          // }
-
-          //////////////////////////////////////////
-          // 설명
-          //////////////////////////////////////////
-
-          this.kpiText = option.annotations[0].show ? option.annotations[0].description : "";
-          this.kpiTextTemp = this.kpiText;
-          // if (!isTextAll) {
-          //   this.kpiTextTarget = this.kpiIconTargetList.length > 1 ? this.kpiIconTargetList[1] : this.kpiIconTargetList[0];
-          // }
+          // this.kpiText = option.annotations[0].show ? option.annotations[0].description : "";
+          // this.kpiTextTemp = this.kpiText;
         }
 
         // 변경된 순서 반영
@@ -330,6 +320,14 @@ export class CommonOptionComponent extends BaseOptionComponent {
         }
         if (!isTextAll) {
           this.kpiTextTarget = this.kpiIconTargetList.length > 1 ? this.kpiIconTargetList[1] : this.kpiIconTargetList[0];
+
+          if( option.annotations[0].show ) {
+            this.kpiText = this.kpiIconTargetList.length > 1 ? option.annotations[0].description : "";
+          }
+          else {
+            this.kpiText = "";
+          }
+          this.kpiTextTemp = this.kpiText;
         }
       }
     }

--- a/discovery-frontend/src/app/page/chart-style/common-option.component.ts
+++ b/discovery-frontend/src/app/page/chart-style/common-option.component.ts
@@ -290,8 +290,10 @@ export class CommonOptionComponent extends BaseOptionComponent {
           // Pivot의 순서가 변경되었을때 처리
           /////////////////////
 
+          let isPush: boolean = false;
           for( let num2: number = 0 ; num2 < this.pivot.aggregations.length ; num2++ ) {
             if( option.series.length >= (num2+1) && _.eq(alias, option.series[num2].name) ) {
+              isPush = true;
               series.push(option.series[num2]);
             }
             if( option.icons.length >= (num2+1) && _.eq(alias, option.icons[num2].seriesName) ) {
@@ -305,8 +307,31 @@ export class CommonOptionComponent extends BaseOptionComponent {
             }
           }
 
-          // this.kpiText = option.annotations[0].show ? option.annotations[0].description : "";
-          // this.kpiTextTemp = this.kpiText;
+          /////////////////////
+          // Change alias process
+          /////////////////////
+
+          if( !isPush ) {
+            option.series[num].name = alias;
+            option.icons[num].seriesName = alias;
+            option.annotations[num].seriesName = alias;
+            option.secondaryIndicators[num].seriesName = alias;
+
+            for( let num2: number = 0 ; num2 < this.pivot.aggregations.length ; num2++ ) {
+              if( option.series.length >= (num2+1) && _.eq(alias, option.series[num2].name) ) {
+                series.push(option.series[num2]);
+              }
+              if( option.icons.length >= (num2+1) && _.eq(alias, option.icons[num2].seriesName) ) {
+                icons.push(option.icons[num2]);
+              }
+              if( option.annotations.length >= (num2+1) && _.eq(alias, option.annotations[num2].seriesName) ) {
+                annotations.push(option.annotations[num2]);
+              }
+              if( option.secondaryIndicators.length >= (num2+1) && _.eq(alias, option.secondaryIndicators[num2].seriesName) ) {
+                secondaryIndicators.push(option.secondaryIndicators[num2]);
+              }
+            }
+          }
         }
 
         // 변경된 순서 반영

--- a/discovery-frontend/src/app/page/chart-style/secondary-indicator.component.ts
+++ b/discovery-frontend/src/app/page/chart-style/secondary-indicator.component.ts
@@ -146,7 +146,10 @@ export class SecondaryIndicatorComponent extends BaseOptionComponent {
         // 타겟
         //////////////////////////////////////////
         const field: any = this.pivot.aggregations[num];
-        const alias: string = field['alias'] ? field['alias'] : field['fieldAlias'] ? field['fieldAlias'] : field['name'];
+        let alias: string = field['alias'] ? field['alias'] : field['fieldAlias'] ? field['fieldAlias'] : field['name'];
+        if( field.aggregationType && field.aggregationType != "" ) {
+          alias = field.aggregationType +"("+ alias +")";
+        }
 
         /////////////////////
         // Pivot이 추가되었을때 처리

--- a/discovery-frontend/src/app/page/chart-style/secondary-indicator.component.ts
+++ b/discovery-frontend/src/app/page/chart-style/secondary-indicator.component.ts
@@ -155,6 +155,7 @@ export class SecondaryIndicatorComponent extends BaseOptionComponent {
         // Pivot이 추가되었을때 처리
         /////////////////////
 
+        //if( option.series.length <= num || option.series.length != this.pivot.aggregations.length ) {
         if( option.series.length <= num ) {
           if( num > 0 ) {
             option.series[num] = {

--- a/discovery-frontend/src/app/page/chart-style/secondary-indicator.component.ts
+++ b/discovery-frontend/src/app/page/chart-style/secondary-indicator.component.ts
@@ -204,8 +204,10 @@ export class SecondaryIndicatorComponent extends BaseOptionComponent {
         // Pivot의 순서가 변경되었을때 처리
         /////////////////////
 
+        let isPush: boolean = false;
         for( let num2: number = 0 ; num2 < this.pivot.aggregations.length ; num2++ ) {
           if( option.series.length >= (num2+1) && _.eq(alias, option.series[num2].name) ) {
+            isPush = true;
             series.push(option.series[num2]);
           }
           if( option.icons.length >= (num2+1) && _.eq(alias, option.icons[num2].seriesName) ) {
@@ -216,6 +218,32 @@ export class SecondaryIndicatorComponent extends BaseOptionComponent {
           }
           if( option.secondaryIndicators.length >= (num2+1) && _.eq(alias, option.secondaryIndicators[num2].seriesName) ) {
             secondaryIndicators.push(option.secondaryIndicators[num2]);
+          }
+        }
+
+        /////////////////////
+        // Change alias process
+        /////////////////////
+
+        if( !isPush ) {
+          option.series[num].name = alias;
+          option.icons[num].seriesName = alias;
+          option.annotations[num].seriesName = alias;
+          option.secondaryIndicators[num].seriesName = alias;
+
+          for( let num2: number = 0 ; num2 < this.pivot.aggregations.length ; num2++ ) {
+            if( option.series.length >= (num2+1) && _.eq(alias, option.series[num2].name) ) {
+              series.push(option.series[num2]);
+            }
+            if( option.icons.length >= (num2+1) && _.eq(alias, option.icons[num2].seriesName) ) {
+              icons.push(option.icons[num2]);
+            }
+            if( option.annotations.length >= (num2+1) && _.eq(alias, option.annotations[num2].seriesName) ) {
+              annotations.push(option.annotations[num2]);
+            }
+            if( option.secondaryIndicators.length >= (num2+1) && _.eq(alias, option.secondaryIndicators[num2].seriesName) ) {
+              secondaryIndicators.push(option.secondaryIndicators[num2]);
+            }
           }
         }
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
KPI차트에서 Aggregation type이 다른 동일한 Pivot의 설명 및 아이콘을 개별 컨트롤할때 같이 변경되는 증상을 해결합니다.

**Related Issue** : #355<!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 차트 생성화면으로 이동합니다.
2. 동일 Measure를 Aggregation type이 다르게 두개 선택합니다.
3. 공통옵션 패널에서 Icon 사용 체크 후 하나의 Measure를 개별 선택합니다.
4. 아이콘 변경시 두개의 pivot이 각각 적용이 되는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
