### PR TITLE
Fix errors on replace and move rules in preparation

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DfMove.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DfMove.java
@@ -136,7 +136,7 @@ public class DfMove extends DataFrame {
       Row newRow = new Row();
       for (int i = 0; i < targetOrder.size(); i++) {
         int colno = targetOrder.get(i);
-        newRow.add(getColName(colno), row.get(colno));
+        newRow.add(prevDf.getColName(colno), row.get(colno));
       }
       rows.add(newRow);
     }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DfReplace.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DfReplace.java
@@ -182,7 +182,7 @@ public class DfReplace extends DataFrame {
             newRow.add(columnName, row.get(colno));
           }
         }
-        this.rows.add(newRow);
+        rows.add(newRow);
       }
     } else { //quote 문자가 있을 경우의 처리(정규식으로 quote를 처리해야 해서 Pattern.compile 사용 불가)
       for (int rowno = offset; rowno < offset + length; cancelCheck(++rowno)) {


### PR DESCRIPTION
### Description
Theres two kinds of bug in move and replace rule.

1. When move rule is applied nameIdxs[] in Row object is mixed, so you can't get right value from row with column name.
2. In DfReplace source code, variables that named "rows" and "this.rows" are used confusingly. So it might be cause snapshot creating failure.

So, corrected these 2 errors.

**Related Issue** : <!--- Please link to the issue here. -->
https://github.com/metatron-app/metatron-discovery/issues/595


### How Has This Been Tested?
1. Apply move rule to a column.
2. Apply other rule to the column.
3. It might be success.
4. Apply replace rule.
5. Create snapshot.
6. It might be success.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
