### PR TITLE
#391 Displaying combo chart data is different from engine data

### DIFF
--- a/discovery-frontend/src/app/common/component/chart/base-chart.ts
+++ b/discovery-frontend/src/app/common/component/chart/base-chart.ts
@@ -45,7 +45,7 @@ import {
   EventType,
   SeriesType,
   ShelveFieldType,
-  ShelveType
+  ShelveType, UIChartDataLabelDisplayType
 } from './option/define/common';
 import { Field as AbstractField, Field } from '../../../domain/workbook/configurations/field/field';
 
@@ -66,6 +66,7 @@ import { ColorRange, UIChartColorGradationByValue } from './option/ui-option/ui-
 import { UIScatterChart } from './option/ui-option/ui-scatter-chart';
 import UI = OptionGenerator.UI;
 import {UIChartAxisGrid} from "./option/ui-option/ui-axis";
+import { TooltipOptionConverter } from './option/converter/tooltip-option-converter';
 
 declare let echarts: any;
 
@@ -2711,6 +2712,96 @@ export abstract class BaseChart extends AbstractComponent implements OnInit, OnD
     return this.chartOption;
   }
 
+  /**
+   * set datalabel when chart has axis
+   * @param {Pivot} prevPivot
+   * @param {boolean} prevPivotCondition - prev pivot has multi series(true) single series(false)
+   * @param {boolean} pivotCondition - pivot has multi series(true) single series(false)
+   * @returns {UIOption}
+   */
+  protected setAxisDataLabel(prevPivot: Pivot, checkChangeSeries: boolean): UIOption {
+
+    if (!this.pivot || !this.pivot.aggregations || !this.pivot.rows) return this.uiOption;
+
+    // 시리즈관련 리스트 제거
+    const spliceSeriesTypeList = ((seriesTypeList, dataLabel: any): any => {
+
+      // displayTypes를 찾는 index
+      let index: number;
+      for (const item of seriesTypeList) {
+        index = dataLabel.displayTypes.indexOf(item);
+
+        if (-1 !== index) {
+          // 라벨에서 제거
+          dataLabel.displayTypes[index] = null;
+        }
+      }
+      return dataLabel.displayTypes;
+    });
+
+    const setDefaultDisplayTypes = ((value): any => {
+
+      if (!value || !value.displayTypes) return [];
+
+      let defaultDisplayTypes = [];
+
+      // when it has single series
+      if (this.pivot.aggregations.length <= 1 && this.pivot.rows.length < 1) {
+
+        // set disabled list when it has single series
+        const disabledList = [UIChartDataLabelDisplayType.SERIES_NAME, UIChartDataLabelDisplayType.SERIES_VALUE, UIChartDataLabelDisplayType.SERIES_PERCENT];
+
+        // remove disabled list
+        defaultDisplayTypes = spliceSeriesTypeList(disabledList, value);
+
+        // set default datalabel, tooltip list
+        defaultDisplayTypes[0] = UIChartDataLabelDisplayType.CATEGORY_NAME;
+        defaultDisplayTypes[1] = UIChartDataLabelDisplayType.CATEGORY_VALUE;
+        // when it has multi series
+      } else {
+
+        // set disabled list when it has multi series
+        const disabledList = [UIChartDataLabelDisplayType.CATEGORY_VALUE, UIChartDataLabelDisplayType.CATEGORY_PERCENT];
+
+        // remove disabled list
+        defaultDisplayTypes = spliceSeriesTypeList(disabledList, value);
+
+        // set default datalabel, tooltip list
+        defaultDisplayTypes[3] = UIChartDataLabelDisplayType.SERIES_NAME;
+        defaultDisplayTypes[4] = UIChartDataLabelDisplayType.SERIES_VALUE;
+      }
+
+      return defaultDisplayTypes;
+    });
+
+    // when draw chart or change single <=> multi series
+    if ((EventType.CHANGE_PIVOT === this.drawByType && checkChangeSeries) || EventType.CHART_TYPE === this.drawByType) {
+
+      // set datalabel display types
+      let datalabelDisplayTypes = setDefaultDisplayTypes(this.uiOption.dataLabel);
+
+      // set tooltip display types
+      let tooltipDisplayTypes = setDefaultDisplayTypes(this.uiOption.toolTip);
+
+      // set default datalabel value
+      if (this.uiOption.dataLabel && this.uiOption.dataLabel.displayTypes) {
+        // set dataLabel
+        this.uiOption.dataLabel.displayTypes = datalabelDisplayTypes;
+        // set previewList
+        this.uiOption.dataLabel.previewList = LabelOptionConverter.setDataLabelPreviewList(this.uiOption);
+      }
+
+      // set default tooltip value
+      if (this.uiOption.toolTip && this.uiOption.toolTip.displayTypes) {
+        // set dataLabel
+        this.uiOption.toolTip.displayTypes = tooltipDisplayTypes;
+        // set previewList
+        this.uiOption.toolTip.previewList = TooltipOptionConverter.setTooltipPreviewList(this.uiOption);
+      }
+    }
+
+    return this.uiOption;
+  }
 }
 
 

--- a/discovery-frontend/src/app/common/component/chart/option/converter/format-option-converter.ts
+++ b/discovery-frontend/src/app/common/component/chart/option/converter/format-option-converter.ts
@@ -794,9 +794,10 @@ export class FormatOptionConverter {
 
       case ChartType.BAR:
       case ChartType.LINE:
+      case ChartType.COMBINE:
         // when bar, line chart has single series
         if ((chartType === ChartType.BAR && pivot.aggregations.length <= 1 && pivot.rows.length < 1) ||
-          (chartType === ChartType.LINE && pivot.aggregations.length <= 1)) {
+          ((chartType === ChartType.LINE || chartType === ChartType.COMBINE) && pivot.aggregations.length <= 1)) {
           displayTypes[0] = UIChartDataLabelDisplayType.CATEGORY_NAME;
           displayTypes[1] = UIChartDataLabelDisplayType.CATEGORY_VALUE;
           // when bar, line chart has multi series
@@ -807,7 +808,6 @@ export class FormatOptionConverter {
         break;
 
       case ChartType.CONTROL:
-      case ChartType.COMBINE:
       case ChartType.WATERFALL:
         displayTypes[0] = UIChartDataLabelDisplayType.CATEGORY_NAME;
         displayTypes[1] = UIChartDataLabelDisplayType.CATEGORY_VALUE;

--- a/discovery-frontend/src/app/common/component/chart/type/bar-chart/bar-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/bar-chart/bar-chart.component.ts
@@ -364,13 +364,13 @@ export class BarChartComponent extends BaseChart implements OnInit, OnDestroy, A
    */
   protected setDataLabel(): UIOption {
 
-    if (!this.pivot || !this.pivot.aggregations || !this.pivot.rows) return this.uiOption;
-
     /**
-     * check multi series <=> single series
-     * @type {() => boolean}
-     */
+      * check multi series <=> single series
+      * @type {() => boolean}
+      */
     const checkChangeSeries = ((): boolean => {
+
+      if (!this.prevPivot) return true;
 
       // prev series is multi(true) or single
       const prevSeriesMulti: boolean = this.prevPivot.aggregations.length > 1 || this.prevPivot.rows.length >= 1 ? true : false;
@@ -388,82 +388,7 @@ export class BarChartComponent extends BaseChart implements OnInit, OnDestroy, A
       return false;
     });
 
-    // 시리즈관련 리스트 제거
-    const spliceSeriesTypeList = ((seriesTypeList, dataLabel: any): any => {
-
-      // displayTypes를 찾는 index
-      let index: number;
-      for (const item of seriesTypeList) {
-        index = dataLabel.displayTypes.indexOf(item);
-
-        if (-1 !== index) {
-          // 라벨에서 제거
-          dataLabel.displayTypes[index] = null;
-        }
-      }
-      return dataLabel.displayTypes;
-    });
-
-    const setDefaultDisplayTypes = ((value): any => {
-
-      if (!value || !value.displayTypes) return [];
-
-      let defaultDisplayTypes = [];
-
-      // when it has single series
-      if (this.pivot.aggregations.length <= 1 && this.pivot.rows.length < 1) {
-
-        // set disabled list when it has single series
-        const disabledList = [UIChartDataLabelDisplayType.SERIES_NAME, UIChartDataLabelDisplayType.SERIES_VALUE, UIChartDataLabelDisplayType.SERIES_PERCENT];
-
-        // remove disabled list
-        defaultDisplayTypes = spliceSeriesTypeList(disabledList, value);
-
-        // set default datalabel, tooltip list
-        defaultDisplayTypes[0] = UIChartDataLabelDisplayType.CATEGORY_NAME;
-        defaultDisplayTypes[1] = UIChartDataLabelDisplayType.CATEGORY_VALUE;
-        // when it has multi series
-      } else {
-
-        // set disabled list when it has multi series
-        const disabledList = [UIChartDataLabelDisplayType.CATEGORY_VALUE, UIChartDataLabelDisplayType.CATEGORY_PERCENT];
-
-        // remove disabled list
-        defaultDisplayTypes = spliceSeriesTypeList(disabledList, value);
-
-        // set default datalabel, tooltip list
-        defaultDisplayTypes[3] = UIChartDataLabelDisplayType.SERIES_NAME;
-        defaultDisplayTypes[4] = UIChartDataLabelDisplayType.SERIES_VALUE;
-      }
-
-      return defaultDisplayTypes;
-    });
-
-    // when draw chart or change single <=> multi series
-    if ((EventType.CHANGE_PIVOT === this.drawByType && (!this.prevPivot || checkChangeSeries())) || EventType.CHART_TYPE === this.drawByType) {
-
-      // set datalabel display types
-      let datalabelDisplayTypes = setDefaultDisplayTypes(this.uiOption.dataLabel);
-
-      // set tooltip display types
-      let tooltipDisplayTypes = setDefaultDisplayTypes(this.uiOption.toolTip);
-
-      // set default datalabel value
-      if (this.uiOption.dataLabel && this.uiOption.dataLabel.displayTypes) {
-        // set dataLabel
-        this.uiOption.dataLabel.displayTypes = datalabelDisplayTypes;
-        // set previewList
-        this.uiOption.dataLabel.previewList = LabelOptionConverter.setDataLabelPreviewList(this.uiOption);
-      }
-
-      // set default tooltip value
-      if (this.uiOption.toolTip && this.uiOption.toolTip.displayTypes) {
-        // set dataLabel
-        this.uiOption.toolTip.displayTypes = tooltipDisplayTypes;
-        // set previewList
-        this.uiOption.toolTip.previewList = TooltipOptionConverter.setTooltipPreviewList(this.uiOption);
-      }
-    }
+    this.uiOption = this.setAxisDataLabel(this.prevPivot,checkChangeSeries());
 
     // set previous pivot value (compare previous pivot, current pivot)
     this.prevPivot = this.pivot;

--- a/discovery-frontend/src/app/common/component/chart/type/combine-chart/combine-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/combine-chart/combine-chart.component.ts
@@ -16,26 +16,33 @@
  * Created by Dolkkok on 2017. 7. 18..
  */
 
+import { AfterViewInit, Component, ElementRef, EventEmitter, Injector, OnDestroy, OnInit, Output } from '@angular/core';
+import { BaseChart, PivotTableInfo } from '../../base-chart';
+import { BaseOption } from '../../option/base-option';
 import {
-  AfterViewInit, Component, ElementRef, Injector, OnInit, OnDestroy,
-  Output, EventEmitter
-} from '@angular/core';
-import {BaseChart, PivotTableInfo} from '../../base-chart';
-import {BaseOption} from "../../option/base-option";
-import {
-  ChartType, SymbolType, ShelveType, ShelveFieldType, CHART_STRING_DELIMITER, SeriesType, AxisType,
-  Orient, SeriesConvertType, BarMarkType, LineMarkType, DataLabelPosition
+  AxisType,
+  BarMarkType,
+  CHART_STRING_DELIMITER,
+  ChartType,
+  DataLabelPosition,
+  LineMarkType,
+  Orient,
+  Position,
+  SeriesType,
+  ShelveFieldType,
+  ShelveType,
+  SymbolType
 } from '../../option/define/common';
-import {OptionGenerator} from '../../option/util/option-generator';
-import {Position} from '../../option/define/common';
-import {Pivot} from "../../../../../domain/workbook/configurations/pivot";
+import { OptionGenerator } from '../../option/util/option-generator';
+import { Pivot } from '../../../../../domain/workbook/configurations/pivot';
 import * as _ from 'lodash';
-import {Series} from "../../option/define/series";
+import { Series } from '../../option/define/series';
 import { UICombineChart } from '../../option/ui-option/ui-combine-chart';
-import {UIChartAxis, UIChartAxisGrid, UIChartAxisLabelValue} from "../../option/ui-option/ui-axis";
-import {AxisOptionConverter} from "../../option/converter/axis-option-converter";
-import {Axis} from "../../option/define/axis";
-import {DataZoomType} from '../../option/define/datazoom';
+import { UIChartAxis, UIChartAxisGrid, UIChartAxisLabelValue } from '../../option/ui-option/ui-axis';
+import { AxisOptionConverter } from '../../option/converter/axis-option-converter';
+import { Axis } from '../../option/define/axis';
+import { DataZoomType } from '../../option/define/datazoom';
+import { UIOption } from '../../option/ui-option';
 
 @Component({
   selector: 'combine-chart',
@@ -46,6 +53,9 @@ export class CombineChartComponent extends BaseChart implements OnInit, OnDestro
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Private Variables
    |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
+
+  // set previous pivot (compare previous pivot, current pivot)
+  private prevPivot: Pivot;
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Protected Variables
@@ -655,5 +665,41 @@ export class CombineChartComponent extends BaseChart implements OnInit, OnDestro
     }
   }
 
+  /**
+   * change dataLabel, tooltip by single series, multi series
+   * @returns {UIOption}
+   */
+  protected setDataLabel(): UIOption {
 
+    /**
+     * check multi series <=> single series
+     * @type {() => boolean}
+     */
+    const checkChangeSeries = ((): boolean => {
+
+      if (!this.prevPivot) return true;
+
+      // prev series is multi(true) or single
+      const prevSeriesMulti: boolean = this.prevPivot.aggregations.length > 1 ? true : false;
+
+      // current series is multi(true) or single
+      const currentSeriesMulti: boolean = this.pivot.aggregations.length > 1 ? true : false;
+
+      // if it's changed
+      if (prevSeriesMulti !== currentSeriesMulti) {
+
+        return true;
+      }
+
+      // not changed
+      return false;
+    });
+
+    this.uiOption = this.setAxisDataLabel(this.prevPivot, checkChangeSeries());
+
+    // set previous pivot value (compare previous pivot, current pivot)
+    this.prevPivot = this.pivot;
+
+    return this.uiOption;
+  }
 }

--- a/discovery-frontend/src/app/common/component/chart/type/line-chart/line-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/line-chart/line-chart.component.ts
@@ -321,13 +321,13 @@ export class LineChartComponent extends BaseChart implements OnInit, AfterViewIn
    */
   protected setDataLabel(): UIOption {
 
-    if (!this.pivot || !this.pivot.aggregations || !this.pivot.rows) return this.uiOption;
-
     /**
      * check multi series <=> single series
      * @type {() => boolean}
      */
     const checkChangeSeries = ((): boolean => {
+
+      if (!this.prevPivot) return true;
 
       // prev series is multi(true) or single
       const prevSeriesMulti: boolean = this.prevPivot.aggregations.length > 1 || this.prevPivot.rows.length > 0 ? true : false;
@@ -345,82 +345,7 @@ export class LineChartComponent extends BaseChart implements OnInit, AfterViewIn
       return false;
     });
 
-    // 시리즈관련 리스트 제거
-    const spliceSeriesTypeList = ((seriesTypeList, dataLabel: any): any => {
-
-      // displayTypes를 찾는 index
-      let index: number;
-      for (const item of seriesTypeList) {
-        index = dataLabel.displayTypes.indexOf(item);
-
-        if (-1 !== index) {
-          // 라벨에서 제거
-          dataLabel.displayTypes[index] = null;
-        }
-      }
-      return dataLabel.displayTypes;
-    });
-
-    const setDefaultDisplayTypes = ((value): any => {
-
-      if (!value || !value.displayTypes) return [];
-
-      let defaultDisplayTypes = [];
-
-      // when it has single series
-      if (this.pivot.aggregations.length <= 1 && this.pivot.rows.length < 1) {
-
-        // set disabled list when it has single series
-        const disabledList = [UIChartDataLabelDisplayType.SERIES_NAME, UIChartDataLabelDisplayType.SERIES_VALUE, UIChartDataLabelDisplayType.SERIES_PERCENT];
-
-        // remove disabled list
-        defaultDisplayTypes = spliceSeriesTypeList(disabledList, value);
-
-        // set default datalabel, tooltip list
-        defaultDisplayTypes[0] = UIChartDataLabelDisplayType.CATEGORY_NAME;
-        defaultDisplayTypes[1] = UIChartDataLabelDisplayType.CATEGORY_VALUE;
-        // when it has multi series
-      } else {
-
-        // set disabled list when it has multi series
-        const disabledList = [UIChartDataLabelDisplayType.CATEGORY_VALUE, UIChartDataLabelDisplayType.CATEGORY_PERCENT];
-
-        // remove disabled list
-        defaultDisplayTypes = spliceSeriesTypeList(disabledList, value);
-
-        // set default datalabel, tooltip list
-        defaultDisplayTypes[3] = UIChartDataLabelDisplayType.SERIES_NAME;
-        defaultDisplayTypes[4] = UIChartDataLabelDisplayType.SERIES_VALUE;
-      }
-
-      return defaultDisplayTypes;
-    });
-
-    // when draw chart or change single <=> multi series
-    if ((EventType.CHANGE_PIVOT === this.drawByType && (!this.prevPivot || checkChangeSeries())) || EventType.CHART_TYPE === this.drawByType) {
-
-      // set datalabel display types
-      let datalabelDisplayTypes = setDefaultDisplayTypes(this.uiOption.dataLabel);
-
-      // set tooltip display types
-      let tooltipDisplayTypes = setDefaultDisplayTypes(this.uiOption.toolTip);
-
-      // set default datalabel value
-      if (this.uiOption.dataLabel && this.uiOption.dataLabel.displayTypes) {
-        // set dataLabel
-        this.uiOption.dataLabel.displayTypes = datalabelDisplayTypes;
-        // set previewList
-        this.uiOption.dataLabel.previewList = LabelOptionConverter.setDataLabelPreviewList(this.uiOption);
-      }
-
-      // set default tooltip value
-      if (this.uiOption.toolTip && this.uiOption.toolTip.displayTypes) {
-        // set dataLabel
-        this.uiOption.toolTip.displayTypes = tooltipDisplayTypes;
-        // set previewList
-        this.uiOption.toolTip.previewList = TooltipOptionConverter.setTooltipPreviewList(this.uiOption);
-      }
-    }
+    this.uiOption = this.setAxisDataLabel(this.prevPivot, checkChangeSeries());
 
     // set previous pivot value (compare previous pivot, current pivot)
     this.prevPivot = this.pivot;

--- a/discovery-frontend/src/app/page/chart-style/datalabel-option.component.ts
+++ b/discovery-frontend/src/app/page/chart-style/datalabel-option.component.ts
@@ -501,19 +501,19 @@ export class DataLabelOptionComponent extends LabelBaseOptionComponent {
 
       case ChartType.BAR:
       case ChartType.LINE:
+      case ChartType.COMBINE:
         // when bar, line chart has single series
         if ((chartType === ChartType.BAR && this.pivot.aggregations.length <= 1 && this.pivot.rows.length < 1) ||
-            (chartType === ChartType.LINE && this.pivot.aggregations.length <= 1)) {
+           ((chartType === ChartType.LINE || chartType === ChartType.COMBINE) && this.pivot.aggregations.length <= 1)) {
           displayTypes[0] = UIChartDataLabelDisplayType.CATEGORY_NAME;
           displayTypes[1] = UIChartDataLabelDisplayType.CATEGORY_VALUE;
-        // when bar, line chart has multi series
+        // when bar, line, combine chart has multi series
         } else {
           displayTypes[3] = UIChartDataLabelDisplayType.SERIES_NAME;
           displayTypes[4] = UIChartDataLabelDisplayType.SERIES_VALUE;
         }
         break;
       case ChartType.CONTROL:
-      case ChartType.COMBINE:
       case ChartType.WATERFALL:
         displayTypes[0] = UIChartDataLabelDisplayType.CATEGORY_NAME;
         displayTypes[1] = UIChartDataLabelDisplayType.CATEGORY_VALUE;

--- a/discovery-frontend/src/app/page/chart-style/labelbase-option.component.ts
+++ b/discovery-frontend/src/app/page/chart-style/labelbase-option.component.ts
@@ -83,8 +83,9 @@ export class LabelBaseOptionComponent extends BaseOptionComponent implements OnI
         }
         break;
 
-      // when line chart has multi series, disable category value, category percentage
+      // when line, combine chart has multi series, disable category value, category percentage
       case ChartType.LINE:
+      case ChartType.COMBINE:
         if (this.pivot.aggregations.length > 1) categoryDisable = true;
         break;
     }
@@ -109,6 +110,7 @@ export class LabelBaseOptionComponent extends BaseOptionComponent implements OnI
 
       // when line chart has single series, disable series
       case ChartType.LINE:
+      case ChartType.COMBINE:
         if (this.pivot.aggregations.length <= 1) seriesDisable = true;
         break;
     }


### PR DESCRIPTION
### Description
- combine차트에서 measure가 복수개로 올라갈때 바 / 라인차트와 동일하게
데이터레이블과 툴팁에서 Category Value / Percent를 disable 처리합니다.
<!--- Describe your changes in detail -->

**Related Issue** : #391 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
1. 차트상세화면에서 combine차트를 선택합니다.
2. dimension 1개와 measure2개를 설정시 데이터레이블과 툴팁에서 Category Value / Percent가 disable 처리가 되는지 확인합니다.
<!--- Please describe in detail how you tested your changes. -->


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
