### PR TITLE
#846 fix error download  included user-defined field widget

### DIFF
--- a/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.html
+++ b/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.html
@@ -481,7 +481,7 @@
             </li>
           </ul>
           <!-- right -->
-          <div class="ddp-ui-rightoption ddp-type-option">
+          <div *ngIf="!isCanNotDownAggr" class="ddp-ui-rightoption ddp-type-option">
             <!-- 클릭시 ddp-selected 추가 : 팝업 show 됨 -->
             <div (click)="showDownloadLayer($event)" class="ddp-box-btn2 ddp-box-selected ddp-selected">
               <a href="javascript:" class="ddp-link-txt">
@@ -514,7 +514,13 @@
               </div>
             </div>
             <!-- 그리드 -->
-            <div #dataGrid grid-component class="ddp-ui-grid2" style="top:44px;"></div>
+            <div *ngIf="!isCanNotDownAggr" #dataGrid grid-component class="ddp-ui-grid2" style="top:44px;"></div>
+            <div *ngIf="isCanNotDownAggr" class="ddp-ui-grid2 ddp-type">
+              <div class="ddp-ui-error-message">
+                {{ 'msg.board.ui.cant-not-down-aggregate' | translate }}
+              </div>
+            </div>
+
             <!-- //그리드 -->
           </div>
           <!-- //tab contents -->

--- a/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
+++ b/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
@@ -971,8 +971,6 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
     this.isOriginDown = isOriginal;
     this.widgetService.previewWidget(this.widget.id, isOriginal, false).then(result => {
 
-
-
       let fields = [];
       const clonePivot: Pivot = _.cloneDeep(this.widgetConfiguration.pivot);
       (clonePivot.rows) && (fields = fields.concat(clonePivot.rows));
@@ -981,7 +979,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
       // 헤더정보 생성
       const headers: header[]
         = fields.map((field: Field) => {
-        const logicalType:string = field['field'] ? field['field'].logicalType.toString() : '';
+        const logicalType:string = ( field['field'] && field['field'].logicalType ) ? field['field'].logicalType.toString() : '';
         let headerName: string = field.name;
         if( field['aggregationType'] ) {
           if( !isOriginal ) {

--- a/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
+++ b/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
@@ -174,6 +174,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
   // is Origin data down
   public isOriginDown: boolean = false;
   public srchText:string;
+  public isCanNotDownAggr:boolean = false;
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Public Variables - Input & Output
@@ -967,15 +968,24 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
    */
   public drawDataGrid(isOriginal: boolean = false) {
 
-    this.loadingShow();
     this.isOriginDown = isOriginal;
+    this.isCanNotDownAggr = false;
+
+    let fields = [];
+    const clonePivot: Pivot = _.cloneDeep(this.widgetConfiguration.pivot);
+    (clonePivot.rows) && (fields = fields.concat(clonePivot.rows));
+    (clonePivot.columns) && (fields = fields.concat(clonePivot.columns));
+    (clonePivot.aggregations) && (fields = fields.concat(clonePivot.aggregations));
+
+    if( isOriginal && fields.some((field: Field) => ( field['field'] && field['field'].aggregated ) ) ) {
+      this.isCanNotDownAggr = true;
+      this.safelyDetectChanges();
+      return false;
+    }
+
+    this.loadingShow();
     this.widgetService.previewWidget(this.widget.id, isOriginal, false).then(result => {
 
-      let fields = [];
-      const clonePivot: Pivot = _.cloneDeep(this.widgetConfiguration.pivot);
-      (clonePivot.rows) && (fields = fields.concat(clonePivot.rows));
-      (clonePivot.columns) && (fields = fields.concat(clonePivot.columns));
-      (clonePivot.aggregations) && (fields = fields.concat(clonePivot.aggregations));
       // 헤더정보 생성
       const headers: header[]
         = fields.map((field: Field) => {

--- a/discovery-frontend/src/assets/css/polaris.v2.page.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.page.css
@@ -6673,6 +6673,7 @@ table.ddp-table-simple tr td .ddp-ui-time {width:100%; color:#90969f; font-size:
 .ddp-wrap-editor {position:absolute; top:33px; left:0; right:0; bottom:41px; background-color:#fff; text-align:left; z-index:10; }
 .ddp-ui-empty {padding:18px 20px; color:#b7b9c3; font-size:12px;}
 
+.ddp-ui-error-message {padding:15px 15px; color:#e70000; font-size:12px;}
 .ddp-box-editer a.ddp-btn-beautifier {position:relative; float:left; width:32px; height:32px;  background:rgba(75,81,91,0.05); margin-right:2px;}
 .ddp-box-editer a.ddp-btn-beautifier:hover .ddp-ui-tooltip-info {display:block;}
 .ddp-box-editer a.ddp-btn-beautifier:before {display:inline-block; content:''; position:absolute; top:50%; left:50%; width:21px; height:18px; margin:-10px 0 0 -9px; background:url(../images/icon_query.png) no-repeat; background-position:left -70px;}

--- a/discovery-frontend/src/assets/i18n/en.json
+++ b/discovery-frontend/src/assets/i18n/en.json
@@ -1508,7 +1508,7 @@
   "msg.board.error.missing-field" : "Field information is missing.",
   "msg.board.unload.title" : "Dashboard can not be loaded",
   "msg.board.unload.desc" : "We can not draw your dashboard for an unknown reason.<br>Please try again",
-
+  "msg.board.ui.cant-not-down-aggregate" : "Original view cannot be supported for custom columns with aggregate functions",
 
   "msg.storage.btn.create.dsource": "Create new datasource",
   "msg.storage.ui.dsource.search.description": "Search by name of datasource",

--- a/discovery-frontend/src/assets/i18n/ko.json
+++ b/discovery-frontend/src/assets/i18n/ko.json
@@ -2533,7 +2533,7 @@
   "msg.page.layer.map.clustering": "클러스터링",
   "msg.page.layer.map.stroke.max.width": "굵기 최대값",
   "msg.page.layer.map.view": "원본보기",
-  "msg.age.format.format.title": "표시 형식",
+  "msg.page.format.format.title": "표시 형식",
   "msg.page.format.xaxis.rotation": "{{value}} 도",
   "msg.page.format.custom.symbol": "사용자 기호 설정",
   "msg.page.format.custom.symbol.enter": "사용자 기호 입력",

--- a/discovery-frontend/src/assets/i18n/ko.json
+++ b/discovery-frontend/src/assets/i18n/ko.json
@@ -1507,6 +1507,7 @@
   "msg.board.error.missing-field" : "필드 정보가 없습니다.",
   "msg.board.unload.title" : "대시보드를 불러올 수 없습니다.",
   "msg.board.unload.desc" : "알수없는 이유로 대시보드를 불러올 수 없습니다.<br>다시 시도해주세요",
+  "msg.board.ui.cant-not-down-aggregate" : "집계함수가 포함된 컬림이 있어서 원본보기를 지원할 수 없습니다.",
 
   "msg.storage.btn.create.dsource": "새로운 데이터소스 생성",
   "msg.storage.ui.dsource.search.description": "데이터소스 이름으로 검색해 주세요",

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/data/SearchQueryRequest.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/data/SearchQueryRequest.java
@@ -17,6 +17,20 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specic language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -310,6 +324,11 @@ public class SearchQueryRequest extends AbstractQueryRequest implements QueryReq
         MeasureField measureField = (MeasureField) field;
         measureField.setAggregationType(MeasureField.AggregationType.NONE);
         measureField.setAlias(measureField.getName());
+        this.projections.add(field);
+      } else if(field instanceof MeasureField
+          && UserDefinedField.REF_NAME.equals(field.getRef())) {
+        // follow ui rule
+        field.setAlias(((MeasureField) field).getUserDefinedAlias());
         this.projections.add(field);
       } else {
         this.projections.add(field);

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/data/SearchQueryRequest.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/data/SearchQueryRequest.java
@@ -3,6 +3,20 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specic language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -286,19 +300,17 @@ public class SearchQueryRequest extends AbstractQueryRequest implements QueryReq
       projections = Lists.newArrayList();
     }
 
-    List<Field> fields = pivot.getAllFields();
+    if(original && checkAggregatedExpressionField()) {
+      throw new QueryTimeExcetpion("original data do not allow aggregated user-defined field.");
+    }
 
-    for(Field field : fields) {
+    for(Field field : pivot.getAllFields()) {
       if(original && field instanceof MeasureField) {
         // 측정값 필드는 집계를 포함하지 않도록 처리
         MeasureField measureField = (MeasureField) field;
         measureField.setAggregationType(MeasureField.AggregationType.NONE);
         measureField.setAlias(measureField.getName());
         this.projections.add(field);
-      } else if(original &&
-          (field instanceof ExpressionField) && ((ExpressionField) field).isAggregated()) {
-        // 원본 데이터일 경우 표현식중 집계가 있는 표현식은 제외
-        continue;
       } else {
         this.projections.add(field);
       }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/field/MeasureField.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/field/MeasureField.java
@@ -3,6 +3,20 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specic language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -159,6 +173,23 @@ public class MeasureField extends Field {
         alias = getColunm();
       } else {
         alias = aggregationType.name() + "(" + getColunm() + ")";
+      }
+    }
+
+    return alias;
+  }
+
+  /**
+   * for following ui naming rule case of user-defined field
+   * @return
+   */
+  public String getUserDefinedAlias() {
+
+    if (StringUtils.isEmpty(alias)) {
+      if(aggregationType == null || aggregationType == NONE) {
+        alias = name;
+      } else {
+        alias = aggregationType.name() + "(" + name + ")";
       }
     }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/widget/WidgetController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/widget/WidgetController.java
@@ -3,6 +3,20 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specic language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -14,7 +28,6 @@
 
 package app.metatron.discovery.domain.workbook.widget;
 
-import app.metatron.discovery.util.HttpUtils;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
@@ -73,6 +86,7 @@ import app.metatron.discovery.domain.workbook.configurations.filter.Filter;
 import app.metatron.discovery.domain.workbook.configurations.filter.InclusionFilter;
 import app.metatron.discovery.domain.workbook.configurations.widget.PageWidgetConfiguration;
 import app.metatron.discovery.util.AuthUtils;
+import app.metatron.discovery.util.HttpUtils;
 
 import static app.metatron.discovery.config.ApiResourceConfig.REDIRECT_PATH_URL;
 import static java.util.stream.Collectors.toList;
@@ -241,8 +255,8 @@ public class WidgetController {
       throw new BadRequestException("Page widget configuration required.");
     }
 
-    if(maxRowsPerSheet > 10000000) {
-      throw new BadRequestException("Not allowed row count. max 10,000,000");
+    if(maxRowsPerSheet > 1000000) {
+      throw new BadRequestException("Not allowed row count. max 1,000,000");
     }
 
     SearchQueryRequest searchQuery = getQueryRequestFromConfig(null,
@@ -431,7 +445,7 @@ public class WidgetController {
 
     // Add Page Configuration
     if(pageConfiguration.getFilters() != null) filters.addAll(pageConfiguration.getFilters());
-    if(pageConfiguration.getFields() != null) userDefinedFields.addAll(pageConfiguration.getFields());
+    //if(pageConfiguration.getFields() != null) userDefinedFields.addAll(pageConfiguration.getFields());
 
     // Set field alias
     for(app.metatron.discovery.domain.workbook.configurations.field.Field field : pivot.getAllFields()) {
@@ -453,6 +467,7 @@ public class WidgetController {
     // Create search query request
     SearchQueryRequest queryRequest = new SearchQueryRequest();
     queryRequest.setDataSource(dataSource);
+    queryRequest.setUserFields(userDefinedFields);
     queryRequest.setFilters(filters);
     queryRequest.setProjections(pageConfiguration.getPivot(), isOriginal);
     queryRequest.setResultFormat(resultFormat);

--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/queries/SelectQueryBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/queries/SelectQueryBuilder.java
@@ -17,6 +17,20 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specic language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -125,7 +139,8 @@ public class SelectQueryBuilder extends AbstractQueryBuilder {
         if(reqField instanceof DimensionField) {
           dimensions.add(new DefaultDimension(fieldName, aliasName));
         } else {
-          metrics.add(fieldName);
+          virtualColumns.put(aliasName, new ExprVirtualColumn(fieldName, aliasName));
+          metrics.add(aliasName);
         }
         unUsedVirtualColumnName.remove(fieldName);
         continue;


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
사용자 정의 필드가 포함된 위젯에서 다운로드 팝업이 정상적으로 표시 되지 않음

**Related Issue** : #240 #846 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 사용자 정의 필드가 포함된 위젯을 생성한다.
2. 대시보드 열람화면에서 데이터 다운로드를 실행하여 정상적으로 미리보기가 표시되고 다운로드가 이루어지는지 확인한다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
