### PR TITLE
#469 Add contain() function in data prep

### DIFF
--- a/discovery-prep-parser/src/main/java/app/metatron/discovery/prep/parser/preparation/rule/expr/BuiltinFunctions.java
+++ b/discovery-prep-parser/src/main/java/app/metatron/discovery/prep/parser/preparation/rule/expr/BuiltinFunctions.java
@@ -1186,6 +1186,23 @@ public interface BuiltinFunctions extends Function.Library {
       }
     }
 
+    class ContainsFunc implements Function {
+      @Override
+      public String name() {
+        return "contains";
+      }
+
+      @Override
+      public boolean validate(List<Expr> args) {
+        if (args.size() > 3 || args.size() < 2) {
+          LOGGER.warn("function 'substring' allows 2 or 3 arguments");
+          return false;
+        }
+
+        return true;
+      }
+    }
+
     class LeftFunc implements Function {
       @Override
       public String name() {

--- a/discovery-prep-parser/src/main/java/app/metatron/discovery/prep/parser/preparation/rule/expr/Expr.java
+++ b/discovery-prep-parser/src/main/java/app/metatron/discovery/prep/parser/preparation/rule/expr/Expr.java
@@ -221,7 +221,7 @@ public interface Expr extends Expression {
           ExprEval exprEval = args.get(0).eval(bindings);
           return (exprEval.value() == null) ? exprEval : ExprEval.of(exprEval.stringValue().toUpperCase());
         } catch (NullPointerException ne){
-          throw new FunctionColumnNotFoundException("upper(): No such column name >> " + args.get(0).toString());
+          throw new FunctionColumnNotFoundException("ExprEval.eval() upper: No such column name >> " + args.get(0).toString());
         } catch (ClassCastException ce) {
           throw new FunctionWorksOnlyOnStringException("ExprEval.eval() upper: This function works only on string");
         } catch (Exception e) {
@@ -236,7 +236,7 @@ public interface Expr extends Expression {
           ExprEval exprEval = args.get(0).eval(bindings);
           return (exprEval.value() == null) ? exprEval : ExprEval.of(exprEval.stringValue().toLowerCase());
         } catch (NullPointerException ne){
-          throw new FunctionColumnNotFoundException("lower(): No such column name >> " + args.get(0).toString());
+          throw new FunctionColumnNotFoundException("ExprEval.eval() lower: No such column name >> " + args.get(0).toString());
         } catch (ClassCastException ce) {
           throw new FunctionWorksOnlyOnStringException("ExprEval.eval() lower: This function works only on string");
         } catch (Exception e) {
@@ -251,7 +251,7 @@ public interface Expr extends Expression {
           ExprEval exprEval = args.get(0).eval(bindings);
           return (exprEval.value() == null) ? exprEval : ExprEval.bestEffortOf(exprEval.stringValue().trim());
         } catch (NullPointerException ne){
-          throw new FunctionColumnNotFoundException("trim(): No such column name >> " + args.get(0).toString());
+          throw new FunctionColumnNotFoundException("ExprEval.eval() trim: No such column name >> " + args.get(0).toString());
         } catch (ClassCastException ce) {
           throw new FunctionWorksOnlyOnStringException("ExprEval.eval() trim: This function works only on string");
         } catch (Exception e) {
@@ -267,7 +267,7 @@ public interface Expr extends Expression {
           ExprEval exprEval = args.get(0).eval(bindings);
           return (exprEval.value() == null) ? exprEval : ExprEval.bestEffortOf(exprEval.stringValue().replaceFirst("^\\s+", ""));
         } catch (NullPointerException ne){
-          throw new FunctionColumnNotFoundException("ltrim(): No such column name >> " + args.get(0).toString());
+          throw new FunctionColumnNotFoundException("ExprEval.eval() ltrim: No such column name >> " + args.get(0).toString());
         } catch (ClassCastException ce) {
           throw new FunctionWorksOnlyOnStringException("ExprEval.eval() ltrim: This function works only on string");
         } catch (Exception e) {
@@ -283,7 +283,7 @@ public interface Expr extends Expression {
           ExprEval exprEval = args.get(0).eval(bindings);
           return (exprEval.value() == null) ? exprEval : ExprEval.bestEffortOf(exprEval.stringValue().replaceFirst("\\s+$", ""));
         } catch (NullPointerException ne){
-          throw new FunctionColumnNotFoundException("rtrim(): No such column name >> " + args.get(0).toString());
+          throw new FunctionColumnNotFoundException("ExprEval.eval() rtrim: No such column name >> " + args.get(0).toString());
         } catch (ClassCastException ce) {
           throw new FunctionWorksOnlyOnStringException("ExprEval.eval() rtrim: This function works only on string");
         } catch (Exception e) {
@@ -321,11 +321,37 @@ public interface Expr extends Expression {
         } catch (StringIndexOutOfBoundsException se) {
           throw new FunctionInvalidIndexNumberException("ExprEval.eval() substring: Wrong index param");
         } catch (NullPointerException ne){
-          throw new FunctionColumnNotFoundException("substring(): No such column name >> " + args.get(0).toString());
+          throw new FunctionColumnNotFoundException("ExprEval.eval() substring: No such column name >> " + args.get(0).toString());
         } catch (ClassCastException ce) {
           throw new FunctionWorksOnlyOnStringException("ExprEval.eval() substring: This function works only on string");
         } catch (Exception e) {
-          throw new FunctionUndefinedException("ExprEval.eval() trim: Unknown error occur");
+          throw new FunctionUndefinedException("ExprEval.eval() substring: Unknown error occur");
+        }
+
+      }
+      else if (function instanceof BuiltinFunctions.Str.ContainsFunc) {
+        // substring(expr)
+        assert (args.size() == 2) : args.size();
+
+        try{
+          ExprEval arg0 = args.get(0).eval(bindings);
+          String targetText = arg0.stringValue();
+
+          if(arg0.value() == null)
+            return arg0;
+
+          ExprEval arg1 = args.get(1).eval(bindings);
+          String searchWord = arg1.stringValue();
+
+          return ExprEval.bestEffortOf(targetText.contains(searchWord));
+        } catch (StringIndexOutOfBoundsException se) {
+          throw new FunctionInvalidIndexNumberException("ExprEval.eval() contains: Wrong index param");
+        } catch (NullPointerException ne){
+          throw new FunctionColumnNotFoundException("ExprEval.eval() contains: No such column name >> " + args.get(0).toString());
+        } catch (ClassCastException ce) {
+          throw new FunctionWorksOnlyOnStringException("ExprEval.eval() contains: This function works only on string");
+        } catch (Exception e) {
+          throw new FunctionUndefinedException("ExprEval.eval() contains: Unknown error occur");
         }
 
       }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DataFrame.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DataFrame.java
@@ -665,6 +665,10 @@ public class DataFrame implements Serializable, Transformable {
           resultType = ColumnType.STRING;
           assertArgsBw(2, 3, args, func);
           break;
+        case "contains":
+          resultType = ColumnType.BOOLEAN;
+          assertArgsEq(2, args, func);
+          break;
         case "timestamptostring":
           resultType = ColumnType.STRING;
           assertArgsEq(2, args, func);


### PR DESCRIPTION
### Description
Preparation에 contains() 함수를 추가합니다.

Add contains() function to preparation.

ex) contains('hello world', 'world') > true.
All arguments should be string or string column.

**Related Issue** : <!--- Please link to the issue here. -->
https://github.com/metatron-app/metatron-discovery/issues/469


### How Has This Been Tested?
Test below rules in data preparation.

1. set col: column1 value: contains(column1, 'text')
>result will be true or false
2. set col: column2 value: 'it contains' row: contains(column1, 'text')


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
