### PR TITLE
F#569 dataset preview on demand

### DIFF
--- a/discovery-frontend/src/app/data-preparation/dataflow/service/dataflow.service.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/service/dataflow.service.ts
@@ -79,7 +79,7 @@ export class DataflowService extends AbstractService {
 
   // 데이터셋 상세 조회
   public getDataset(dsId: string): Promise<Dataset> {
-    const url = this.API_URL + 'preparationdatasets/' + dsId;
+    const url = this.API_URL + 'preparationdatasets/' + dsId + '?projection=detail';
     return this.get(url);
   }
 

--- a/discovery-frontend/src/app/data-preparation/dataset/detail-dataset/dataset-detail.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataset/detail-dataset/dataset-detail.component.ts
@@ -489,8 +489,8 @@ export class DatasetDetailComponent extends AbstractComponent implements OnInit,
       this.setDatasetName();
       this.setDatasetDescription();
 
-      if (this.dataset['_embedded'] && this.dataset['_embedded']['dataflows']) {
-        this.dataset.dataflows = this.dataset['_embedded']['dataflows'];
+      if (this.dataset['dataflows'] && this.dataset['dataflows']) {
+       this.dataset.dataflows = this.dataset['dataflows'];
       } else {
         this.dataset.dataflows = [];
       }

--- a/discovery-frontend/src/app/data-preparation/dataset/service/dataset.service.ts
+++ b/discovery-frontend/src/app/data-preparation/dataset/service/dataset.service.ts
@@ -118,7 +118,7 @@ export class DatasetService extends AbstractService {
   }
 
   public getDataPreview(dsId: string) {
-    return this.get(this.API_URL + 'preparationdatasets/' + dsId);
+    return this.get(this.API_URL + 'preparationdatasets/' + dsId +'?projection=detail');
   }
 
   /*

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDataset.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDataset.java
@@ -17,10 +17,7 @@ package app.metatron.discovery.domain.dataprep;
 import app.metatron.discovery.common.GlobalObjectMapper;
 import app.metatron.discovery.domain.AbstractHistoryEntity;
 import app.metatron.discovery.domain.dataprep.exceptions.PrepException;
-import app.metatron.discovery.domain.dataprep.teddy.ColumnDescription;
-import app.metatron.discovery.domain.dataprep.teddy.ColumnType;
 import app.metatron.discovery.domain.dataprep.teddy.DataFrame;
-import app.metatron.discovery.domain.dataprep.teddy.Row;
 import app.metatron.discovery.domain.dataprep.transform.PrepTransformRule;
 import app.metatron.discovery.domain.dataprep.transform.PrepTransformRuleStringinfo;
 import app.metatron.discovery.domain.dataprep.transform.PrepTransition;
@@ -28,18 +25,14 @@ import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import org.hibernate.annotations.GenericGenerator;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.persistence.*;
 import javax.validation.constraints.Size;
-import java.io.File;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -187,6 +180,28 @@ public class PrepDataset extends AbstractHistoryEntity {
     @Lob
     @Column(name = "custom")
     private String custom;
+
+    @Transient
+    DataFrame gridResponse;
+
+    @Transient
+    Map<String,Object> connectionInfo;
+
+    public Map<String, Object> getConnectionInfo() {
+        return connectionInfo;
+    }
+
+    public void setConnectionInfo(Map<String, Object> connectionInfo) {
+        this.connectionInfo = connectionInfo;
+    }
+
+    public DataFrame getGridResponse() {
+        return gridResponse;
+    }
+
+    public void setGridResponse(DataFrame gridResponse) {
+        this.gridResponse = gridResponse;
+    }
 
     public String getDsId() {
         return dsId;
@@ -489,13 +504,14 @@ public class PrepDataset extends AbstractHistoryEntity {
         return ruleStringinfos;
     }
 
+    /*
     public DataFrame getGridResponse() throws PrepException {
         DataFrame dataFrame = null;
 
         try {
             String previewPath = getCustomValue("previewPath");
             if(null!=previewPath) {
-                ObjectMapper mapper = new ObjectMapper();
+                ObjectMapper mapper = GlobalObjectMapper.getDefaultMapper();
                 File theFile = new File(previewPath+File.separator+dsId+".df");
                 if(true==theFile.exists()) {
                     dataFrame = mapper.readValue(theFile, DataFrame.class);
@@ -535,6 +551,7 @@ public class PrepDataset extends AbstractHistoryEntity {
 
         return dataFrame;
     }
+    */
 
     // TODO: think about LOCAL/REMOTE, HDFS, FTP later
     @JsonIgnore

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetController.java
@@ -27,6 +27,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.projection.ProjectionFactory;
+import org.springframework.data.rest.webmvc.PersistentEntityResourceAssembler;
 import org.springframework.data.rest.webmvc.RepositoryRestController;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -42,6 +44,9 @@ import java.util.UUID;
 public class PrepDatasetController {
 
     private static Logger LOGGER = LoggerFactory.getLogger(PrepDatasetController.class);
+
+    @Autowired
+    ProjectionFactory projectionFactory;
 
     @Autowired
     PrepPreviewLineService previewLineService;
@@ -94,6 +99,36 @@ public class PrepDatasetController {
             }
         }
         return limitSize;
+    }
+
+    @RequestMapping(value = "/{dsId}", method = RequestMethod.GET)
+    @ResponseBody
+    public ResponseEntity<?> getDataset(
+            @PathVariable("dsId") String dsId,
+            @RequestParam(value="projection", required=false, defaultValue="default") String projection,
+            PersistentEntityResourceAssembler persistentEntityResourceAssembler
+    ) {
+        PrepDataset dataset = null;
+        try {
+            dataset = this.datasetRepository.findOne(dsId);
+            if(dataset!=null) {
+                if(true == projection.equalsIgnoreCase("detail")) {
+                    DataFrame dataFrame = this.previewLineService.getPreviewLines(dsId);
+                    dataset.setGridResponse(dataFrame);
+                }
+
+                Map<String,Object> connectionInfo = this.datasetService.getConnectionInfo(dataset.getDcId());
+                dataset.setConnectionInfo(connectionInfo);
+
+            } else {
+                throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_NO_DATASET, dsId);
+            }
+        } catch (Exception e) {
+            LOGGER.error("getDataset(): caught an exception: ", e);
+            throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, e);
+        }
+
+        return ResponseEntity.status(HttpStatus.SC_OK).body(persistentEntityResourceAssembler.toFullResource(dataset));
     }
 
     @RequestMapping(value = "/{dsId}", method = RequestMethod.DELETE)
@@ -324,6 +359,7 @@ public class PrepDatasetController {
             @RequestParam(value = "sheetindex", required = false, defaultValue = "0") String sheetindex,
             @RequestParam(value = "resultSize", required = false, defaultValue = "2000") String size ) {
         Map<String, Object> response = null;
+        /*
         try {
             PrepDataset dataset = this.datasetRepository.findOne(dsId);
             if(null==dataset) {
@@ -363,6 +399,7 @@ public class PrepDatasetController {
             LOGGER.error("previewFileCheckSheet(): caught an exception: ", e);
             throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE,e);
         }
+        */
         return ResponseEntity.ok(response);
     }
 
@@ -494,5 +531,19 @@ public class PrepDatasetController {
             throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE,e);
         }
         return ResponseEntity.status(HttpStatus.SC_CREATED).body(resumableResult);
+    }
+
+    @RequestMapping(value = "/ready_to_preview/{dsId}", method = RequestMethod.GET, produces = "application/json")
+    public @ResponseBody ResponseEntity<?> ready_to_preview(
+            @PathVariable("dsId") String dsId
+    ) {
+        Map<String, Object> response = null;
+        try {
+            response = this.previewLineService.ready_to_preview(dsId);
+        } catch (Exception e) {
+            LOGGER.error("ready_to_preview(): caught an exception: ", e);
+            throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE,e);
+        }
+        return ResponseEntity.status(HttpStatus.SC_OK).body(response);
     }
 }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetProjections.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetProjections.java
@@ -20,6 +20,7 @@ import org.joda.time.DateTime;
 import org.springframework.data.rest.core.config.Projection;
 
 import java.util.List;
+import java.util.Map;
 
 public class PrepDatasetProjections {
 
@@ -27,29 +28,6 @@ public class PrepDatasetProjections {
     public interface DefaultProjection {
 
         String getDsId();
-        String getDsName();
-        String getDsDesc();
-
-        Integer getRefDfCount();
-
-        String getDsType();
-
-        String getImportType();
-        String getCustom();
-        String getCreatorDfId();
-
-        DateTime getCreatedTime();
-        String getCreatedBy();
-        DateTime getModifiedTime();
-        String getModifiedBy();
-
-        // added for pycli
-        String getQueryStmt();
-    }
-
-    @Projection(name = "detail", types = { PrepDataset.class })
-    public interface DetailProjection {
-
         String getDsName();
         String getDsDesc();
         String getDsType();
@@ -79,6 +57,43 @@ public class PrepDatasetProjections {
         List<PrepTransformRuleStringinfo> getRuleStringInfos();
 
         DataFrame getGridResponse();
+        Map<String,Object> getConnectionInfo();
+    }
+
+    @Projection(name = "detail", types = { PrepDataset.class })
+    public interface DetailProjection {
+
+        String getDsId();
+        String getDsName();
+        String getDsDesc();
+        String getDsType();
+        String getImportType();
+        String getFileType();
+        String getDbType();
+        String getFilename();
+        String getFilekey();
+        String getCustom();
+        String getRsType();
+        String getDcId();
+        String getTableName();
+        String getQueryStmt();
+        Long getTotalLines();
+        Long getTotalBytes();
+
+        Integer getRefDfCount();
+        DateTime getCreatedTime();
+        String getCreatedBy();
+        DateTime getModifiedTime();
+        String getModifiedBy();
+
+        String getCreatorDfId();
+        Integer getRuleCurIdx();
+
+        List<PrepDataflow> getDataflows();
+        List<PrepTransformRuleStringinfo> getRuleStringInfos();
+
+        DataFrame getGridResponse();
+        Map<String,Object> getConnectionInfo();
     }
 
     @Projection(name = "listing", types = { PrepDataset.class })

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetService.java
@@ -17,6 +17,7 @@ package app.metatron.discovery.domain.dataprep;
 import app.metatron.discovery.domain.dataprep.teddy.DataFrame;
 import app.metatron.discovery.domain.datasource.connection.DataConnection;
 import app.metatron.discovery.domain.datasource.connection.DataConnectionRepository;
+import com.google.common.collect.Maps;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -159,7 +160,22 @@ public class PrepDatasetService {
         Map<String,Object> connectionInfo = null;
         if(null!=dcId) {
             DataConnection dataConnection = this.dataConnectionRepository.getOne(dcId);
+
+            // hibernate lazy problem
+            /*
+            DataConnection lazyDataConnection = this.dataConnectionRepository.getOne(dcId);
+            Hibernate.initialize(lazyDataConnection);
+            if (lazyDataConnection instanceof HibernateProxy) {
+                dataConnection = (DataConnection) ((HibernateProxy) lazyDataConnection).getHibernateLazyInitializer().getImplementation();
+            }
+            if( dataConnection == null ) {
+                dataConnection = lazyDataConnection;
+            }
+            */
+
             if(null!=dataConnection) {
+                connectionInfo = Maps.newHashMap();
+
                 connectionInfo.put("implementor", dataConnection.getImplementor());
                 connectionInfo.put("name", dataConnection.getName());
                 connectionInfo.put("description", dataConnection.getDescription());

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepHdfsService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepHdfsService.java
@@ -39,7 +39,7 @@ public class PrepHdfsService {
 
     private Configuration hadoopConf = null;
 
-    private String getUploadPath() {
+    public String getUploadPath() {
         if(null==uploadHdfsPath && null!=prepProperties.getStagingBaseDir(true)) {
             String stagingBaseDir = prepProperties.getStagingBaseDir(true);
             uploadHdfsPath = stagingBaseDir + File.separator + PrepProperties.dirUpload;

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepPreviewLineService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepPreviewLineService.java
@@ -14,16 +14,29 @@
 
 package app.metatron.discovery.domain.dataprep;
 
+import app.metatron.discovery.common.GlobalObjectMapper;
 import app.metatron.discovery.domain.dataprep.exceptions.PrepErrorCodes;
 import app.metatron.discovery.domain.dataprep.exceptions.PrepException;
+import app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey;
+import app.metatron.discovery.domain.dataprep.teddy.ColumnDescription;
+import app.metatron.discovery.domain.dataprep.teddy.ColumnType;
 import app.metatron.discovery.domain.dataprep.teddy.DataFrame;
+import app.metatron.discovery.domain.dataprep.teddy.Row;
+import app.metatron.discovery.domain.dataprep.transform.PrepTransformResponse;
+import app.metatron.discovery.domain.dataprep.transform.PrepTransformService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.io.File;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 @Service
 public class PrepPreviewLineService {
@@ -35,10 +48,16 @@ public class PrepPreviewLineService {
     @Autowired
     PrepDatasetRepository datasetRepository;
 
+    @Autowired
+    PrepDatasetService datasetService;
+
+    @Autowired
+    PrepTransformService transformService;
+
     Integer limit;
 
     PrepPreviewLineService() {
-        this.limit = 50;
+        this.limit = 200;
     }
 
     private String getPreviewPath() {
@@ -61,15 +80,10 @@ public class PrepPreviewLineService {
 
     public int putPreviewLines(String dsId, DataFrame gridResponse) {
         int size = 0;
-        int limitSize = 2000;
 
         LOGGER.trace("putPreviewLines(): start");
         PrepDataset dataset = this.datasetRepository.findRealOne(this.datasetRepository.findOne(dsId));
         assert(dataset!=null);
-
-        if(dataset.getDsTypeForEnum()== PrepDataset.DS_TYPE.WRANGLED) {
-            limitSize = 100;
-        }
 
         DataFrame previewGrid = new DataFrame();
         previewGrid.colCnt = gridResponse.colCnt;
@@ -82,16 +96,17 @@ public class PrepPreviewLineService {
         previewGrid.dsName = gridResponse.dsName;
         previewGrid.slaveDsNameMap = gridResponse.slaveDsNameMap;
         previewGrid.ruleString = gridResponse.ruleString;
+
         size = gridResponse.rows.size();
-        if(limitSize<size) {
-            previewGrid.rows = gridResponse.rows.subList(0, limitSize);
+        if(this.limit<size) {
+            previewGrid.rows = gridResponse.rows.subList(0, this.limit);
         } else {
             previewGrid.rows = gridResponse.rows;
         }
 
         String previewPath = getPreviewPath(dsId);
         try {
-            ObjectMapper mapper = new ObjectMapper();
+            ObjectMapper mapper = GlobalObjectMapper.getDefaultMapper();
             mapper.writeValue(new File(previewPath), previewGrid);
         } catch(Exception e) {
             e.printStackTrace();
@@ -102,6 +117,139 @@ public class PrepPreviewLineService {
 
         LOGGER.trace("putPreviewLines(): end");
         return size;
+    }
+
+    public DataFrame getPreviewLines(String dsId) {
+        DataFrame dataFrame = null;
+
+        try {
+            PrepDataset dataset = this.datasetRepository.findRealOne(this.datasetRepository.findOne(dsId));
+            assert(dataset!=null);
+
+            String previewPathKey = "previewPath";
+            String previewPath = dataset.getCustomValue(previewPathKey);
+            if (null != previewPath) {
+                ObjectMapper mapper = GlobalObjectMapper.getDefaultMapper();
+                String filepath = previewPath + File.separator + dataset.getDsId() + ".df";
+                File theFile = new File(filepath);
+                if (true == theFile.exists()) {
+                    dataFrame = mapper.readValue(theFile, DataFrame.class);
+                } else {
+                    dataFrame = this.remakePreviewLines(dsId);
+                    // regenerate
+                    // throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_FILE_NOT_FOUND, filepath);
+                }
+            } else {
+                throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_PROPERTY_NOT_AVAILABLE, previewPathKey+"==(null)");
+            }
+
+            if(dataFrame!=null) {
+                List<ColumnDescription> columnDescs = dataFrame.colDescs;
+                List<Integer> colNos = Lists.newArrayList();
+                int colIdx = 0;
+                for (ColumnDescription columnDesc : columnDescs) {
+                    if (columnDesc.getType().equals(ColumnType.TIMESTAMP)) {
+                        colNos.add(colIdx);
+                    }
+                    colIdx++;
+                }
+
+                if (0 < colNos.size()) {
+                    for (Row row : dataFrame.rows) {
+                        for (Integer colNo : colNos) {
+                            Object jodaTime = row.get(colNo);
+                            if (jodaTime instanceof LinkedHashMap) {
+                                LinkedHashMap mapTime = (LinkedHashMap) jodaTime;
+                                DateTime dateTime = new DateTime(Long.parseLong(mapTime.get("millis").toString()));
+                                row.objCols.set(colNo, dateTime);
+                            }
+                        }
+                    }
+                }
+            } else {
+                throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_PREVIEWLINES_CRASHED, "get preview==(null)");
+            }
+        } catch (Exception e) {
+            LOGGER.debug(e.getMessage());
+            throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, e);
+        }
+
+        return dataFrame;
+    }
+
+    public Map<String,Object> ready_to_preview(String dsId) {
+        Map<String,Object> response = Maps.newHashMap();
+
+        boolean remake = false;
+        DataFrame dataFrame = null;
+        try {
+            dataFrame = this.getPreviewLines(dsId);
+        } catch(PrepException e) {
+            if( e.getMessageKey().equals(PrepMessageKey.MSG_DP_ALERT_FILE_NOT_FOUND)
+                || e.getMessageKey().equals(PrepMessageKey.MSG_DP_ALERT_PREVIEWLINES_CRASHED) ) {
+                remake = true;
+            } else {
+                LOGGER.debug(e.getMessage());
+                throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, e);
+            }
+        } catch(Exception e) {
+            LOGGER.debug(e.getMessage());
+            throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, e);
+        }
+
+        try {
+            if (true == remake) {
+                dataFrame = this.remakePreviewLines(dsId);
+                if (null != dataFrame) {
+                    int size = this.putPreviewLines(dsId, dataFrame);
+                } else {
+                    throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_PREVIEWLINES_CRASHED, "remake preview==(null)");
+                }
+            }
+        } catch(Exception e) {
+            LOGGER.debug(e.getMessage());
+            throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, e);
+        }
+
+        response.put("gridResponse", dataFrame);
+
+        return response;
+    }
+
+    public DataFrame remakePreviewLines(String dsId) {
+        DataFrame dataFrame = null;
+
+        try {
+            PrepDataset dataset = this.datasetRepository.findRealOne(this.datasetRepository.findOne(dsId));
+            assert(dataset!=null);
+
+            if(dataset.getDsTypeForEnum()== PrepDataset.DS_TYPE.IMPORTED) {
+                dataFrame = this.datasetService.getImportedPreview(dataset);
+                if(null==dataFrame) {
+                    throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_PREVIEWLINES_CRASHED, "get Imported preview==(null)");
+                }
+            } else if(dataset.getDsTypeForEnum()== PrepDataset.DS_TYPE.WRANGLED) {
+                PrepTransformResponse transformResponse = this.transformService.fetch(dsId, null);
+                dataFrame = transformResponse.getGridResponse();
+                if(null==dataFrame) {
+                    throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_PREVIEWLINES_CRASHED, "get Wrangled preview==(null)");
+                }
+            } else {
+                // not reachable
+            }
+
+            if(dataFrame!=null) {
+                int size = putPreviewLines(dsId, dataFrame);
+            } else {
+                LOGGER.debug(dsId + " dataframe is null");
+                throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_PREVIEWLINES_CRASHED, "no dataframe of preview");
+            }
+        } catch(Exception e) {
+            LOGGER.debug(e.getMessage());
+            throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, e);
+        }
+
+        return dataFrame;
     }
 }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/exceptions/PrepMessageKey.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/exceptions/PrepMessageKey.java
@@ -17,6 +17,9 @@ package app.metatron.discovery.domain.dataprep.exceptions;
 public enum PrepMessageKey {
     MSG_DP_ALERT_REQUIRED_PROPERTY_MISSING(                     "msg.dp.alert.required.property.missing"),
 
+    MSG_DP_ALERT_FILE_NOT_FOUND(                                 "msg.dp.alert.file.not.found"),
+    MSG_DP_ALERT_PROPERTY_NOT_AVAILABLE(                      "msg.dp.alert.property.not.available"),
+    MSG_DP_ALERT_PREVIEWLINES_CRASHED(                  "msg.dp.alert.previewlines.creashed"),
     MSG_DP_ALERT_DATASET_FAILED_AFTERCREATE(                     "msg.dp.alert.dataset.failed.aftercreate"),
     MSG_DP_ALERT_DATASET_UPLOAD_NO_KEY(                          "msg.dp.alert.dataset.upload.no.key"),
     MSG_DP_ALERT_JDBC_CONNECTION_ERROR(                          "msg.dp.alert.jdbc.connection.error"),


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
1. Create and use GET datasets controller without using jpa repository
2. If the preview does not exist, it creates a new preview and returns it.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
[#569](https://github.com/metatron-app/metatron-discovery/issues/569)


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. create a dataset
2. get the dataset with the option that the projection is detail
3. if the dataset has a preview grid, that is ok 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
