### PR TITLE
#530 lower column names for Hive tables in ORC format

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DataFrame.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DataFrame.java
@@ -1334,6 +1334,18 @@ public class DataFrame implements Serializable, Transformable {
     }
   }
 
+  public void lowerColNames() throws IllegalColumnNameForHiveException {
+    List<String> lowerColNames = new ArrayList();
+    for (String colName : colNames) {
+      String lowerColName = colName.toLowerCase();
+      if (lowerColNames.contains(lowerColName)) {
+        throw new IllegalColumnNameForHiveException("Column names become duplicated while saving into a Hive table: " + colName);
+      }
+      lowerColNames.add(lowerColName);
+    }
+    colNames = lowerColNames;
+  }
+
   protected String makeParsable(String colName) {
     if(colName.matches("^\'.+\'"))
         colName = colName.substring(1, colName.length()-1);

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/TeddyExecutor.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/TeddyExecutor.java
@@ -21,6 +21,7 @@ import app.metatron.discovery.domain.dataprep.PrepSnapshot.FORMAT;
 import app.metatron.discovery.domain.dataprep.PrepSnapshotService;
 import app.metatron.discovery.domain.dataprep.exceptions.PrepException;
 import app.metatron.discovery.domain.dataprep.jdbc.JdbcDataPrepService;
+import app.metatron.discovery.domain.dataprep.teddy.exceptions.IllegalColumnNameForHiveException;
 import app.metatron.discovery.domain.dataprep.teddy.exceptions.JdbcQueryFailedException;
 import app.metatron.discovery.domain.dataprep.teddy.exceptions.JdbcTypeNotSupportedException;
 import app.metatron.discovery.domain.dataprep.teddy.exceptions.TeddyException;
@@ -698,7 +699,7 @@ public class TeddyExecutor {
   }
 
   public String writeToHdfs(String ssId, String dsId, String extHdfsDir, String dbName, String tblName,
-                            FORMAT format, COMPRESSION compression) throws IOException {
+                            FORMAT format, COMPRESSION compression) throws IOException, IllegalColumnNameForHiveException {
     Integer[] rowCnt = new Integer[2];
     FileSystem fs = FileSystem.get(conf);
 
@@ -721,6 +722,7 @@ public class TeddyExecutor {
         rowCnt[0] = writeCsv(ssId, df, br, null);
         break;
       case ORC:
+        df.lowerColNames();
         file = new Path(dir.toString() + File.separator + "part-00000-" + dsId + ".orc");
         TeddyOrcWriter orcWriter = new TeddyOrcWriter();
         rowCnt = orcWriter.writeOrc(df, conf, file, compression);


### PR DESCRIPTION
### Description
When creating a Hive table with ORC format, all column names become lowercase.
If column names become duplicated in this process (when only the letter cases were different), you'll get an exception.

_ORC format으로 이루어진 Hive table을 만들 때에는 column 이름들을 모두 소문자화하도록 했습니다.
이 과정에서 중복되는 이름이 생기는 경우(원래 대소문자만 달랐던 경우)에는 exception을 발생시키도록 했습니다._

**Related Issue** : https://github.com/metatron-app/metatron-discovery/issues/530


### How Has This Been Tested?
I've made a Hive table in ORC format and I could see all the contents.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
