### PR TITLE
#407 workbench editor indent error

### DIFF
--- a/discovery-frontend/src/app/workbench/workbench.component.ts
+++ b/discovery-frontend/src/app/workbench/workbench.component.ts
@@ -291,6 +291,7 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
     matchBrackets: true,
     autofocus: true,
     indentUnit: 4,
+    smartIndent:false,
     showSearchButton: true,
     extraKeys: {
       'Ctrl-Space': 'autocomplete',


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
쿼리 입력 후 엔터키를 이용해 line을 추가할 경우 indent 위치가 정상적이지 않은 현상

**Related Issue** : #407 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 워크벤치 화면으로 이동합니다.
2. 여러줄 쿼리를 입력합니다. ( 아래의 쿼리는 입력 예시 )
select part_hour, count(distinct(user_key))
–- select *
FROM tmap.log_channel
where (part_hour >= '2018080100')
and terminal_code = '010121'
group by part_hour;
3. 엔터키를 입력합니다.
4. 자동으로 들여쓰기가 적용되지 않고 커서가 다음줄 앞으로 이동하는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
