### PR TITLE
#701 Fix null point exception when some rows has null contained columns

### DIFF
--- a/discovery-prep-parser/src/main/java/app/metatron/discovery/prep/parser/preparation/rule/expr/Expr.java
+++ b/discovery-prep-parser/src/main/java/app/metatron/discovery/prep/parser/preparation/rule/expr/Expr.java
@@ -186,12 +186,12 @@ public interface Expr extends Expression {
         assert (args.size() == 2) : args.size();
         try {
           ExprEval exprEval = args.get(0).eval(bindings);
-          String colType = args.get(1).eval(bindings).stringValue().replace("'", "");
+          String colType = args.get(1).eval(bindings).stringValue().replace("'", "").toUpperCase();
 
           if(exprEval.value() == null)
             return ExprEval.of(false);
           else
-            return exprEval.type().toString().equals(colType) ? ExprEval.of(false) : ExprEval.of(true);
+            return exprEval.type().toString().toUpperCase().equals(colType) ? ExprEval.of(false) : ExprEval.of(true);
         } catch (NullPointerException ne){
           throw new FunctionColumnNotFoundException("isnull(): No such column name >> " + args.get(0).toString());
         }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetFileService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetFileService.java
@@ -617,22 +617,25 @@ public class PrepDatasetFileService {
                             int[] typeCount = new int[5];
 
                             for(List<ColumnType> types : gussedTypesByRows) {
-                                ColumnType type = types.get(i) != null ? types.get(i) : ColumnType.STRING;
-                                switch (type) {
-                                    case BOOLEAN:
-                                        typeCount[0]++;
-                                        break;
-                                    case LONG:
-                                        typeCount[1]++;
-                                        break;
-                                    case DOUBLE:
-                                        typeCount[2]++;
-                                        break;
-                                    case TIMESTAMP:
-                                        typeCount[3]++;
-                                        break;
-                                    default:
-                                        typeCount[4]++;
+
+                                if (i <types.size() && types.get(i) != null) {
+                                    ColumnType type = types.get(i) != null ? types.get(i) : ColumnType.STRING;
+                                    switch (type) {
+                                        case BOOLEAN:
+                                            typeCount[0]++;
+                                            break;
+                                        case LONG:
+                                            typeCount[1]++;
+                                            break;
+                                        case DOUBLE:
+                                            typeCount[2]++;
+                                            break;
+                                        case TIMESTAMP:
+                                            typeCount[3]++;
+                                            break;
+                                        default:
+                                            typeCount[4]++;
+                                    }
                                 }
                             }
 


### PR DESCRIPTION
### Description
When csv file has null contains columns, dataset preview is not displayed.
Dataset preview should be always displayed.


**Related Issue** : <!--- Please link to the issue here. -->
https://github.com/metatron-app/metatron-discovery/issues/701


### How Has This Been Tested?
Create dataset with attached csv file.
Dataset preview will be displayed.
[cat.csv.txt](https://github.com/metatron-app/metatron-discovery/files/2575421/cat.csv.txt)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
