### PR TITLE
#609 Show notifications when browsing back

### DIFF
--- a/discovery-frontend/src/app/workbench/workbench.component.ts
+++ b/discovery-frontend/src/app/workbench/workbench.component.ts
@@ -335,6 +335,7 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
    */
   public ngOnInit() {
     super.ngOnInit();
+    this.useUnloadConfirm = true;
 
     if (this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN) === '') {
       this.router.navigate(['/user/login']).then();
@@ -447,7 +448,6 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
    * @param {string} editorId
    */
   public saveLocalStorage(value: string, editorId: string): void {
-    this.useUnloadConfirm = true;
     localStorage.setItem('workbench' + this.workbenchId + editorId, value);
   }
 
@@ -456,7 +456,6 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
    * @param {string} editorId
    */
   public removeLocalStorage(editorId: string): void {
-    this.useUnloadConfirm = false;
     localStorage.removeItem('workbench' + this.workbenchId + editorId);
   }
 
@@ -2349,7 +2348,6 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
   // 뒤로 돌아가기
   public goBack() {
     // unload false
-    this.useUnloadConfirm = false;
     const cookieWs = this.cookieService.get(CookieConstant.KEY.CURRENT_WORKSPACE);
     let cookieWorkspace = null;
     if (cookieWs) {

--- a/discovery-frontend/src/app/workbench/workbench.module.ts
+++ b/discovery-frontend/src/app/workbench/workbench.module.ts
@@ -30,10 +30,11 @@ import {AnalysisPredictionService} from "../page/component/analysis/service/anal
 import { DetailWorkbenchSchemaBrowserComponent } from './component/detail-workbench/detail-workbench-schema-browser/detail-workbench-schema-browser.component';
 import { CodemirrorComponent } from '../workbench/component/editor-workbench/codemirror.component';
 import { MetadataService } from '../meta-data-management/metadata/service/metadata.service';
+import { CanDeactivateGuard } from '../common/gaurd/can.deactivate.guard';
 
 // 라우트
 const workbenchRoutes: Routes = [
-  { path: ':id', component: WorkbenchComponent },
+  { path: ':id', component: WorkbenchComponent, canDeactivate:[CanDeactivateGuard] },
   { path: ':id/schemabrowser', component: DetailWorkbenchSchemaBrowserComponent}
 ];
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
편집중에 브라우저 뒤로가기 버튼을 눌렀을 경우 바로 화면에서 벗어나기 전에 확인을 거치는 과정이 필요합니다.

**Related Issue** : #609 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 워크벤치 화면의 띄웁니다.
2. 브라우저 뒤로가기 버튼이나 새로고침 버튼을 누릅니다.
3. 화면을 바로 벗어나지 않고 확인창이 뜨는지 확인하고 확인을 누른 후에 벗어나는지 확인합니다.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
