### PR TITLE
F#543 response grids of excel at once

### DIFF
--- a/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-selectfile.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-selectfile.component.ts
@@ -230,7 +230,7 @@ export class CreateDatasetSelectfileComponent extends AbstractPopupComponent imp
    */
   public fetchUploadStatus(fileKey: string) {
     this.datasetService.checkFileUploadStatus(fileKey).then((result) => {
-      this.loadingHide();
+
       if (result.state === 'done' && result.success) { // Upload finished
         clearInterval(this.interval);
         this.interval = undefined;
@@ -240,6 +240,7 @@ export class CreateDatasetSelectfileComponent extends AbstractPopupComponent imp
         Alert.error(this.translateService.instant('Failed to upload. Please select another file'));
         clearInterval(this.interval);
         this.interval = undefined;
+        this.loadingHide();
         return;
       }
     });

--- a/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-selectsheet.component.html
+++ b/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-selectsheet.component.html
@@ -100,7 +100,7 @@
   <div class="ddp-ui-buttons">
     <a href="javascript:" class="ddp-btn-type-popup" (click)="prev()">{{'msg.comm.btn.cancl' | translate}}</a>
     <!-- disabled 시 ddp-disabled 추가 -->
-    <a href="javascript:" class="ddp-btn-type-popup ddp-bg-black" (click)="next()">{{'msg.comm.btn.next' | translate}}</a>
+    <a href="javascript:" [ngClass]="{'ddp-disabled':clearGrid}" class="ddp-btn-type-popup ddp-bg-black" (click)="next()">{{'msg.comm.btn.next' | translate}}</a>
   </div>
   <!-- //buttons -->
 

--- a/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-selectsheet.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-selectsheet.component.ts
@@ -434,12 +434,20 @@ export class CreateDatasetSelectsheetComponent extends AbstractPopupComponent im
    * @param {Field[]} fields
    */
   private updateGrid(data: any, fields: Field[]) {
-    // headers
-    const headers: header[] = this.getHeaders(fields);
-    // rows
-    const rows: any[] = this.getRows(data);
-    // grid 그리기
-    this.drawGrid(headers, rows);
+
+    if (data.length > 0 && fields.length > 0) {
+      this.clearGrid = false;
+      // headers
+      const headers: header[] = this.getHeaders(fields);
+      // rows
+      const rows: any[] = this.getRows(data);
+      // grid 그리기
+      this.drawGrid(headers, rows);
+    } else {
+      this.clearGrid = true;
+    }
+
+
   }
 
   /**

--- a/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-selectsheet.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-selectsheet.component.ts
@@ -83,6 +83,10 @@ export class CreateDatasetSelectsheetComponent extends AbstractPopupComponent im
 
   // Change Detect
   public changeDetect: ChangeDetectorRef;
+
+  public defaultSheetIndex : number = 0;
+
+  public gridInfo : any;
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Constructor
    |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
@@ -231,11 +235,21 @@ export class CreateDatasetSelectsheetComponent extends AbstractPopupComponent im
   // excel 시 sheet 아이디 세팅
   public setDataSetSheetIndex(event,sheetname, idx) {
     event.stopPropagation();
+
     this.isChanged = false;
+    this.defaultSheetIndex = idx;
     this.datasetFile.sheetname = sheetname;
     this.datasetFile.sheetIndex = idx;
-    this.getDataFile();
+
+    // this.getDataFile();
+
+    if (!isNullOrUndefined(this.gridInfo) && this.gridInfo[this.defaultSheetIndex]) {
+      this.updateGrid(this.gridInfo[this.defaultSheetIndex].data, this.gridInfo[this.defaultSheetIndex].fields);
+    } else {
+      this.clearGrid = true;
+    }
   }
+
 
   /**
    * Move to next step
@@ -247,6 +261,10 @@ export class CreateDatasetSelectsheetComponent extends AbstractPopupComponent im
     if(isUndefined(this.datasetFile.delimiter) || this.datasetFile.delimiter === '' ){
       this.columnDelimiter = '';
       Alert.warning(this.translateService.instant('msg.dp.alert.col.delim.required'));
+      return;
+    }
+
+    if (this.clearGrid) {
       return;
     }
 
@@ -314,6 +332,7 @@ export class CreateDatasetSelectsheetComponent extends AbstractPopupComponent im
     }
 
     if(this.isChanged) { // when uploaded file is changed
+      this.defaultSheetIndex = 0;
       const response: any = this.uploadResult.response;
       this.datasetFile.filename = response.filename;
       this.datasetFile.filepath = response.filepath;
@@ -462,13 +481,15 @@ export class CreateDatasetSelectsheetComponent extends AbstractPopupComponent im
   private getGridInformation(param) {
 
     this.datasetService.getFileGridInfo(param).then((result) => {
-      if (result.data && result.data.length > 0 && result.fields && result.fields.length > 0) {
+      if (result.grids.length > 0) {
         this.clearGrid = false;
-        this.updateGrid(result.data , result.fields);
+        this.gridInfo = result.grids;
+        this.updateGrid(this.gridInfo[this.defaultSheetIndex].data , this.gridInfo[this.defaultSheetIndex].fields);
       } else {
+        this.gridInfo = [];
         this.clearGrid = true;
-        this.loadingHide();
       }
+      this.loadingHide();
     }).catch((error) => {
       this.clearGrid = true;
       this.loadingHide();

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetController.java
@@ -413,7 +413,7 @@ public class PrepDatasetController {
                                                           @RequestParam(value = "hasFields", required = false, defaultValue = "N") String hasFieldsFlag) {
         Map<String, Object> response = null;
         try {
-            response = this.datasetFileService.fileCheckSheet2( fileKey, sheetname, sheetindex, size, delimiterRow, delimiterCol, hasFieldsFlag);
+            response = this.datasetFileService.fileCheckSheet3( fileKey, size, delimiterRow, delimiterCol );
         } catch (Exception e) {
             LOGGER.error("fileCheckSheet(): caught an exception: ", e);
             throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE,e);


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Originally grid information was requested every time user clicks on the sheet button.
Now grid information is returned with an array so the user doesn't need to wait for the server response 
every time user clicks on the sheet button.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#543 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Go to create dataset by file (excel)
Make sure excel file has at least two sheets
Click on the sheets, check if grid is shown without delay

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
