### PR TITLE
#872 make the lower layer code of the suppression throws only Excepti…

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/exceptions/PrepException.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/exceptions/PrepException.java
@@ -93,6 +93,7 @@ public class PrepException extends MetatronException {
         return new PrepException(code, messageKey.getMessageKey(), detail);
     }
 
+    // FIXME: convert all TeddyException into PrepException WITH the detail messages.
     static public PrepException fromTeddyException(TeddyException e) {
         if (e instanceof CannotCastFromException)
             return create(PrepErrorCodes.PREP_TEDDY_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_TEDDY_CANNOT_CAST_FROM);

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DataFrame.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DataFrame.java
@@ -1337,11 +1337,12 @@ public class DataFrame implements Serializable, Transformable {
     });
   }
 
-  protected List<Row> filter2(DataFrame prevDf, Expression condExpr, boolean keep, int offset, int length) throws TeddyException {
+  protected List<Row> filter2(DataFrame prevDf, Expression condExpr, boolean keep, int offset, int length) throws NoAssignmentStatementIsAllowedException, ColumnNotFoundException {
     List<Row> rows = new ArrayList<>();
 
-    if(condExpr instanceof Expr.BinAsExpr)
-      throw PrepException.fromTeddyException(new NoAssignmentStatementIsAllowedException(condExpr.toString()));
+    if(condExpr instanceof Expr.BinAsExpr) {
+      throw new NoAssignmentStatementIsAllowedException(condExpr.toString());
+    }
 
     for (int rowno = offset; rowno < offset + length; rowno++) {
       try {
@@ -1349,7 +1350,7 @@ public class DataFrame implements Serializable, Transformable {
           rows.add(prevDf.rows.get(rowno));
         }
       } catch (Exception e) {
-        throw PrepException.fromTeddyException(new ColumnNotFoundException(e.getMessage()));
+        throw new ColumnNotFoundException(e.getMessage());    // FIXME: throw a better exception based on e
       }
     }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
@@ -680,11 +680,7 @@ public class PrepTransformService {
 
     for (int i = 1; i < ruleStrings.size(); i++) {
       String ruleString = ruleStrings.get(i);
-      try {
-        gridResponse = teddyImpl.append(dsId, i - 1, ruleString, true);
-      } catch (TeddyException te) {
-        LOGGER.info("load_internal(): A TeddyException is suppressed: {}", te.getMessage());
-      }
+      gridResponse = teddyImpl.append(dsId, i - 1, ruleString, true);
     }
     updateTransformRules(dsId);
     adjustStageIdx(dsId, ruleStrings.size() - 1, true);

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/TeddyImpl.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/TeddyImpl.java
@@ -143,7 +143,7 @@ public class TeddyImpl {
   }
 
   // APPEND *AFTER* stageIdx
-  public DataFrame append(String dsId, int stageIdx, String ruleString, boolean forced) throws TeddyException {
+  public DataFrame append(String dsId, int stageIdx, String ruleString, boolean forced) {
     Revision rev = getCurRev(dsId);     // rule apply == revision generate, so always use the last one.
     Revision newRev = new Revision(rev, stageIdx + 1);
     DataFrame newDf = null;
@@ -153,9 +153,10 @@ public class TeddyImpl {
       newDf = apply(rev.get(stageIdx), ruleString);
     } catch (TeddyException te) {
       if (forced == false) {
-        throw te;
+        throw PrepException.fromTeddyException(te);   // RuntimeException
       }
       suppressed = true;
+      LOGGER.info("append(): TeddyException is suppressed: {}", te.getMessage());
     }
 
     if (suppressed) {


### PR DESCRIPTION
### Description
Make the lower layer code of the suppression throws only Exceptions not RuntimeExceptions.

**Related Issue** : https://github.com/metatron-app/metatron-discovery/issues/872


### How Has This Been Tested?
Run locally.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
