### PR TITLE
#865 edit LNB area in full screen of editor

### DIFF
--- a/discovery-frontend/src/app/workbench/workbench.component.html
+++ b/discovery-frontend/src/app/workbench/workbench.component.html
@@ -104,7 +104,8 @@
     <!-- lnb --->
     <div class="sys-workbench-lnb-panel ddp-ui-benchlnb"
          [ngClass]="{
-         'ddp-close':!isLeftMenuOpen || isQueryEditorFull,
+         'ddp-close':!isLeftMenuOpen,
+         'ddp-none':isQueryEditorFull,
          'ddp-fold' : !isOpenTableSchema && isLeftMenuOpen && !isQueryEditorFull }"
          style="width:20%;">
       <div class="ddp-view-benchlnb" >

--- a/discovery-frontend/src/assets/css/polaris.v2.page.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.page.css
@@ -6262,6 +6262,7 @@ ul.ddp-ui-tab.ddp-type li .ddp-box-layout4.ddp-information a {padding:0px; borde
 .ddp-wrap-workbench .ddp-ui-benchlnb.ddp-fold .ddp-ui-benchtable {display:none;}
 .ddp-wrap-workbench .ddp-ui-benchlnb .ddp-view-benchlnb {position:relative; float:left; height:100%; width:55%;}
 .ddp-ui-benchlnb.ddp-close {width:9px ;}
+.ddp-ui-benchlnb.ddp-none {display:none;}
 .ddp-ui-benchlnb.ddp-close .ddp-view-benchlnb {width:9px;}
 .ddp-ui-benchlnb.ddp-close .ddp-box-benchlnb {display:none;}
 .ddp-ui-benchlnb.ddp-close .ddp-ui-benchtable {display:none;}
@@ -6549,7 +6550,7 @@ table.ddp-table-simple tr td .ddp-ui-time {width:100%; color:#90969f; font-size:
 .ddp-ui-query {display:table-cell; position:relative; padding:0 13px 11px 2px; z-index:5; vertical-align:top; box-sizing:border-box;}
 /*.ddp-ui-query.ddp-tablepop {left:500px}*/
 /*.ddp-ui-query.ddp-full {left:13px;}*/
-.ddp-box-editer.ddp-full {position:fixed !important; left:26px !important; right:64px !important; bottom:2px !important; top:101px !important; height:auto !important; background-color:#fff; z-index:15;}
+.ddp-box-editer.ddp-full {position:fixed !important; left:13px !important; right:64px !important; bottom:2px !important; top:101px !important; height:auto !important; background-color:#fff; z-index:15;}
 .ddp-box-editer.ddp-full .ddp-box-full {display:none;}
 .ddp-box-editer.ddp-full .ddp-box-reduce {display:block;}
 .ddp-box-editer {position:absolute; top:0; left:12px; right:13px; bottom:60%; padding-bottom:33px; border:1px solid #ddd; background-color:#fff; overflow:hidden;}


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
워크벤치화면에서 에디터 전체화면 시 LNB open 영역이 나타납니다. 

**Related Issue** : #865  <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 워크벤치화면으로 이동합니다. 
2. 에디터 전체 화면 버튼을 클릭합니다. 
3. 왼쪽의 LNB 영역이 숨겨졌는지 확인합니다. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
