### PR TITLE
Error in querying a specific column statistics in data source

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/engine/model/SegmentMetaDataResponse.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/engine/model/SegmentMetaDataResponse.java
@@ -87,6 +87,8 @@ public class SegmentMetaDataResponse implements Serializable {
    */
   Granularity segmentGranularity;
 
+  String errorMessage;
+
 
   public SegmentMetaDataResponse() {
   }
@@ -100,7 +102,8 @@ public class SegmentMetaDataResponse implements Serializable {
                          @JsonProperty("numRows") Long numRows,
                          @JsonProperty("ingestedNumRows") Long ingestedNumRows,
                          @JsonProperty("queryGranularity") Granularity queryGranularity,
-                         @JsonProperty("segmentGranularity") Granularity segmentGranularity) {
+                         @JsonProperty("segmentGranularity") Granularity segmentGranularity,
+                         @JsonProperty("errorMessage") String errorMessage) {
 
     this.id = id;
     this.intervals = intervals;
@@ -111,6 +114,7 @@ public class SegmentMetaDataResponse implements Serializable {
     this.ingestedNumRows = ingestedNumRows;
     this.queryGranularity = queryGranularity;
     this.segmentGranularity = segmentGranularity;
+    this.errorMessage = errorMessage;
   }
 
   public List<DateTime> extractMinMaxTime() {
@@ -162,6 +166,10 @@ public class SegmentMetaDataResponse implements Serializable {
           SegmentMetaDataResponse.ColumnInfo info = this.columns.get(key);
           field = new Field(key, DataType.engineToFieldDataType(info.getType()), seq++);
         }
+      }
+
+      if (this.columns.get(key).getErrorMessage() != null){
+        field.setUnloaded(true);
       }
       convertedFields.add(field);
     }
@@ -236,6 +244,10 @@ public class SegmentMetaDataResponse implements Serializable {
     this.queryGranularity = queryGranularity;
   }
 
+  public String getErrorMessage() { return errorMessage; }
+
+  public void setErrorMessage(String errorMessage) { this.errorMessage = errorMessage; }
+
   public static SegmentMetaDataResponse empty() {
     SegmentMetaDataResponse data = new SegmentMetaDataResponse();
     data.setId("");
@@ -259,6 +271,7 @@ public class SegmentMetaDataResponse implements Serializable {
         ", ingestedNumRows=" + ingestedNumRows +
         ", queryGranularity=" + queryGranularity +
         ", segmentGranularity=" + segmentGranularity +
+        ", errorMessage=" + errorMessage +
         '}';
   }
 
@@ -294,6 +307,8 @@ public class SegmentMetaDataResponse implements Serializable {
      */
     Object maxValue;
 
+    String errorMessage;
+
     public ColumnInfo() {
     }
 
@@ -303,13 +318,16 @@ public class SegmentMetaDataResponse implements Serializable {
                       @JsonProperty("serializedSize") Long size,
                       @JsonProperty("nullCount") Long nullCount,
                       @JsonProperty("minValue") Object minValue,
-                      @JsonProperty("maxValue") Object maxValue) {
+                      @JsonProperty("maxValue") Object maxValue,
+                      @JsonProperty("errorMessage") String errorMessage
+                      ) {
       this.type = type;
       this.cardinality = cardinality;
       this.size = size;
       this.nullCount = nullCount;
       this.minValue = minValue;
       this.maxValue = maxValue;
+      this.errorMessage = errorMessage;
     }
 
     public String getType() {
@@ -328,6 +346,10 @@ public class SegmentMetaDataResponse implements Serializable {
       this.cardinality = cardinality;
     }
 
+    public String getErrorMessage() { return errorMessage; }
+
+    public void setErrorMessage(String errorMessage) { this.errorMessage = errorMessage; }
+
     @Override
     public String toString() {
       return "ColumnInfo{" +
@@ -337,6 +359,7 @@ public class SegmentMetaDataResponse implements Serializable {
           ", nullCount=" + nullCount +
           ", minValue=" + minValue +
           ", maxValue=" + maxValue +
+          ", errorMessage = " + errorMessage +
           '}';
     }
   }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Colomn statistics in datasource error when has anomally ingeted column.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#710 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

(Druid)
1. 데이터 소스 적재
2. segmentmeta 쿼리 결과에 error를 포함하도록 append
    > 처음 적재한 스펙과 다르게 (dimension <-> metric)을 변경하여 새로운 세그멘트 생성 

(Discovery)
3. 데이터소스 > 새로운 데이터소스 생성 > 메타트론 엔진
4. 위에서 만든 error를 포함한 데이터 소스 import

정상적으로 데이터소스가 생성되고, 
데이터소스 상세 > 컬럼상세조회를 하면 에러가 발생한 컬럼은 조회되지 않아야 함

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
