### PR TITLE
F#690 suppress exceptions from broken rules

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepPreviewLineService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepPreviewLineService.java
@@ -128,19 +128,21 @@ public class PrepPreviewLineService {
 
             String previewPathKey = "previewPath";
             String previewPath = dataset.getCustomValue(previewPathKey);
-            if (null != previewPath) {
-                ObjectMapper mapper = GlobalObjectMapper.getDefaultMapper();
-                String filepath = previewPath + File.separator + dataset.getDsId() + ".df";
-                File theFile = new File(filepath);
-                if (true == theFile.exists()) {
-                    dataFrame = mapper.readValue(theFile, DataFrame.class);
-                } else {
-                    dataFrame = this.remakePreviewLines(dsId);
-                    // regenerate
-                    // throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_FILE_NOT_FOUND, filepath);
-                }
+            if (null == previewPath) {
+                this.remakePreviewLines(dsId);
+                previewPath = dataset.getCustomValue(previewPathKey);
+                assert previewPath != null;
+            }
+
+            ObjectMapper mapper = GlobalObjectMapper.getDefaultMapper();
+            String filepath = previewPath + File.separator + dataset.getDsId() + ".df";
+            File theFile = new File(filepath);
+            if (true == theFile.exists()) {
+                dataFrame = mapper.readValue(theFile, DataFrame.class);
             } else {
-                throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_PROPERTY_NOT_AVAILABLE, previewPathKey+"==(null)");
+                dataFrame = this.remakePreviewLines(dsId);
+                // regenerate
+                // throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_FILE_NOT_FOUND, filepath);
             }
 
             if(dataFrame!=null) {

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DataFrameService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DataFrameService.java
@@ -15,22 +15,21 @@
 package app.metatron.discovery.domain.dataprep.teddy;
 
 import app.metatron.discovery.domain.dataprep.PrepProperties;
-import app.metatron.discovery.domain.dataprep.exceptions.PrepErrorCodes;
 import app.metatron.discovery.domain.dataprep.exceptions.PrepException;
-import app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey;
 import app.metatron.discovery.domain.dataprep.teddy.exceptions.TeddyException;
 import app.metatron.discovery.domain.dataprep.teddy.exceptions.TransformExecutionFailedException;
 import app.metatron.discovery.domain.dataprep.teddy.exceptions.TransformExecutionInterrupteddException;
 import app.metatron.discovery.domain.dataprep.teddy.exceptions.TransformTimeoutException;
 import app.metatron.discovery.prep.parser.exceptions.RuleException;
 import app.metatron.discovery.prep.parser.preparation.RuleVisitorParser;
-import app.metatron.discovery.prep.parser.preparation.rule.*;
+import app.metatron.discovery.prep.parser.preparation.rule.Join;
+import app.metatron.discovery.prep.parser.preparation.rule.Rule;
+import app.metatron.discovery.prep.parser.preparation.rule.Union;
 import app.metatron.discovery.prep.parser.preparation.rule.expr.Constant;
 import app.metatron.discovery.prep.parser.preparation.rule.expr.Expression;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.AsyncResult;
 import org.springframework.stereotype.Service;

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformController.java
@@ -170,7 +170,7 @@ public class PrepTransformController {
       Integer stageIdx = request.getRuleIdx();
       assert stageIdx == null || stageIdx >= 0 : stageIdx;
 
-      response = transformService.transform(wrangledDsId, request.getOp(), stageIdx, request.getRuleString());
+      response = transformService.transform(wrangledDsId, request.getOp(), stageIdx, request.getRuleString(), false);
     } catch (Exception e) {
       LOGGER.error("transform(): caught an exception: ", e);
       throw PrepException.create(PrepErrorCodes.PREP_TRANSFORM_ERROR_CODE, e);

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
@@ -24,6 +24,7 @@ import app.metatron.discovery.domain.dataprep.rule.ExprFunction;
 import app.metatron.discovery.domain.dataprep.rule.ExprFunctionCategory;
 import app.metatron.discovery.domain.dataprep.teddy.*;
 import app.metatron.discovery.domain.dataprep.teddy.exceptions.IllegalColumnNameForHiveException;
+import app.metatron.discovery.domain.dataprep.teddy.exceptions.TeddyException;
 import app.metatron.discovery.domain.datasource.connection.DataConnection;
 import app.metatron.discovery.domain.datasource.connection.DataConnectionRepository;
 import app.metatron.discovery.prep.parser.exceptions.RuleException;
@@ -304,7 +305,7 @@ public class PrepTransformService {
           String setTypeRule = setTypeRules.get(i);
           try {
             // 주의: response를 갱신하면 안됨. 기존의 create()에 대한 response를 그대로 주어야 함.
-            transform(wrangledDsId, PrepDataset.OP_TYPE.APPEND, i, setTypeRule);
+            transform(wrangledDsId, PrepDataset.OP_TYPE.APPEND, i, setTypeRule, false);
           } catch (Exception e) {
             LOGGER.error("create(): caught an exception: this setType rule might be wrong [" + setTypeRule + "]", e);
           }
@@ -482,7 +483,11 @@ public class PrepTransformService {
     List<PrepTransformRule> transformRules = getRulesInOrder(wrangledDsId);
     for (int i = 1; i < transformRules.size(); i++) {
       String ruleString = transformRules.get(i).getRuleString();
-      response = transform(cloneDsId, OP_TYPE.APPEND, i - 1, ruleString);
+      try {
+        response = transform(cloneDsId, OP_TYPE.APPEND, i - 1, ruleString, true);
+      } catch (TeddyException te) {
+        LOGGER.info("clone(): A TeddyException is suppressed: {}", te.getMessage());
+      }
     }
     return response;
   }
@@ -591,7 +596,12 @@ public class PrepTransformService {
 
     for (int i = 1; i < ruleStrings.size(); i++) {
       String ruleString = ruleStrings.get(i);
-      gridResponse = teddyImpl.append(dsId, i - 1, ruleString);
+      try {
+        gridResponse = teddyImpl.append(dsId, i - 1, ruleString, true);
+        updateTransformRules(dsId);
+      } catch (TeddyException te) {
+        LOGGER.info("load_internal(): A TeddyException is suppressed: {}", te.getMessage());
+      }
     }
     adjustStageIdx(dsId, ruleStrings.size() - 1, true);
 
@@ -642,7 +652,7 @@ public class PrepTransformService {
 
   // transform (PUT)
   @Transactional(rollbackFor = Exception.class)
-  public PrepTransformResponse transform(String dsId, OP_TYPE op, Integer stageIdx, String ruleString) throws Exception {
+  public PrepTransformResponse transform(String dsId, OP_TYPE op, Integer stageIdx, String ruleString, boolean forced) throws Exception {
     LOGGER.trace("transform(): start: dsId={} op={} stageIdx={} ruleString={}", dsId, op, stageIdx, ruleString);
 
     if(op==OP_TYPE.APPEND || op==OP_TYPE.UPDATE || op==OP_TYPE.PREVIEW) {
@@ -673,7 +683,7 @@ public class PrepTransformService {
     // rule list는 transform()을 마칠 때에 채움. 모든 op에 대해 동일하기 때문에.
     switch (op) {
       case APPEND:
-        teddyImpl.append(dsId, stageIdx, ruleString);
+        teddyImpl.append(dsId, stageIdx, ruleString, forced);
         if (stageIdx >= origStageIdx) {
           adjustStageIdx(dsId, stageIdx + 1, true);
         } else {


### PR DESCRIPTION
### Description
Fixed an issue where loading and cloning could not be done with broken rules.
In the following cases, loading and cloning of broken rules will occur.
* Uploaded file change / destruction
* Dataset swapping to unmatched schema
* Server rebooting
* Binary patch which changed the behavior (This case was the problem recently. We used to put "_" instead of the space character. Now I have changed to use the space as it is.)

_Broken rule이 있는 경우 loading, cloning이 안되던 문제를 해결했습니다.
다음의 경우에 broken rule에 대한 loading, cloning이 벌어집니다._
* _Uploaded file 변경/훼손_
* _Schema가 다른 dataset으로 swapping_
* _서버 재기동_
* _동작이 바뀐 binary patch (이번에 문제가 된 경우. 공백대신 _를 넣던 것을 그냥 공백을 컬럼명으로 사용하게 했음)_


**Related Issue** : https://github.com/metatron-app/metatron-discovery/issues/690


### How Has This Been Tested?
Honestly, the following is the best way:
1. Grap a wrangled dataset from the testbed.
2. Make a copy by the context menu. -> A red toast poped out, back then. If you see, this PR fails.
3. Click "Edit rules"
4. See the red rule strings -> This is the successful result.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
During loading and cloning, all TeddyExceptions are suppressed.
However, there are some TeddyExceptions that makes too severe problems to go on.
These exceptions should be handled separately later.
For more information, see https://github.com/metatron-app/metatron-discovery/issues/690.

_Loading, cloning 과정에서 모든 TeddyException이 suppress되게 되었습니다.
하지만, 더 이상 일을 진행할 수 없는 TeddyException도 존재합니다.
차후 이러한 Exception들을 따로 분리해서 처리해야합니다.
자세한 내용은 https://github.com/metatron-app/metatron-discovery/issues/690 를 참고바랍니다._