### PR TITLE
#621 empty strings are not treated as missing values

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/Histogram.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/Histogram.java
@@ -102,7 +102,7 @@ public class Histogram implements Serializable {
       Object obj = rows.get(rowno).get(colno);
 
       // missing, mismatch 처리
-      if (obj == null || obj.toString().isEmpty()) {
+      if (obj == null) {
         missing++;
         missingRows.add(rowno);
         continue;
@@ -157,7 +157,7 @@ public class Histogram implements Serializable {
       Object obj = rows.get(rowno).get(colno);
 
       // missing, mismatch 처리
-      if (obj == null || obj.toString().isEmpty()) {
+      if (obj == null) {
         missing++;
         missingRows.add(rowno);
         continue;
@@ -210,7 +210,7 @@ public class Histogram implements Serializable {
       Object obj = rows.get(rowno).get(colno);
 
       // missing, mismatch 처리
-      if (obj == null || obj.toString().isEmpty()) {
+      if (obj == null) {
         missing++;
         missingRows.add(rowno);
         continue;
@@ -269,7 +269,7 @@ public class Histogram implements Serializable {
       Object obj = rows.get(rowno).get(colno);
 
       // missing, mismatch 처리
-      if (obj == null || obj.toString().isEmpty()) {
+      if (obj == null) {
         missing++;
         missingRows.add(rowno);
         continue;
@@ -310,7 +310,7 @@ public class Histogram implements Serializable {
       Object obj = rows.get(rowno).get(colno);
 
       // missing, mismatch 처리
-      if (obj == null || obj.toString().isEmpty()) {
+      if (obj == null) {
         missing++;
         missingRows.add(rowno);
         continue;
@@ -509,7 +509,7 @@ public class Histogram implements Serializable {
       Object obj = rows.get(rowno).get(colno);
 
       // missing, mismatch 처리
-      if (obj == null || obj.toString().isEmpty()) {
+      if (obj == null) {
         missing++;
         missingRows.add(rowno);
         continue;
@@ -608,7 +608,7 @@ public class Histogram implements Serializable {
       Object obj = rows.get(rowno).get(colno);
 
       // missing, mismatch 처리
-      if (obj == null || obj.toString().isEmpty()) {
+      if (obj == null) {
         missing++;
         missingRows.add(rowno);
         continue;


### PR DESCRIPTION
### Description
Now, if the column value is an empty string, it's not classified as a missing value, but as a matched value in the histogram.

_이제 column value가 empty string인 경우, histogram에서 더이상 missing이 아닌 matched로 분류됩니다._

**Related Issue** : https://github.com/metatron-app/metatron-discovery/issues/621


### How Has This Been Tested?
Tested with the case in the related issue.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
