### PR TITLE
F#479 the preview will always be shown 

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepAutowireHelper.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepAutowireHelper.java
@@ -1,0 +1,35 @@
+package app.metatron.discovery.domain.dataprep;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Component;
+
+// https://guylabs.ch/2014/02/22/autowiring-pring-beans-in-hibernate-jpa-entity-listeners/
+@Component
+public final class PrepAutowireHelper implements ApplicationContextAware {
+
+    private static final PrepAutowireHelper INSTANCE = new PrepAutowireHelper();
+    private static ApplicationContext applicationContext;
+
+    private PrepAutowireHelper() {
+    }
+
+    public static void autowire(Object classToAutowire, Object... beansToAutowireInClass) {
+        for (Object bean : beansToAutowireInClass) {
+            if (bean == null) {
+                applicationContext.getAutowireCapableBeanFactory().autowireBean(classToAutowire);
+                return;
+            }
+        }
+    }
+
+    @Override
+    public void setApplicationContext(final ApplicationContext applicationContext) {
+        PrepAutowireHelper.applicationContext = applicationContext;
+    }
+
+    public static PrepAutowireHelper getInstance() {
+        return INSTANCE;
+    }
+
+}

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetFileService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetFileService.java
@@ -435,7 +435,7 @@ public class PrepDatasetFileService {
 
             File theFile = new File(filePath);
             if(false==theFile.exists()) {
-                throw new IllegalArgumentException("Invalid filekey.");
+                throw new IllegalArgumentException("Uploaded file does not found.");
             } else {
                 totalBytes = theFile.length();
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetFileService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetFileService.java
@@ -414,7 +414,7 @@ public class PrepDatasetFileService {
         return responseMap;
     }
 
-    DataFrame getPreviewLinesFromFileForDataFrame( PrepDataset dataset, String fileKey, String sheetindex, String size) {
+    DataFrame getPreviewLinesFromFileForDataFrame( PrepDataset dataset, String fileKey, String size) {
         DataFrame dataFrame = new DataFrame();
 
         try {
@@ -428,7 +428,6 @@ public class PrepDatasetFileService {
                 filePath = getPathLocal_new( fileKey );
             }
             String extensionType = FilenameUtils.getExtension(fileKey);
-            int findSheetIndex = Integer.parseInt(sheetindex);
             int limitSize = Integer.parseInt(size);
             long totalBytes = 0L;
             int totalRows = 0;

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetListner.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetListner.java
@@ -1,0 +1,109 @@
+package app.metatron.discovery.domain.dataprep;
+
+import app.metatron.discovery.domain.dataprep.exceptions.PrepErrorCodes;
+import app.metatron.discovery.domain.dataprep.exceptions.PrepException;
+import app.metatron.discovery.domain.dataprep.teddy.ColumnDescription;
+import app.metatron.discovery.domain.dataprep.teddy.ColumnType;
+import app.metatron.discovery.domain.dataprep.teddy.DataFrame;
+import app.metatron.discovery.domain.dataprep.teddy.Row;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import javax.persistence.PostLoad;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import java.io.File;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+public class PrepDatasetListner {
+    private static Logger LOGGER = LoggerFactory.getLogger(PrepDatasetController.class);
+
+    @Autowired
+    PrepDatasetService datasetService;
+
+    @PostLoad
+    public void postLoad(Object entity) throws PrepException {
+        PrepDataset dataset = (PrepDataset) entity;
+        getGridResponse(dataset);
+    }
+
+    public void getGridResponse(PrepDataset dataset) {
+        DataFrame dataFrame = dataset.getGridResponse();
+
+        if (null == dataFrame) {
+            try {
+                String previewPath = dataset.getCustomValue("previewPath");
+                if (null != previewPath) {
+                    ObjectMapper mapper = new ObjectMapper();
+                    File theFile = new File(previewPath + File.separator + dataset.getDsId() + ".df");
+                    if (true == theFile.exists()) {
+                        dataFrame = mapper.readValue(theFile, DataFrame.class);
+
+                        List<ColumnDescription> columnDescs = dataFrame.colDescs;
+                        List<Integer> colNos = Lists.newArrayList();
+                        int colIdx = 0;
+                        for (ColumnDescription columnDesc : columnDescs) {
+                            if (columnDesc.getType().equals(ColumnType.TIMESTAMP)) {
+                                colNos.add(colIdx);
+                            }
+                            colIdx++;
+                        }
+
+                        if (0 < colNos.size()) {
+                            for (Row row : dataFrame.rows) {
+                                for (Integer colNo : colNos) {
+                                    Object jodaTime = row.get(colNo);
+                                    if (jodaTime instanceof LinkedHashMap) {
+                                        try {
+                                            LinkedHashMap mapTime = (LinkedHashMap) jodaTime;
+                                            DateTime dateTime = new DateTime(Long.parseLong(mapTime.get("millis").toString()));
+                                            row.objCols.set(colNo, dateTime);
+                                        } catch (Exception e) {
+                                            LOGGER.debug(e.getMessage());
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    } else {
+                        if(this.datasetService==null) {
+                            PrepAutowireHelper.autowire(this, this.datasetService);
+                        }
+
+                        if(dataset.getDsTypeForEnum()== PrepDataset.DS_TYPE.IMPORTED) {
+                            dataFrame = this.datasetService.getPreviewImportedDataset(dataset);
+                            if(null!=dataFrame) {
+                                HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+                                String oAuthToken = "bearer ";
+                                Cookie[] cookies = request.getCookies();
+                                for (int i = 0; i < cookies.length; i++) {
+                                    if (cookies[i].getName().equals("LOGIN_TOKEN"))
+                                        oAuthToken = oAuthToken + cookies[i].getValue();
+                                }
+                                this.datasetService.savePreview(dataset, oAuthToken);
+                            }
+                        } else {
+                            dataFrame = new DataFrame(dataset.getDsName());
+                            Row row = new Row();
+                            row.add("Preview is missing", new String("Try to edit some rules of this dataset. preview will be made soon."));
+                            dataFrame.addColumn("error", ColumnType.STRING);
+                            dataFrame.addColumn("solution", ColumnType.STRING);
+                            dataFrame.rows.add(row);
+                        }
+                    }
+                }
+                dataset.setDataFrame(dataFrame);
+            } catch (Exception e) {
+                LOGGER.debug(e.getMessage());
+                throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, e);
+            }
+        }
+    }
+}

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepPreviewLineService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepPreviewLineService.java
@@ -42,7 +42,7 @@ public class PrepPreviewLineService {
     }
 
     private String getPreviewPath() {
-        String tempDirPath = prepProperties.getLocalBaseDir() + File.separator + PrepProperties.dirDataprep;
+        String tempDirPath = prepProperties.getLocalBaseDir() + File.separator + PrepProperties.dirPreview;
 
         File tempPath = new File(tempDirPath);
         if(!tempPath.exists()){

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/exceptions/PrepMessageKey.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/exceptions/PrepMessageKey.java
@@ -24,6 +24,7 @@ public enum PrepMessageKey {
     MSG_DP_ALERT_NO_DATAFLOW(                                    "msg.dp.alert.no.dataflow"),
     MSG_DP_ALERT_USING_OTHER_DATAFLOW(                           "msg.dp.alert.using.other.dataflow"),
     MSG_DP_ALERT_NO_DATASET(                                     "msg.dp.alert.no.dataset"),
+    MSG_DP_ALERT_NO_DATAFRAME(                                   "msg.dp.alert.no.dataframe"),
     MSG_DP_ALERT_NO_UPSTREAM(                                    "msg.dp.alert.no.upstream"),
     MSG_DP_ALERT_NO_SNAPSHOT(                                    "msg.dp.alert.no.snapshot"),
     MSG_DP_ALERT_NOT_IMPORTED_DATASET(                           "msg.dp.alert.not.imported.dataset"),


### PR DESCRIPTION
### Description
if the preview directory is missing, we need to make new preview files
when user requests dataset(JPA), if there is no preview, 
1. imported dataset -> create new preview file
2. wrangled dataset -> show a message that says 'try to edit rules' -> transform stage makes new preview 

**Related Issue** : <!--- Please link to the issue here. -->
[#479](https://github.com/metatron-app/metatron-discovery/issues/479)


### How Has This Been Tested?
1. make a dataset what is imported type or wrangled type
2. see the details of the dataset. there is a preview
3. delete a preview files where is in preview directory
4. see the details of the dataset again. there is still a preview. the preview is new one.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
