### PR TITLE
Make longValue function can cast boolean as 0 or 1

### DIFF
--- a/discovery-prep-parser/src/main/java/app/metatron/discovery/prep/parser/preparation/rule/expr/ExprEval.java
+++ b/discovery-prep-parser/src/main/java/app/metatron/discovery/prep/parser/preparation/rule/expr/ExprEval.java
@@ -172,7 +172,12 @@ public class ExprEval extends Pair<Object, ExprType>
   }
 
   public long asLong() {
-    return isNull() ? 0L : lhs instanceof Number ? ((Number) lhs).longValue() : Long.valueOf(asString());
+    if(isNull())
+      return 0L;
+    if(lhs instanceof Boolean)
+      return ((Boolean) lhs) ? 1L : 0L;
+
+    return lhs instanceof Number ? ((Number) lhs).longValue() : Long.valueOf(asString());
   }
 
   public int asInt() {

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DataFrame.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DataFrame.java
@@ -1326,7 +1326,7 @@ public class DataFrame implements Serializable, Transformable {
 
     for (int rowno = offset; rowno < offset + length; rowno++) {
       try {
-        if (((Expr) condExpr).eval(prevDf.rows.get(rowno)).longValue() == ((keep) ? 1 : 0)) {
+        if (((Expr) condExpr).eval(prevDf.rows.get(rowno)).asLong() == ((keep) ? 1 : 0)) {
           rows.add(prevDf.rows.get(rowno));
         }
       } catch (Exception e) {


### PR DESCRIPTION
### Description
If you enter function expression on condition field of keep/delete rule, it makes error.
Keep and delete rules are converted as filter(), and filter() uses Long.longValue function.
longValue() function is used for convert result of condition expression as long value.
But when condition expression returns boolean, longValue() function cannot cast it as long.
So change longValue () to the asLong () function, which can handle boolean input.

**Related Issue** : <!--- Please link to the issue here. -->
https://github.com/metatron-app/metatron-discovery/issues/638

### How Has This Been Tested?
Try this on preparation.

1. Keep/Delete rule condition with true
2. Keep/Delete rule condition with false
3. Keep/Delete rule condition with contains(column_name, 'txt')


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
