### PR TITLE
#868 Fix new column counting logic for window rule

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformRuleService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformRuleService.java
@@ -369,7 +369,8 @@ public class PrepTransformRuleService {
         // N columns
         String strColumns = "a new column";
         if (((Map) val).size() == 1) {
-          strColumns = ((Map) val).size() + " columns";
+          List functions = (List) ((Map) val).get("functions");
+          strColumns = functions.size() + " columns";
         }
 
         // order


### PR DESCRIPTION
### Description
For window rule, a shortened rule string is always generated as one "1 columns" added.

**Related Issue** : <!--- Please link to the issue here. -->
https://github.com/metatron-app/metatron-discovery/issues/868


### How Has This Been Tested?
1. Go to preparation
2. Add window rule with more than 2 expressions.
3. Apply it.
4. See shortened rule string.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
