### PR TITLE
#885 skip to add a dataset if it's duplicated

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
@@ -604,7 +604,9 @@ public class PrepTransformService {
     for (PrepDataset dataset : datasets) {
       if (dataset.getDsId().equals(oldDsId)) {
         datasets.remove(dataset);
-        datasets.add(newDataset);
+        if (!datasets.contains(newDataset)) {
+          datasets.add(newDataset);
+        }
         dataflow.setDatasets(datasets);
         dataflowRepository.save(dataflow);
         break;


### PR DESCRIPTION
### Description
If the dataflow already have the dataset, skip to add it.

_Dataflow에 이미 해당되는 dataset이 있는 경우, 추가하지 않음_

**Related Issue** : https://github.com/metatron-app/metatron-discovery/issues/885


### How Has This Been Tested?
Run locally.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
