### PR TITLE
DDL error when init with mySQL

### DIFF
--- a/discovery-server/src/main/resources/schema-mysql.sql
+++ b/discovery-server/src/main/resources/schema-mysql.sql
@@ -223,8 +223,8 @@ create table oauth_approvals (
   clientId VARCHAR(255),
   scope VARCHAR(255),
   status VARCHAR(10),
-  expiresAt TIMESTAMP,
-  lastModifiedAt TIMESTAMP
+  expiresAt TIMESTAMP default CURRENT_TIMESTAMP,
+  lastModifiedAt TIMESTAMP default CURRENT_TIMESTAMP
 );
 
 drop table if exists ClientDetails;


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Our ddl schema has an error in mySQL > 5.7
It caused by mysql strict mode and we have to set default value of timestamp columns.

**Related Issue** : <!--- Please link to the issue here. -->
#567 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Initialize discovery app with mysql-default-db option.
2. All tables created without MySQLSyntaxErrorException.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
