### PR TITLE
#634 Can not click common settings of KPI charts

### DIFF
--- a/discovery-frontend/src/app/page/chart-style/common-option.component.html
+++ b/discovery-frontend/src/app/page/chart-style/common-option.component.html
@@ -844,8 +844,7 @@
         <!-- wrap divide -->
         <div class="ddp-wrap-divide ">
           <!--  divide -->
-          <div [class.ddp-disabled]="!uiOption?.icons[0]?.show"
-               class="ddp-divide2 ddp-wrap-disabled">
+          <div [ngClass]="{'ddp-wrap-disabled ddp-disabled' : !uiOption?.icons[0]?.show }" class="ddp-divide2">
             <!-- slider -->
             <div class="ddp-wrap-option-slider">
               <span class="ddp-label-slider">{{'msg.page.common.kpi.icon' | translate}}</span>
@@ -894,8 +893,7 @@
         <!-- //wrap divide -->
         <!-- wrap divide -->
         <div class="ddp-wrap-divide ">
-          <div [class.ddp-disabled]="!uiOption?.annotations[0]?.show"
-               class="ddp-divide2 ddp-wrap-disabled">
+          <div [ngClass]="{'ddp-wrap-disabled ddp-disabled':!uiOption?.annotations[0]?.show}" class="ddp-divide2">
             <!--  divide -->
             <div class="ddp-divide2">
               <!-- slider -->

--- a/discovery-frontend/src/app/page/chart-style/secondary-indicator.component.html
+++ b/discovery-frontend/src/app/page/chart-style/secondary-indicator.component.html
@@ -35,8 +35,7 @@
             <!-- //Slide THREE -->
           </div>
           <!-- //slider -->
-          <div [class.ddp-disabled]="!isShow()"
-               class="ddp-list-sub2 ddp-wrap-disabled">
+          <div [ngClass]="{ 'ddp-wrap-disabled ddp-disabled' : !isShow() }" class="ddp-list-sub2">
             <!-- divide -->
             <div class="ddp-divide2">
               <div class="ddp-list-label">{{'msg.page.common.kpi.indocator.target' | translate}}</div>


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
KPI 차트의 공통 설정에서 아이콘/설명 기능에 대해서 On 으로 변경해도 클릭할 수 없어 기능을 사용할 수 없습니다.

**Related Issue** : #634 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 대시보드를 생성합니다.
2. 차트 생성 화면으로 이동합니다.
3. KPI 차트를 선택하고 measure 를 하나 선반에 올립니다.
4. 우측의 공통 설정 탭을 열고 그래픽 아이콘 사용을 On 으로 변경합니다.
5. 버튼들이 클릭되는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

### Additional Context<!-- if not appropriate, remove this topic. -->
