### PR TITLE
#770 Delete created snapshot files or hive tables when snapshot cancelation requested

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
@@ -1671,8 +1671,12 @@ public class PrepTransformService {
           case CANCELED:
               return "THIS_SNAPSHOT_IS_ALREADY_CANCELED";
           case SUCCEEDED:
+              snapshotService.deleteSnapshot(ssId);
+              snapshotService.updateSnapshotStatus(ssId, PrepSnapshot.STATUS.CANCELED);
+              return "OK";
           case FAILED:
-              return "THIS_SNAPSHOT_IS_ALREADY_CREATED_OR_FAILED";
+              snapshotService.updateSnapshotStatus(ssId, PrepSnapshot.STATUS.CANCELED);
+              return "OK";
           case NOT_AVAILABLE:
           default:
               return "UNKNOWN_ERROR";


### PR DESCRIPTION
### Description
Sometimes, canceling snapshot creation fails because snapshot has already been created.
When this commit is applied, it deletes the snapshots that were not created as desired.

**Related Issue** : <!--- Please link to the issue here. -->
https://github.com/metatron-app/metatron-discovery/issues/770

### How Has This Been Tested?
1. creat snapshot.
2. click cancel button before it end.
3. Do not click "Yes" button on the pop up window. Wait for the snapshot to be generated.
4. Then Click "Yes"
5. Snapshot should be canceled and file or table will be deleted.

You can also test with REST API
http://localhost:8180/api/preparationsnapshots/{ssId}/cancel

Local test is recommended. You can check if file is really gone.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
