### PR TITLE
#608 Improved editor name automatic naming policy

### DIFF
--- a/discovery-frontend/src/app/workbench/workbench.component.html
+++ b/discovery-frontend/src/app/workbench/workbench.component.html
@@ -220,8 +220,9 @@
                   </li>
                 </ul>
 
-                <a href="javascript:" class="ddp-btn-plus" (click)="createNewEditor('', true, true)"><em
-                  class="ddp-icon-plus"></em></a>
+                <a href="javascript:" class="ddp-btn-plus" (click)="createNewEditor('', true)">
+                  <em class="ddp-icon-plus"></em>
+                </a>
               </div>
             </div>
             <!-- //tab -->

--- a/discovery-frontend/src/app/workbench/workbench.component.ts
+++ b/discovery-frontend/src/app/workbench/workbench.component.ts
@@ -89,9 +89,6 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
   @ViewChild(LoadingComponent)
   private loadingBar: LoadingComponent;
 
-  // 탭 번호
-  private tabNum: number = 0;
-
   // 선택된 탭 번호
   private selectedTabNum: number = 0;
 
@@ -539,28 +536,19 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
    * 새로운 에디터 만들기
    * @param {string} text
    * @param {boolean} selectedParam
-   * @param {boolean} increase
    */
-  public createNewEditor(text: string = '', selectedParam: boolean = true, increase: boolean = false) {
-    // 탭번호 증가
-    if (increase === true) {
-      this.tabNum = Number(this.textList.length);
-    }
+  public createNewEditor(text: string = '', selectedParam: boolean = true) {
 
-    const tabPrefix: string = this.translateService.instant('msg.bench.ui.tab-prefix');
-    const prefixReg: RegExp = new RegExp(tabPrefix);
-    const numRegExp: RegExp = /^[0-9]+$/;
-    const numList: number[]
-      = this.textList
-      .map(item => item.name.replace(prefixReg, '').trim())
-      .filter(item => numRegExp.test(item))
-      .map(item => Number(item));
-    const lastTabNum: number = (numList && 0 < numList.length) ? _.max(numList) : 0;
+    const cntEditorTabs: number = this.textList.length;
+    const currMaxIndex =
+      this.textList.reduce( ( acc:number, curr:any ) => {
+        return _.max( [acc, isNullOrUndefined( curr.index ) ? 0 : curr.index ] );
+      }, cntEditorTabs );
 
     const queryEditor: QueryEditor = new QueryEditor();
-    queryEditor.name = tabPrefix + ' ' + (lastTabNum + 1);
+    queryEditor.name = this.translateService.instant('msg.bench.ui.tab-prefix') + ' ' + (currMaxIndex + 1);
     queryEditor.workbench = CommonConstant.API_CONSTANT.API_URL + 'workbenchs/' + this.workbenchId;
-    queryEditor.order = this.tabNum;
+    queryEditor.order = currMaxIndex;
     queryEditor.query = '';
 
     this.loadingShow();
@@ -573,6 +561,7 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
           name: queryEditor.name,
           query: text === '' ? '' : text,
           editorId: data.id,
+          index: data.index,
           editorMode: false
         });
         // 슬라이드 아이콘 show hide
@@ -1569,6 +1558,7 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
       });
   } // function - checkQueryStatus
 
+  // noinspection JSMethodCanBeStatic
   /**
    * set number format
    * @param {number} num
@@ -1912,7 +1902,7 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
    */
   private readQuery(queryEditors: any[]) {
     if (queryEditors.length === 0) {
-      this.createNewEditor('', true, false);
+      this.createNewEditor('', true);
     } else {
       const editors = queryEditors.sort((a, b) => {
         return a.order - b.order;
@@ -2701,8 +2691,7 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
    */
   public setSchemaBrowser(): void {
 
-    let connInfo: any = {};
-    connInfo = this.workbench;
+    let connInfo: any = this.workbench;
 
     const selectedSecurityType = [
         { label: this.translateService.instant('msg.storage.li.connect.always'), value: 'MANUAL' },
@@ -2974,16 +2963,16 @@ class ResultTab {
 }
 
 class QueryResult {
-  public auditId: string;
+  // public auditId: string;
   public csvFilePath: string;
   public data: any[];
   public fields: Field[];
   public numRows: number;
   public queryEditorId: string;
-  public queryHistoryId: number;
+  // public queryHistoryId: number;
   public queryResultStatus: 'SUCCESS' | 'FAIL';
   public runQuery: string;
   public startDateTime: string;
-  public finishDateTime: string;
-  public tempTable: string;
+  // public finishDateTime: string;
+  // public tempTable: string;
 }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
에디터탭 추가 시 자동 이름 설정에서 숫자 지정에 대한 정책을 개선합니다.

**Related Issue** : #608 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 워크벤치 화면을 띄웁니다.
2. 에디터 탭 추가 버튼을 클릭합니다.
3. 에디터 탭의 이름뒤에 붙는 숫자가 현재 에디터 탭의 갯수 혹은 기존에 생성된 탭의 번호 중 큰 수의 다음 수로 생성되는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
