### PR TITLE
#672 Error where multiple timestamp filters are registered in a multi data source

### DIFF
--- a/discovery-frontend/src/app/dashboard/component/dashboard-layout/dashboard.layout.component.ts
+++ b/discovery-frontend/src/app/dashboard/component/dashboard-layout/dashboard.layout.component.ts
@@ -27,10 +27,10 @@ import {
   ViewChild
 } from '@angular/core';
 
-import { Widget } from '../../../domain/dashboard/widget/widget';
-import { AbstractComponent } from '../../../common/component/abstract.component';
-import { DashboardWidgetComponent } from './dashboard.widget.component';
-import { DashboardWidgetHeaderComponent } from './dashboard.widget.header.component';
+import {Widget} from '../../../domain/dashboard/widget/widget';
+import {AbstractComponent} from '../../../common/component/abstract.component';
+import {DashboardWidgetComponent} from './dashboard.widget.component';
+import {DashboardWidgetHeaderComponent} from './dashboard.widget.header.component';
 import {
   BoardConfiguration,
   BoardDataSource,
@@ -50,12 +50,12 @@ import {
   FieldValueAlias,
   LogicalType
 } from '../../../domain/datasource/datasource';
-import { PageWidget, PageWidgetConfiguration } from '../../../domain/dashboard/widget/page-widget';
-import { Filter } from '../../../domain/workbook/configurations/filter/filter';
-import { FilterWidget, FilterWidgetConfiguration } from '../../../domain/dashboard/widget/filter-widget';
-import { DatasourceService } from '../../../datasource/service/datasource.service';
-import { PopupService } from '../../../common/service/popup.service';
-import { FilterUtil } from '../../util/filter.util';
+import {PageWidget, PageWidgetConfiguration} from '../../../domain/dashboard/widget/page-widget';
+import {Filter} from '../../../domain/workbook/configurations/filter/filter';
+import {FilterWidget, FilterWidgetConfiguration} from '../../../domain/dashboard/widget/filter-widget';
+import {DatasourceService} from '../../../datasource/service/datasource.service';
+import {PopupService} from '../../../common/service/popup.service';
+import {FilterUtil} from '../../util/filter.util';
 import {
   BoardGlobalOptions,
   BoardLayoutOptions,
@@ -63,14 +63,14 @@ import {
   BoardWidgetOptions,
   WidgetShowType
 } from 'app/domain/dashboard/dashboard.globalOptions';
-import { WidgetService } from '../../service/widget.service';
-import { CustomField } from '../../../domain/workbook/configurations/field/custom-field';
-import { isNullOrUndefined, isUndefined } from 'util';
-import { DashboardUtil } from '../../util/dashboard.util';
-import { EventBroadcaster } from '../../../common/event/event.broadcaster';
-import { TimeFilter } from '../../../domain/workbook/configurations/filter/time-filter';
-import { IntervalFilter } from '../../../domain/workbook/configurations/filter/interval-filter';
-import { TimeUnit } from '../../../domain/workbook/configurations/field/timestamp-field';
+import {WidgetService} from '../../service/widget.service';
+import {CustomField} from '../../../domain/workbook/configurations/field/custom-field';
+import {isNullOrUndefined, isUndefined} from 'util';
+import {DashboardUtil} from '../../util/dashboard.util';
+import {EventBroadcaster} from '../../../common/event/event.broadcaster';
+import {TimeFilter} from '../../../domain/workbook/configurations/filter/time-filter';
+import {IntervalFilter} from '../../../domain/workbook/configurations/filter/interval-filter';
+import {TimeUnit} from '../../../domain/workbook/configurations/field/timestamp-field';
 
 declare let GoldenLayout: any;
 
@@ -308,7 +308,7 @@ export abstract class DashboardLayoutComponent extends AbstractComponent impleme
       const nameAliasList: FieldNameAlias[] = boardInfo.aliases.filter(alias => alias['nameAlias']).map(item => <FieldNameAlias>item);
       const valueAliasList: FieldValueAlias[] = boardInfo.aliases.filter(alias => alias['valueAlias']).map(item => <FieldValueAlias>item);
 
-      let summary: { reorderDsList: Datasource[], totalFields: Field[] } = { reorderDsList: [], totalFields: [] };
+      let summary: { reorderDsList: Datasource[], totalFields: Field[] } = {reorderDsList: [], totalFields: []};
       if ('multi' === boardDs.type) {
         summary = boardDs.dataSources.reduce((acc, currVal) => {
           const singleSummary: { reorderDsList: Datasource[], totalFields: Field[] }
@@ -316,7 +316,7 @@ export abstract class DashboardLayoutComponent extends AbstractComponent impleme
           acc.reorderDsList = acc.reorderDsList.concat(singleSummary.reorderDsList);
           acc.totalFields = acc.totalFields.concat(singleSummary.totalFields);
           return acc;
-        }, { reorderDsList: [], totalFields: [] });
+        }, {reorderDsList: [], totalFields: []});
       } else {
         summary = this._setSingleDataSource(boardDs, boardInfo, nameAliasList, valueAliasList);
       }
@@ -348,7 +348,7 @@ export abstract class DashboardLayoutComponent extends AbstractComponent impleme
     let masterDsInfo: Datasource = DashboardUtil.getDataSourceFromBoardDataSource(boardInfo, dataSource);
 
     if (isNullOrUndefined(masterDsInfo)) {
-      return { reorderDsList: [], totalFields: [] };
+      return {reorderDsList: [], totalFields: []};
     }
 
     // 설정에 있는 Datasource Mapping 정보에 connType, engineName 추가해줌 - MasterDatasource
@@ -386,7 +386,7 @@ export abstract class DashboardLayoutComponent extends AbstractComponent impleme
         {
           const oneDepthDsInfo: Datasource = boardInfo.dataSources.find(dsItem => dsItem.id === joinItem.id);
           // 설정에 있는 Datasource Mapping 정보에 engineName 추가해줌 - OneDepthDatasource
-          joinItem = _.merge(joinItem, { engineName: oneDepthDsInfo.engineName });
+          joinItem = _.merge(joinItem, {engineName: oneDepthDsInfo.engineName});
           // 데이터소스 정렬
           reorderDsList.push(oneDepthDsInfo);
           // 제외 필드 선정
@@ -409,7 +409,7 @@ export abstract class DashboardLayoutComponent extends AbstractComponent impleme
         if (joinItem.join) {
           const twoDepthDsInfo: Datasource = boardInfo.dataSources.find(dsItem => dsItem.id === joinItem.join.id);
           // 설정에 있는 Datasource Mapping 정보에 engineName 추가해줌 - TwoDepthDatasource
-          joinItem.join = _.merge(joinItem.join, { engineName: twoDepthDsInfo.engineName });
+          joinItem.join = _.merge(joinItem.join, {engineName: twoDepthDsInfo.engineName});
           // 데이터소스 정렬
           reorderDsList.push(twoDepthDsInfo);
           // 제외 필드 선정
@@ -626,7 +626,7 @@ export abstract class DashboardLayoutComponent extends AbstractComponent impleme
 
     if (widgetInfo) {
 
-      let $componentContainer = $('<div/>').css({ width: '100%', height: '100%' });
+      let $componentContainer = $('<div/>').css({width: '100%', height: '100%'});
       container.getElement().prepend($componentContainer);
       let widgetCompFactory = this.componentFactoryResolver.resolveComponentFactory(DashboardWidgetComponent);
       let widgetComp = this.appRef.bootstrap(widgetCompFactory, $componentContainer.get(0));
@@ -693,12 +693,12 @@ export abstract class DashboardLayoutComponent extends AbstractComponent impleme
         } else if (0 < colItems.length) {
           colItems[0].addChild(newItemConfig);
         } else if (0 < stackItems.length) {
-          let newRowItem = rootItem.layoutManager.createContentItem({ type: 'row' }, rootItem);
+          let newRowItem = rootItem.layoutManager.createContentItem({type: 'row'}, rootItem);
           rootItem.replaceChild(stackItems[0], newRowItem);
           newRowItem.addChild(stackItems[0]);
           newRowItem.addChild(newItemConfig);
         } else {
-          rootItem.addChild({ type: 'row', content: [newItemConfig] });
+          rootItem.addChild({type: 'row', content: [newItemConfig]});
         }
       });
       this.updateLayoutSize();
@@ -770,7 +770,7 @@ export abstract class DashboardLayoutComponent extends AbstractComponent impleme
 
       // 신규 위젯 인스턴스 추가
       let $widgetContainer = this._getLayoutCompContainerByWidgetId(widgetInfo.id);
-      let $componentContainer = $('<div/>').css({ width: '100%', height: '100%' });
+      let $componentContainer = $('<div/>').css({width: '100%', height: '100%'});
       $widgetContainer.container.getElement().append($componentContainer);
       let widgetCompFactory = this.componentFactoryResolver.resolveComponentFactory(DashboardWidgetComponent);
       let widgetComp = this.appRef.bootstrap(widgetCompFactory, $componentContainer.get(0));
@@ -817,13 +817,13 @@ export abstract class DashboardLayoutComponent extends AbstractComponent impleme
         }
         this._widgetComps = [];
         this._$layoutContainer = $(this.layoutContainer.nativeElement);
-        this._$layoutContainer.parent().css({ 'height': '', 'overflow': '' });    // remove height
+        this._$layoutContainer.parent().css({'height': '', 'overflow': ''});    // remove height
 
         if (BoardLayoutType.FIT_TO_HEIGHT === globalOptsLayout.layoutType) {
           if (this._$layoutContainer.parent().height() > globalOptsLayout.layoutHeight) {
-            this._$layoutContainer.parent().css({ 'height': globalOptsLayout.layoutHeight });
+            this._$layoutContainer.parent().css({'height': globalOptsLayout.layoutHeight});
           }
-          this._$layoutContainer.css({ 'height': globalOptsLayout.layoutHeight });
+          this._$layoutContainer.css({'height': globalOptsLayout.layoutHeight});
         } else {
           this._$layoutContainer.parent().css('overflow', 'hidden');
           objLayout.dimensions.height = '100%';
@@ -928,7 +928,9 @@ export abstract class DashboardLayoutComponent extends AbstractComponent impleme
 
               // 대시보드 필터 설정 ( 기본 데이터와 저장된 정보와의 병합 ) - Start
               if (savedFilters && 0 < savedFilters.length) {
-                let savedIdx: number = savedFilters.findIndex((item: Filter) => item.field === field.name);
+                let savedIdx: number = savedFilters.findIndex((item: Filter) => {
+                  return item.field === field.name && item.dataSource === dsInfo.engineName;
+                });
                 if (-1 < savedIdx) {
                   const savedItem: Filter = savedFilters[savedIdx];
                   savedFilters.splice(savedIdx, 1);
@@ -1119,7 +1121,7 @@ export abstract class DashboardLayoutComponent extends AbstractComponent impleme
    * 저장을 위해 스크린에 맞는 형태로 사이즈를 조절한다
    */
   public resizeToFitScreenForSave() {
-    this._$layoutContainer.parent().css({ 'height': '', 'overflow': 'hidden' });    // remove height
+    this._$layoutContainer.parent().css({'height': '', 'overflow': 'hidden'});    // remove height
     this._$layoutContainer.width('100%').height('100%');
     this.updateLayoutSize();
   } // function - resizeToFitScreenForSave
@@ -1228,6 +1230,18 @@ export abstract class DashboardLayoutComponent extends AbstractComponent impleme
 
       // Data migration
       {
+        // remove duplicate filters
+        let filters: Filter[] = boardInfo.configuration.filters;
+        if (filters) {
+          boardInfo.configuration.filters
+            = filters.reduce((acc: Filter[], curr: Filter) => {
+            if (!acc.some(item => item.dataSource === curr.dataSource && item.field === curr.field)) {
+              acc.push(curr);
+            }
+            return acc;
+          }, []);
+        }
+
         // Updating information about deleted dataSources
         const boardDataSource: BoardDataSource = boardInfo.configuration.dataSource;
         const dataSource: Datasource[] = boardInfo.dataSources;

--- a/discovery-frontend/src/app/dashboard/update-dashboard.component.ts
+++ b/discovery-frontend/src/app/dashboard/update-dashboard.component.ts
@@ -28,43 +28,43 @@ import {
   SimpleChanges,
   SimpleChange
 } from '@angular/core';
-import { Workbook } from '../domain/workbook/workbook';
+import {Workbook} from '../domain/workbook/workbook';
 import {
   BoardConfiguration,
   BoardDataSource,
   Dashboard,
   LayoutMode
 } from '../domain/dashboard/dashboard';
-import { ConnectionType, Datasource, Field, FieldRole, TempDsStatus } from '../domain/datasource/datasource';
-import { TextWidget } from '../domain/dashboard/widget/text-widget';
-import { PageWidget, PageWidgetConfiguration } from 'app/domain/dashboard/widget/page-widget';
-import { Widget } from '../domain/dashboard/widget/widget';
-import { PopupService } from '../common/service/popup.service';
-import { SubscribeArg } from '../common/domain/subscribe-arg';
-import { Alert } from '../common/util/alert.util';
-import { DashboardService } from './service/dashboard.service';
-import { CustomField } from '../domain/workbook/configurations/field/custom-field';
-import { Filter } from '../domain/workbook/configurations/filter/filter';
-import { WidgetService } from './service/widget.service';
-import { ImageService } from '../common/service/image.service';
-import { DashboardLayoutComponent } from './component/dashboard-layout/dashboard.layout.component';
-import { Modal } from '../common/domain/modal';
-import { FilterWidget, FilterWidgetConfiguration } from '../domain/dashboard/widget/filter-widget';
-import { DatasourceService } from '../datasource/service/datasource.service';
-import { isNullOrUndefined } from 'util';
-import { Pivot } from '../domain/workbook/configurations/pivot';
-import { CommonUtil } from '../common/util/common.util';
-import { PageRelationComponent } from './component/update-dashboard/page-relation.component';
-import { EventBroadcaster } from '../common/event/event.broadcaster';
-import { TextWidgetPanelComponent } from './component/update-dashboard/text-widget-panel.component';
-import { DatasourcePanelComponent } from './component/update-dashboard/datasource-panel.component';
-import { PageComponent } from '../page/page.component';
-import { ActivatedRoute } from '@angular/router';
-import { DashboardPageRelation, DashboardWidgetRelation } from 'app/domain/dashboard/widget/page-widget.relation';
-import { ConfigureFiltersComponent } from './filters/configure-filters.component';
-import { DashboardUtil } from './util/dashboard.util';
-import { WidgetShowType } from '../domain/dashboard/dashboard.globalOptions';
-import { FilterUtil } from './util/filter.util';
+import {ConnectionType, Datasource, Field, FieldRole, TempDsStatus} from '../domain/datasource/datasource';
+import {TextWidget} from '../domain/dashboard/widget/text-widget';
+import {PageWidget, PageWidgetConfiguration} from 'app/domain/dashboard/widget/page-widget';
+import {Widget} from '../domain/dashboard/widget/widget';
+import {PopupService} from '../common/service/popup.service';
+import {SubscribeArg} from '../common/domain/subscribe-arg';
+import {Alert} from '../common/util/alert.util';
+import {DashboardService} from './service/dashboard.service';
+import {CustomField} from '../domain/workbook/configurations/field/custom-field';
+import {Filter} from '../domain/workbook/configurations/filter/filter';
+import {WidgetService} from './service/widget.service';
+import {ImageService} from '../common/service/image.service';
+import {DashboardLayoutComponent} from './component/dashboard-layout/dashboard.layout.component';
+import {Modal} from '../common/domain/modal';
+import {FilterWidget, FilterWidgetConfiguration} from '../domain/dashboard/widget/filter-widget';
+import {DatasourceService} from '../datasource/service/datasource.service';
+import {isNullOrUndefined} from 'util';
+import {Pivot} from '../domain/workbook/configurations/pivot';
+import {CommonUtil} from '../common/util/common.util';
+import {PageRelationComponent} from './component/update-dashboard/page-relation.component';
+import {EventBroadcaster} from '../common/event/event.broadcaster';
+import {TextWidgetPanelComponent} from './component/update-dashboard/text-widget-panel.component';
+import {DatasourcePanelComponent} from './component/update-dashboard/datasource-panel.component';
+import {PageComponent} from '../page/page.component';
+import {ActivatedRoute} from '@angular/router';
+import {DashboardPageRelation, DashboardWidgetRelation} from 'app/domain/dashboard/widget/page-widget.relation';
+import {ConfigureFiltersComponent} from './filters/configure-filters.component';
+import {DashboardUtil} from './util/dashboard.util';
+import {WidgetShowType} from '../domain/dashboard/dashboard.globalOptions';
+import {FilterUtil} from './util/filter.util';
 
 @Component({
   selector: 'app-update-dashboard',
@@ -465,7 +465,7 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
       const modal = new Modal();
       modal.name = this.translateService.instant('msg.comm.ui.del.description');
       modal.btnName = this.translateService.instant('msg.comm.btn.del');
-      modal.data = { type: 'removeTextWidget' };
+      modal.data = {type: 'removeTextWidget'};
       modal.afterConfirm = () => {
         this.deleteWidgetIds.push(event.widget.id);  // 삭제 위젯 등록
         this.removeWidget(event.widget.id);          // 대시보드상의 위젯 제거
@@ -585,7 +585,7 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
     modal.name = this.translateService.instant('msg.board.alert.title.change');
     modal.description = this.translateService.instant('msg.board.alert.desc.move');
     modal.btnName = this.translateService.instant('msg.comm.btn.mov');
-    modal.data = { type: 'changeDashboard' };
+    modal.data = {type: 'changeDashboard'};
     modal.afterConfirm = () => {
       if (dashboardItem) {
         this.selectedDashboard.emit(dashboardItem);
@@ -631,10 +631,10 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
     // 위젯 등록/수정
     DashboardUtil.getWidgets(this.dashboard).forEach((result: Widget) => {
 
-      if( -1 === this.deleteWidgetIds.indexOf( result.id ) ) {
-        const param = { configuration: _.cloneDeep(result.configuration), name: result.name };
+      if (-1 === this.deleteWidgetIds.indexOf(result.id)) {
+        const param = {configuration: _.cloneDeep(result.configuration), name: result.name};
         if ('page' === result.type) {
-          if( -1 < this._removeDsEngineNames.indexOf( param.configuration['dataSource']['engineName'] ) ) {
+          if (-1 < this._removeDsEngineNames.indexOf(param.configuration['dataSource']['engineName'])) {
             this.hierarchy.del(result.id);
             this.dashboard.configuration.relations = this.hierarchy.get().map(node => node.toPageRelation());
             this.deleteWidgetIds.push(result.id);     // 삭제 위젯 등록
@@ -651,8 +651,8 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
             promises.push(() => this.widgetService.updateWidget(result.id, param));   // update widget
           }
         } else if ('filter' === result.type) {
-          if( -1 < this._removeDsEngineNames.indexOf( param.configuration['filter']['dataSource'] ) ) {
-            this.deleteWidgetIds.push( result.id );
+          if (-1 < this._removeDsEngineNames.indexOf(param.configuration['filter']['dataSource'])) {
+            this.deleteWidgetIds.push(result.id);
             this.removeWidgetComponent(result.id);    // 대시보드상의 위젯 제거
           } else {
             param.configuration['filter'] = FilterUtil.convertToServerSpecForDashboard(param.configuration['filter']);
@@ -702,7 +702,7 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
     modal.name = this.translateService.instant('msg.board.alert.title.change');
     modal.description = this.translateService.instant('msg.board.alert.desc.exit');
     modal.btnName = this.translateService.instant('msg.comm.btn.exit');
-    modal.data = { type: 'dismiss' };
+    modal.data = {type: 'dismiss'};
     modal.afterConfirm = () => {
       // 대시보드 변경취소
       this.changeMode.emit('VIEW');
@@ -843,7 +843,7 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
       const modal = new Modal();
       modal.name = this.translateService.instant('msg.comm.ui.del.description');
       modal.btnName = this.translateService.instant('msg.comm.btn.del');
-      modal.data = { type: 'removePageWidget' };
+      modal.data = {type: 'removePageWidget'};
       modal.afterConfirm = () => {
         // 연관관계 정보 삭제 및 relation 정보 갱신
         this.hierarchy.del(widgetId);
@@ -1031,17 +1031,17 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
     }
 
     this.dashboardService.updateDashboard(
-      this.dashboard.id, { configuration: DashboardUtil.getBoardConfiguration(this.dashboard) }
+      this.dashboard.id, {configuration: DashboardUtil.getBoardConfiguration(this.dashboard)}
     ).then((result) => {
       if (result.hasOwnProperty('configuration')) {
-        result = DashboardUtil.convertSpecToUI( result );
+        result = DashboardUtil.convertSpecToUI(result);
         this.dashboard = DashboardUtil.updateBoardConfiguration(this.dashboard, result.configuration);
         this.dashboard.updateId = CommonUtil.getUUID();
-        this.broadCaster.broadcast('SET_CUSTOM_FIELDS', { customFields: customFields });
+        this.broadCaster.broadcast('SET_CUSTOM_FIELDS', {customFields: customFields});
         if (isEdit) {
-          Alert.success(this.translateService.instant('msg.board.custom.ui.update', { name: customField.name }));
+          Alert.success(this.translateService.instant('msg.board.custom.ui.update', {name: customField.name}));
         } else {
-          Alert.success(this.translateService.instant('msg.board.custom.ui.create', { name: customField.name }));
+          Alert.success(this.translateService.instant('msg.board.custom.ui.create', {name: customField.name}));
         }
         this.hideBoardLoading();
       }
@@ -1064,23 +1064,23 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
       widgets.forEach((widget: Widget) => {
         //  차트인 의 컬럼이 사용중일경우
         if (widget.configuration && widget.configuration.hasOwnProperty('pivot') && widget.configuration['pivot'].hasOwnProperty('columns')) {
-          const idx = _.findIndex(widget.configuration['pivot']['columns'], { name: field.name });
+          const idx = _.findIndex(widget.configuration['pivot']['columns'], {name: field.name});
           if (idx > -1) useChartList.push(widget.name);
         }
         //
         if (widget.configuration && widget.configuration.hasOwnProperty('pivot') && widget.configuration['pivot'].hasOwnProperty('aggregations')) {
-          const idx = _.findIndex(widget.configuration['pivot']['aggregations'], { name: field.name });
+          const idx = _.findIndex(widget.configuration['pivot']['aggregations'], {name: field.name});
           if (idx > -1) useChartList.push(widget.name);
         }
         if (widget.configuration && widget.configuration.hasOwnProperty('pivot') && widget.configuration['pivot'].hasOwnProperty('rows')) {
-          const idx = _.findIndex(widget.configuration['pivot']['rows'], { name: field.name });
+          const idx = _.findIndex(widget.configuration['pivot']['rows'], {name: field.name});
           if (idx > -1) useChartList.push(widget.name);
         }
       });
     }
 
     // 차트필터에서 사용중인지 체크
-    let idx = _.findIndex(this.chartFilters, { field: field.name });
+    let idx = _.findIndex(this.chartFilters, {field: field.name});
     if (idx > -1) useFilterList.push(this.chartFilters[idx].type + '_' + this.chartFilters[idx].field);
     // 글로벌필터에서 사용중인지 체크
     const boardFilter: Filter = DashboardUtil.getBoardFilter(this.dashboard, field);
@@ -1101,7 +1101,7 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
       modal.name = this.translateService.instant('msg.board.ui.not.delete.custom');
       modal.description = description;
       modal.isShowCancel = false;
-      modal.data = { type: 'deleteCustomField' };
+      modal.data = {type: 'deleteCustomField'};
       CommonUtil.confirm(modal);
       return;
     }
@@ -1109,7 +1109,7 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
     // 사용중인 곳이 없다면 바로 삭제
     const customFields = DashboardUtil.getCustomFields(this.dashboard);
 
-    idx = _.findIndex(customFields, { name: field.name });
+    idx = _.findIndex(customFields, {name: field.name});
 
     if (idx > -1) {
       customFields.splice(idx, 1);
@@ -1120,7 +1120,7 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
       this.safelyDetectChanges();
 
       // 페이지 위젯내 커스텀 필드 재설정
-      this.broadCaster.broadcast('SET_CUSTOM_FIELDS', { customFields: customFields });
+      this.broadCaster.broadcast('SET_CUSTOM_FIELDS', {customFields: customFields});
 
       this.hideBoardLoading();
     }
@@ -1150,7 +1150,7 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
       this._configFilterComp.close();
       this.hideBoardLoading();
       if (isSetPanel) {
-        this.popupService.notiFilter({ name: 'change-filter', data: filter });
+        this.popupService.notiFilter({name: 'change-filter', data: filter});
       }
       this.safelyDetectChanges();
     });
@@ -1199,7 +1199,7 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
       if (widget) {
 
         // 위젯에서 필터제거
-        _.remove(widget.configuration.filters, { field: filter.field });
+        _.remove(widget.configuration.filters, {field: filter.field});
 
         // 차트 필터에서 필터제거
         const removeIdx: number
@@ -1208,7 +1208,7 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
 
         // 위젯 필터 재설정
         this._syncFilterWidget();
-        this.popupService.notiFilter({ name: 'remove-filter', data: filter });
+        this.popupService.notiFilter({name: 'remove-filter', data: filter});
       }
     } else {
 
@@ -1227,7 +1227,7 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
 
     // 위젯 필터 재설정
     this._syncFilterWidget();
-    this.popupService.notiFilter({ name: 'remove-filter', data: filter });
+    this.popupService.notiFilter({name: 'remove-filter', data: filter});
   } // function - deleteFilter
 
   // noinspection JSMethodCanBeStatic
@@ -1248,7 +1248,7 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
     const modal = new Modal();
     modal.name = this.translateService.instant('msg.board.filter.alert.change.global');
     modal.description = this.translateService.instant('msg.board.filter.alert.change.global.des');
-    modal.data = { filter, type: 'changeFilter' };
+    modal.data = {filter, type: 'changeFilter'};
     CommonUtil.confirm(modal);
   } // function - openChangeFilterConfirm
 
@@ -1282,12 +1282,12 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
     // 위젯에서 필터 제거
     DashboardUtil.getPageWidgets(this.dashboard).forEach((widget: PageWidget) => {
       if (widget.configuration.filters && widget.configuration.filters.length > 0) {
-        _.remove(widget.configuration.filters, { field: targetFilter.field });
+        _.remove(widget.configuration.filters, {field: targetFilter.field});
       }
     });
 
     // 차트필터에서 필터 제거
-    _.remove(this.chartFilters, { field: targetFilter.field });
+    _.remove(this.chartFilters, {field: targetFilter.field});
 
     delete targetFilter.ui.widgetId;
   } // function - _changeChartFilterToGlobalFilter
@@ -1301,7 +1301,7 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
    */
   private _syncWidgetsAndFilters(customFields: CustomField[], fields: Field[], changeWidgetId: string) {
 
-    customFields = CommonUtil.objectToArray( customFields );
+    customFields = CommonUtil.objectToArray(customFields);
 
     // 사용자 정의 필드를 위젯에 셋팅
     DashboardUtil.getPageWidgets(this.dashboard).forEach((widget: Widget) => {
@@ -1318,7 +1318,7 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
       }
     });
     this._organizeAllFilters(true).then(() => {
-      this._syncFilterWidget( changeWidgetId );
+      this._syncFilterWidget(changeWidgetId);
     });
 
   } // function - _syncWidgetsAndFilters
@@ -1433,17 +1433,17 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
       const mainDsList: Datasource[] = DashboardUtil.getMainDataSources(boardInfo);
 
       if (0 < mainDsList.length) {
-        const linkedDsList:Datasource[] = mainDsList.filter( item => item.connType === ConnectionType.LINK );
+        const linkedDsList: Datasource[] = mainDsList.filter(item => item.connType === ConnectionType.LINK);
 
-        if ( linkedDsList && 0 < linkedDsList.length ) {
+        if (linkedDsList && 0 < linkedDsList.length) {
           // Multi Datasource Dashboard
           this.showBoardLoading();
 
           const promises = [];
 
-          linkedDsList.forEach( dsInfo => {
-            promises.push( new Promise<any>((res, rej) => {
-              const boardDsInfo:BoardDataSource = DashboardUtil.getBoardDataSourceFromDataSource(boardInfo,dsInfo);
+          linkedDsList.forEach(dsInfo => {
+            promises.push(new Promise<any>((res, rej) => {
+              const boardDsInfo: BoardDataSource = DashboardUtil.getBoardDataSourceFromDataSource(boardInfo, dsInfo);
               this.datasourceService.getDatasourceDetail(boardDsInfo['temporaryId']).then((ds: Datasource) => {
                 boardDsInfo.metaDataSource = ds;
                 res();
@@ -1546,7 +1546,7 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
   private _callUpdateDashboardService(imageUrl) {
 
     // params
-    const param: any = { configuration: DashboardUtil.getBoardConfiguration(this.dashboard) };
+    const param: any = {configuration: DashboardUtil.getBoardConfiguration(this.dashboard)};
     param.imageUrl = imageUrl;
 
     this.showBoardLoading();
@@ -1589,18 +1589,18 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
    * @param {string} excludeWidgetId
    * @private
    */
-  private _syncFilterWidget( excludeWidgetId?:string ) {
+  private _syncFilterWidget(excludeWidgetId?: string) {
 
-    const boardFilters:Filter[] = DashboardUtil.getBoardFilters(this.dashboard);
+    const boardFilters: Filter[] = DashboardUtil.getBoardFilters(this.dashboard);
     // Compares the filter widget with the filter information and deletes it for widgets that do not have filter information.
     this.getWidgetComps().forEach((widgetComp) => {
       if (widgetComp.isFilterWidget) {
-        const filterWidget:FilterWidget = <FilterWidget>widgetComp.getWidget();
-        const filter = boardFilters.find( item => DashboardUtil.isSameFilterAndWidget( this.dashboard, item, filterWidget ) );
+        const filterWidget: FilterWidget = <FilterWidget>widgetComp.getWidget();
+        const filter = boardFilters.find(item => DashboardUtil.isSameFilterAndWidget(this.dashboard, item, filterWidget));
 
-        if ( filter ) {
+        if (filter) {
           filterWidget.configuration.filter = filter;
-          this.dashboard = DashboardUtil.updateWidget( this.dashboard, filterWidget );
+          this.dashboard = DashboardUtil.updateWidget(this.dashboard, filterWidget);
           this.broadCaster.broadcast('SET_WIDGET_CONFIG', {
             widgetId: filterWidget.id,
             config: filterWidget.configuration
@@ -1611,9 +1611,9 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
       }
     });
 
-    const boardCastData = { filters: boardFilters };
-    ( excludeWidgetId ) && ( boardCastData['excludeWidgetId'] = excludeWidgetId );
-    this.broadCaster.broadcast('SET_GLOBAL_FILTER', boardCastData );
+    const boardCastData = {filters: boardFilters};
+    (excludeWidgetId) && (boardCastData['excludeWidgetId'] = excludeWidgetId);
+    this.broadCaster.broadcast('SET_GLOBAL_FILTER', boardCastData);
 
   } // function - syncFilterWidget
 

--- a/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
+++ b/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
@@ -852,6 +852,9 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
    * @param {string} brushType
    */
   public changeMouseSelectMode(mode: string, brushType: string) {
+    if( isNullOrUndefined(this.chart) ) {
+      return;
+    }
     if (ChartMouseMode.SINGLE.toString() === mode) {
       this.mouseMode = 'SINGLE';
       this.chart.convertMouseMode(ChartMouseMode.SINGLE);


### PR DESCRIPTION
### Description
멀티 데이터소스에서 타임스탬프 필터 중복해서 등록되는 현상이 있습니다.

**Related Issue** : #672 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 대시보드를 생성합니다.
2. 대시보드 편집화면에서 필터 패널을 엽니다.
3. 중복된 필터없이 정상적으로 필터가 표시되는지 확인합니다. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

### Additional Context<!-- if not appropriate, remove this topic. -->
