### PR TITLE
Change response message as OK for snapshot cancel request when snapsh…

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
@@ -1662,7 +1662,7 @@ public class PrepTransformService {
               return "THIS_SNAPSHOT_IS_ALREADY_CANCELED";
           case SUCCEEDED:
           case FAILED:
-              return "THIS_SNAPSHOT_IS_ALREADY_CREATED_OR_FAILED";
+              return "OK";
           case NOT_AVAILABLE:
           default:
               return "UNKNOWN_ERROR";


### PR DESCRIPTION
### Description
Original issue is about error msg when snapshot cancelation is requested for hdfs snapshot.
It seems to that snapshot canceling is impossible because snapshot generating process is already passed cancel point.

So I changed response message for this case as OK.

**Related Issue** : <!--- Please link to the issue here. -->
https://github.com/metatron-app/metatron-discovery/issues/528

### How Has This Been Tested?
1. Create any type of snapshot.
2. Cancel it.
3. It should be always success.
4. Even if a snapshot created, cancelation request will not fail.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
