### PR TITLE
#384 add to apply pre-defined option and override user-defined option

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourceController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourceController.java
@@ -76,9 +76,8 @@ import app.metatron.discovery.domain.datasource.ingestion.IngestionHistory;
 import app.metatron.discovery.domain.datasource.ingestion.IngestionHistoryRepository;
 import app.metatron.discovery.domain.datasource.ingestion.IngestionInfo;
 import app.metatron.discovery.domain.datasource.ingestion.IngestionOption;
-import app.metatron.discovery.domain.datasource.ingestion.IngestionOptionPredicate;
 import app.metatron.discovery.domain.datasource.ingestion.IngestionOptionProjections;
-import app.metatron.discovery.domain.datasource.ingestion.IngestionOptionRepository;
+import app.metatron.discovery.domain.datasource.ingestion.IngestionOptionService;
 import app.metatron.discovery.domain.engine.EngineIngestionService;
 import app.metatron.discovery.domain.engine.EngineLoadService;
 import app.metatron.discovery.domain.engine.EngineQueryService;
@@ -95,7 +94,7 @@ import static app.metatron.discovery.domain.datasource.DataSourceTemporary.ID_PR
 import static app.metatron.discovery.domain.datasource.ingestion.IngestionHistory.IngestionStatus.FAILED;
 
 /**
- * Created by kyungtaak on 2016. 7. 22..
+ *
  */
 @RepositoryRestController
 public class DataSourceController {
@@ -124,9 +123,6 @@ public class DataSourceController {
   DataConnectionRepository dataConnectionRepository;
 
   @Autowired
-  IngestionOptionRepository ingestionOptionRepository;
-
-  @Autowired
   DataSourceService dataSourceService;
 
   @Autowired
@@ -134,6 +130,9 @@ public class DataSourceController {
 
   @Autowired
   EngineLoadService engineLoadService;
+
+  @Autowired
+  IngestionOptionService ingestionOptionService;
 
   @Autowired
   PagedResourcesAssembler pagedResourcesAssembler;
@@ -640,13 +639,11 @@ public class DataSourceController {
     IngestionOption.IngestionType ingestionEnumType = SearchParamValidator
         .enumUpperValue(IngestionOption.IngestionType.class, ingestionType, "ingestionType");
 
-    Iterable<IngestionOption> resultOptions = ingestionOptionRepository.findAll(
-        IngestionOptionPredicate.searchList(optionEnumType, ingestionEnumType)
-    );
+    List resultOptions = ingestionOptionService.findIngestionOptions(optionEnumType, ingestionEnumType);
 
     return ResponseEntity.ok(ProjectionUtils.toListResource(projectionFactory,
                                                             IngestionOptionProjections.DefaultProjection.class,
-                                                            Lists.newArrayList(resultOptions)));
+                                                            resultOptions));
   }
 
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/ingestion/IngestionOptionService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/ingestion/IngestionOptionService.java
@@ -1,0 +1,64 @@
+package app.metatron.discovery.domain.datasource.ingestion;
+
+import com.google.common.collect.Lists;
+
+import org.apache.commons.collections4.MapUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+public class IngestionOptionService {
+
+  @Autowired
+  IngestionOptionRepository ingestionOptionRepository;
+
+  public List<IngestionOption> findIngestionOptions(IngestionOption.OptionType optionEnumType,
+                                                    IngestionOption.IngestionType ingestionEnumType) {
+    Iterable<IngestionOption> resultOptions = ingestionOptionRepository.findAll(
+        IngestionOptionPredicate.searchList(optionEnumType, ingestionEnumType)
+    );
+
+    return Lists.newArrayList(resultOptions);
+
+  }
+
+  public Map<String, Object> findTuningOptionMap(IngestionOption.IngestionType ingestionEnumType,
+                                                 Map<String, Object> overrideOptions) {
+
+    Map<String, Object> tuningOptions = findIngestionOptions(IngestionOption.OptionType.TUNING, ingestionEnumType)
+        .stream().collect(Collectors.toMap(k -> k.getName(), v -> v.defaultValueByType()));
+
+    if (MapUtils.isEmpty(overrideOptions)) {
+      return tuningOptions;
+    }
+
+    for (String key : overrideOptions.keySet()) {
+      tuningOptions.put(key, overrideOptions.get(key));
+    }
+
+    return tuningOptions;
+
+  }
+
+  public Map<String, Object> findJobOptionMap(IngestionOption.IngestionType ingestionEnumType,
+                                              Map<String, Object> overrideOptions) {
+
+    Map<String, Object> jobOptions = findIngestionOptions(IngestionOption.OptionType.JOB, ingestionEnumType)
+        .stream().collect(Collectors.toMap(k -> k.getName(), v -> v.defaultValueByType()));
+
+    if (MapUtils.isEmpty(overrideOptions)) {
+      return jobOptions;
+    }
+
+    for (String key : overrideOptions.keySet()) {
+      jobOptions.put(key, overrideOptions.get(key));
+    }
+
+    return jobOptions;
+
+  }
+}

--- a/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/IngestionSpecBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/IngestionSpecBuilder.java
@@ -35,7 +35,7 @@ import app.metatron.discovery.spec.druid.ingestion.tuning.RealTimeTuningConfig;
 import app.metatron.discovery.spec.druid.ingestion.tuning.TuningConfig;
 
 /**
- * Created by kyungtaak on 2016. 7. 30..
+ *
  */
 public class IngestionSpecBuilder extends AbstractSpecBuilder {
 
@@ -50,23 +50,14 @@ public class IngestionSpecBuilder extends AbstractSpecBuilder {
     return this;
   }
 
-  public IngestionSpecBuilder defaultBatchTuningConfig() {
-
-    tuningConfig = BatchTuningConfig.defaultConfig();
-
-    return this;
-  }
-
-  public IngestionSpecBuilder defaultRealtimeTuningConfig() {
-
-    tuningConfig = RealTimeTuningConfig.defaultConfig();
+  public IngestionSpecBuilder batchTuningConfig(Map<String, Object> tuningProperties) {
+    tuningConfig = new BatchTuningConfig(tuningProperties);
 
     return this;
   }
 
-  public IngestionSpecBuilder defaultHiveTuningConfig() {
-
-    tuningConfig = HadoopTuningConfig.hiveDefaultConfig();
+  public IngestionSpecBuilder realTimeTuningConfig(Map<String, Object> tuningProperties) {
+    tuningConfig = new RealTimeTuningConfig(tuningProperties);
 
     return this;
   }
@@ -117,8 +108,8 @@ public class IngestionSpecBuilder extends AbstractSpecBuilder {
     firehose.setBaseDir(baseDir);
     firehose.setFilter(filter);
 
-//    RealTimeIoConfig config = new RealTimeIoConfig();
-//    config.setFirehose(firehose);
+    //    RealTimeIoConfig config = new RealTimeIoConfig();
+    //    config.setFirehose(firehose);
 
     BatchIoConfig config = new BatchIoConfig();
     config.setFirehose(firehose);
@@ -141,7 +132,7 @@ public class IngestionSpecBuilder extends AbstractSpecBuilder {
   public IngestionSpecBuilder hdfsIoConfig(List<String> paths, boolean findRecursive, String splitSize) {
 
     HadoopIoConfig hadoopIoConfig = new HadoopIoConfig();
-    if(fileFormat == null) {
+    if (fileFormat == null) {
       hadoopIoConfig.setInputSpec(new HadoopInputSpec(paths, findRecursive, splitSize));
     } else {
       hadoopIoConfig.setInputSpec(new HadoopInputSpec(paths, findRecursive, splitSize, fileFormat.getInputFormat()));

--- a/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/tuning/BatchTuningConfig.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/tuning/BatchTuningConfig.java
@@ -14,10 +14,15 @@
 
 package app.metatron.discovery.spec.druid.ingestion.tuning;
 
+import org.apache.commons.beanutils.BeanUtils;
+import org.apache.commons.collections4.MapUtils;
+
+import java.util.Map;
+
 import app.metatron.discovery.spec.druid.ingestion.partition.PartitionSpec;
 
 /**
- * Created by kyungtaak on 2016. 6. 17..
+ *
  */
 public class BatchTuningConfig implements TuningConfig {
 
@@ -48,13 +53,21 @@ public class BatchTuningConfig implements TuningConfig {
   public BatchTuningConfig() {
   }
 
-  public static BatchTuningConfig defaultConfig() {
-    BatchTuningConfig config = new BatchTuningConfig();
-    config.setIgnoreInvalidRows(true);
-    config.setMaxRowsInMemory(75000);
-    config.setBuildV9Directly(true);
+  public BatchTuningConfig(Map<String, Object> tuningConfig) {
+    overrideConfig(tuningConfig);
+  }
 
-    return config;
+  public void overrideConfig(Map<String, Object> tuningConfig) {
+
+    if(MapUtils.isNotEmpty(tuningConfig)) {
+      for (String key : tuningConfig.keySet()) {
+        try {
+          BeanUtils.setProperty(this, key, tuningConfig.get(key));
+        } catch (Exception e) {
+        }
+      }
+    }
+
   }
 
   public String getWorkingPath() {

--- a/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/tuning/RealTimeTuningConfig.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/tuning/RealTimeTuningConfig.java
@@ -16,6 +16,9 @@ package app.metatron.discovery.spec.druid.ingestion.tuning;
 
 import com.google.common.collect.Maps;
 
+import org.apache.commons.beanutils.BeanUtils;
+import org.apache.commons.collections4.MapUtils;
+
 import java.util.Map;
 
 /**
@@ -56,6 +59,23 @@ public class RealTimeTuningConfig implements TuningConfig {
   Boolean ignorePreviousSegments;
 
   public RealTimeTuningConfig() {
+  }
+
+  public RealTimeTuningConfig(Map<String, Object> tuningConfig) {
+    overrideConfig(tuningConfig);
+  }
+
+  public void overrideConfig(Map<String, Object> tuningConfig) {
+
+    if(MapUtils.isNotEmpty(tuningConfig)) {
+      for (String key : tuningConfig.keySet()) {
+        try {
+          BeanUtils.setProperty(this, key, tuningConfig.get(key));
+        } catch (Exception e) {
+        }
+      }
+    }
+
   }
 
   public static RealTimeTuningConfig defaultConfig() {


### PR DESCRIPTION
### Description
데이터 소스 적재시 기본 옵션처리가 UI 에서 개발되었으나, 이에 대한 서버측에서 기본설정 처리가 누락되어 이를 수정합니다.

**Related Issue** : #384 

### How Has This Been Tested?
- 데이터 소스 관리 권한이 있는 사용자로 로그인 (ex. admin)
- 데이터 소스 관리 > 데이터 소스 목록 보기 > 데이터 소스 생성
- File/JDBC/StageDB 형태로 전달 
- "Please complete ingestion settings" 부분내 
   : Ingestion tuning configuration 기본값과 다른 값 입력
   : Ingestion tuning configuration 에서 기본값 외 다른 값 입력 (ex. cleanupOnFailure = false)
   : (StageDB 의 경우) "Job Properties" 부분내 기본값과 다른 값 입력, 기본값 외 다른값 입력  (ex. mapreduce.map.log.level=DEBUG) 
- 확인 1:  Server Log 내 실제 Druid Ingestion 확인 : "Ingestion Spec" 을 grep 하여 확인
   (ex. tail -f metatron-discovery.log | grep "Ingestion Spec")
  : Spec. 내 "tuningConfig" 속성이 정상적으로 전달 되는지 확인 
- 확인 2: druid overlord console 내 
  : "Running Tasks" 내 목록에서  more 컬럼 내 "payload" 클릭하여 적재 Spec. 확인 
  : Spec. 내 "tuningConfig" 속성이 정상적으로 전달 되는지 확인 
  : 적재 Task 가 Success 가 되는지 확인
  
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project. _it will be added soon_
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. _it will be added soon_
- [x] I have added tests to cover my changes.
- [] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
