### PR TITLE
#704 fix derive, advanced editor, invalid data error

### DIFF
--- a/discovery-frontend/src/app/data-preparation/component/create-snapshot-popup.component.ts
+++ b/discovery-frontend/src/app/data-preparation/component/create-snapshot-popup.component.ts
@@ -136,7 +136,7 @@ export class CreateSnapshotPopup extends AbstractPopupComponent implements OnIni
     this.getConfig();
     //this.getHiveDatabase();
 
-    this.changeSsType('FILE');
+
   } // function - init
 
 
@@ -316,8 +316,15 @@ export class CreateSnapshotPopup extends AbstractPopupComponent implements OnIni
 
       //this.snapshot.location = this.fileLocations[0].value;
       if(0<this.fileLocations.length) {
-        this.snapshot.location = this.fileLocations[0].value;
-        this.snapshot.uri = this.fileUris[0];
+        let idx = this.fileLocations.findIndex((item) => {
+          return item.value.toUpperCase() === 'LOCAL';
+        });
+
+        if (idx === -1) {
+          idx = 0;
+        }
+        this.snapshot.location = this.fileLocations[idx].value;
+        this.snapshot.uri = this.fileUris[idx];
       }
     }
 
@@ -384,7 +391,7 @@ export class CreateSnapshotPopup extends AbstractPopupComponent implements OnIni
           } else {
             this.isHiveDisable = true;
           }
-
+          this.changeSsType('FILE');
           this.loadingHide();
         })
         .catch((error) => {
@@ -466,7 +473,7 @@ export class CreateSnapshotPopup extends AbstractPopupComponent implements OnIni
 
     this.fileFormat = [
       { value: 'CSV', label: 'CSV' },
-      { value: 'JSON', label: 'JSON' }
+      // { value: 'JSON', label: 'JSON' }
     ];
 
     this.ssName = '';

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-dataflow-rule-2.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-dataflow-rule-2.component.ts
@@ -1131,6 +1131,8 @@ export class EditDataflowRule2Component extends AbstractPopupComponent implement
       val = 'inputValue';
     } else if (command === 'replace' || command === 'setCondition') {
       val = 'condition';
+    } else if (command === 'keep') {
+      val = 'keepRow';
     }
 
     this.extendInputFormulaComponent.open(fields, command, this._editRuleComp.getValue( val ));
@@ -1934,9 +1936,7 @@ export class EditDataflowRule2Component extends AbstractPopupComponent implement
         this.isRedoRunning = false;
       }
 
-      if (this.editorUseFlag) {
-        this.inputRuleCmd = '';
-      }
+      this.inputRuleCmd = '';
 
     });
 

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/edit-rule-grid.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/edit-rule-grid.component.ts
@@ -1857,8 +1857,13 @@ export class EditRuleGridComponent extends AbstractComponent implements OnInit, 
    * @private
    */
   private _setTimeStampFormat(value: string, timestampStyle?: string): string {
+
     (timestampStyle) || (timestampStyle = 'YYYY-MM-DDTHH:mm:ss');
-    return moment.utc(value).format(timestampStyle.replace(/y/g, 'Y').replace(/dd/g, 'DD').replace(/'/g, ''));
+    let result = moment.utc(value).format(timestampStyle.replace(/y/g, 'Y').replace(/dd/g, 'DD').replace(/'/g, ''));
+    if (result === 'Invalid date') {
+      result = value;
+    }
+    return result;
 
     // if (-1 > timestampStyle.indexOf('H')) {
     //   // return moment(value + `+0000`).format(timestampStyle);

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-derive.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-derive.component.ts
@@ -17,7 +17,7 @@ import {
 } from '@angular/core';
 import { EditRuleComponent } from './edit-rule.component';
 import { Alert } from '../../../../../../common/util/alert.util';
-import { isUndefined } from "util";
+import {isNullOrUndefined, isUndefined} from "util";
 import { StringUtil } from '../../../../../../common/util/string.util';
 import { PreparationCommonUtil } from '../../../../../util/preparation-common.util';
 import { RuleConditionInputComponent } from './rule-condition-input.component';
@@ -160,7 +160,10 @@ export class EditRuleDeriveComponent extends EditRuleComponent implements OnInit
    * @protected
    */
   protected afterShowComp() {
-    this.deriveAs = 'col_1';
+
+    if (this.deriveAs === '' || isNullOrUndefined(this.deriveAs)) {
+      this.deriveAs = 'col_1';
+    }
   } // function - afterShowComp
 
   /**
@@ -177,6 +180,7 @@ export class EditRuleDeriveComponent extends EditRuleComponent implements OnInit
 
     // NEW COLUMN NAME
     this.deriveAs = data.jsonRuleString.as;
+    this.deriveAs = PreparationCommonUtil.removeQuotation(this.deriveAs);
 
   } // function - parsingRuleString
 

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-extract.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-extract.component.ts
@@ -17,7 +17,7 @@ import { AfterViewInit, Component, ElementRef, Injector, OnDestroy, OnInit } fro
 import { Field } from '../../../../../../domain/data-preparation/dataset';
 import { Alert } from '../../../../../../common/util/alert.util';
 import { StringUtil } from '../../../../../../common/util/string.util';
-import { isUndefined } from "util";
+import {isNullOrUndefined, isUndefined} from "util";
 import { EventBroadcaster } from '../../../../../../common/event/event.broadcaster';
 import { PreparationCommonUtil } from '../../../../../util/preparation-common.util';
 
@@ -206,7 +206,10 @@ export class EditRuleExtractComponent extends EditRuleComponent implements OnIni
     this.isIgnoreCase = Boolean(data.jsonRuleString.ignoreCase);
 
     // IGNORE BETWEEN CHRACTERS
-    this.ignore = data.jsonRuleString.quote.escapedValue;
+
+    if (!isNullOrUndefined(data.jsonRuleString.quote)) {
+      this.ignore = data.jsonRuleString.quote.escapedValue;
+    }
 
   } // function - _parsingRuleString
 

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-merge.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-merge.component.ts
@@ -17,7 +17,7 @@ import { AfterViewInit, Component, ElementRef, Injector, OnDestroy, OnInit, View
 import { Field } from '../../../../../../domain/data-preparation/dataset';
 import { Alert } from '../../../../../../common/util/alert.util';
 import { StringUtil } from '../../../../../../common/util/string.util';
-import { isUndefined } from "util";
+import {isNullOrUndefined, isUndefined} from "util";
 import { EventBroadcaster } from '../../../../../../common/event/event.broadcaster';
 import { PreparationCommonUtil } from '../../../../../util/preparation-common.util';
 
@@ -156,8 +156,11 @@ export class EditRuleMergeComponent extends EditRuleComponent implements OnInit,
    * @protected
    */
   protected afterShowComp() {
-    if (this.selectedFields.length > 0) {
-      this.newValue = this.selectedFields[0].name + '_1';
+
+    if (this.newValue === '' || isNullOrUndefined(this.newValue)) {
+      if (this.selectedFields.length > 0) {
+        this.newValue = this.selectedFields[0].name + '_1';
+      }
     }
   } // function - _afterShowComp
 
@@ -173,10 +176,11 @@ export class EditRuleMergeComponent extends EditRuleComponent implements OnInit,
 
     // NEW COLUMN NAME
     this.newValue = data.jsonRuleString.as;
+    this.newValue = PreparationCommonUtil.removeQuotation(this.newValue);
 
     // DELIMITER
     this.delimiter = data.jsonRuleString.with;
-
+    this.delimiter = PreparationCommonUtil.removeQuotation(this.delimiter);
   } // function - _parsingRuleString
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-nest.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-nest.component.ts
@@ -20,7 +20,8 @@ import { Field } from '../../../../../../domain/data-preparation/dataset';
 import { EditRuleComponent } from './edit-rule.component';
 import { Alert } from '../../../../../../common/util/alert.util';
 import { RuleConditionInputComponent } from './rule-condition-input.component';
-import { isUndefined } from "util";
+import {isNullOrUndefined, isUndefined} from "util";
+import {PreparationCommonUtil} from "../../../../../util/preparation-common.util";
 
 @Component({
   selector: 'edit-rule-nest',
@@ -160,8 +161,11 @@ export class EditRuleNestComponent extends EditRuleComponent implements OnInit, 
    * @protected
    */
   protected afterShowComp() {
-    if (this.selectedFields.length > 0) {
-      this.inputValue = this.selectedFields[0].name + '_1';
+
+    if (this.inputValue === '' || isNullOrUndefined(this.inputValue)) {
+      if (this.selectedFields.length > 0) {
+        this.inputValue = this.selectedFields[0].name + '_1';
+      }
     }
   } // function - _afterShowComp
 
@@ -184,6 +188,7 @@ export class EditRuleNestComponent extends EditRuleComponent implements OnInit, 
 
     // NEW COLUMN NAME
     this.inputValue = data.jsonRuleString.as;
+    this.inputValue = PreparationCommonUtil.removeQuotation(this.inputValue);
   } // function - _parsingRuleString
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
1 . Fixed the new column value when editing derive.
2. Show already typed condition when advanced editor is opened
3. Show original data when data is invalid

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#704

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. When editing derive rule check if new column name value is same as the value you wrote
2. In derive, type a condition -> click advanced editor -> check if you can see the condition in the popup
3. When there's an invalid value in timestamp type column, check if you can see the original value instead of `invalid date`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
