### PR TITLE
F#481 improve window rule in data preparation

### DIFF
--- a/discovery-prep-parser/src/main/java/app/metatron/discovery/prep/parser/preparation/rule/Window.java
+++ b/discovery-prep-parser/src/main/java/app/metatron/discovery/prep/parser/preparation/rule/Window.java
@@ -28,7 +28,7 @@ public class Window implements Rule, Rule.Factory {
    */
   Expression order;
 
-  Expression partition;
+  Expression group;
 
   Expression rowsBetween;
 
@@ -36,10 +36,10 @@ public class Window implements Rule, Rule.Factory {
   public Window() {
   }
 
-  public Window(Expression value, Expression order, Expression partition, Expression rowsBetween) {
+  public Window(Expression value, Expression order, Expression group, Expression rowsBetween) {
     this.value = value;
     this.order = order;
-    this.partition = partition;
+    this.group = group;
     this.rowsBetween = rowsBetween;
   }
 
@@ -59,12 +59,12 @@ public class Window implements Rule, Rule.Factory {
     this.order = order;
   }
 
-  public Expression getPartition() {
-    return partition;
+  public Expression getGroup() {
+    return group;
   }
 
-  public void setPartition(Expression partition) {
-    this.partition = partition;
+  public void setGroup(Expression group) {
+    this.group = group;
   }
 
   public Expression getRowsBetween() {
@@ -90,7 +90,7 @@ public class Window implements Rule, Rule.Factory {
     return "Window{" +
         "value=" + value +
         ", order=" + order +
-        ", partition=" + partition +
+        ", group=" + group +
         ", rowsBetween=" + rowsBetween +
         '}';
   }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DataFrame.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DataFrame.java
@@ -449,6 +449,32 @@ public class DataFrame implements Serializable, Transformable {
     Util.showSep(widths);
   }
 
+  public void dropColumns(List<String> targetColNames) throws TeddyException{
+    for(String colName : targetColNames) {
+      colDescs.remove(getColnoByColName(colName));
+    }
+
+    colNames.removeAll(targetColNames);
+
+    mapColno.clear();
+
+    int i = 0;
+    for(String colName : colNames) {
+      mapColno.put(colName, i);
+      i++;
+    }
+
+    List<Row> newRows = new ArrayList<>();
+    for (Row row : this.rows) {
+      Row newRow = new Row();
+      for (String column : colNames) {
+        newRow.add(column, row.get(column));
+      }
+      newRows.add(newRow);
+    }
+    rows = newRows;
+  }
+
   public DataFrame drop(List<String> targetColNames) {
     DataFrame newDf = new DataFrame();
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DataFrame.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DataFrame.java
@@ -477,31 +477,6 @@ public class DataFrame implements Serializable, Transformable {
     rows = newRows;
   }
 
-  public DataFrame drop(List<String> targetColNames) {
-    DataFrame newDf = new DataFrame();
-
-    List<Integer> survivedColNos = new ArrayList<>();
-    for (int i = 0; i < getColCnt(); i++) {
-      if (targetColNames.contains(getColName(i))) {
-        continue;   // drop 대상 컬럼들은 새 df에서 누락
-      }
-      survivedColNos.add(i);
-    }
-
-    for (int colno : survivedColNos) {
-      newDf.addColumnWithDf(this, colno);
-    }
-
-    for (Row row : this.rows) {
-      Row newRow = new Row();
-      for (int colno : survivedColNos) {
-        newRow.add(getColName(colno), row.get(colno));
-      }
-      newDf.rows.add(newRow);
-    }
-    return newDf;
-  }
-
   //check if Args size are exactly matched with desirable size.
   private void assertArgsEq(int desirable, List<Expr> args, String func) throws TeddyException {
     if (args.size() != desirable) {

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DataFrame.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DataFrame.java
@@ -472,6 +472,8 @@ public class DataFrame implements Serializable, Transformable {
       }
       newRows.add(newRow);
     }
+
+    colCnt = colCnt - targetColNames.size();
     rows = newRows;
   }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DataFrameService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DataFrameService.java
@@ -104,7 +104,7 @@ public DataFrame applyRule(DataFrame df, String ruleString, List<DataFrame> slav
 
         if (rowcnt > 0) {
           if (DataFrame.isParallelizable(rule)) {
-            int partSize = rowcnt / (cores + 1);  // +1 to prevent being 0
+            int partSize = rowcnt / cores + 1;  // +1 to prevent being 0
 
             for (int rowno = 0; rowno < rowcnt; rowno += partSize) {
               LOGGER.debug("applyRuleString(): add thread: rowno={} partSize={} rowcnt={}", rowno, partSize, rowcnt);


### PR DESCRIPTION
### Description
Resolve these inconveniences in window rule.

Change label of "Grouping column" value from partition to group.
Drop dummy column that generated automatically when there's no grouping column.

**Related Issue** : <!--- Please link to the issue here. -->
https://github.com/metatron-app/metatron-discovery/issues/481


### How Has This Been Tested?
Try test codes below

1. window value: [row_number(), rolling_sum(col1, 2, 2)] group: col2 order: col3
2. window value: [avg(col1), lead(col1, 3)] group: order: col3


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
