### PR TITLE
#329 Time range filter forces the date value with previous date

### DIFF
--- a/discovery-frontend/src/app/dashboard/filters/component/time-range.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/component/time-range.component.ts
@@ -195,7 +195,9 @@ export class TimeRangeComponent extends AbstractComponent implements OnInit, OnD
 
       if (TimeUnit.WEEK === this.compData.timeUnit) {
         this.comboList = _.cloneDeep(this._weekList);
-        const startWeek: number = fromMoment.week();
+        const arrDateInfo = (<string>interval.startDate).split( '-' );
+        fromMoment = moment( arrDateInfo[0] + '-01-01' );
+        const startWeek: number = Number(arrDateInfo[1]);
         this.fromComboIdx = this.comboList.findIndex(item => item.value === startWeek);
         this.selectedFromComboItem = this.comboList[this.fromComboIdx];
       } else if (TimeUnit.QUARTER === this.compData.timeUnit) {
@@ -205,7 +207,11 @@ export class TimeRangeComponent extends AbstractComponent implements OnInit, OnD
         this.selectedFromComboItem = this.comboList[this.fromComboIdx];
       }
 
-      this._fromDate = fromMoment.subtract(9, 'hours').toDate();
+      if( TimeUnit.HOUR === this.compData.timeUnit || TimeUnit.MINUTE === this.compData.timeUnit ) {
+        this._fromDate = fromMoment.subtract(9, 'hours').toDate();
+      } else {
+        this._fromDate = fromMoment.toDate();
+      }
 
       // 시작일 DatePicker 생성
       const startPickerSettings: TimeRangePickerSettings
@@ -235,7 +241,9 @@ export class TimeRangeComponent extends AbstractComponent implements OnInit, OnD
 
       if (TimeUnit.WEEK === this.compData.timeUnit) {
         this.comboList = _.cloneDeep(this._weekList);
-        const endWeek: number = toMoment.week();
+        const arrDateInfo = (<string>interval.endDate).split( '-' );
+        toMoment = moment( arrDateInfo[0] + '-01-01' );
+        const endWeek: number = Number(arrDateInfo[1]);
         this.toComboIdx = this.comboList.findIndex(item => item.value === endWeek);
         this.selectedToComboItem = this.comboList[this.toComboIdx];
       } else if (TimeUnit.QUARTER === this.compData.timeUnit) {
@@ -245,7 +253,11 @@ export class TimeRangeComponent extends AbstractComponent implements OnInit, OnD
         this.selectedToComboItem = this.comboList[this.toComboIdx];
       }
 
-      this._toDate = toMoment.subtract(9, 'hours').toDate();
+      if( TimeUnit.HOUR === this.compData.timeUnit || TimeUnit.MINUTE === this.compData.timeUnit ) {
+        this._toDate = toMoment.subtract(9, 'hours').toDate();
+      } else {
+        this._toDate = toMoment.toDate();
+      }
 
       // 종료일 DatePicker 생성
       if (interval.endDate !== TimeRangeFilter.LATEST_DATETIME) {
@@ -377,7 +389,7 @@ export class TimeRangeComponent extends AbstractComponent implements OnInit, OnD
    * @private
    */
   private _getRangeFromWeek(sWeek: number, sYear: number, eWeek: number, eYear: number): TimeRange {
-    return this._getRangeFromMoment(moment().year(sYear).week(sWeek), moment().year(eYear).week(eWeek), 'week');
+    return new TimeRange( sYear + '-' + sWeek, eYear + '-' + eWeek );
   } // function - _getRangeFromWeek
 
   // noinspection JSMethodCanBeStatic

--- a/discovery-frontend/src/app/dashboard/filters/time-filter/time-filter-panel.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/time-filter/time-filter-panel.component.ts
@@ -34,6 +34,8 @@ import { TimeRelativeFilter } from '../../../domain/workbook/configurations/filt
 import { TimeListFilter } from '../../../domain/workbook/configurations/filter/time-list-filter';
 import { isNullOrUndefined } from "util";
 import { Filter } from '../../../domain/workbook/configurations/filter/filter';
+import { PopupService } from '../../../common/service/popup.service';
+import { SubscribeArg } from '../../../common/domain/subscribe-arg';
 
 @Component({
   selector: 'time-filter-panel',
@@ -86,7 +88,8 @@ export class TimeFilterPanelComponent extends AbstractFilterPanelComponent imple
    |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
 
   // 생성자
-  constructor(protected elementRef: ElementRef,
+  constructor(private popupService: PopupService,
+              protected elementRef: ElementRef,
               protected injector: Injector) {
     super(elementRef, injector);
   }
@@ -109,6 +112,20 @@ export class TimeFilterPanelComponent extends AbstractFilterPanelComponent imple
     super.ngAfterViewInit();
     // 컴포넌트 초기화
     this._initialize(this.originalFilter);
+
+    // 위젯에서 필터를 업데이트 popup은 아니지만 동일한 기능이 필요해서 popupService를 사용
+    const popupSubscribe = this.popupService.filterView$.subscribe((data: SubscribeArg) => {
+
+      // 페이지에서 호출했는데 대시보드인경우 처리 하지 않음
+      if (data.type === 'page' && this.isDashboardMode) return;
+
+      // 필터 위젯에서 값이 변경될 경우
+      if ('change-filter' === data.name && this.filter.field === data.data.field && this.filter.dataSource === data.data.dataSource) {
+        this._initialize(data.data);
+      }
+    });
+    this.subscriptions.push(popupSubscribe);
+
   } // function - ngAfterViewInit
 
   /**

--- a/discovery-frontend/src/app/dashboard/util/filter.util.ts
+++ b/discovery-frontend/src/app/dashboard/util/filter.util.ts
@@ -419,7 +419,8 @@ export class FilterUtil {
       case TimeUnit.DAY:
         return moment(date).format('YYYY-MM-DD');
       case TimeUnit.WEEK:
-        return moment(date).format('YYYY-WW');
+        // return moment(date).format('YYYY-WW');
+        return (<string>date);
       case TimeUnit.MONTH:
         return moment(date).format('YYYY-MM');
       case TimeUnit.QUARTER:


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Time range filter에서 대시보드 편집 화면의 값과 열람 화면의 값이 달리 표시되는 현상

**Related Issue** : #329 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 대시보드 편집화면으로 이동합니다.
2. 필터 패털을 열어 타임 필드를 필터로 추가하고 타입을 specific 으로 변경합니다.
3. 날짜 범위를 2018-01-01, 2018-12-31 로 설정한 후 대시보드에 필터를 위젯으로 배치합니다.
4. 대시보드를 저장 후, 열람화면에서 Filter의 날짜가 설정한 값으로 표시되는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
