### PR TITLE
#708 table column size exception handling

### DIFF
--- a/discovery-frontend/src/app/workbench/component/detail-workbench/detail-workbench-schema-browser/detail-workbench-schema-browser.component.ts
+++ b/discovery-frontend/src/app/workbench/component/detail-workbench/detail-workbench-schema-browser/detail-workbench-schema-browser.component.ts
@@ -906,7 +906,12 @@ export class DetailWorkbenchSchemaBrowserComponent extends AbstractWorkbenchComp
       // Logical name
       enableMetaData && (row['LogicalName'] = data[idx]['name']);
       // Type
-      row['type'] = data[idx]['columnType'] + '(' + data[idx]['columnSize'] + ')';
+      // column size가 없을 경우 확인
+      if( isUndefined( data[idx]['columnSize'] ) ){
+        row['type'] = data[idx]['columnType'];
+      } else {
+        row['type'] = data[idx]['columnType'] + '(' + data[idx]['columnSize'] + ')';
+      }
       // Desc
       row['description'] = data[idx]['description'];
       rows.push(row);

--- a/discovery-frontend/src/app/workbench/component/detail-workbench/detail-workbench-table-info-schema/detail-workbench-table-info-schema.html
+++ b/discovery-frontend/src/app/workbench/component/detail-workbench/detail-workbench-table-info-schema/detail-workbench-table-info-schema.html
@@ -39,8 +39,11 @@
           <div class="ddp-data-char">
             {{column.columnName}}
           </div>
-          <div class="ddp-data-columnname">
+          <div *ngIf="column.columnSize !== undefined" class="ddp-data-columnname">
             {{column.columnType}} ({{column.columnSize}})
+          </div>
+          <div *ngIf="column.columnSize === undefined" class="ddp-data-columnname">
+            {{column.columnType}}
           </div>
           <em class="ddp-btn-more"></em>
         </a>


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
테이블 컬럼 정보 에서 컬럼사이즈가 있을경우만 보여지도록 수정합니다. 

**Related Issue** : #708  <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Presto 워크벤치 화면으로 이동합니다. 
2. 테이블 컬럼 정보 화면, 스키마 브라우저의 컬럼 탭으로 이동합니다. 
3. 컬럼명만 표시되는지 확인합니다. 
4. Hive 워크벤치로 이동합니다.
5. 테이블 컬럼 정보 화면, 스키마 브라우저의 컬럼 탭으로 이동합니다. 
6. 컬럼명과 컬럼사이즈가 같이 표시되는지 확인합니다.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
