### PR TITLE
F#709 enable download hdfs snapshot

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/TeddyExecutor.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/TeddyExecutor.java
@@ -277,7 +277,7 @@ public class TeddyExecutor {
     LOGGER.info("createHdfsSnapshot() path={}", file.toString());
 
     DataFrame df = cache.get(masterFullDsId);
-    int totalLines = writeCsv(ssId, df, br, null);
+    int totalLines = writeCsv(ssId, df, br, df.colNames);
 
     // master를 비롯해서, 스냅샷 생성을 위해 새로 만들어진 모든 full dataset을 제거
     for (String fullDsId : reverseMap.keySet()) {


### PR DESCRIPTION
### Description
we did not support to download HDFS type snapshots.
now it can.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
[#709](https://github.com/metatron-app/metatron-discovery/issues/709)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. create a dataset
2. create a dataflow
3. edit the rules of the dataset
4. make a snapshot of 'HDFS type'
5. see the details of snapshot
6. click download CSV

if a CSV file is downloading, it is ok

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
