### PR TITLE
#518 tab delimiter string convert to character

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/HiveTableInformation.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/HiveTableInformation.java
@@ -14,19 +14,17 @@
 
 package app.metatron.discovery.domain.datasource.connection.jdbc;
 
-import com.google.common.collect.Lists;
-
-import org.apache.commons.lang3.StringUtils;
-
-import java.util.List;
-import java.util.Map;
-
 import app.metatron.discovery.common.datasource.DataType;
 import app.metatron.discovery.domain.datasource.Field;
 import app.metatron.discovery.domain.datasource.ingestion.file.CsvFileFormat;
 import app.metatron.discovery.domain.datasource.ingestion.file.FileFormat;
 import app.metatron.discovery.domain.datasource.ingestion.file.OrcFileFormat;
 import app.metatron.discovery.domain.datasource.ingestion.jdbc.SelectQueryBuilder;
+import com.google.common.collect.Lists;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.List;
+import java.util.Map;
 
 public class HiveTableInformation {
 
@@ -71,6 +69,10 @@ public class HiveTableInformation {
           return new OrcFileFormat();
         case TEXT_INPUT_FORMAT :
           String delimiter = (String) this.storageInformation.get(FIELD_DELIMITER_PROP);
+          //convert tab delimiter string to character
+          if("\\t".equals(delimiter)){
+            delimiter = "\t";
+          }
           CsvFileFormat csvFileFormat = new CsvFileFormat();
           csvFileFormat.setDelimeter(delimiter);
           return csvFileFormat;


### PR DESCRIPTION
### Description
StagingDB로 데이터소스를 생성할때 delimiter가 탭인 테이블일 경우 에러 발생함.
An error occurs when delimiter is a tabbed table when creating a data source with StagingDB.

**Related Issue** : #518 

### How Has This Been Tested?
1. http://52.231.189.217:8080/app/v2/index.html
2. create datasource from StagingDB
3. choose schema 'omniture', table 'omnitureslogs'
4. create datasource complete.
5. Check the state of the created datasource is an enable.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
