### PR TITLE
#629 In the case of series by dimension, the tooltip representation is incorrect

### DIFF
--- a/discovery-frontend/src/app/common/component/chart/option/converter/format-option-converter.ts
+++ b/discovery-frontend/src/app/common/component/chart/option/converter/format-option-converter.ts
@@ -812,8 +812,8 @@ export class FormatOptionConverter {
       case ChartType.LINE:
       case ChartType.COMBINE:
         // when bar, line chart has single series
-        if ((chartType === ChartType.BAR && pivot.aggregations.length <= 1 && pivot.rows.length < 1) ||
-          ((chartType === ChartType.LINE || chartType === ChartType.COMBINE) && pivot.aggregations.length <= 1)) {
+        if (((chartType === ChartType.BAR || chartType === ChartType.LINE) && pivot.aggregations.length <= 1 && pivot.rows.length < 1) ||
+          (chartType === ChartType.COMBINE && pivot.aggregations.length <= 1)) {
           displayTypes[0] = UIChartDataLabelDisplayType.CATEGORY_NAME;
           displayTypes[1] = UIChartDataLabelDisplayType.CATEGORY_VALUE;
           // when bar, line chart has multi series


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
라인차트에서 교차선반에 추가된 dimension으로 시리즈가 생성될때 툴팁에 잘못된 값이 노출되고 있음

**Related Issue** : #629 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
1. 차트화면에서 라인차트를 선택합니다.
2. 열선반에 dimension, 교차선반에 measure와 dimension을 추가합니다.
3. 툴팁을 확인시 툴팁표현이 중복되게 나오지 않는지 확인합니다.
<!--- Please describe in detail how you tested your changes. -->


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
