### PR TITLE
#909 get datasource after inject connection's database

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcConnectionService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcConnectionService.java
@@ -912,7 +912,6 @@ public class JdbcConnectionService {
   }
 
   public JdbcQueryResultResponse selectQueryForIngestion(JdbcDataConnection connection,
-                                                         DataSource dataSource,
                                                          String schema,
                                                          JdbcIngestionInfo.DataType type,
                                                          String query,
@@ -926,6 +925,8 @@ public class JdbcConnectionService {
         connection.setDatabase(schema);
       }
     }
+
+    DataSource dataSource = getDataSource(connection, true);
 
     JdbcQueryResultResponse queryResultSet = null;
 
@@ -962,31 +963,10 @@ public class JdbcConnectionService {
                                                          String schema,
                                                          JdbcIngestionInfo.DataType type,
                                                          String query,
-                                                         List<Map<String, Object>> partitionList,
                                                          int limit,
                                                          boolean extractColumnName) {
-    return selectQueryForIngestion(connection, getDataSource(connection, true),
-            schema, type, query, partitionList, limit, extractColumnName);
+    return selectQueryForIngestion(connection, schema, type, query, null, limit, extractColumnName);
   }
-
-  public JdbcQueryResultResponse selectQueryForIngestion(JdbcDataConnection connection,
-                                                         String schema,
-                                                         JdbcIngestionInfo.DataType type,
-                                                         String query,
-                                                         int limit,
-                                                         boolean extractColumnName) {
-    return selectQueryForIngestion(connection, getDataSource(connection, true),
-                                   schema, type, query, null, limit, extractColumnName);
-  }
-
-//  public JdbcQueryResultResponse selectQueryForIngestion(JdbcDataConnection connection,
-//                                                         String schema,
-//                                                         JdbcIngestionInfo.DataType type,
-//                                                         String query,
-//                                                         int limit) {
-//    return selectQueryForIngestion(connection, getDataSource(connection, true),
-//                                   schema, type, query, null, limit, false);
-//  }
 
   public JdbcQueryResultResponse ddlQuery(JdbcDataConnection connection,
                                           DataSource dataSource,


### PR DESCRIPTION
### Description
An error occurs when previewing data of query type when creating data source.
Fixed an error that occurred when creating a data source before injecting the Connection's Database property.

**Related Issue** : 
#909 

### How Has This Been Tested?
1. create datasource
2. select database
3. select query tab
4. input simple select query without database;
select * from users;
5. see preview without error.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
