### PR TITLE
#874 fix Workbench LNB screen related issues

### DIFF
--- a/discovery-frontend/src/app/workbench/component/detail-workbench/detail-workbench-database/detail-workbench-database.html
+++ b/discovery-frontend/src/app/workbench/component/detail-workbench/detail-workbench-database/detail-workbench-database.html
@@ -22,14 +22,16 @@
     <!-- box layout -->
     <div class="ddp-box-layout4" *ngIf="isDatabaseSearchShow" (click)="$event.stopImmediatePropagation()">
       <!-- search -->
-      <div class="ddp-form-search">
-        <em class="ddp-icon-search"></em>
-        <input
-          #inputSearch
-          [ngModel]="searchText"
-          (keypress)="onSearchDatabase($event)" (keyup.esc)="onSearchDatabaseInit()"
-          type="text" placeholder="{{'msg.bench.ui.db.name.search'|translate}}" >
-        <em *ngIf="isShowBtnClear()" (click)="onSearchDatabaseInit()" class="ddp-btn-search-close" ></em>
+      <div class="ddp-wrap-search">
+        <div class="ddp-form-search">
+          <em class="ddp-icon-search"></em>
+          <input
+            #inputSearch
+            [ngModel]="searchText"
+            (keypress)="onSearchDatabase($event)" (keyup.esc)="onSearchDatabaseInit()"
+            type="text" placeholder="{{'msg.bench.ui.db.name.search'|translate}}" >
+          <em *ngIf="isShowBtnClear()" (click)="onSearchDatabaseInit()" class="ddp-btn-search-close" ></em>
+        </div>
       </div>
       <!-- //search -->
       <div class="ddp-ui-list-type">

--- a/discovery-frontend/src/app/workbench/component/detail-workbench/detail-workbench-dataconnection-info/detail-workbench-dataconnection-info.ts
+++ b/discovery-frontend/src/app/workbench/component/detail-workbench/detail-workbench-dataconnection-info/detail-workbench-dataconnection-info.ts
@@ -16,6 +16,7 @@ import { Component, ElementRef, EventEmitter, Injector, Input, OnDestroy, OnInit
 import { AbstractComponent } from '../../../../common/component/abstract.component';
 import { Dataconnection } from '../../../../domain/dataconnection/dataconnection';
 import { StringUtil } from '../../../../common/util/string.util';
+import {isNullOrUndefined} from 'util';
 
 @Component({
   selector: 'detail-workbench-dataconnection-info',
@@ -61,6 +62,10 @@ export class DetailWorkbenchDataconnectionInfo extends AbstractComponent impleme
 
   public ngOnInit(): void {
     console.info('dataconnection', this.dataconnection);
+    // 권한 정보가 없을 경우
+    if( isNullOrUndefined(this.dataconnection.authenticationType)  ){
+      this.dataconnection.authenticationType = 'MANUAL';
+    }
   }
 
   public ngOnDestroy() {

--- a/discovery-frontend/src/app/workbench/workbench.component.html
+++ b/discovery-frontend/src/app/workbench/workbench.component.html
@@ -108,7 +108,7 @@
          'ddp-none':isQueryEditorFull,
          'ddp-fold' : !isOpenTableSchema && isLeftMenuOpen && !isQueryEditorFull }"
          style="width:20%;">
-      <div class="ddp-view-benchlnb" >
+      <div class="ddp-view-benchlnb" [ngStyle]="{'min-width': isLeftMenuOpen ? '260px;':''}">
         <a href="javascript:" class="ddp-btn-folding" (click)="leftMenuOpen()"></a>
         <div class="ddp-box-benchlnb">
           <!-- wrap name -->

--- a/discovery-frontend/src/app/workbench/workbench.component.ts
+++ b/discovery-frontend/src/app/workbench/workbench.component.ts
@@ -2931,6 +2931,7 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
     this._splitHorizontal = Split(['.sys-workbench-lnb-panel', '.sys-workbench-content-panel'], {
       direction: 'horizontal',
       sizes: [18, 82],
+      minSize: [230, 300],
       elementStyle: (dimension, size, gutterSize) => {
         return { 'width': `${size}%` };
       },

--- a/discovery-frontend/src/app/workbench/workbench.component.ts
+++ b/discovery-frontend/src/app/workbench/workbench.component.ts
@@ -2931,7 +2931,7 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
     this._splitHorizontal = Split(['.sys-workbench-lnb-panel', '.sys-workbench-content-panel'], {
       direction: 'horizontal',
       sizes: [18, 82],
-      minSize: [230, 300],
+      minSize: [260, 300],
       elementStyle: (dimension, size, gutterSize) => {
         return { 'width': `${size}%` };
       },

--- a/discovery-frontend/src/assets/css/metatron/page/metatron.page.09WorkbenchDetail.css
+++ b/discovery-frontend/src/assets/css/metatron/page/metatron.page.09WorkbenchDetail.css
@@ -36,6 +36,9 @@ html.ddp-width-auto body {min-width:auto;}
 .page-workbench .ddp-tablelist-header .ddp-table-title [class*="ddp-icon-sort"]:before {display:inline-block; position:absolute; top:50%; left:50%; width:7px; height:10px; margin:-5px 0 0 -4px; background:url(../../../images/icon_sorting.png);content:'';}
 .page-workbench .ddp-tablelist-header .ddp-table-title .ddp-icon-sort-asc:before {background-position:-8px top;}
 .page-workbench .ddp-tablelist-header .ddp-table-title .ddp-icon-sort-des:before {background-position:-16px top;}
+.page-workbench .ddp-ui-benchlnb .ddp-data-namesub .ddp-data-in .ddp-wrap-search {padding:0 15px;}
+.page-workbench .ddp-ui-benchlnb .ddp-data-namesub .ddp-data-in .ddp-box-layout4 {width:265px;}
+.page-workbench .ddp-ui-benchlnb .ddp-data-namesub .ddp-data-in .ddp-box-layout4 .ddp-form-search {margin:0; width:100%;}
 
 /**************************************************************
   Page : 워크벤치 상세 (contents)


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
워크벤치 LNB 영역에서 
1. 데이터베이스명 검색시 검색 영역 우측이 잘리는 현상, 
2. 프레스토, mysql 타입일때 브라우저 사이즈 줄이면 정렬깨짐,
3. 커넥션 권한 정보없을 경우 (테스트용 no-auth-conn 커넥션 사용해서 테스트 가능)
위의 부분에 대한 내용을 보완합니다. 

**Related Issue** : #874  <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 워크벤치 화면으로 이동합니다. 
2. 데이터 베이스 명 클릭 시, 검색의 place holder 부분이 짤리는지 확인합니다. 
3. presto, mysql 타입일때 브라우저 사이즈를 줄일 경우 정렬이 깨지는지 확인합니다. 
4. 커넥션 인포메이션 마우스 오버 시, 권한 정보가 없을 경우 기본값이 MANUAL로 표시 되는지 확인합니다. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
