### PR TITLE
#585 increase the size of the rule string field

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformRule.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformRule.java
@@ -17,7 +17,6 @@ package app.metatron.discovery.domain.dataprep.transform;
 import app.metatron.discovery.domain.dataprep.PrepDataset;
 
 import javax.persistence.*;
-import javax.validation.constraints.Size;
 
 @Entity
 @IdClass(PrepTransformRuleId.class)
@@ -32,7 +31,7 @@ public class PrepTransformRule {
     @JoinColumn(name = "ds_id")
     private PrepDataset dataset;
 
-    @Size(max = 4000)
+    @Lob
     @Column(name = "rule_string", nullable = false)
     private String ruleString;
 


### PR DESCRIPTION
### Description
the rule string field length is 4000.
sometimes this is not enough.
so we changed the type of rule string from 4000 chars to text.

**Related Issue** : 
[#585](https://github.com/metatron-app/metatron-discovery/issues/585)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. create new dataset
2. make a dataflow with the dataset
3. create a wrangled dataset
4. edit the rules of that
5. add a rule longer than 4000. 
ex) set column with value 'xxx(over 4000)...'    

if the rule was successfully created. that is Ok

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
