### PR TITLE
F#625 unpaired single quote in csv file causes error when importing

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetFileService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetFileService.java
@@ -25,6 +25,7 @@ import app.metatron.discovery.domain.dataprep.teddy.Util;
 import app.metatron.discovery.domain.dataprep.transform.TimestampTemplate;
 import app.metatron.discovery.domain.datasource.Field;
 import app.metatron.discovery.util.ExcelProcessor;
+import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.monitorjbl.xlsx.StreamingReader;
@@ -45,10 +46,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.*;
 import java.nio.charset.Charset;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.Future;
 
 @Service
@@ -225,11 +223,11 @@ public class PrepDatasetFileService {
         return ColumnType.STRING;
     }
 
-    private Field makeFieldFromCSV(int idx, String fieldKey, String str){
+    private Field makeFieldFromCSV(int idx, String fieldKey, ColumnType columnType){
         DataType fieldType;
         Field.FieldRole fieldBIType;
 
-        switch (getTypeFormString(str)) {
+        switch (columnType) {
             case BOOLEAN:
                 fieldType = DataType.BOOLEAN;
                 fieldBIType = Field.FieldRole.DIMENSION;
@@ -339,7 +337,7 @@ public class PrepDatasetFileService {
                                 f = fields.get(cellIdx);
                             }
                             if(f==null) {
-                                f = makeFieldFromCSV(cellIdx, prefixColumnName + String.valueOf(cellIdx+1), "STRING");
+                                f = makeFieldFromCSV(cellIdx, prefixColumnName + String.valueOf(cellIdx+1), ColumnType.STRING);
                                 fields.add(cellIdx, f);
                             }
 
@@ -381,42 +379,89 @@ public class PrepDatasetFileService {
                 } else if ( "csv".equals(extensionType) ) {
                     BufferedReader br = null;
                     String line;
-                    String[] csv_fields;
+                    String[] csvFields;
+                    List<ColumnType> fieldsTypes = new ArrayList<>();
+                    List<List<ColumnType>> gussedTypesByRows = Lists.newArrayList();
                     int maxColLength = 0;
+
                     try {
                         br = new BufferedReader(new InputStreamReader(new FileInputStream(theFile)));
 
-                        //0번 라인의 Type 검사. String이 아닌 컬럼이 1개라도 있으면 header로 인정하지 않음.
+                        //Check types of row number 0. If all column types are string, it might be filed name.
                         hasFields=true;
                         line = br.readLine();
-                        csv_fields = Util.csvLineSplitter(line, delimiterCol, "\"");
-                        for(String str : csv_fields) {
+                        csvFields = Util.csvLineSplitter(line, delimiterCol, "\"");
+                        for(String str : csvFields) {
                             if(!getTypeFormString(str).equals(ColumnType.STRING)) {
                                 hasFields = false;
                                 break;
                             }
                         }
+                        //Check type of row number 1 to 100.
+                        int rowNo = 0;
+                        while((line = br.readLine())!=null && rowNo <100) {
+                            List<ColumnType> guessedTypes = new ArrayList<>();
+                            String[] csvColumns = Util.csvLineSplitter(line, delimiterCol, "\"");
+                            maxColLength = maxColLength < csvColumns.length ? csvColumns.length : maxColLength;
 
+                            for (String str : csvColumns) {
+                                guessedTypes.add(getTypeFormString(str));
+                            }
+
+                            gussedTypesByRows.add(guessedTypes);
+                            rowNo++;
+                        }
+
+                        ColumnType[] columnTypes = {ColumnType.BOOLEAN, ColumnType.LONG, ColumnType.DOUBLE, ColumnType.TIMESTAMP, ColumnType.STRING};
+
+                        for(int i = 0; i < maxColLength; i++) {
+                            int[] typeCount = new int[5];
+
+                            for(List<ColumnType> types : gussedTypesByRows) {
+                                ColumnType type = types.get(i) != null ? types.get(i) : ColumnType.STRING;
+                                switch (type) {
+                                    case BOOLEAN:
+                                        typeCount[0]++;
+                                        break;
+                                    case LONG:
+                                        typeCount[1]++;
+                                        break;
+                                    case DOUBLE:
+                                        typeCount[2]++;
+                                        break;
+                                    case TIMESTAMP:
+                                        typeCount[3]++;
+                                        break;
+                                    default:
+                                        typeCount[4]++;
+                                }
+                            }
+
+                            int j = 1;
+                            int index=0;
+                            while(j < 5) {
+                                index = typeCount[index] > typeCount[j] ? index : j;
+                                j++;
+                            }
+
+                            fieldsTypes.add(columnTypes[index]);
+                        }
+
+                        maxColLength =0;
                         if(hasFields) {
-                            //1번 라인의 type검사. String이 아닌 컬럼이 1개라도 있어야 0번 라인은 header로 인정.
-                            hasFields =false;
-                            line = br.readLine();
-                            String[] csv_fields2 = Util.csvLineSplitter(line, delimiterCol, "\"");
-                            for(String str : csv_fields2) {
-                                if(!getTypeFormString(str).equals(ColumnType.STRING)) {
-                                    hasFields = true;
+                            //포인터를 1번 라인에 맞춰줌.
+                            br = new BufferedReader(new InputStreamReader(new FileInputStream(theFile)));
+
+                            hasFields = false;
+                            for(ColumnType columnType : fieldsTypes) {
+                                if(columnType != ColumnType.STRING) {
+                                    br.readLine();
+                                    maxColLength = csvFields.length;
+                                    hasFields=true;
                                     break;
                                 }
                             }
 
-                            if(hasFields) {
-                                //포인터를 1번 라인에 맞춰줌.
-                                br = new BufferedReader(new InputStreamReader(new FileInputStream(theFile)));
-                                br.readLine();
-                                maxColLength = csv_fields.length;
-                            } else {
-                                br = new BufferedReader(new InputStreamReader(new FileInputStream(theFile)));
-                            }
                         } else {
                             br = new BufferedReader(new InputStreamReader(new FileInputStream(theFile)));
                         }
@@ -429,14 +474,14 @@ public class PrepDatasetFileService {
 
                             if(!hasFields && maxColLength<cols.length) {
                                 maxColLength = cols.length;
-                                csv_fields = new String[cols.length];
+                                csvFields = new String[cols.length];
                                 for(int i=0; i<cols.length; i++){
-                                    csv_fields[i]=prefixColumnName+String.valueOf(i+1);
+                                    csvFields[i]=prefixColumnName+String.valueOf(i+1);
                                 }
                             }
                             Map<String,String> result = Maps.newTreeMap();
                             for(int colIdx=0;colIdx<cols.length;colIdx++) {
-                                result.put(csv_fields[colIdx],cols[colIdx]);
+                                result.put(csvFields[colIdx],cols[colIdx]);
                             }
                             resultSet.add(result);
 
@@ -444,8 +489,7 @@ public class PrepDatasetFileService {
                         }
 
                         for (int colIdx = 0; colIdx < maxColLength; colIdx++) {
-                            String field = csv_fields[colIdx];
-                            fields.add(makeFieldFromCSV(colIdx, field, resultSet.get(0).get(field)));
+                            fields.add(makeFieldFromCSV(colIdx, csvFields[colIdx], fieldsTypes.get(colIdx)));
                         }
                     } catch (FileNotFoundException e) {
                         e.printStackTrace();

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/Util.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/Util.java
@@ -159,7 +159,7 @@ public class Util {
     for(Integer delimiterIdx : listDelimiter) {
       String column = line.substring(start,delimiterIdx);
       start = delimiterIdx + delimiterLength;
-      if( column.startsWith(quote) && column.endsWith(quote) ) {
+      if( !column.equals(quote) && column.startsWith(quote) && column.endsWith(quote) ) {
         column = column.substring(quoteLength,column.length()-quoteLength);
       }
       if( column.contains(quote) ) {
@@ -169,7 +169,7 @@ public class Util {
     }
     if(start<lineLength) {
       String column = line.substring(start);
-      if (column.startsWith(quote) && column.endsWith(quote)) {
+      if (!column.equals(quote) && column.startsWith(quote) && column.endsWith(quote)) {
         column = column.substring(quoteLength, column.length() - quoteLength);
       }
       if (column.contains(quote)) {


### PR DESCRIPTION
### Description
When importing CSV file, if last column contains only single quote character and nothing else. Then a parsing error occurs.
This commit will makes CSV parsing function can handle single quote.

And additionally, improve CSV file preview quality. Now Preview check first 100 rows column type, not only first row.

**Related Issue** : <!--- Please link to the issue here. -->
https://github.com/metatron-app/metatron-discovery/issues/625


### How Has This Been Tested?
[고양이.csv.txt](https://github.com/metatron-app/metatron-discovery/files/2537509/csv.txt)
(Remove ".txt" from filename)

1. Create dataset with attached CSV file and check if it success.
2. Create dataset with various CSV files that contains various column types.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
