### PR TITLE
#369 userinfo auth-type use AuthUtils.getAuthUserName() 

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/WorkbenchService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/WorkbenchService.java
@@ -84,9 +84,7 @@ public class WorkbenchService {
 
       switch (authenticationType){
         case USERINFO:
-          connectionUsername = StringUtils.isEmpty(jdbcDataConnection.getUsername())
-                  ? AuthUtils.getAuthUserName()
-                  : jdbcDataConnection.getUsername();
+          connectionUsername = AuthUtils.getAuthUserName();
           User user = cachedUserService.findUser(connectionUsername);
           if(user == null){
             throw new ResourceNotFoundException("User(" + connectionUsername + ")");


### PR DESCRIPTION
### Description
3.0.2 이전 버전에서 생성된 Auth-Type이 UserInfo인 커넥션일 경우 커넥션에 불필요한 사용자 정보가 저장되어 있어 권한처리 오류 발생
Auth-Type이 UserInfo인 커넥션일 경우 사용하는 사용자 정보는 DataConnection 정보 참조 안하도록 변경함

**Related Issue** : <!--- Please link to the issue here. -->
#369 

### How Has This Been Tested?
1. login testbed1 user
(id : testbed1, pw : testbed1)

2. create workbench with dataconnection test3.0.2 (MYSQL)
test3.0.2 dataconnection created by polaris user before 3.0.1 release

3. click created workbench
4. open workbench without permission error

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
