### PR TITLE
#749 colour rule in red when rule is broken (dataflow panel)

### DIFF
--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/dataset-info-popup/dataset-info-popup.component.html
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/dataset-info-popup/dataset-info-popup.component.html
@@ -256,7 +256,7 @@
             <span class="ddp-data-type">
               <em class="ddp-ui-round">{{rule.alias}}</em>
             </span>
-            <div class="ddp-ui-code">{{rule.simplifiedRule !=='' ? rule.simplifiedRule : rule.ruleString}}</div>
+            <div class="ddp-ui-code" [ngClass]="{'ddp-error': !rule.valid}">{{rule.simplifiedRule !=='' ? rule.simplifiedRule : rule.ruleString}}</div>
           </li>
         </ul>
         <div class="ddp-ui-empty" *ngIf="ruleList && 0 === ruleList.length">


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Broken rule colour should be red 

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#749 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Go to dataflow detail -> click wrangled data -> see dataflow panel -> check if broken rule is coloured red

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
