### PR TITLE
#570 supports_txt_file_upload_to_dataset

### DIFF
--- a/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-name.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-name.component.ts
@@ -296,7 +296,12 @@ export class CreateDatasetNameComponent extends AbstractPopupComponent implement
 
       if(extension.toUpperCase() === 'XLSX' || extension.toUpperCase() === 'XLS') {
         this.name = `${fileName} - ${this.datasetFile.sheetname} (EXCEL)`;
+      } else if(extension.toUpperCase() === 'JSON') {
+        this.name = `${fileName} (JSON)`;
       } else if(extension.toUpperCase() === 'CSV') {
+        this.name = `${fileName} (CSV)`;
+      } else {
+        // 불명의 확장자는 CSV로 간주함
         this.name = `${fileName} (CSV)`;
       }
     } else if ('DB' === type) {

--- a/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-selectsheet.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-selectsheet.component.ts
@@ -492,6 +492,7 @@ export class CreateDatasetSelectsheetComponent extends AbstractPopupComponent im
       if (result.grids.length > 0) {
         this.clearGrid = false;
         this.gridInfo = result.grids;
+        this.datasetFile.sheetname = this.gridInfo[this.defaultSheetIndex].sheetName;
         this.updateGrid(this.gridInfo[this.defaultSheetIndex].data , this.gridInfo[this.defaultSheetIndex].fields);
       } else {
         this.gridInfo = [];

--- a/discovery-frontend/src/assets/i18n/en.json
+++ b/discovery-frontend/src/assets/i18n/en.json
@@ -996,7 +996,7 @@
   "msg.dp.ui.fail": "Fail",
   "msg.dp.ui.file.drop" :"or drop file here",
   "msg.dp.ui.file.import" : "Import",
-  "msg.dp.ui.file.upload.description" : "xls, xlsx, txt and csv formats are allowed.",
+  "msg.dp.ui.file.upload.description" : "Excel, CSV files are allowed.",
   "msg.dp.ui.flows": "Dataflows",
   "msg.dp.ui.grid.view": "Grid view",
   "msg.dp.ui.imported" : "IMPORTED",

--- a/discovery-frontend/src/assets/i18n/ko.json
+++ b/discovery-frontend/src/assets/i18n/ko.json
@@ -996,7 +996,7 @@
   "msg.dp.ui.fail": "실패",
   "msg.dp.ui.file.drop" :"or drop file here",
   "msg.dp.ui.file.import" : "Import",
-  "msg.dp.ui.file.upload.description" : "xls, xlsx, txt 및 csv 형식은 허용됩니다.",
+  "msg.dp.ui.file.upload.description" : "Excel, CSV 형식의 파일이 허용됩니다.",
   "msg.dp.ui.flows": "데이터플로우",
   "msg.dp.ui.grid.view": "그리드 뷰",
   "msg.dp.ui.imported" : "IMPORTED",

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetController.java
@@ -421,6 +421,7 @@ public class PrepDatasetController {
         return ResponseEntity.ok(response);
     }
 
+    /*
     @RequestMapping(value = "/upload", method = RequestMethod.POST, produces = "application/json")
     public @ResponseBody ResponseEntity<?> uploadExcelfile(@RequestParam("file") MultipartFile file) {
         Map<String, Object> response = null;
@@ -432,6 +433,7 @@ public class PrepDatasetController {
         }
         return ResponseEntity.status(HttpStatus.SC_CREATED).body(response);
     }
+    */
 
     @RequestMapping(value = "/upload_async", method = RequestMethod.POST, produces = "application/json")
     public @ResponseBody ResponseEntity<?> upload_async(@RequestParam("file") MultipartFile file) {

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetFileService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetFileService.java
@@ -568,7 +568,11 @@ public class PrepDatasetFileService {
                         }
                     }
 
-                } else if ( "csv".equals(extensionType) ) {
+                } else if ( "csv".equals(extensionType) ||
+                        "json".equals(extensionType) ||
+                        "txt".equals(extensionType) ||
+                        true // 기타 확장자는 csv로 간주
+                    ) {
                     boolean hasFields;
                     int totalRows = 0;
 
@@ -785,7 +789,13 @@ public class PrepDatasetFileService {
 
                 List<Map<String, String>> resultSet = Lists.newArrayList();
 
-                if ("csv".equals(extensionType)) {
+                if("json".equals(extensionType)) {
+                    // 현재 FILE이면 무조건 csv로 치환됨
+                } else if ("xlsx".equals(extensionType) || "xls".equals(extensionType)) {
+                    // 현재 FILE이면 무조건 csv로 치환됨
+                } else if ("csv".equals(extensionType)
+                        || true // 기타 확장자는 모두 csv로 간주
+                        ) {
                     BufferedReader br = null;
                     String line;
                     String[] csv_fields = null;
@@ -886,10 +896,6 @@ public class PrepDatasetFileService {
                         }
                         dataFrame.rows.add(row);
                     }
-                } else if("json".equals(extensionType)) {
-                    // 현재 FILE이면 무조건 csv로 치환됨
-                } else if ("xlsx".equals(extensionType) || "xls".equals(extensionType)) {
-                    // 현재 FILE이면 무조건 csv로 치환됨
                 }
 
                 dataset.setTotalBytes(totalBytes);
@@ -908,9 +914,6 @@ public class PrepDatasetFileService {
 
         String fileName = file.getOriginalFilename();
         String extensionType = FilenameUtils.getExtension(fileName).toLowerCase();
-        if(extensionType!=null && extensionType.isEmpty()) {
-            extensionType = "none";
-        }
 
         FileOutputStream fos=null;
         try {
@@ -919,7 +922,8 @@ public class PrepDatasetFileService {
 
             int i=0;
             while(i<5) {
-                tempFileName = UUID.randomUUID().toString() + "." + extensionType;
+                tempFileName = UUID.randomUUID().toString();
+                if(0<extensionType.length()) { tempFileName = tempFileName + "." + extensionType; }
                 tempFilePath = this.getPathLocal_new(tempFileName);
 
                 File newFile = new File(tempFilePath);
@@ -1009,7 +1013,8 @@ public class PrepDatasetFileService {
                 responseMap.put("success", false);
                 responseMap.put("message", "making UUID was failed. try again");
             } else {
-                if(extensionType.equals("csv")) {
+                // BOM 처리는 CSV 유틸로 넘어갈 것임
+                if(extensionType.equals("csv") || extensionType.equals("txt")) {
                     ByteOrderMark byteOrderMark = ByteOrderMark.UTF_8;
                     Charset charSet = Charset.defaultCharset();
                     BOMInputStream bomInputStream = new BOMInputStream(file.getInputStream(),

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetFileService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetFileService.java
@@ -555,6 +555,7 @@ public class PrepDatasetFileService {
 
                             Map<String, Object> grid = Maps.newHashMap();
 
+                            grid.put("sheetName", sheetName);
                             grid.put("headers", headers);
                             grid.put("fields", fields);
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetFileUploadService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetFileUploadService.java
@@ -36,7 +36,12 @@ public class PrepDatasetFileUploadService {
         FileInputStream fis = null;
         FileOutputStream fos = null;
         try {
-            if(extensionType.equals("csv")) {
+            if(extensionType.equals("csv")
+                || extensionType.equals("txt") // txt is csv
+                || extensionType.equals("json") // json is not implement
+                || false==("xlsx".equals(extensionType) ||"xls".equals(extensionType)) // excel is not csv
+                || true // the others are csv
+            ) {
                 boolean convert = true;
                 fis = new FileInputStream(filePath);
                 ByteOrderMark byteOrderMark = ByteOrderMark.UTF_8;
@@ -120,6 +125,8 @@ public class PrepDatasetFileUploadService {
                     }
                     */
                 }
+            } else {
+                // not reachable
             }
 
             responseMap.put("success", true);

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetService.java
@@ -47,44 +47,6 @@ public class PrepDatasetService {
     @Autowired
     private DataConnectionRepository dataConnectionRepository;
 
-    // not using
-    /*
-    @Autowired
-    PrepDatasetRepository datasetRepository;
-
-    @Autowired
-    DataConnectionRepository dataConnectionRepository;
-
-    public void setTotalLines(String dsId, Integer totalLines) {
-        PrepDataset dataset = this.datasetRepository.findOne(dsId);
-        dataset.setTotalLines(totalLines);
-    }
-
-    public String extendDsName(PrepDataset dataset) {
-        String dsName = dataset.getDsName();
-        if(dataset.getImportTypeEnum().equals(PrepDataset.IMPORT_TYPE.FILE)) {
-            String extensionType = FilenameUtils.getExtension(dataset.getFilename());
-            if(extensionType.equalsIgnoreCase("csv")) {
-                dsName = dsName + " (CSV)";
-            } else if(extensionType.toUpperCase().startsWith("XLS")) {
-                dsName = dsName + " (EXCEL)";
-            } else {
-                dsName = dsName + " ("+extensionType.toLowerCase()+")";
-            }
-        } else {
-            if(dataset.getImportTypeEnum()== PrepDataset.IMPORT_TYPE.HIVE) {
-                dsName = dsName +" (HIVE)";
-            } else {
-                DataConnection dc = dataConnectionRepository.findOne(dataset.getDcId());
-                assert (dc != null);
-
-                dsName = dsName +" ("+dc.getImplementor()+")";
-            }
-        }
-        return dsName;
-    }
-    */
-
     private String filePreviewSize = "2000";
     private String hivePreviewSize = "50";
     private String jdbcPreviewSize = "50";
@@ -132,7 +94,6 @@ public class PrepDatasetService {
         if (filekey != null) {
             if(true==dataset.isEXCEL()) {
                 String csvFileName = this.datasetFilePreviewService.moveExcelToCsv(filekey,sheetName,delimiter);
-                dataset.putCustomValue("fileType", "DSV");
                 dataset.putCustomValue("filePath", csvFileName);
                 int lastIdx = csvFileName.lastIndexOf(File.separator);
                 String newFileKey = csvFileName.substring(lastIdx+1);

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
@@ -1210,13 +1210,15 @@ public class PrepTransformService {
     if (importedDataset.getImportType().equalsIgnoreCase("FILE")) {
       String path = importedDataset.getCustomValue("filePath"); // datasetFileService.getPath2(importedDataset);
       LOGGER.debug(wrangledDsId + " path=[" + path + "]");
-      if (importedDataset.isDSV()) {
+      if (importedDataset.isDSV() || importedDataset.isEXCEL()) {
         gridResponse = teddyImpl.loadFileDataset(wrangledDsId, path, importedDataset.getDelimiter(), wrangledDataset.getDsName());
       }
+      /* excel type dataset has csv file
       else if (importedDataset.isEXCEL()) {
         LOGGER.error("createStage0(): EXCEL not supported: " + path);
         throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_FILE_FORMAT_WRONG);
       }
+      */
       else if (importedDataset.isJSON()) {
         LOGGER.error("createStage0(): EXCEL not supported: " + path);
         throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_FILE_FORMAT_WRONG);


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Previously, the server did not support txt file but the client did.
Now, The txt extension is considered csv file

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
[#570](https://github.com/metatron-app/metatron-discovery/issues/570)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. create a dataset using txt file
2. make sure that preview is shown
3. create wrangled dataset
4. edit rules
5. make a snapshot

if you can download a snapshot file. it is ok.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
