### PR TITLE
#477 Fix replace rule to do not change prevDF when make new rows

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DataFrame.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DataFrame.java
@@ -449,19 +449,19 @@ public class DataFrame implements Serializable, Transformable {
     Util.showSep(widths);
   }
 
-  public void dropColumns(List<String> targetColNames) throws TeddyException{
-    for(String colName : targetColNames) {
-      colDescs.remove(getColnoByColName(colName));
-    }
+  public void dropColumn(String targetColName) throws TeddyException{
+    if(colNames.contains(targetColName)) {
+      colDescs.remove(getColnoByColName(targetColName));
+      colNames.remove(targetColName);
+      mapColno.clear();
 
-    colNames.removeAll(targetColNames);
+      int i = 0;
+      for (String colName : colNames) {
+        mapColno.put(colName, i);
+        i++;
+      }
 
-    mapColno.clear();
-
-    int i = 0;
-    for(String colName : colNames) {
-      mapColno.put(colName, i);
-      i++;
+      colCnt = colCnt -1;
     }
 
     List<Row> newRows = new ArrayList<>();
@@ -472,8 +472,6 @@ public class DataFrame implements Serializable, Transformable {
       }
       newRows.add(newRow);
     }
-
-    colCnt = colCnt - targetColNames.size();
     rows = newRows;
   }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DfPivot.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DfPivot.java
@@ -265,7 +265,7 @@ public class DfPivot extends DataFrame {
       for (int i = 0; i < aggrTargetColNames.size(); i++) {
         String aggrTargetColName = aggrTargetColNames.get(i);
         newRow.set(buildPivotNewColName(aggrTypes.get(i), aggrTargetColName, pivotColNames, groupByColNames, row), row.get(aggregatedDataPointer+i));
-      } //이름 당연히 있으니까 중복되지...ㅜ
+      }
     }
     rows.add(newRow); // add the last retained row
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DfReplace.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DfReplace.java
@@ -163,54 +163,62 @@ public class DfReplace extends DataFrame {
     if(quoteStr == null) {
       for (int rowno = offset; rowno < offset + length; cancelCheck(++rowno)) {
         Row row = prevDf.rows.get(rowno);
-        for (String targetColName : targetColNames) {
-          String targetStr = (String) row.get(targetColName);
-          if (targetStr == null || !checkCondition(replacedConditionExprs.get(targetColName), row)) {
-            continue;
-          }
-          Matcher matcher = pattern.matcher(targetStr);
-          if (matcher.find()) {
-            if (globalReplace) {
-              row.set(targetColName, matcher.replaceAll(((Expr) withExpr).eval(row).stringValue()));
-            } else {
-              row.set(targetColName, matcher.replaceFirst(((Expr) withExpr).eval(row).stringValue()));
+        Row newRow = new Row();
+        for (int colno = 0; colno < getColCnt(); colno++) {
+          String columnName = getColName(colno);
+          if (targetColNames.contains(columnName) && checkCondition(replacedConditionExprs.get(columnName), row)) {
+            String targetStr = (String) row.get(colno);
+            Matcher matcher = pattern.matcher(targetStr);
+            if (matcher.find()) {
+              if (globalReplace) {
+                newRow.add(columnName, matcher.replaceAll(((Expr) withExpr).eval(row).stringValue()));
+              } else {
+                newRow.add(columnName, matcher.replaceFirst(((Expr) withExpr).eval(row).stringValue()));
+              }
             }
+          } else {
+            newRow.add(getColName(colno), row.get(colno));
           }
+
         }
-        rows.add(row);
+        this.rows.add(newRow);
       }
     } else { //quote 문자가 있을 경우의 처리(정규식으로 quote를 처리해야 해서 Pattern.compile 사용 불가)
       for (int rowno = offset; rowno < offset + length; cancelCheck(++rowno)) {
         Row row = prevDf.rows.get(rowno);
-        for (String targetColName : targetColNames) {
-          String targetStr = (String) row.get(targetColName);
-          if (targetStr == null || !checkCondition(replacedConditionExprs.get(targetColName), row)) {
-            continue;
-          }
-          if(StringUtils.countMatches(targetStr, originalQuoteStr)%2 == 0){
-            Matcher matcher = pattern.matcher(targetStr);
-            if (matcher.find()) {
-              if (globalReplace) {
-                row.set(targetColName, matcher.replaceAll(((Expr) withExpr).eval(row).stringValue()));
-              } else {
-                row.set(targetColName, matcher.replaceFirst(((Expr) withExpr).eval(row).stringValue()));
+        Row newRow = new Row();
+        for (int colno = 0; colno < getColCnt(); colno++) {
+          String columnName = getColName(colno);
+          if (targetColNames.contains(columnName) && checkCondition(replacedConditionExprs.get(columnName), row)) {
+            String targetStr = (String) row.get(colno);
+            if (StringUtils.countMatches(targetStr, originalQuoteStr) % 2 == 0) {
+              Matcher matcher = pattern.matcher(targetStr);
+              if (matcher.find()) {
+                if (globalReplace) {
+                  newRow.add(columnName, matcher.replaceAll(((Expr) withExpr).eval(row).stringValue()));
+                } else {
+                  newRow.set(columnName, matcher.replaceFirst(((Expr) withExpr).eval(row).stringValue()));
+                }
               }
-            }
-          } else {//quote가 홀수개일 때는 마지막 quote 이후의 문자열은 처리 하지 않는다.
-            String targetStr2 = targetStr.substring(targetStr.lastIndexOf(originalQuoteStr));
-            targetStr = targetStr.substring(0, targetStr.lastIndexOf(originalQuoteStr));
+            } else {//quote가 홀수개일 때는 마지막 quote 이후의 문자열은 처리 하지 않는다.
+              String targetStr2 = targetStr.substring(targetStr.lastIndexOf(originalQuoteStr));
+              targetStr = targetStr.substring(0, targetStr.lastIndexOf(originalQuoteStr));
 
-            Matcher matcher = pattern.matcher(targetStr);
-            if (matcher.find()) {
-              if (globalReplace) {
-                row.set(targetColName, matcher.replaceAll(((Expr) withExpr).eval(row).stringValue()) + targetStr2);
-              } else {
-                row.set(targetColName, matcher.replaceFirst(((Expr) withExpr).eval(row).stringValue()) + targetStr2);
+              Matcher matcher = pattern.matcher(targetStr);
+              if (matcher.find()) {
+                if (globalReplace) {
+                  newRow.add(columnName, matcher.replaceAll(((Expr) withExpr).eval(row).stringValue()) + targetStr2);
+                } else {
+                  newRow.add(columnName, matcher.replaceFirst(((Expr) withExpr).eval(row).stringValue()) + targetStr2);
+                }
               }
             }
+          } else {
+            newRow.add(getColName(colno), row.get(colno));
           }
         }
-        rows.add(row);
+
+        rows.add(newRow);
       }
     }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DfReplace.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DfReplace.java
@@ -166,7 +166,7 @@ public class DfReplace extends DataFrame {
         Row newRow = new Row();
         for (int colno = 0; colno < getColCnt(); colno++) {
           String columnName = getColName(colno);
-          if (targetColNames.contains(columnName) && checkCondition(replacedConditionExprs.get(columnName), row)) {
+          if (targetColNames.contains(columnName) && row.get(colno)!=null && checkCondition(replacedConditionExprs.get(columnName), row)) {
             String targetStr = (String) row.get(colno);
             Matcher matcher = pattern.matcher(targetStr);
             if (matcher.find()) {
@@ -175,11 +175,12 @@ public class DfReplace extends DataFrame {
               } else {
                 newRow.add(columnName, matcher.replaceFirst(((Expr) withExpr).eval(row).stringValue()));
               }
+            } else {
+              newRow.add(columnName, row.get(colno));
             }
           } else {
-            newRow.add(getColName(colno), row.get(colno));
+            newRow.add(columnName, row.get(colno));
           }
-
         }
         this.rows.add(newRow);
       }
@@ -189,7 +190,7 @@ public class DfReplace extends DataFrame {
         Row newRow = new Row();
         for (int colno = 0; colno < getColCnt(); colno++) {
           String columnName = getColName(colno);
-          if (targetColNames.contains(columnName) && checkCondition(replacedConditionExprs.get(columnName), row)) {
+          if (targetColNames.contains(columnName) && row.get(colno)!=null && checkCondition(replacedConditionExprs.get(columnName), row)) {
             String targetStr = (String) row.get(colno);
             if (StringUtils.countMatches(targetStr, originalQuoteStr) % 2 == 0) {
               Matcher matcher = pattern.matcher(targetStr);
@@ -199,6 +200,8 @@ public class DfReplace extends DataFrame {
                 } else {
                   newRow.set(columnName, matcher.replaceFirst(((Expr) withExpr).eval(row).stringValue()));
                 }
+              } else {
+                newRow.add(columnName, row.get(colno));
               }
             } else {//quote가 홀수개일 때는 마지막 quote 이후의 문자열은 처리 하지 않는다.
               String targetStr2 = targetStr.substring(targetStr.lastIndexOf(originalQuoteStr));
@@ -212,9 +215,12 @@ public class DfReplace extends DataFrame {
                   newRow.add(columnName, matcher.replaceFirst(((Expr) withExpr).eval(row).stringValue()) + targetStr2);
                 }
               }
+              else {
+                newRow.add(columnName, row.get(colno));
+              }
             }
           } else {
-            newRow.add(getColName(colno), row.get(colno));
+            newRow.add(columnName, row.get(colno));
           }
         }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
@@ -1563,10 +1563,6 @@ public class PrepTransformService {
         Window window = (Window) rule;
         Expression order = window.getOrder();
         Expression value = window.getValue();
-        if (null == order) {
-          LOGGER.error("confirmRuleStringForException(): aggregate group is null");
-          throw PrepException.create(PrepErrorCodes.PREP_TRANSFORM_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_TEDDY_PARSE_FAILED_BY_AGGREGATE_GROUP);
-        }
         if (null == value) {
           LOGGER.error("confirmRuleStringForException(): aggregate value is null");
           throw PrepException.create(PrepErrorCodes.PREP_TRANSFORM_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_TEDDY_PARSE_FAILED_BY_AGGREGATE_VALUE);


### PR DESCRIPTION
### Description
기존의 Replace Rule이 이전 Dataframe의 값을 바꾸는 문제가 있었습니다.
로직이 기존 Dataframe에서 row objecte들을 얻어와서 변형한 뒤 새 dataframe에 추가하도록 설계되어 있었습니다.
새로운 row object를 생성하도록 로직을 변경합니다.

Old "Replace Rule" logic changes previous Dataframe's data.
Because the logic designed to get row objects of old Dataframe  and modify & add it to new Dataframe.
So, change the logic to create new row object and do not change old Dataframe.


**Related Issue** : <!--- Please link to the issue here. -->
https://github.com/metatron-app/metatron-discovery/issues/477


### How Has This Been Tested?
Create replace rule and delete or edit it.
And check the result.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
