### PR TITLE
#398 fix vertical scroll in column dictionary and code table

### DIFF
--- a/discovery-frontend/src/app/meta-data-management/code-table/create-code-table/create-code-table.component.ts
+++ b/discovery-frontend/src/app/meta-data-management/code-table/create-code-table/create-code-table.component.ts
@@ -12,19 +12,19 @@
  * limitations under the License.
  */
 
-import { AbstractPopupComponent } from '../../../common/component/abstract-popup.component';
 import { Component, ElementRef, EventEmitter, Injector, OnDestroy, OnInit, Output } from '@angular/core';
 import { CodeTableService } from '../service/code-table.service';
 import { Alert } from '../../../common/util/alert.util';
 import * as _ from 'lodash';
 import { CodeValuePair } from '../../../domain/meta-data-management/code-value-pair';
 import { CommonUtil } from '../../../common/util/common.util';
+import { AbstractComponent } from '../../../common/component/abstract.component';
 
 @Component({
   selector: 'app-create-code-table',
   templateUrl: './create-code-table.component.html'
 })
-export class CreateCodeTableComponent extends AbstractPopupComponent implements OnInit, OnDestroy {
+export class CreateCodeTableComponent extends AbstractComponent implements OnInit, OnDestroy {
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
   | Private Variables

--- a/discovery-frontend/src/app/meta-data-management/column-dictionary/create-column-dictionary/create-column-dictionary.component.ts
+++ b/discovery-frontend/src/app/meta-data-management/column-dictionary/create-column-dictionary/create-column-dictionary.component.ts
@@ -12,7 +12,6 @@
  * limitations under the License.
  */
 
-import { AbstractPopupComponent } from '../../../common/component/abstract-popup.component';
 import { Component, ElementRef, EventEmitter, Injector, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
 import { ColumnDictionaryService } from '../service/column-dictionary.service';
 import { Alert } from '../../../common/util/alert.util';
@@ -20,12 +19,13 @@ import { CommonUtil } from '../../../common/util/common.util';
 import { ChooseCodeTableComponent } from '../../component/choose-code-table/choose-code-table.component';
 import { CodeTable } from '../../../domain/meta-data-management/code-table';
 import { FieldFormat, FieldFormatType } from '../../../domain/datasource/datasource';
+import { AbstractComponent } from '../../../common/component/abstract.component';
 
 @Component({
   selector: 'app-create-column-dictionary',
   templateUrl: './create-column-dictionary.component.html'
 })
-export class CreateColumnDictionaryComponent extends AbstractPopupComponent implements OnInit, OnDestroy {
+export class CreateColumnDictionaryComponent extends AbstractComponent implements OnInit, OnDestroy {
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
   | Private Variables


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
column dictionary 상세화면에서 스크롤이 안생기는 현상 수정

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#398 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Go to 'Metadata > Column Dictionary > detail view'
2. Can not see bottom contents


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project. _it will be added soon_
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
