### PR TITLE
F#890 query history message duplication

### DIFF
--- a/discovery-frontend/src/app/workbench/component/detail-workbench/detail-workbench-history/detail-workbench-history.html
+++ b/discovery-frontend/src/app/workbench/component/detail-workbench/detail-workbench-history/detail-workbench-history.html
@@ -45,11 +45,6 @@
     {{pageResult.totalElements}} Results of '{{completeSearchText}}'
   </div>
   <!-- //검색어 -->
-  <!-- No data -->
-  <div *ngIf="histories.length === 0" class="ddp-nodata">
-    No list
-  </div>
-  <!-- //No data -->
 
   <ul class="ddp-list-history">
     <li *ngFor="let item of histories; let idx = index" (click)="setTableSql(item)">

--- a/discovery-frontend/src/app/workbench/component/detail-workbench/detail-workbench-history/detail-workbench-history.html
+++ b/discovery-frontend/src/app/workbench/component/detail-workbench/detail-workbench-history/detail-workbench-history.html
@@ -39,10 +39,10 @@
 
   <!-- 검색어 -->
   <div class="ddp-data-list-num" *ngIf="completeSearchText === ''">
-    {{pageResult.totalElements}} Results
+    {{pageResult.totalElements}} Result(s)
   </div>
   <div class="ddp-data-list-num" *ngIf="completeSearchText !== ''">
-    {{pageResult.totalElements}} Results of '{{completeSearchText}}'
+    {{pageResult.totalElements}} Result(s) of '{{completeSearchText}}'
   </div>
   <!-- //검색어 -->
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
워크벤치 쿼리 히스토리 팝업에서 목록이 없을경우 의미가 중복된 메세지를 삭제합니다. 

**Related Issue** : #890  <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 워크벤치 화면으로 이동합니다. 
2. 쿼리 히스토리 에서 검색결과가 없을경우,  리스트가 없는경우 'No list' 부분이 제거 되었는지 확인합니다. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
