### PR TITLE
F#563 scrolling issue show end time

### DIFF
--- a/discovery-frontend/src/app/common/service/abstract.service.ts
+++ b/discovery-frontend/src/app/common/service/abstract.service.ts
@@ -435,7 +435,11 @@ export class AbstractService {
 
     let errorMessage: any;
     if (error.status && error.status !== 404) {
-      errorMessage = error ? error.json() : 'Server error';
+      try {
+        errorMessage = error ? error.json() : 'Server error';
+      } catch (e) {
+        errorMessage = 'Server error';
+      }
     } else {
       error.name === 'TimeoutError' ? errorMessage = 'Timeout' : errorMessage = 'Server error';
     }

--- a/discovery-frontend/src/app/workbench/service/workbench.service.ts
+++ b/discovery-frontend/src/app/workbench/service/workbench.service.ts
@@ -185,7 +185,7 @@ export class WorkbenchService extends AbstractService {
   public checkConnectionStatus(queryEditorId: string, socketId: string)  {
     const param = {
       webSocketId : socketId
-    }
+    };
     return this.post(this.API_URL + `queryeditors/${queryEditorId}/status`, param);
   }
 

--- a/discovery-frontend/src/app/workbench/workbench.component.html
+++ b/discovery-frontend/src/app/workbench/workbench.component.html
@@ -244,14 +244,33 @@
               <!--</div>-->
               <!-- //row 수 -->
               <!-- SQL BEAUTIFIER -->
-              <a href="javascript:" class="ddp-btn-beautifier" (click)="setSqlFormatter()" title="SQL BEAUTIFIER"></a>
+              <a href="javascript:" class="ddp-btn-beautifier" (click)="setSqlFormatter()">
+                <div class="ddp-ui-tooltip-info">
+                  <em class="ddp-icon-view-down"></em>
+                  SQL BEAUTIFIER
+                </div>
+              </a>
               <!-- //SQL BEAUTIFIER -->
               <!-- foot button -->
               <div class="ddp-ui-edit-foot">
-                <a href="javascript:" class="ddp-btn-play" (click)="setExecuteSql('ALL')" title="ALL SQL EXECUTE"></a>
-                <a href="javascript:" class="ddp-btn-stop" (click)="setExecuteSql('SELECTED')"
-                   title="SELECTED  SQL EXECUTE"></a>
-                <a href="javascript:" class="ddp-btn-delete" (click)="clearSql()" title="CLEAR SQL"></a>
+                <a href="javascript:" class="ddp-btn-play" (click)="setExecuteSql('ALL')" >
+                  <div class="ddp-ui-tooltip-info">
+                    <em class="ddp-icon-view-down"></em>
+                    ALL SQL EXECUTE
+                  </div>
+                </a>
+                <a href="javascript:" class="ddp-btn-stop" (click)="setExecuteSql('SELECTED')" >
+                  <div class="ddp-ui-tooltip-info">
+                    <em class="ddp-icon-view-down"></em>
+                    SELECTED  SQL EXECUTE
+                  </div>
+                </a>
+                <a href="javascript:" class="ddp-btn-delete" (click)="clearSql()" title="">
+                  <div class="ddp-ui-tooltip-info">
+                    <em class="ddp-icon-view-down"></em>
+                    CLEAR SQL
+                  </div>
+                </a>
               </div>
               <!-- //foot button -->
               <!-- 클릭시 ddp-selected 추가 -->
@@ -552,7 +571,7 @@
                     <span class="ddp-data-label">{{'msg.bench.ui.query.start.date' | translate}}</span>
                     <span class="ddp-data-txt">{{visibleResultTab.startDate}}</span>
                   </span>
-                  <span class="ddp-data-time">
+                  <span *ngIf="visibleResultTab.finishDate" class="ddp-data-time">
                     <span class="ddp-data-label">{{'msg.bench.ui.query.finish.date' | translate}}</span>
                     <span class="ddp-data-txt">{{visibleResultTab.finishDate}}</span>
                   </span>

--- a/discovery-frontend/src/app/workbench/workbench.component.html
+++ b/discovery-frontend/src/app/workbench/workbench.component.html
@@ -553,6 +553,10 @@
                     <span class="ddp-data-txt">{{visibleResultTab.startDate}}</span>
                   </span>
                   <span class="ddp-data-time">
+                    <span class="ddp-data-label">{{'msg.bench.ui.query.finish.date' | translate}}</span>
+                    <span class="ddp-data-txt">{{visibleResultTab.finishDate}}</span>
+                  </span>
+                  <span class="ddp-data-time">
                     <span class="ddp-data-label">{{'msg.bench.ui.query.running.time' | translate}}</span>
                     <span class="ddp-data-txt">{{ setNumberFormat( visibleResultTab.executeTime, 2 ) }} Secs.</span>
                   </span>

--- a/discovery-frontend/src/app/workbench/workbench.component.ts
+++ b/discovery-frontend/src/app/workbench/workbench.component.ts
@@ -2010,6 +2010,8 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
             resultTabInfo.setExecuteStatus(data.command);
           } // end if - command log, done
 
+          this.safelyDetectChanges();
+
           // log data 가 있을경우 scroll 이동
           const $logContainer = $('#workbenchLogText');
           if (this._isEqualRunningVisibleTab() && '' !== $logContainer.text()) {
@@ -2018,9 +2020,6 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
             let offsetTop = textAreaHeight * (Math.ceil(lineBreakLength / 8));
             $logContainer.scrollTop(offsetTop);
           }
-
-          this.safelyDetectChanges();
-
         }
 
         if (data['connected'] === true) {
@@ -2839,6 +2838,7 @@ class ResultTab {
   public log: string[];
   public sql: string;
   public startDate: string;
+  public finishDate: string;
   public executeTime: number;
   public executeStatus: ('GET_CONNECTION' | 'CREATE_STATEMENT' | 'EXECUTE_QUERY' | 'LOG' | 'GET_RESULTSET' | 'DONE');
   public resultStatus: ('NONE' | 'SUCCESS' | 'FAIL' | 'CANCEL');
@@ -2879,10 +2879,12 @@ class ResultTab {
 
   public doneTimer() {
     // if (this.data) {
-    //   this.startTime = moment(this.data.startDateTime).format('YYYY-MM-DD HH:mm:ss');
+    //   this.startDate = moment(this.data.startDateTime).format('YYYY-MM-DD HH:mm:ss');
+    //   this.finishDate = moment(this.data.finishDateTime).format('YYYY-MM-DD HH:mm:ss');
     //   this.runningTime = moment(this.data.finishDateTime).diff(this.data.startDateTime, 'seconds');
     // }
     clearInterval(this._timer);
+    this.finishDate = moment().format('YYYY-MM-DD HH:mm:ss');
   } // function - doneTimer
 
   public setResultStatus(status: ('NONE' | 'SUCCESS' | 'FAIL' | 'CANCEL') ) {
@@ -2938,12 +2940,12 @@ class QueryResult {
   public csvFilePath: string;
   public data: any[];
   public fields: Field[];
-  public finishDateTime: string;
   public numRows: number;
   public queryEditorId: string;
   public queryHistoryId: number;
   public queryResultStatus: 'SUCCESS' | 'FAIL';
   public runQuery: string;
   public startDateTime: string;
+  public finishDateTime: string;
   public tempTable: string;
 }

--- a/discovery-frontend/src/assets/css/polaris.v2.page.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.page.css
@@ -6527,7 +6527,7 @@ table.ddp-table-simple tr td .ddp-ui-action {height:30px; white-space:normal; ov
 .ddp-box-editer a.ddp-btn-beautifier {position:relative; float:left; width:32px; height:32px;  background:rgba(75,81,91,0.05); margin-right:2px;}
 .ddp-box-editer a.ddp-btn-beautifier:hover .ddp-ui-tooltip-info {display:block;}
 .ddp-box-editer a.ddp-btn-beautifier:before {display:inline-block; content:''; position:absolute; top:50%; left:50%; width:21px; height:18px; margin:-10px 0 0 -9px; background:url(../images/icon_query.png) no-repeat; background-position:left -70px;}
-.ddp-box-editer a.ddp-btn-beautifier:hover:before {background-position:right -70px;}
+.ddp-box-editer a.ddp-btn-beautifier:hover:before {background-position:-22px -70px;}
 
 .ddp-box-editer .ddp-wrap-question {position:relative;float:left;}
 .ddp-box-editer .ddp-wrap-question a.ddp-btn-question {position:relative; float:left; width:32px; height:32px; margin-left:3px;  background:rgba(75,81,91,0.05); margin-right:2px;}

--- a/discovery-frontend/src/assets/i18n/en.json
+++ b/discovery-frontend/src/assets/i18n/en.json
@@ -552,6 +552,7 @@
   "msg.bench.ui.wb.del.description" : "Are you sure you want to delete this workbench?",
   "msg.bench.ui.result.empty.description" : "No query results. Please run the query.",
   "msg.bench.ui.query.start.date" : "Started Time",
+  "msg.bench.ui.query.finish.date" : "Finished Time",
   "msg.bench.ui.query.running.time" : "Elapsed Time",
   "msg.bench.ui.query.running.message" : "Running query..",
   "msg.bench.ui.query.fail.message" : "Query execution failed..",

--- a/discovery-frontend/src/assets/i18n/ko.json
+++ b/discovery-frontend/src/assets/i18n/ko.json
@@ -552,6 +552,7 @@
   "msg.bench.ui.wb.del.description" : "해당 워크벤치를 삭제하시겠습니까?",
   "msg.bench.ui.result.empty.description" : "쿼리 결과가 없습니다. 쿼리를 실행해 주세요.",
   "msg.bench.ui.query.start.date" : "실행 시작",
+  "msg.bench.ui.query.finish.date" : "실행 종료",
   "msg.bench.ui.query.running.time" : "소요 시간",
   "msg.bench.ui.query.running.message" : "쿼리 실행중..",
   "msg.bench.ui.query.fail.message" : "쿼리 실행 실패..",


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
로그 출력 시 스크롤이 아래로 이동하지 않는 현상과 쿼리 실행 종료시간이 출력되지 않는 문제가 있습니다.
sql beautifier 버튼의 아이콘이 잘려서 표시되는 현상이 있습니다.

**Related Issue** : #563 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Hive Connection으로 생성된 워크벤치 메뉴로 이동합니다.
2. 쿼리를 실행합니다.
3. 로그가 출력되면서 스크롤이 내려가는지 확인합니다.
4. 쿼리 실행 종료 후 종료 시간이 정상적으로 표시되는지 확인합니다.
5. sql beautifier 버튼에 마우스를 올렸을 때 정상적으로 표시되는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

### Additional Context<!-- if not appropriate, remove this topic. -->
