### PR TITLE
F#730 fixed editor screen scroll error

### DIFF
--- a/discovery-frontend/src/app/workbench/workbench.component.html
+++ b/discovery-frontend/src/app/workbench/workbench.component.html
@@ -480,7 +480,7 @@
             </div>
           </div>
           <!-- //tab -->
-          <div class="ddp-wrap-editor" style="overflow-y: auto;">
+          <div class="ddp-wrap-editor">
             <codemirror [config]="config" (keyup)="editorKeyEvent($event)"
                         (textChanged)="editorTextChange($event)"></codemirror>
           </div>

--- a/discovery-frontend/src/app/workbench/workbench.component.ts
+++ b/discovery-frontend/src/app/workbench/workbench.component.ts
@@ -374,7 +374,6 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
       this.loadingBar.hide(); // 초기에 표시되는 문제로 숨김
       this.loadingShow();
       this._loadInitData(() => {
-        this.onEndedResizing();
         this.webSocketCheck(() => this.loadingHide());
 
         this._splitVertical = Split(['.sys-workbench-top-panel', '.sys-workbench-bottom-panel'], {
@@ -383,6 +382,7 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
             this.onEndedResizing();
           }
         });
+        this.onEndedResizing();
         this._activeHorizontalSlider();
       });
     }, 500);

--- a/discovery-frontend/src/app/workbench/workbench.component.ts
+++ b/discovery-frontend/src/app/workbench/workbench.component.ts
@@ -2836,7 +2836,7 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
   private _activeHorizontalSlider() {
     this._splitHorizontal = Split(['.sys-workbench-lnb-panel', '.sys-workbench-content-panel'], {
       direction: 'horizontal',
-      sizes: [20, 80],
+      sizes: [18, 82],
       elementStyle: (dimension, size, gutterSize) => {
         return { 'width': `${size}%` };
       },


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
워크벤치 에디터 창에서 스크롤 두개가 발생합니다. 

**Related Issue** : #730  <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 워크벤치 화면으로 이동합니다. 
2. 에디터 화면에 스크롤이 생성되게 입력을 한 후, 다른 화면으로 이동합니다. 
3. 다시 워크벤치 화면으로 진입하여 추가 텍스트를 입력 후 스크롤이 하나만 생성되어 작동하는지 확인합니다. 


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
