### PR TITLE
#654 Show notification when you click 'Delete' in workbench editor

### DIFF
--- a/discovery-frontend/src/app/workbench/workbench.component.ts
+++ b/discovery-frontend/src/app/workbench/workbench.component.ts
@@ -2254,8 +2254,15 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
       return;
     }
 
-    this.closeEditorTab(this.selectedTabNum);
-    this.tabLayer = false;
+    const modal = new Modal();
+    modal.name = this.translateService.instant('msg.bench.confirm.delete-editor');
+    modal.btnName = this.translateService.instant('msg.comm.ui.del');
+    modal.afterConfirm = () => {
+      this.closeEditorTab(this.selectedTabNum);
+      this.tabLayer = false;
+    };
+    CommonUtil.confirm(modal);
+
   } // function - tabLayerDelete
 
   /**

--- a/discovery-frontend/src/assets/i18n/en.json
+++ b/discovery-frontend/src/assets/i18n/en.json
@@ -497,6 +497,7 @@
   "msg.bench.alert.execute.query": "Please enter a query to run.",
   "msg.bench.alert.no.selected.query": "No queries selected.",
   "msg.bench.alert.no.result": "There are no results for your selection.",
+  "msg.bench.confirm.delete-editor": "Are you sure you want to delete editor tab?",
   "msg.bench.ui.del": "Delete this workbench",
   "msg.bench.ui.tab-prefix" : "Editor",
   "msg.bench.btn.maximize": "Full page",

--- a/discovery-frontend/src/assets/i18n/ko.json
+++ b/discovery-frontend/src/assets/i18n/ko.json
@@ -497,6 +497,7 @@
   "msg.bench.alert.execute.query": "실행할 쿼리를 입력해 주세요",
   "msg.bench.alert.no.selected.query": "선택된 쿼리가 없습니다",
   "msg.bench.alert.no.result":"선택하신 결과 데이터가 없습니다",
+  "msg.bench.confirm.delete-editor": "에디터 탭을 삭제하시겠습니까?",
   "msg.bench.ui.del": "워크벤치 삭제",
   "msg.bench.ui.tab-prefix" : "에디터",
   "msg.bench.btn.maximize" : "전체 보기",


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
- 워크벤치 쿼리 에디터에서 "Delete" 클릭 시 경고 문구 없이 쿼리 내용 전체가 삭제되며, 삭제 후 복구할 방법이 없음
- "Edit name" 버튼을 누르려다가 실수로 "Delete" 버튼을 누르는 사례들이 발생됨
- Notification 을 통해 확인을 거진 후 삭제하는 것이 필요함

**Related Issue** : #654 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 워크벤치로 이동합니다.
2. 에디터 탭을 1개 이상 생성합니다.
3. 생성한 에디터 탭 중 하나를 선택하여 삭제 버튼을 클릭합니다.
4. 바로 삭제되지 않고 확인창이 나타나는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
