### PR TITLE
Show only enabled datasources

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourcePredicate.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourcePredicate.java
@@ -107,7 +107,7 @@ public class DataSourcePredicate {
     BooleanExpression published = dataSource.id
         .in(JPAExpressions.select(dataSource.id)
                           .from(dataSource)
-                          .where(dataSource.published.eq(true)));
+                          .where(dataSource.published.eq(true), dataSource.status.eq(DataSource.Status.ENABLED)));
 
     BooleanBuilder builder = new BooleanBuilder();
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourcePredicate.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourcePredicate.java
@@ -118,7 +118,7 @@ public class DataSourcePredicate {
           .in(JPAExpressions.select(dataSource.id)
                             .from(dataSource)
                             .innerJoin(dataSource.workspaces)
-                            .where(dataSource.workspaces.any().eq(workspace)));
+                            .where(dataSource.workspaces.any().eq(workspace), dataSource.status.eq(DataSource.Status.ENABLED)));
       builder.andAnyOf(workspaceContains, published);
     }
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
워크북. 대시보드 생성 시에, PREPARING이나 FAIL 상태인 데이터소스도 리스트에 나타나며 선택 가능합니다.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 워크북 > 대시보드 생성
2. 사용할 수 없는 데이터 소스 목록이 조회되지 않아야 함

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Additional Context<!-- if not appropriate, remove this topic. -->
