### PR TITLE
#617 Map chart does not appear on dashboard preview

### DIFF
--- a/discovery-frontend/package.json
+++ b/discovery-frontend/package.json
@@ -31,7 +31,7 @@
     "core-js": "^2.5.0",
     "dragula": "^3.7.2",
     "file-saver": "^1.3.3",
-    "html2canvas": "^0.5.0-beta4",
+    "html2canvas": "^1.0.0-alpha.12",
     "inputmask": "^3.3.11",
     "jquery": "^1.12.4",
     "json5": "^0.5.1",

--- a/discovery-frontend/src/app/common/component/chart/type/map-chart/map-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/map-chart/map-chart.component.ts
@@ -166,18 +166,22 @@ export class MapChartComponent extends BaseChart implements OnInit, OnDestroy, A
   }
 
   public osmLayer = new ol.layer.Tile({
-      source: new ol.source.OSM()
+      source: new ol.source.OSM({
+        crossOrigin: 'anonymous'
+      })
   });
 
   public cartoPositronLayer = new ol.layer.Tile({
       source: new ol.source.XYZ({
-        url:'http://{1-4}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png'
+        url:'http://{1-4}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png',
+        crossOrigin: 'anonymous'
       })
   });
 
   public cartoDarkLayer = new ol.layer.Tile({
       source: new ol.source.XYZ({
-        url:'http://{1-4}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png'
+        url:'http://{1-4}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png',
+        crossOrigin: 'anonymous'
       })
   });
 

--- a/discovery-frontend/src/app/common/service/image.service.ts
+++ b/discovery-frontend/src/app/common/service/image.service.ts
@@ -60,7 +60,7 @@ export class ImageService {
       }
 
       setTimeout( () => {
-        html2canvas($element).then((result) => {
+        html2canvas($element.get(0), { useCORS:true, allowTaint: true, logging: false }).then((result) => {
           const dataUrl = result.toDataURL('image/jpeg');
           const byteString = atob(dataUrl.split(',')[1]);
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
대시보드 목록에서 맵뷰영역은 표시되지 않는 현상이 있습니다. 

**Related Issue** : #617 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 대시보드를 생성하고, 맵뷰를 하나 생성합니다.
2. 대시보드를 저장하여 대시보드 목록에서 해당 대시보드의 이미지가 정상적으로 표시되는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
