### PR TITLE
#495 Secondary indicators receive empty result

### DIFF
--- a/discovery-frontend/src/app/common/component/chart/type/label-chart/label-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/label-chart/label-chart.component.ts
@@ -598,7 +598,7 @@ export class LabelChartComponent extends BaseChart implements OnInit, OnDestroy,
         timeField.alias = fields[idx].alias;
         //timeField.granularity = fields[idx].granularity;
         timeField.format = {
-          type: "time_custom",
+          type: "time_format",
           format: "yyyy-MM-dd HH:mm:ss",
           timeZone: "UTC",
           locale: "en"

--- a/discovery-frontend/src/app/page/chart-style/secondary-indicator.component.ts
+++ b/discovery-frontend/src/app/page/chart-style/secondary-indicator.component.ts
@@ -785,7 +785,7 @@ export class SecondaryIndicatorComponent extends BaseOptionComponent {
     timeField.alias = fields[idx].alias;
     timeField.granularity = fields[idx].granularity;
     timeField.format = {
-      type: "time_custom",
+      type: "time_format",
       format: "yyyy-MM-dd HH:mm:ss",
       timeZone: "UTC",
       locale: "en"

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/data/DataQueryController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/data/DataQueryController.java
@@ -277,7 +277,7 @@ public class DataQueryController {
                                                             timeUnit.name(),
                                                             null, false,
                                                             Lists.newArrayList(
-                                                                timeUnit.parsedDateTime(dateTime, timeUnit.sortFormat(), null)
+                                                                timeUnit.parsedDateTime(dateTime, timeUnit.format(), null)
                                                             ),
                                                             null);
 


### PR DESCRIPTION
### Description
TImeFiled의 type을 서버 변경에 맞게 `time_format` 으로 수정

**Related Issue** : <!--- Please link to the issue here. -->
#516 

### How Has This Been Tested?
KPI Chart에서 Secondary Index 설정 시 스크립트 에러 발생하지 않고, 데이터가 나타남

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] My code follows the code style of this project. _it will be added soon_
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document. _it will be added soon_
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
