### PR TITLE
#845 Fix shorten rule string function for window rule

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformRuleService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformRuleService.java
@@ -112,6 +112,11 @@ public class PrepTransformRuleService {
         return Strings.join((List) val, ", ");
       }
 
+      Object func = map.get("functions");
+      if(func instanceof List) {
+        return nodeToString(func);
+      }
+
       return map.get("value").toString();
     }
 
@@ -363,8 +368,8 @@ public class PrepTransformRuleService {
 
         // N columns
         String strColumns = "a new column";
-        if (val instanceof List) {
-          strColumns = ((List) val).size() + " columns";
+        if (((Map) val).size() == 1) {
+          strColumns = ((Map) val).size() + " columns";
         }
 
         // order


### PR DESCRIPTION
### Description
A null pointer error occurs when there is more than one expression in the window rule.
This error caused by shortenRuleString function which do not capable parsing Window rule.
This commit will fix this problem.


**Related Issue** : <!--- Please link to the issue here. -->
https://github.com/metatron-app/metatron-discovery/issues/845


### How Has This Been Tested?
1. go to preparation
2. add a window rule like this :
![image](https://user-images.githubusercontent.com/8232266/48925496-68fcaf00-ef07-11e8-84fa-fb9ba5aa9ab1.png)
3. Also test single function window rule


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
