### PR TITLE
#217 Error that prevents selection filtering on a texttable (grid) chart with a global filter

### DIFF
--- a/discovery-frontend/src/app/dashboard/dashboard.component.ts
+++ b/discovery-frontend/src/app/dashboard/dashboard.component.ts
@@ -40,7 +40,6 @@ import { DatasourceService } from '../datasource/service/datasource.service';
 import {
   ConnectionType,
   Datasource,
-  Status,
   TempDsStatus,
   TemporaryDatasource
 } from 'app/domain/datasource/datasource';
@@ -190,7 +189,7 @@ export class DashboardComponent extends DashboardLayoutComponent implements OnIn
     // 대시보드 필터 정보 조회 및 각 위젯 적용
     const boardFilters: Filter[] = DashboardUtil.getBoardFilters(this.dashboard);
     if (boardFilters && boardFilters.length > 0) {
-      this.broadCaster.broadcast('SET_EXTERNAL_FILTER', { filters: boardFilters });
+      this.broadCaster.broadcast('SET_GLOBAL_FILTER', { filters: boardFilters });
     }
     this.selectionFilter.init();
     // TODO 필터 변경알림 나중에 제거할 로직
@@ -213,10 +212,7 @@ export class DashboardComponent extends DashboardLayoutComponent implements OnIn
       // console.info('셀렉션필터에 의한 변경', selectionFilters);
       // console.info('모든 차트에 필터 추가');
 
-      this.broadCaster.broadcast(
-        'SET_EXTERNAL_FILTER',
-        { filters: DashboardUtil.getBoardFilters(this.dashboard).concat(selectionFilters) }
-      );
+      this.broadCaster.broadcast( 'SET_SELECTION_FILTER', { filters: selectionFilters } );
 
     } else {
       // 차트에 의한 변경
@@ -234,7 +230,6 @@ export class DashboardComponent extends DashboardLayoutComponent implements OnIn
       }
 
       // 2. 선택 필터 데이터 변환
-      let cloneBoardFilters: Filter[] = DashboardUtil.getBoardFilters(this.dashboard, true);
       let selectionFilters: SelectionFilter[] = data.filters.map((filter: SelectionFilter) => {
         filter.valueList = _.uniq(_.flattenDeep(filter.valueList));
         (widgetId) && (filter.selectedWidgetId = widgetId); // detail 차트를 위해 필터 선택을 한 위젯의 아이디를 저장해준다.
@@ -242,6 +237,8 @@ export class DashboardComponent extends DashboardLayoutComponent implements OnIn
       });
 
       // 3. 선택필터와 보드필터 병합 ( 같은 필드 )
+/*
+      let cloneBoardFilters: Filter[] = DashboardUtil.getBoardFilters(this.dashboard, true);
       cloneBoardFilters.forEach(item1 => {
         const idx: number = selectionFilters.findIndex(item2 => item1.field === item2.field && item1.ref === item2.ref);
         if (-1 < idx) {
@@ -252,10 +249,12 @@ export class DashboardComponent extends DashboardLayoutComponent implements OnIn
           }
         }
       });
-
       externalFilterData.filters = cloneBoardFilters.concat(selectionFilters);
+*/
 
-      this.broadCaster.broadcast('SET_EXTERNAL_FILTER', externalFilterData);
+      externalFilterData.filters = selectionFilters;
+
+      this.broadCaster.broadcast('SET_SELECTION_FILTER', externalFilterData);
 
     }
   } // function - changedSelectionFilter

--- a/discovery-frontend/src/app/dashboard/update-dashboard.component.ts
+++ b/discovery-frontend/src/app/dashboard/update-dashboard.component.ts
@@ -1613,7 +1613,7 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
 
     const boardCastData = { filters: boardFilters };
     ( excludeWidgetId ) && ( boardCastData['excludeWidgetId'] = excludeWidgetId );
-    this.broadCaster.broadcast('SET_EXTERNAL_FILTER', boardCastData );
+    this.broadCaster.broadcast('SET_GLOBAL_FILTER', boardCastData );
 
   } // function - syncFilterWidget
 

--- a/discovery-frontend/src/app/dashboard/widgets/filter-widget/filter-widget.component.ts
+++ b/discovery-frontend/src/app/dashboard/widgets/filter-widget/filter-widget.component.ts
@@ -684,11 +684,13 @@ export class FilterWidgetComponent extends AbstractWidgetComponent implements On
    * 스크롤바 표시 여부를 설정한다.
    */
   private _setIsVisibleScrollbar() {
-    const $container: JQuery = $(this.filterWidget.nativeElement);
-    const $title: JQuery = $container.find('.ddp-ui-title');
-    const $contents: JQuery = $container.find('.ddp-ui-widget-contents');
-    this.isVisibleScrollbar = ($container.height() < $title.height() + $contents.height());
-    this.safelyDetectChanges();
+    if( this.filterWidget ) {
+      const $container: JQuery = $(this.filterWidget.nativeElement);
+      const $title: JQuery = $container.find('.ddp-ui-title');
+      const $contents: JQuery = $container.find('.ddp-ui-widget-contents');
+      this.isVisibleScrollbar = ($container.height() < $title.height() + $contents.height());
+      this.safelyDetectChanges();
+    }
   } // function - _setIsVisibleScrollbar
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
+++ b/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
@@ -101,8 +101,8 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
   // 현재 위젯에서 발생시킨 필터정보
   private _selectFilterList: any[] = [];
 
-  // 마지막으로 호출된 필터 목록
-  private _externalFilters: Filter[] = [];
+  // Current Selection Filters
+  private _currentSelectionFilters: Filter[] = [];
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Protected Variables
@@ -268,11 +268,22 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
 
     // 외부 필터 설정
     this.subscriptions.push(
-      this.broadCaster.on<any>('SET_EXTERNAL_FILTER').subscribe(data => {
+      this.broadCaster.on<any>('SET_GLOBAL_FILTER').subscribe(data => {
         if (data.widgetId && data.widgetId === this.widget.id) {
           this._search(data.filters);
         } else if (data.excludeWidgetId !== this.widget.id) {
           this._search(data.filters);
+        }
+      })
+    );
+
+    // 선택 필터 설정
+    this.subscriptions.push(
+      this.broadCaster.on<any>('SET_SELECTION_FILTER').subscribe(data => {
+        if (data.widgetId && data.widgetId === this.widget.id) {
+          this._search(null, data.filters);
+        } else if (data.excludeWidgetId !== this.widget.id) {
+          this._search(null, data.filters);
         }
       })
     );
@@ -441,22 +452,13 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
       if (data.data) {
         data.data.map((field) => {
           let isExternalFilter: boolean = false;
-          if (this._externalFilters) {
-            this._externalFilters.map((filter) => {
-              // 동일한 필터가 있는지 찾는다.
-              if (_.eq(field.alias, filter.field)) {
-                isExternalFilter = true;
-              }
-            });
+          if (this._currentSelectionFilters) {
+            // 동일한 필터가 있는지 찾는다.
+            isExternalFilter = this._currentSelectionFilters.some(filter => field.alias === filter.field);
           }
 
           // 내가 선택한거면 예외
-          let isAlreadyFilter: boolean = false;
-          this._selectFilterList.map((filter) => {
-            if (_.eq(field.alias, filter.alias)) {
-              isAlreadyFilter = true;
-            }
-          });
+          let isAlreadyFilter: boolean = this._selectFilterList.some(filter => field.alias === filter.alias);
 
           if (!isExternalFilter || isAlreadyFilter) {
             selectData.push(field);
@@ -574,6 +576,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
    */
   public changeExternalFilterList(externalFilters?: Filter[]): Filter[] {
 
+    ( isNullOrUndefined( externalFilters ) ) && ( externalFilters = [] );
 
     // 대시보드에서 필터를 발생시킨경우 => 필터 목록 제거
     for (let num = (this._selectFilterList.length - 1); num >= 0; num--) {
@@ -999,10 +1002,11 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
 
   /**
    * 데이터 검색
-   * @param {Filter[]} externalFilters
+   * @param {Filter[]} globalFilters
+   * @param {Filter[]} selectionFilters
    * @private
    */
-  private _search(externalFilters?: Filter[]) {
+  private _search(globalFilters?:Filter[], selectionFilters?: Filter[]) {
 
     // 프로세스 실행 등록
     this.processStart();
@@ -1013,20 +1017,19 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
       return;
     }
 
-    // 현재 위젯에서 발생시킨 필터정보 제외처리
-    externalFilters = this.changeExternalFilterList(externalFilters);
-    this._externalFilters = externalFilters;
-
     // 버전 확인
     if (!this.uiOption.version || this.uiOption.version < SPEC_VERSION) {
       // 옵션 초기화
       this.uiOption = OptionGenerator.initUiOption(this.uiOption);
     }
 
+    // 현재 위젯에서 발생시킨 필터정보 제외처리
+    this._currentSelectionFilters = this.changeExternalFilterList(selectionFilters);
+
     // Hierarchy View 설정
     if (this.parentWidget) {
-      if (externalFilters) {
-        const idx = externalFilters.findIndex(item => this.parentWidget.id === item['selectedWidgetId']);
+      if (selectionFilters) {
+        const idx = selectionFilters.findIndex(item => this.parentWidget.id === item['selectedWidgetId']);
         if (-1 < idx) {
           this.isShowHierarchyView = false;
         } else {
@@ -1083,12 +1086,14 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
       return;
     }
 
-    if (isNullOrUndefined(externalFilters)) {
-      // 외부필터가 없고 글로벌 필터가 있을 경우 추가 (초기 진입시)
-      const boardFilter: Filter[] = DashboardUtil.getAllFiltersDsRelations(this.widget.dashBoard, widgetDataSource.engineName);
-      (boardFilter && 0 < boardFilter.length) && (uiCloneQuery.filters = boardFilter.concat(uiCloneQuery.filters));
-    } else {
-      // 외부 필터 ( 글로벌 필터 + Selection Filter )
+    // 외부필터가 없고 글로벌 필터가 있을 경우 추가 (초기 진입시)
+    if (isNullOrUndefined(globalFilters)) {
+      globalFilters = DashboardUtil.getAllFiltersDsRelations(this.widget.dashBoard, widgetDataSource.engineName);
+    }
+
+    // 외부 필터 ( 글로벌 필터 + Selection Filter )
+    {
+      let externalFilters = selectionFilters ? globalFilters.concat( selectionFilters ) : globalFilters;
       externalFilters = DashboardUtil.getAllFiltersDsRelations(this.widget.dashBoard, widgetDataSource.engineName, externalFilters);
 
       uiCloneQuery.filters.forEach(item1 => {
@@ -1132,7 +1137,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
         uiOption: this.uiOption,
         params: {
           widgetId: this.widget.id,
-          externalFilters: (externalFilters !== undefined),
+          externalFilters: (selectionFilters !== undefined),
           // 현재 차트가 선택한 필터목록
           selectFilterListList: this._selectFilterList
         }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
특정 차원값으로 만들어진 글로벌 필터가 위젯으로 있는 경우
글로벌 필터로 우선 필터링을 하고,
텍스트그리드 차트에서 해당 차원값을 선택 필터링 하면 선택 필터가 다른 차트에 반영되지 안되는 현상

**Related Issue** : #217 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 동일한 차원값, 측정값으로 구성된 바차트와 그리드 차트를 생성합니다.
2. 차트에서 사용한 차원값을 이용하여 글로벌 필터 위젯을 생성합니다.
3. 대시보드를 저장한 후 대시보드 열람모드로 이동합니다.
4. 글로벌 필터를 이용하여 필터링을 합니다.
5. 텍스트 그리드에서 하나의 값을 선택 필터링을 하여 필터링이 되는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
