### PR TITLE
#374 Add lag and lead functions

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DfWindow.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DfWindow.java
@@ -185,6 +185,16 @@ public class DfWindow extends DataFrame {
                         throw new WrongWindowFunctionExpressionException("DfWindow.gather(): Invalid window function args: " + func.getName());
                     newColType = prevDf.getColTypeByColName(func.getArgs().get(0).toString());
                     break;
+                case "lag":
+                    if(func.getArgs().size()!=2)
+                        throw new WrongWindowFunctionExpressionException("DfWindow.gather(): Invalid window function args: " + func.getName());
+                    newColType = prevDf.getColTypeByColName(func.getArgs().get(0).toString());
+                    break;
+                case "lead":
+                    if(func.getArgs().size()!=2)
+                        throw new WrongWindowFunctionExpressionException("DfWindow.gather(): Invalid window function args: " + func.getName());
+                    newColType = prevDf.getColTypeByColName(func.getArgs().get(0).toString());
+                    break;
                 case "sum":
                 case "max":
                 case "min":
@@ -291,6 +301,50 @@ public class DfWindow extends DataFrame {
                                     }
                                 }
                                 value=value/avg_count;
+                                row.add(newColNames.get(j), value);
+                            }
+                            break;
+                        case "lag":
+                            targetColName = func.getArgs().get(0).toString();
+                            start = i - func.getArgs().get(1).eval(row).asInt();
+
+                            if (this.getColTypeByColName(targetColName) ==ColumnType.LONG) {
+                                Long value = 0L;
+                                if(start>=0 && partitionNumber.get(start)==partitionIndex) {
+                                        value = (long) rows.get(start).get(targetColName);
+                                } else {
+                                    value = null;
+                                }
+                                row.add(newColNames.get(j), value);
+                            } else {
+                                Double value = 0D;
+                                if(start>=0 && partitionNumber.get(start)==partitionIndex) {
+                                        value = value + (double) rows.get(start).get(targetColName);
+                                } else {
+                                    value = null;
+                                }
+                                row.add(newColNames.get(j), value);
+                            }
+                            break;
+                        case "lead":
+                            targetColName = func.getArgs().get(0).toString();
+                            start = i + func.getArgs().get(1).eval(row).asInt();
+
+                            if (this.getColTypeByColName(targetColName) ==ColumnType.LONG) {
+                                Long value = 0L;
+                                if(start>=0 && start<rows.size() && partitionNumber.get(start)==partitionIndex) {
+                                    value = (long) rows.get(start).get(targetColName);
+                                } else {
+                                    value = null;
+                                }
+                                row.add(newColNames.get(j), value);
+                            } else {
+                                Double value = 0D;
+                                if(start>=0 && start<rows.size() && partitionNumber.get(start)==partitionIndex) {
+                                    value = value + (double) rows.get(start).get(targetColName);
+                                } else {
+                                    value = null;
+                                }
                                 row.add(newColNames.get(j), value);
                             }
                             break;


### PR DESCRIPTION
### Description
Window 룰에 lag와 lead 함수를 추가합니다.

Add lag and lead function on window rule.

**Related Issue** : <!--- Please link to the issue here. -->
https://github.com/metatron-app/metatron-discovery/issues/374

### How Has This Been Tested?
Test below command on data preparation.

window value: [row_number(), max(column4), lag(column4, 2), lead(column4, 2)] partition: column2, column3 order: column1


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
