### PR TITLE
F#476 fetching grid over over

### DIFF
--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-dataflow-rule-2.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-dataflow-rule-2.component.ts
@@ -1950,7 +1950,7 @@ export class EditDataflowRule2Component extends AbstractPopupComponent implement
 
       if (command !== 'join' && command !== 'derive' && command !== 'aggregate' && command !== 'move') {
         // 저장된 위치로 이동
-        this._editRuleGridComp.moveToSavedPosition();
+        // this._editRuleGridComp.moveToSavedPosition();
       }
       // 계속 클릭하는거 방지
       if (isUndo && this.isUndoRunning) {

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/edit-rule-grid.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/edit-rule-grid.component.ts
@@ -206,6 +206,7 @@ export class EditRuleGridComponent extends AbstractComponent implements OnInit, 
       method = 'put';
     }
 
+    // if(this._gridComp!=null){try{this._gridComp.getGridCore().scrollRowIntoView(0);}catch (error){}}
     return this.dataflowService.transformAction(this.dataSetId, method, params).then(data => {
       // 데이터 초기화
       {
@@ -216,6 +217,8 @@ export class EditRuleGridComponent extends AbstractComponent implements OnInit, 
         this._gridData = null;
         this._selectedRows = [];
         this._selectedColumns = [];
+
+
 
         // Histogram
         this._charts = [];
@@ -244,6 +247,7 @@ export class EditRuleGridComponent extends AbstractComponent implements OnInit, 
       const gridData: GridData = this._getGridDataFromGridResponse(this._apiGridData);
       this._gridData = gridData;
 
+
       // Column Width 설정
       // (this.columnWidths) || (this.columnWidths = {});
       // this.columnWidths = this._setColumnWidthInfo(this.columnWidths, this._apiGridData.colNames, gridData);
@@ -271,16 +275,9 @@ export class EditRuleGridComponent extends AbstractComponent implements OnInit, 
       // 그리드 생성
       gridData.fields.forEach(field => field.isHover = false);
 
-      // 데이터 전체 카운트 & ruleIdx
-      if(this._gridComp) {
-        this._gridComp.setTotalRowCnt(data.totalRowCnt);
-        this._gridComp.setRuleIndex(this.ruleIdx);
-      }
-
-
       // 히스토그램 정보 설정
       return this._getHistogramInfoByWidths(this.columnWidths, gridData.fields.length).then(() => {
-        this._renderGrid(gridData, params.ruleIdx);
+        this._renderGrid(gridData, this.ruleIdx, data.totalRowCnt);
         // 그리드 요약 정보 설정
         this._summaryGridInfo(gridData);
         this.totalRowCnt = data.totalRowCnt;
@@ -1680,9 +1677,8 @@ export class EditRuleGridComponent extends AbstractComponent implements OnInit, 
    * @param {number} ruleIdx
    * @private
    */
-  private _renderGrid(gridData: GridData, ruleIdx: number) {
-
-    const ruleIndex: number = ruleIdx;
+  private _renderGrid(gridData: GridData, ruleIdx: number, totalRowCnt: number) {
+    // const ruleIndex: number = ruleIdx;
 
     const fields: Field[] = gridData.fields;
 
@@ -1790,7 +1786,9 @@ export class EditRuleGridComponent extends AbstractComponent implements OnInit, 
         .ExplicitInitialization(true)
         .NullCellStyleActivate(true)
         .EnableMultiSelectionWithCtrlAndShift(true)
-        .build()
+        .build(),
+      ruleIdx,
+      totalRowCnt
     );
 
     // 그리드 실행

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/edit-rule-grid.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/edit-rule-grid.component.ts
@@ -261,7 +261,7 @@ export class EditRuleGridComponent extends AbstractComponent implements OnInit, 
       // Column Width 설정
       (this.columnWidths) || (this.columnWidths = {});
       this.columnWidths = this._setColumnWidthInfo(this.columnWidths, colNameTypes, gridData);
-      
+
       // 클릭 시리즈 정보 초기화
       this._apiGridData.colNames.forEach((item, index) => {
         this._clickedSeries[index] = [];
@@ -1748,7 +1748,7 @@ export class EditRuleGridComponent extends AbstractComponent implements OnInit, 
     this._gridComp.create(
       headers,
       new ScrollLoadingGridModel(
-        (pageNum: number = 0, pageSize: number) => {
+        (ruleIdx:number, pageNum: number = 0, pageSize: number) => {
           if (this.isApiMode) {
             return this.dataflowService.getSearchCountDataSets(this.dataSetId, ruleIndex, pageNum, pageSize);
           } else {

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/edit-rule-grid.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/edit-rule-grid.component.ts
@@ -271,9 +271,10 @@ export class EditRuleGridComponent extends AbstractComponent implements OnInit, 
       // 그리드 생성
       gridData.fields.forEach(field => field.isHover = false);
 
-      // 최초 로딩시 데이터 전체 카운트
+      // 데이터 전체 카운트 & ruleIdx
       if(this._gridComp) {
         this._gridComp.setTotalRowCnt(data.totalRowCnt);
+        this._gridComp.setRuleIndex(this.ruleIdx);
       }
 
 
@@ -1789,8 +1790,7 @@ export class EditRuleGridComponent extends AbstractComponent implements OnInit, 
         .ExplicitInitialization(true)
         .NullCellStyleActivate(true)
         .EnableMultiSelectionWithCtrlAndShift(true)
-        .build(),
-      ruleIndex
+        .build()
     );
 
     // 그리드 실행

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/edit-rule-grid.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/edit-rule-grid.component.ts
@@ -1750,7 +1750,7 @@ export class EditRuleGridComponent extends AbstractComponent implements OnInit, 
       new ScrollLoadingGridModel(
         (ruleIdx:number, pageNum: number = 0, pageSize: number) => {
           if (this.isApiMode) {
-            return this.dataflowService.getSearchCountDataSets(this.dataSetId, ruleIndex, pageNum, pageSize);
+            return this.dataflowService.getSearchCountDataSets(this.dataSetId, ruleIdx, pageNum, pageSize);
           } else {
             return new Promise<any>((resolve) => {
               let startIdx = ((pageNum - 1) * pageSize);

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/edit-rule-grid.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/edit-rule-grid.component.ts
@@ -209,6 +209,7 @@ export class EditRuleGridComponent extends AbstractComponent implements OnInit, 
     return this.dataflowService.transformAction(this.dataSetId, method, params).then(data => {
       // 데이터 초기화
       {
+
         // Grid
         this._apiGridData = data['gridResponse'];
         this._$gridElm = null;
@@ -255,6 +256,12 @@ export class EditRuleGridComponent extends AbstractComponent implements OnInit, 
 
       // 그리드 생성
       gridData.fields.forEach(field => field.isHover = false);
+
+      // 최초 로딩시 데이터 전체 카운트
+      if(this._gridComp) {
+        this._gridComp.setTotalRowCnt(data.totalRowCnt);
+      }
+
 
       // 히스토그램 정보 설정
       return this._getHistogramInfoByWidths(this.columnWidths, gridData.fields.length).then(() => {

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/edit-rule-grid.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/edit-rule-grid.component.ts
@@ -248,7 +248,6 @@ export class EditRuleGridComponent extends AbstractComponent implements OnInit, 
       // (this.columnWidths) || (this.columnWidths = {});
       // this.columnWidths = this._setColumnWidthInfo(this.columnWidths, this._apiGridData.colNames, gridData);
 
-      /******************************************************************/
       const colTypes = [];
       const colNameTypes = [];
       this._apiGridData.colDescs.forEach( item =>{ colTypes.push(item.type);});
@@ -262,10 +261,7 @@ export class EditRuleGridComponent extends AbstractComponent implements OnInit, 
       // Column Width 설정
       (this.columnWidths) || (this.columnWidths = {});
       this.columnWidths = this._setColumnWidthInfo(this.columnWidths, colNameTypes, gridData);
-      /******************************************************************/
-
-
-
+      
       // 클릭 시리즈 정보 초기화
       this._apiGridData.colNames.forEach((item, index) => {
         this._clickedSeries[index] = [];

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/scroll-loading-grid.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/scroll-loading-grid.component.ts
@@ -189,7 +189,7 @@ export class ScrollLoadingGridComponent implements OnInit, AfterViewInit, OnDest
     // 최초 로딩시 데이터 전체 카운트
     if(this._gridModel) {
       this._gridModel.setTotalRowCnt(this.totalRowCnt);
-      this._gridModel.setTotalRowCnt(this.totalRowCnt);
+      this._gridModel.setRuleIndex(ruleIndex);
 
     }
 

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/scroll-loading-grid.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/scroll-loading-grid.component.ts
@@ -128,24 +128,23 @@ export class ScrollLoadingGridComponent implements OnInit, AfterViewInit, OnDest
   | Public Method
   |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
 
-  /**
-   *  전체 row count
-   */
-  public setTotalRowCnt(totalRowCnt: number): void {
-    this.totalRowCnt = totalRowCnt;
-  }
-
-  /**
-   *  ruleIndex
-   */
-  public setRuleIndex(ruleIndex: number): void {
-    if(ruleIndex == null || ruleIndex == undefined){
-      this.ruleIndex = null;
-    }else{
-      this.ruleIndex = ruleIndex;
-    }
-
-  }
+  // /**
+  //  *  전체 row count
+  //  */
+  // public setTotalRowCnt(totalRowCnt: number): void {
+  //   this.totalRowCnt = totalRowCnt;
+  // }
+  //
+  // /**
+  //  *  ruleIndex
+  //  */
+  // public setRuleIndex(ruleIndex: number): void {
+  //   if(ruleIndex == null || ruleIndex == undefined){
+  //     this.ruleIndex = null;
+  //   }else{
+  //     this.ruleIndex = ruleIndex;
+  //   }
+  // }
 
   /**
    * 그리드 생성
@@ -153,7 +152,7 @@ export class ScrollLoadingGridComponent implements OnInit, AfterViewInit, OnDest
    * @param {ScrollLoadingGridModel} gridModel
    * @param {Option} option
    */
-  public create(headers: header[], gridModel: ScrollLoadingGridModel, option: Option = null) {
+  public create(headers: header[], gridModel: ScrollLoadingGridModel, option: Option = null, ruleIdx: number, totalRowCnt: number) {
 
     // 기존 그리드 삭제
     this.destroy();
@@ -201,9 +200,8 @@ export class ScrollLoadingGridComponent implements OnInit, AfterViewInit, OnDest
 
     // 데이터 전체 카운트 & ruleIdx
     if(this._gridModel) {
-      this._gridModel.setTotalRowCnt(this.totalRowCnt);
-      this._gridModel.setRuleIndex(this.ruleIndex);
-
+      this._gridModel.setTotalRowCnt(totalRowCnt);
+      this._gridModel.setRuleIndex(ruleIdx);
     }
 
     // 그리드 생성
@@ -257,6 +255,7 @@ export class ScrollLoadingGridComponent implements OnInit, AfterViewInit, OnDest
   public search(searchText: string = '') {
     try {
       // 선택표시 전체 해제
+      this._grid.scrollRowIntoView(0);
       this._grid.setSelectedRows([]);
       this._gridModel.search(searchText);
     } catch (e) {
@@ -727,6 +726,7 @@ export class ScrollLoadingGridComponent implements OnInit, AfterViewInit, OnDest
         }
       }
     });
+
 
     // -----------------------------------------------------------------------------------------------------------------
     // 윈도우 리사이징에 대한 이벤트 처리

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/scroll-loading-grid.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/scroll-loading-grid.component.ts
@@ -140,8 +140,7 @@ export class ScrollLoadingGridComponent implements OnInit, AfterViewInit, OnDest
    * @param {ScrollLoadingGridModel} gridModel
    * @param {Option} option
    */
-  public create(headers: header[], gridModel: ScrollLoadingGridModel, option: Option = null) {
-
+  public create(headers: header[], gridModel: ScrollLoadingGridModel, option: Option = null, ruleIndex:number) {
 
     // 기존 그리드 삭제
     this.destroy();
@@ -188,7 +187,11 @@ export class ScrollLoadingGridComponent implements OnInit, AfterViewInit, OnDest
     this._gridModel = gridModel;
 
     // 최초 로딩시 데이터 전체 카운트
-    if(this._gridModel) {this._gridModel.setTotalRowCnt(this.totalRowCnt);}
+    if(this._gridModel) {
+      this._gridModel.setTotalRowCnt(this.totalRowCnt);
+      this._gridModel.setTotalRowCnt(this.totalRowCnt);
+
+    }
 
     // 그리드 생성
     this._grid = this._generateGrid(headers, gridModel);

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/scroll-loading-grid.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/scroll-loading-grid.component.ts
@@ -81,6 +81,8 @@ export class ScrollLoadingGridComponent implements OnInit, AfterViewInit, OnDest
 
   @Output() private onHeaderRowCellRendered = new EventEmitter();
 
+  public totalRowCnt: number = 0;
+
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
   | Constructor
   |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
@@ -125,12 +127,21 @@ export class ScrollLoadingGridComponent implements OnInit, AfterViewInit, OnDest
   |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
 
   /**
+   *  전체 row count
+   */
+  public setTotalRowCnt(totalRowCnt: number): void {
+    this.totalRowCnt = totalRowCnt;
+  }
+
+
+  /**
    * 그리드 생성
    * @param {header[]} headers
    * @param {ScrollLoadingGridModel} gridModel
    * @param {Option} option
    */
   public create(headers: header[], gridModel: ScrollLoadingGridModel, option: Option = null) {
+
 
     // 기존 그리드 삭제
     this.destroy();
@@ -175,6 +186,9 @@ export class ScrollLoadingGridComponent implements OnInit, AfterViewInit, OnDest
 
     // 그리드 모델 정의
     this._gridModel = gridModel;
+
+    // 최초 로딩시 데이터 전체 카운트
+    if(this._gridModel) {this._gridModel.setTotalRowCnt(this.totalRowCnt);}
 
     // 그리드 생성
     this._grid = this._generateGrid(headers, gridModel);

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/scroll-loading-grid.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/scroll-loading-grid.component.ts
@@ -83,6 +83,8 @@ export class ScrollLoadingGridComponent implements OnInit, AfterViewInit, OnDest
 
   public totalRowCnt: number = 0;
 
+  public ruleIndex: number;
+
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
   | Constructor
   |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
@@ -133,6 +135,17 @@ export class ScrollLoadingGridComponent implements OnInit, AfterViewInit, OnDest
     this.totalRowCnt = totalRowCnt;
   }
 
+  /**
+   *  ruleIndex
+   */
+  public setRuleIndex(ruleIndex: number): void {
+    if(ruleIndex == null || ruleIndex == undefined){
+      this.ruleIndex = null;
+    }else{
+      this.ruleIndex = ruleIndex;
+    }
+
+  }
 
   /**
    * 그리드 생성
@@ -140,7 +153,7 @@ export class ScrollLoadingGridComponent implements OnInit, AfterViewInit, OnDest
    * @param {ScrollLoadingGridModel} gridModel
    * @param {Option} option
    */
-  public create(headers: header[], gridModel: ScrollLoadingGridModel, option: Option = null, ruleIndex:number) {
+  public create(headers: header[], gridModel: ScrollLoadingGridModel, option: Option = null) {
 
     // 기존 그리드 삭제
     this.destroy();
@@ -186,10 +199,10 @@ export class ScrollLoadingGridComponent implements OnInit, AfterViewInit, OnDest
     // 그리드 모델 정의
     this._gridModel = gridModel;
 
-    // 최초 로딩시 데이터 전체 카운트
+    // 데이터 전체 카운트 & ruleIdx
     if(this._gridModel) {
       this._gridModel.setTotalRowCnt(this.totalRowCnt);
-      this._gridModel.setRuleIndex(ruleIndex);
+      this._gridModel.setRuleIndex(this.ruleIndex);
 
     }
 

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/scroll-loading-grid.model.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/scroll-loading-grid.model.ts
@@ -148,7 +148,7 @@ export class ScrollLoadingGridModel {
     if( this._isLoadingData ) {
       return;
     }
-
+    // console.info(from + ':this.totalRowCnt:'+ this.totalRowCnt);
     let lastPageNumber: number = Math.floor(this.totalRowCnt / this._pageSize);
     if(this.totalRowCnt % this._pageSize !== 0) lastPageNumber = lastPageNumber +1;
 
@@ -167,14 +167,14 @@ export class ScrollLoadingGridModel {
     const startIdx: number = nextPage * this._pageSize;
     if (this.data.length <= startIdx) {
       this._isLoadingData = true;
-      // this.onDataLoading.notify({ from: from, to: to });
+      this.onDataLoading.notify({ from: from, to: to });
       this.loadData(this.ruleIndex, startIdx, this._pageSize)
         .then((data) => {
           const result = this.loadSuccess(data);
           if (result) {
             //
             this.totalRowCnt = data.totalRowCnt;
-            this.ruleIndex = data.ruleCurIdx;
+            // this.ruleIndex = data.ruleCurIdx;
 
             let currLength: number = this.data.length;
 

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/scroll-loading-grid.model.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/scroll-loading-grid.model.ts
@@ -64,12 +64,16 @@ export class ScrollLoadingGridModel {
    */
   public loadFail: Function;
 
+
+  public totalRowCnt: number = 0;
+
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
   | Constructor
   |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
 
   // 생성자
   constructor(loadData: Function, loadSuccess: Function, data?: any[]) {
+    // console.info('loadData', data);
     this.loadData = loadData;
     this.loadSuccess = loadSuccess;
     if (data) {
@@ -90,6 +94,13 @@ export class ScrollLoadingGridModel {
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
   | Public Method
   |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
+
+  /**
+   *  전체 row count
+   */
+  public setTotalRowCnt(totalRowCnt: number): void {
+    this.totalRowCnt = totalRowCnt;
+  }
 
   /**
    * 검색
@@ -124,9 +135,16 @@ export class ScrollLoadingGridModel {
       return;
     }
 
+    let lastPageNumber: number = Math.floor(this.totalRowCnt / this._pageSize);
+    if(this.totalRowCnt % this._pageSize !== 0) lastPageNumber = lastPageNumber +1;
+
     // 페이지 지정 ( to 에 20을 더한 것은 그만큼 미리 부르기 위한 것임 )
     const viewPortBottom:number = (isNaN(to) || ( to + 20 ) < 0) ? 0 : ( to + 20 );
     let nextPage: number = Math.floor( viewPortBottom / this._pageSize);
+
+    if( lastPageNumber <= nextPage ) {
+      return;
+    }
 
     if( this._currentPage >= nextPage ) {
       return;
@@ -135,11 +153,13 @@ export class ScrollLoadingGridModel {
     const startIdx: number = nextPage * this._pageSize;
     if (this.data.length <= startIdx) {
       this._isLoadingData = true;
-      this.onDataLoading.notify({ from: from, to: to });
-      this.loadData(nextPage, this._pageSize)
+      // this.onDataLoading.notify({ from: from, to: to });
+      this.loadData(startIdx, this._pageSize)
         .then((data) => {
           const result = this.loadSuccess(data);
           if (result) {
+            //
+            this.totalRowCnt = data.totalRowCnt;
 
             let currLength: number = this.data.length;
 

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/scroll-loading-grid.model.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/scroll-loading-grid.model.ts
@@ -174,6 +174,7 @@ export class ScrollLoadingGridModel {
           if (result) {
             //
             this.totalRowCnt = data.totalRowCnt;
+            this.ruleIndex = data.ruleCurIdx;
 
             let currLength: number = this.data.length;
 

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/scroll-loading-grid.model.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/scroll-loading-grid.model.ts
@@ -67,13 +67,14 @@ export class ScrollLoadingGridModel {
 
   public totalRowCnt: number = 0;
 
+  public ruleIndex: number;
+
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
   | Constructor
   |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
 
   // 생성자
   constructor(loadData: Function, loadSuccess: Function, data?: any[]) {
-    // console.info('loadData', data);
     this.loadData = loadData;
     this.loadSuccess = loadSuccess;
     if (data) {
@@ -101,6 +102,19 @@ export class ScrollLoadingGridModel {
   public setTotalRowCnt(totalRowCnt: number): void {
     this.totalRowCnt = totalRowCnt;
   }
+
+  /**
+   *  ruleIndex
+   */
+  public setRuleIndex(ruleIndex: number): void {
+    if(ruleIndex == null || ruleIndex == undefined){
+      this.ruleIndex = null;
+    }else{
+      this.ruleIndex = ruleIndex;
+    }
+
+  }
+
 
   /**
    * 검색
@@ -154,7 +168,7 @@ export class ScrollLoadingGridModel {
     if (this.data.length <= startIdx) {
       this._isLoadingData = true;
       // this.onDataLoading.notify({ from: from, to: to });
-      this.loadData(startIdx, this._pageSize)
+      this.loadData(this.ruleIndex, startIdx, this._pageSize)
         .then((data) => {
           const result = this.loadSuccess(data);
           if (result) {

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformController.java
@@ -103,7 +103,7 @@ public class PrepTransformController {
     } else {
       int toIndex = offset + count;
       if(gridResponse.rows.size()<toIndex) {
-        toIndex = subGrid.rows.size();
+        toIndex = gridResponse.rows.size();
       }
 
       subGrid.rows = gridResponse.rows.subList(offset, toIndex);

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformController.java
@@ -31,7 +31,6 @@ import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.rest.webmvc.RepositoryRestController;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -102,7 +101,12 @@ public class PrepTransformController {
     if (offset == 0 && count >= gridResponse.rows.size()) {
       subGrid.rows = gridResponse.rows;
     } else {
-      subGrid.rows = gridResponse.rows.subList(offset, offset + count);
+      int toIndex = offset + count;
+      if(subGrid.rows.size()<toIndex) {
+        toIndex = subGrid.rows.size();
+      }
+
+      subGrid.rows = gridResponse.rows.subList(offset, toIndex);
     }
 
     return subGrid;

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformController.java
@@ -102,7 +102,7 @@ public class PrepTransformController {
       subGrid.rows = gridResponse.rows;
     } else {
       int toIndex = offset + count;
-      if(subGrid.rows.size()<toIndex) {
+      if(gridResponse.rows.size()<toIndex) {
         toIndex = subGrid.rows.size();
       }
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
apply current rule index at scroll down in the main grid of Dataprep
modify by proper column size

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#476 
#486 
#515 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

1. select wrangle data [Annual Revenue Data 2013-2016.xlsx](https://github.com/metatron-app/metatron-discovery/files/2509337/Annual.Revenue.Data.2013-2016.xlsx)

2. Click "Edit rules"
3. add delete command
4. Scroll down
5. Verify that delete command has been applied, 
    Verify  that the same result is repeated
    Check that the proper column size is displayed

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
