### PR TITLE
#738 properties projection use only JdbcDataConnection

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/DataConnectionProjections.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/DataConnectionProjections.java
@@ -19,8 +19,6 @@ import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.rest.core.config.Projection;
 
-import java.util.Map;
-
 /**
  * Created by kyungtaak on 2016. 11. 12..
  */
@@ -73,7 +71,7 @@ public class DataConnectionProjections {
 
     DateTime getModifiedTime();
 
-    @Value("#{target.getPropertiesMap()}")
+    @Value("#{target instanceof T(app.metatron.discovery.domain.datasource.connection.jdbc.JdbcDataConnection) ? target.getPropertiesMap() : null}")
     Object getProperties();
   }
 


### PR DESCRIPTION
### Description
There was an error in the projection process when adding the properteis of dataconnection.
Modified to handle projection for properteis only in case of JDBCDataConnection.
<img width="851" alt="2018-11-22 4 07 04" src="https://user-images.githubusercontent.com/3770446/48925530-efb18c00-ef07-11e8-8279-fab08d618068.png">

**Related Issue** : <!--- Please link to the issue here. -->
#738  

### How Has This Been Tested?
1. goto workbench
2. global variable create, update, delete without error.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
