### PR TITLE
#395 handle duplicate column name for mysql

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcCSVWriter.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcCSVWriter.java
@@ -147,6 +147,11 @@ public class JdbcCSVWriter extends CsvResultSetWriter implements ICsvResultSetWr
     super.writeRow(headers);
   }
 
+  public void writeHeaders(List<String> headerList) throws SQLException, IOException {
+    super.incrementRowAndLineNo(); // This will allow the correct row/line numbers to be used in any exceptions
+    super.writeRow(headerList);
+  }
+
   private void writeContents(ResultSet resultSet) throws SQLException, IOException {
     final int numberOfColumns = resultSet.getMetaData().getColumnCount();
     final List<Object> objects = new LinkedList<Object>();

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/QueryEditorService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/QueryEditorService.java
@@ -60,6 +60,7 @@ import java.sql.Statement;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static app.metatron.discovery.domain.workbench.WorkbenchErrorCodes.CSV_FILE_NOT_FOUND;
 
@@ -403,15 +404,21 @@ public class QueryEditorService {
     String tempFileName = generateTempCSVFileName(csvBaseDir, queryEditorId, queryIndex);
     LOGGER.debug("writeResultSetToCSV csvBaseDir : {}", csvBaseDir);
     LOGGER.debug("writeResultSetToCSV tempFileName : {}", tempFileName);
-    int rowNumber = jdbcConnectionService.writeResultSetToCSV(resultSet, csvBaseDir + tempFileName);
 
     //2. get field info from resultset
     List<Field> fieldList = jdbcConnectionService.getFieldList(resultSet, false);
 
-    //3. get data list from csv file
+    //3. write csv
+    int rowNumber = jdbcConnectionService.writeResultSetToCSV(
+            resultSet,
+            csvBaseDir + tempFileName,
+            fieldList.stream().map(field -> field.getName()).collect(Collectors.toList()));
+
+
+    //4. get data list from csv file
     List<Map<String, Object>> dataList = readCsv(csvBaseDir + tempFileName, fieldList, 0, pageSize);
 
-    //4. generate Query Result
+    //5. generate Query Result
     QueryResult queryResult = new QueryResult();
     queryResult.setRunQuery(query);
     queryResult.setFields(fieldList);


### PR DESCRIPTION
### Description
handle duplicate column name for mysql

**Related Issue** : <!--- Please link to the issue here. -->
#395 

### How Has This Been Tested?
1. goto mysql workbench
2. execute query with duplicate column
select * from polaris.book a join polaris.book b on a.id = b.id
3. see grid

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
