### PR TITLE
#770 Allow non-numeric values for lag and lead functions

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/exceptions/PrepException.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/exceptions/PrepException.java
@@ -59,6 +59,8 @@ public class PrepException extends MetatronException {
     static public PrepException create(ErrorCodes code, Exception e) {
         if (e instanceof PrepException) {
             return (PrepException) e;
+        } else if(e instanceof  TeddyException) {
+            return PrepException.fromTeddyException((TeddyException) e);
         } else {
             if (e.getMessage()!=null && e.getMessage().contains("jdbc:hive2")) {
                 StackTraceElement[] stackTraceElements = e.getStackTrace();

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DfWindow.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DfWindow.java
@@ -187,11 +187,15 @@ public class DfWindow extends DataFrame {
                 case "rolling_avg":
                     if(func.getArgs().size()!=3)
                         throw new WrongWindowFunctionExpressionException("DfWindow.gather(): Invalid window function args: " + func.getName());
+                    if(!prevDf.getColTypeByColName(func.getArgs().get(0).toString()).equals(ColumnType.LONG) && !prevDf.getColTypeByColName(func.getArgs().get(0).toString()).equals(ColumnType.DOUBLE))
+                        throw new WrongWindowFunctionExpressionException("DfWindow.gather(): This function works with numeric values only: " + func.getName());
                     newColType = ColumnType.DOUBLE;
                     break;
                 case "rolling_sum":
                     if(func.getArgs().size()!=3)
                         throw new WrongWindowFunctionExpressionException("DfWindow.gather(): Invalid window function args: " + func.getName());
+                    if(!prevDf.getColTypeByColName(func.getArgs().get(0).toString()).equals(ColumnType.LONG) && !prevDf.getColTypeByColName(func.getArgs().get(0).toString()).equals(ColumnType.DOUBLE))
+                        throw new WrongWindowFunctionExpressionException("DfWindow.gather(): This function works with numeric values only: " + func.getName());
                     newColType = prevDf.getColTypeByColName(func.getArgs().get(0).toString());
                     break;
                 case "lag":
@@ -322,44 +326,20 @@ public class DfWindow extends DataFrame {
                                 targetColName = func.getArgs().get(0).toString();
                                 start = i - func.getArgs().get(1).eval(row).asInt();
 
-                                if (this.getColTypeByColName(targetColName) == ColumnType.LONG) {
-                                    Long value = 0L;
-                                    if (start >= 0 && partitionNumber.get(start) == partitionIndex) {
-                                        value = (long) rows.get(start).get(targetColName);
-                                    } else {
-                                        value = null;
-                                    }
-                                    newRow.add(getColName(j), value);
+                                if (start >= 0 && partitionNumber.get(start) == partitionIndex) {
+                                    newRow.add(getColName(j), rows.get(start).get(targetColName));
                                 } else {
-                                    Double value = 0D;
-                                    if (start >= 0 && partitionNumber.get(start) == partitionIndex) {
-                                        value = value + (double) rows.get(start).get(targetColName);
-                                    } else {
-                                        value = null;
-                                    }
-                                    newRow.add(getColName(j), value);
+                                    newRow.add(getColName(j), null);
                                 }
                                 break;
                             case "lead":
                                 targetColName = func.getArgs().get(0).toString();
                                 start = i + func.getArgs().get(1).eval(row).asInt();
 
-                                if (this.getColTypeByColName(targetColName) == ColumnType.LONG) {
-                                    Long value = 0L;
-                                    if (start >= 0 && start < rows.size() && partitionNumber.get(start) == partitionIndex) {
-                                        value = (long) rows.get(start).get(targetColName);
-                                    } else {
-                                        value = null;
-                                    }
-                                    newRow.add(getColName(j), value);
+                                if (start >= 0 && start < rows.size() && partitionNumber.get(start) == partitionIndex) {
+                                    newRow.add(getColName(j), rows.get(start).get(targetColName));
                                 } else {
-                                    Double value = 0D;
-                                    if (start >= 0 && start < rows.size() && partitionNumber.get(start) == partitionIndex) {
-                                        value = value + (double) rows.get(start).get(targetColName);
-                                    } else {
-                                        value = null;
-                                    }
-                                    newRow.add(getColName(j), value);
+                                    newRow.add(getColName(j), null);
                                 }
                                 break;
                             default:


### PR DESCRIPTION
### Description
Lag and lead function can not process non-numeric values now.
This commit will allow non-numeric values for lag and lead functions, because there's no numeric calculation in lag and lead functions

**Related Issue** : <!--- Please link to the issue here. -->
https://github.com/metatron-app/metatron-discovery/issues/788


### How Has This Been Tested?
Tested window rule with lead and lag function like below.

window value: lag(`Call Date`, 2) group: City
window value: lead(Name, 2) group: City

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
