### PR TITLE
#422 fix sorting popularity

### DIFF
--- a/discovery-frontend/src/app/meta-data-management/metadata/metadata-detail-columnschema.component.ts
+++ b/discovery-frontend/src/app/meta-data-management/metadata/metadata-detail-columnschema.component.ts
@@ -423,14 +423,7 @@ export class MetadataDetailColumnschemaComponent extends AbstractComponent imple
           break;
       }
     }
-    this.columnList.sort((prev, next) => {
-      // 내림 차순
-      if (this.selectedContentSort.sort === 'desc') {
-        return prev[this.selectedContentSort.key] > next[this.selectedContentSort.key] ? -1 : prev[this.selectedContentSort.key] < next[this.selectedContentSort.key]? 1 : 0;
-      } else {
-        return prev[this.selectedContentSort.key] < next[this.selectedContentSort.key] ? -1 : prev[this.selectedContentSort.key] > next[this.selectedContentSort.key] ? 1 : 0;
-      }});
-
+    this.columnList = _.orderBy(this.columnList, this.selectedContentSort.key, this.selectedContentSort.sort);
   }
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=


### PR DESCRIPTION
### Description
모든 컬럼 인기도가 0인경우 정렬시 정렬이 작동하는 것 수정
![2018-10-11 5 14 30](https://user-images.githubusercontent.com/42233627/46790244-70159680-cd79-11e8-919e-41119861f193.png)
![2018-10-11 5 14 33](https://user-images.githubusercontent.com/42233627/46790245-70159680-cd79-11e8-9c87-897bc8f05f61.png)


**Related Issue** : <!--- Please link to the issue here. -->
#422 


### How Has This Been Tested?
메타데이터 > 모든 인기도가 0인 메타데이터 상세화면 > 컬럼 스키마
인기도 정렬 시도 > 컬럼이 바뀌지 않는것 확인


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project. _it will be added soon_
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.