### PR TITLE
#346 No error message when the chart can not be loaded

### DIFF
--- a/discovery-frontend/src/app/common/service/abstract.service.ts
+++ b/discovery-frontend/src/app/common/service/abstract.service.ts
@@ -123,7 +123,7 @@ export class AbstractService {
     const headers = new Headers({
       'Content-Type': 'application/json',
       Authorization: this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN_TYPE)
-      + ' ' + this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN),
+        + ' ' + this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN),
 
     });
 
@@ -158,7 +158,7 @@ export class AbstractService {
     const headers = new Headers({
       'Content-Type': 'multipart/form-data',
       Authorization: this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN_TYPE)
-      + ' ' + this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN),
+        + ' ' + this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN),
 
     });
 
@@ -188,7 +188,7 @@ export class AbstractService {
     const headers = new Headers({
       'Content-Type': 'text/html',
       Authorization: this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN_TYPE)
-      + ' ' + this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN),
+        + ' ' + this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN),
 
     });
 
@@ -223,15 +223,21 @@ export class AbstractService {
     const headers = new Headers({
       'Content-Type': 'application/json',
       Authorization: this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN_TYPE)
-      + ' ' + this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN),
+        + ' ' + this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN),
 
     });
 
-    // 호출
-    return this.http.post(url, JSON.stringify(data), { headers })
-      .toPromise()
-      .then(response => scope.resultHandler(scope, response))
-      .catch(error => scope.errorHandler(scope, error, httpMethod.POST, data));
+    try {
+      // 호출
+      return this.http.post(url, JSON.stringify(data), { headers })
+        .toPromise()
+        .then(response => scope.resultHandler(scope, response))
+        .catch(error => scope.errorHandler(scope, error, httpMethod.POST, data));
+    } catch (err) {
+      console.error( err );
+      return Promise.reject(err);
+    }
+
   }
 
   // Post 바이너리
@@ -242,7 +248,7 @@ export class AbstractService {
       Accept: 'application/octet-stream',
       'Content-Type': 'application/json',
       Authorization: this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN_TYPE)
-      + ' ' + this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN),
+        + ' ' + this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN),
     });
     this.http.post(url, JSON.stringify(data), { headers }).subscribe(
       (response) => {
@@ -262,7 +268,7 @@ export class AbstractService {
       Accept: 'application/octet-stream',
       'Content-Type': 'application/json',
       Authorization: this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN_TYPE)
-      + ' ' + this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN),
+        + ' ' + this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN),
     });
 
     // 호출
@@ -282,7 +288,7 @@ export class AbstractService {
     const headers = new Headers({
       'Content-Type': contentType,
       Authorization: this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN_TYPE)
-      + ' ' + this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN),
+        + ' ' + this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN),
 
     });
 
@@ -328,7 +334,7 @@ export class AbstractService {
     const headers = new Headers({
       'Content-Type': type,
       Authorization: this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN_TYPE)
-      + ' ' + this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN),
+        + ' ' + this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN),
 
     });
 
@@ -370,7 +376,7 @@ export class AbstractService {
     const headers = new Headers({
       'Content-Type': 'application/json',
       Authorization: this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN_TYPE)
-      + ' ' + this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN),
+        + ' ' + this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN),
 
     });
 
@@ -453,7 +459,7 @@ export class AbstractService {
           const headers = new Headers({
             'Content-Type': 'application/json',
             Authorization: this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN_TYPE)
-            + ' ' + this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN),
+              + ' ' + this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN),
           });
 
           // 기존 API를 다시 호출

--- a/discovery-frontend/src/app/dashboard/util/dashboard.util.ts
+++ b/discovery-frontend/src/app/dashboard/util/dashboard.util.ts
@@ -32,8 +32,77 @@ import { DashboardPageRelation } from '../../domain/dashboard/widget/page-widget
 import { BoardWidgetOptions, WidgetShowType } from '../../domain/dashboard/dashboard.globalOptions';
 import { StringUtil } from '../../common/util/string.util';
 import { CommonUtil } from '../../common/util/common.util';
+import { ChartType } from '../../common/component/chart/option/define/common';
 
 export class DashboardUtil {
+
+  /**
+   * 차트의 아이콘 클래스명 반환
+   * @return {string}
+   */
+  public static getChartIconClass(widget:PageWidget): string {
+    let iconClass: string = '';
+    switch (widget.configuration.chart.type) {
+      case ChartType.BAR :
+        iconClass = 'ddp-chart-bar';
+        break;
+      case ChartType.LINE :
+        iconClass = 'ddp-chart-linegraph';
+        break;
+      case ChartType.GRID :
+        iconClass = 'ddp-chart-table';
+        break;
+      case ChartType.SCATTER :
+        iconClass = 'ddp-chart-scatter';
+        break;
+      case ChartType.HEATMAP :
+        iconClass = 'ddp-chart-heatmap';
+        break;
+      case ChartType.PIE :
+        iconClass = 'ddp-chart-pie';
+        break;
+      case ChartType.MAPVIEW :
+        iconClass = 'ddp-chart-map';
+        break;
+      case ChartType.CONTROL :
+        iconClass = 'ddp-chart-cont';
+        break;
+      case ChartType.LABEL :
+        iconClass = 'ddp-chart-kpi';
+        break;
+      case ChartType.LABEL2 :
+        iconClass = 'ddp-chart-kpi';
+        break;
+      case ChartType.BOXPLOT :
+        iconClass = 'ddp-chart-boxplot';
+        break;
+      case ChartType.WATERFALL :
+        iconClass = 'ddp-chart-waterfall';
+        break;
+      case ChartType.WORDCLOUD :
+        iconClass = 'ddp-chart-wordcloud';
+        break;
+      case ChartType.COMBINE :
+        iconClass = 'ddp-chart-combo';
+        break;
+      case ChartType.TREEMAP :
+        iconClass = 'ddp-chart-treemap';
+        break;
+      case ChartType.RADAR :
+        iconClass = 'ddp-chart-radar';
+        break;
+      case ChartType.NETWORK :
+        iconClass = 'ddp-chart-network';
+        break;
+      case ChartType.SANKEY :
+        iconClass = 'ddp-chart-sankey';
+        break;
+      case ChartType.GAUGE :
+        iconClass = 'ddp-chart-bar';
+        break;
+    }
+    return iconClass;
+  } // function - getChartIconClass
 
   /**
    * 생성/수정 시 대시보드의 데이터소스와 데이터소스 연관 관계를 설정함
@@ -897,4 +966,4 @@ export class DashboardUtil {
     return boardInfo;
   } // function - convertSpecToUI
 
-} // class - DashboardModelService
+} // class - DashboardUtil

--- a/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.html
+++ b/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.html
@@ -389,7 +389,7 @@
       <div class="ddp-wrap-data-none">
         <div class="ddp-ui-data-none">
           <div class="ddp-txt-none">
-            <em class="{{getChartIconClass()}} ddp-error"></em>
+            <em class="{{boardUtil.getChartIconClass(widget)}} ddp-error"></em>
             <span class="ddp-data-name">{{widget.name}}</span>
             <span class="ddp-txt-det" [innerHTML]="'msg.board.ui.invalid-pivot' | translate"></span>
           </div>
@@ -405,7 +405,7 @@
       <div class="ddp-wrap-data-none">
         <div class="ddp-ui-data-none">
           <div class="ddp-txt-none">
-            <em class="{{getChartIconClass()}}"></em>
+            <em class="{{boardUtil.getChartIconClass(widget)}}"></em>
             <span class="ddp-data-name">{{widget.name}}</span>
             <span class="ddp-txt-det">
               {{'msg.page.ui.no.data.show' | translate}}
@@ -423,7 +423,7 @@
       <div class="ddp-wrap-data-none">
         <div class="ddp-ui-data-none">
           <div class="ddp-txt-none">
-            <em class="{{getChartIconClass()}} ddp-error"></em>
+            <em class="{{boardUtil.getChartIconClass(widget)}} ddp-error"></em>
             <span class="ddp-data-name">{{widget.name}}</span>
             <span class="ddp-txt-det">{{ 'msg.page.ui.no.data.error' | translate }}</span>
           </div>

--- a/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
+++ b/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
@@ -325,6 +325,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Public Method
    |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
+  public boardUtil = DashboardUtil;
 
   /**
    * 범례 표시여부 변경
@@ -691,74 +692,6 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
   public isShowWidgetName(): boolean {
     return this.isViewMode && this.widget && this.widget.name && this.isShowTitle && !this.isShowHierarchyView;
   } // function - isShowWidgetName
-
-  /**
-   * 차트의 아이콘 클래스명 반환
-   * @return {string}
-   */
-  public getChartIconClass(): string {
-    let iconClass: string = '';
-    switch (this.widget.configuration.chart.type) {
-      case ChartType.BAR :
-        iconClass = 'ddp-chart-bar';
-        break;
-      case ChartType.LINE :
-        iconClass = 'ddp-chart-linegraph';
-        break;
-      case ChartType.GRID :
-        iconClass = 'ddp-chart-table';
-        break;
-      case ChartType.SCATTER :
-        iconClass = 'ddp-chart-scatter';
-        break;
-      case ChartType.HEATMAP :
-        iconClass = 'ddp-chart-heatmap';
-        break;
-      case ChartType.PIE :
-        iconClass = 'ddp-chart-pie';
-        break;
-      case ChartType.MAPVIEW :
-        iconClass = 'ddp-chart-map';
-        break;
-      case ChartType.CONTROL :
-        iconClass = 'ddp-chart-cont';
-        break;
-      case ChartType.LABEL :
-        iconClass = 'ddp-chart-kpi';
-        break;
-      case ChartType.LABEL2 :
-        iconClass = 'ddp-chart-kpi';
-        break;
-      case ChartType.BOXPLOT :
-        iconClass = 'ddp-chart-boxplot';
-        break;
-      case ChartType.WATERFALL :
-        iconClass = 'ddp-chart-waterfall';
-        break;
-      case ChartType.WORDCLOUD :
-        iconClass = 'ddp-chart-wordcloud';
-        break;
-      case ChartType.COMBINE :
-        iconClass = 'ddp-chart-combo';
-        break;
-      case ChartType.TREEMAP :
-        iconClass = 'ddp-chart-treemap';
-        break;
-      case ChartType.RADAR :
-        iconClass = 'ddp-chart-radar';
-        break;
-      case ChartType.NETWORK :
-        iconClass = 'ddp-chart-network';
-        break;
-      case ChartType.SANKEY :
-        iconClass = 'ddp-chart-sankey';
-        break;
-      case ChartType.GAUGE :
-        iconClass = 'ddp-chart-bar';
-        break;
-    }
-    return iconClass;
-  } // function - getChartIconClass
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Public Method - for Header

--- a/discovery-frontend/src/app/page/page.component.html
+++ b/discovery-frontend/src/app/page/page.component.html
@@ -1134,18 +1134,35 @@
                   <div *ngIf="isSankeyNotAllNode && !isNoData && isChartView && selectChart == 'sankey'" class="ddp-txt-detail">※ {{'msg.page.ui.sankey.data.part' | translate}}</div>
                   <!-- //Sankey Information -->
 
-                  <!-- data none -->
+                  <!-- No Data 영역 -->
                   <div *ngIf="isNoData" class="ddp-box-data-none">
                     <div class="ddp-wrap-data-none">
                       <div class="ddp-ui-data-none">
                         <div class="ddp-txt-none">
-                          {{'msg.page.ui.no.data.show' | translate}}
+                          <em class="{{boardUtil.getChartIconClass(widget)}}"></em>
+                          <span class="ddp-data-name">{{widget.name}}</span>
+                          <span class="ddp-txt-det">
+                            {{'msg.page.ui.no.data.show' | translate}}
+                          </span>
                         </div>
-
                       </div>
                     </div>
                   </div>
-                  <!-- //data none -->
+                  <!-- // No Data 영역 -->
+
+                  <!-- Error 표시 영역 -->
+                  <div *ngIf="isError" class="ddp-box-data-none">
+                    <div class="ddp-wrap-data-none">
+                      <div class="ddp-ui-data-none">
+                        <div class="ddp-txt-none">
+                          <em class="{{boardUtil.getChartIconClass(widget)}} ddp-error"></em>
+                          <span class="ddp-data-name">{{widget.name}}</span>
+                          <span class="ddp-txt-det">{{ 'msg.page.ui.no.data.error' | translate }}</span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <!-- // Error 표시 영역 -->
 
                   <!-- page -->
                   <!-- 차트 개발 붙이고 디자인 수정 예정 -->
@@ -1170,7 +1187,7 @@
                   </div>
 
                   <div style="width: 100%; height: 100%"
-                       [style.display]="!isNoData && isChartView ? 'block' : 'none'">
+                       [style.display]="!isError && !isNoData && isChartView ? 'block' : 'none'">
                     <bar-chart #chart
                                [isPage]="true"
                                *ngIf="selectChart == 'bar'"

--- a/discovery-frontend/src/app/page/page.component.ts
+++ b/discovery-frontend/src/app/page/page.component.ts
@@ -285,8 +285,8 @@ export class PageComponent extends AbstractPopupComponent implements OnInit, OnD
   // Data Detail 팝업: 컬럼 디테일 여부
   public isColumnDetail: boolean = false;
 
-  // No Data 여부
-  public isNoData: boolean = false;
+  public isNoData: boolean = false;   // No Data 여부
+  public isError: boolean = false;    // 에러 상태 표시 여부
 
   // 센키차트 모든노트 표시안함 여부
   public isSankeyNotAllNode: boolean = false;
@@ -601,6 +601,8 @@ export class PageComponent extends AbstractPopupComponent implements OnInit, OnD
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Public Method
    |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
+  public boardUtil = DashboardUtil;
+
   /**
    * 차트 이미지 업로드
    * @param {string} widgetId
@@ -1241,6 +1243,7 @@ export class PageComponent extends AbstractPopupComponent implements OnInit, OnD
 
         })
         .catch((error) => {
+          this.isError = true;
           this.loadingHide();
           console.info('error', error);
         });
@@ -3463,6 +3466,7 @@ export class PageComponent extends AbstractPopupComponent implements OnInit, OnD
     // chart pivot valid
     if (false === this.chart.isValid(this.pivot)) {
       this.isChartShow = false;
+      this.isError = true;
       return;
     }
 
@@ -3485,6 +3489,7 @@ export class PageComponent extends AbstractPopupComponent implements OnInit, OnD
     }
     this.loadingShow();
     this.isNoData = false;
+    this.isError = false;
     this.isChartShow = true;
 
     // 변경사항 반영 (resultData설정시 설정할 옵션전에 패널이 켜지므로 off)
@@ -3545,7 +3550,7 @@ export class PageComponent extends AbstractPopupComponent implements OnInit, OnD
                     .getAnalysisPredictionLineFromPage(this.widgetConfiguration, this.widget, this.lineChartComponent, resultData)
                     .catch(() => {
                       this.loadingHide();
-                      throw new Error('getAnalysis API error');
+                      this.isError = true;
                     });
                 } else {
                   this.lineChartComponent.analysis = null;
@@ -3571,6 +3576,7 @@ export class PageComponent extends AbstractPopupComponent implements OnInit, OnD
     ).catch((reason) => {
       console.error('Search Query Error =>', reason);
       this.isChartShow = false;
+      this.isError = true;
 
       // 변경사항 반영
       this.changeDetect.detectChanges();


### PR DESCRIPTION
### Description
차트를 그릴 수 없는 상황일 때
차트와 대시보드 편집 화면의 차트 영역에 아무것도 나타나지 않아서 사용자가 어떤 상황인지 알수 없습니다.

**Related Issue** : #346 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 대시보드를 생성합니다. ( 테스트는 sales datasource를 이용하여 진행함 )
2. 라인 차트를 생성하고 예측선 기능을 추가합니다.
( 테스트 예 > dimension : OrderDate ( Granularity : year ) / measure : sales / 예측선 추가 => 오류가 나는 상황을 만들기 위한 설정 )
3. 차트 화면에 '데이터를 표시할 수 없음'이 표시되어야 합니다.
4. 차트를 저장합니다.
5. 대시보드 편집화면에서 차트 위젯에 '데이터를 표시할 수 없음' 이 표시되어야 합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
