### PR TITLE
F#790 multi column split and extract on dataprep

### DIFF
--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-extract.component.html
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-extract.component.html
@@ -17,8 +17,12 @@
     {{'msg.lineage.ui.list.search.column' | translate}}<em class="ddp-icon-essential"></em>
   </div>
   <!-- Select box -->
-  <edit-rule-field-combo [fields]="fields" [selected]="selectedFields" [tabIndex]="2"
-                         (onChange)="changeFields($event)" ></edit-rule-field-combo>
+  <edit-rule-field-combo [isMulti]="true"
+                         [fields]="fields"
+                         [selected]="selectedFields"
+                         [tabIndex]="2"
+                         (onChange)="changeFields($event)">
+  </edit-rule-field-combo>
   <!-- // Select box -->
 </div>
 <!-- //part -->
@@ -45,8 +49,11 @@
         </div>
       </div>
       <div class="ddp-wrap-boxwrap">
-        <input [(ngModel)]="pattern" (focus)="showHidePatternLayer(true)" (blur)="showHidePatternLayer(false)"
-               type="text" tabindex="3" class="ddp-input-typebasic" placeholder="{{ 'msg.dp.th.pattern.ph' | translate }}" >
+        <input [(ngModel)]="pattern"
+               (focus)="showHidePatternLayer(true)"
+               (blur)="showHidePatternLayer(false)"
+               tabindex="3" class="ddp-input-typebasic"
+               placeholder="{{ 'msg.dp.th.pattern.ph' | translate }}">
       </div>
     </div>
   </div>
@@ -60,7 +67,8 @@
   </div>
   <div class="ddp-wrap-datainput">
     <input [(ngModel)]="limit" [input-mask]="'number'"
-           type="text" tabindex="5" class="ddp-input-typebasic" placeholder="{{'msg.dp.ui.extract.ph' | translate}}" >
+          tabindex="4" class="ddp-input-typebasic"
+           placeholder="{{'msg.dp.ui.extract.ph' | translate}}">
   </div>
 </div>
 <!--//part-->
@@ -69,7 +77,9 @@
 <div *ngIf="isShow" class="ddp-box-part ddp-box-s" >
   <div class="ddp-box-title"> {{'msg.dp.th.quote' | translate}} </div>
   <div class="ddp-wrap-datainput">
-    <input [(ngModel)]="ignore" type="text" class="ddp-input-typebasic" tabindex="6" placeholder="{{'msg.dp.ui.enter.value' | translate}}" >
+    <input [(ngModel)]="ignore"
+           class="ddp-input-typebasic"
+           tabindex="5" placeholder="{{'msg.dp.ui.enter.value' | translate}}">
   </div>
 </div>
 <!--//part-->

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-extract.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-extract.component.ts
@@ -19,7 +19,7 @@ import { Alert } from '../../../../../../common/util/alert.util';
 import { StringUtil } from '../../../../../../common/util/string.util';
 import {isNullOrUndefined, isUndefined} from "util";
 import { EventBroadcaster } from '../../../../../../common/event/event.broadcaster';
-import { PreparationCommonUtil } from '../../../../../util/preparation-common.util';
+import * as _ from 'lodash';
 
 @Component({
   selector : 'edit-rule-extract',
@@ -96,31 +96,32 @@ export class EditRuleExtractComponent extends EditRuleComponent implements OnIni
    */
   public getRuleData(): { command: string, ruleString: string } {
 
-    // 컬럼
+    // Column (must select more than one)
     if (0 === this.selectedFields.length) {
       Alert.warning(this.translateService.instant('msg.dp.alert.sel.col'));
       return undefined;
     }
 
-    // 패턴
-    if (isUndefined(this.pattern) || '' === this.pattern || this.pattern === '//' || this.pattern === '\'\'') {
+    // pattern
+    let clonedPattern = this.pattern;
+    if (isUndefined(clonedPattern) || '' === clonedPattern || clonedPattern === '//' || clonedPattern === '\'\'') {
       Alert.warning(this.translateService.instant('msg.dp.alert.insert.pattern'));
       return undefined;
     }
-    const patternResult:[boolean, string] = StringUtil.checkSingleQuote(this.pattern, { isWrapQuote: !StringUtil.checkRegExp(this.pattern) });
+    const patternResult:[boolean, string] = StringUtil.checkSingleQuote(clonedPattern, { isWrapQuote: !StringUtil.checkRegExp(clonedPattern) });
     if (!patternResult[0]) {
       Alert.warning(this.translateService.instant('msg.dp.alert.pattern.error'));
       return undefined;
     }
-    this.pattern = patternResult[1];
+    clonedPattern = patternResult[1];
 
-    // 횟수
+    // limit
     if (isUndefined(this.limit) ) {
       Alert.warning(this.translateService.instant('msg.dp.alert.insert.times'));
       return undefined;
     }
 
-    const columnsStr: string = this.selectedFields.map((item) => {
+    const columnsStr: string = _.cloneDeep(this.selectedFields).map((item) => {
       if (-1 !== item.name.indexOf(' ')) {
         item.name = '`' + item.name + '`';
       }
@@ -128,7 +129,7 @@ export class EditRuleExtractComponent extends EditRuleComponent implements OnIni
     }).join(', ');
 
     let ruleString = 'extract col: ' + columnsStr
-      + ' on: ' + this.pattern + ' limit : ' + this.limit + ' ignoreCase: ' + this.isIgnoreCase;
+      + ' on: ' + clonedPattern + ' limit : ' + this.limit + ' ignoreCase: ' + this.isIgnoreCase;
 
     // 다음 문자 사이 무시
     if (this.ignore && '' !== this.ignore.trim() && '\'\'' !== this.ignore.trim()) {
@@ -193,7 +194,7 @@ export class EditRuleExtractComponent extends EditRuleComponent implements OnIni
   protected parsingRuleString(data: {ruleString : string, jsonRuleString : any}) {
 
     // COLUMN
-    let arrFields:string[] = [data.jsonRuleString.col];
+    let arrFields:string[] = typeof data.jsonRuleString.col.value === 'string' ? [data.jsonRuleString.col.value] : data.jsonRuleString.col.value;
     this.selectedFields = arrFields.map( item => this.fields.find( orgItem => orgItem.name === item ) ).filter(field => !!field);
 
     // NUMBER OF MATCHES
@@ -209,8 +210,7 @@ export class EditRuleExtractComponent extends EditRuleComponent implements OnIni
     // IGNORE CASE
     this.isIgnoreCase = Boolean(data.jsonRuleString.ignoreCase);
 
-    // IGNORE BETWEEN CHRACTERS
-
+    // IGNORE BETWEEN CHARACTERS
     if (!isNullOrUndefined(data.jsonRuleString.quote)) {
       this.ignore = data.jsonRuleString.quote.escapedValue;
     }

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-replace.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-replace.component.ts
@@ -23,7 +23,6 @@ import { StringUtil } from '../../../../../../common/util/string.util';
 import { isUndefined } from "util";
 import { EventBroadcaster } from '../../../../../../common/event/event.broadcaster';
 import * as _ from 'lodash';
-import { PreparationCommonUtil } from '../../../../../util/preparation-common.util';
 import {RuleConditionInputComponent} from "./rule-condition-input.component";
 
 @Component({

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-split.component.html
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-split.component.html
@@ -12,13 +12,17 @@
   ~ limitations under the License.
   -->
 
-<div *ngIf="isShow" class="ddp-box-part" >
+<div *ngIf="isShow" class="ddp-box-part">
   <div class="ddp-box-title">
     {{'msg.lineage.ui.list.search.column' | translate}}<em class="ddp-icon-essential"></em>
   </div>
   <!-- Select box -->
-  <edit-rule-field-combo [fields]="fields" [selected]="selectedFields" [tabIndex]="2"
-                         (onChange)="changeFields($event)" ></edit-rule-field-combo>
+  <edit-rule-field-combo [fields]="fields"
+                         [isMulti]="true"
+                         [selected]="selectedFields"
+                         [tabIndex]="2"
+                         (onChange)="changeFields($event)">
+  </edit-rule-field-combo>
   <!-- // Select box -->
 </div>
 <!-- //part -->
@@ -45,8 +49,11 @@
         </div>
       </div>
       <div class="ddp-wrap-boxwrap">
-        <input [(ngModel)]="pattern" (focus)="showHidePatternLayer(true)" (blur)="showHidePatternLayer(false)"
-               type="text" tabindex="3" class="ddp-input-typebasic" placeholder="{{ 'msg.dp.th.pattern.ph' | translate }}" >
+        <input [(ngModel)]="pattern"
+               (focus)="showHidePatternLayer(true)"
+               (blur)="showHidePatternLayer(false)"
+               tabindex="3" class="ddp-input-typebasic"
+               placeholder="{{ 'msg.dp.th.pattern.ph' | translate }}">
       </div>
     </div>
   </div>
@@ -59,8 +66,10 @@
     {{'msg.dp.th.num.times' | translate}}<em class="ddp-icon-essential"></em>
   </div>
   <div class="ddp-wrap-datainput">
-    <input [(ngModel)]="limit" [input-mask]="'number'"
-           type="text" tabindex="5" class="ddp-input-typebasic" placeholder="{{'msg.dp.th.num.times.ph' | translate}}" >
+    <input [(ngModel)]="limit"
+           [input-mask]="'number'"
+           tabindex="5" class="ddp-input-typebasic"
+           placeholder="{{'msg.dp.th.num.times.ph' | translate}}">
   </div>
 </div>
 <!--//part-->
@@ -69,7 +78,8 @@
 <div *ngIf="isShow" class="ddp-box-part ddp-box-s" >
   <div class="ddp-box-title"> {{'msg.dp.th.quote' | translate}} </div>
   <div class="ddp-wrap-datainput">
-    <input [(ngModel)]="ignore" type="text" class="ddp-input-typebasic" tabindex="6" placeholder="{{'msg.dp.ui.enter.value' | translate}}" >
+    <input [(ngModel)]="ignore" class="ddp-input-typebasic"
+           tabindex="6" placeholder="{{'msg.dp.ui.enter.value' | translate}}">
   </div>
 </div>
 <!-- //part -->

--- a/discovery-prep-parser/src/main/java/app/metatron/discovery/prep/parser/preparation/rule/Extract.java
+++ b/discovery-prep-parser/src/main/java/app/metatron/discovery/prep/parser/preparation/rule/Extract.java
@@ -21,7 +21,7 @@ public class Extract implements Rule, Rule.Factory {
   /**
    * Allows only single column
    */
-  String col;
+  Expression col;
 
   /**
    * RegularExpr or StringExpr
@@ -47,7 +47,7 @@ public class Extract implements Rule, Rule.Factory {
   public Extract() {
   }
 
-  public Extract(String col, Expression on, Integer limit, Expression quote, Boolean ignoreCase) {
+  public Extract(Expression col, Expression on, Integer limit, Expression quote, Boolean ignoreCase) {
     this.col = col;
     this.on = on;
     this.limit = limit;
@@ -65,11 +65,11 @@ public class Extract implements Rule, Rule.Factory {
     return new Extract();
   }
 
-  public String getCol() {
+  public Expression getCol() {
     return col;
   }
 
-  public void setCol(String col) {
+  public void setCol(Expression col) {
     this.col = col;
   }
 

--- a/discovery-prep-parser/src/main/java/app/metatron/discovery/prep/parser/preparation/rule/Split.java
+++ b/discovery-prep-parser/src/main/java/app/metatron/discovery/prep/parser/preparation/rule/Split.java
@@ -21,7 +21,7 @@ public class Split implements Rule, Rule.Factory {
   /**
    * Allows only single column
    */
-  String col;
+  Expression col;
 
   /**
    * RegularExpr or StringExpr
@@ -47,7 +47,7 @@ public class Split implements Rule, Rule.Factory {
   public Split() {
   }
 
-  public Split(String col, Expression on, Integer limit, Expression quote, Boolean ignoreCase) {
+  public Split(Expression col, Expression on, Integer limit, Expression quote, Boolean ignoreCase) {
     this.col = col;
     this.on = on;
     this.limit = limit;
@@ -65,11 +65,11 @@ public class Split implements Rule, Rule.Factory {
     return new Split();
   }
 
-  public String getCol() {
+  public Expression getCol() {
     return col;
   }
 
-  public void setCol(String col) {
+  public void setCol(Expression col) {
     this.col = col;
   }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/exceptions/PrepMessageKey.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/exceptions/PrepMessageKey.java
@@ -104,6 +104,7 @@ public enum PrepMessageKey {
     MSG_DP_ALERT_TEDDY_PARSE_FAILED_BY_UNPIVOT_GROUPEVERY(       "msg.dp.alert.teddy.parse.failed.by.unpivot.groupevery"),
     MSG_DP_ALERT_TEDDY_PARSE_FAILED_BY_JOIN_DATASET2(            "msg.dp.alert.teddy.parse.failed.by.join.dataset2"),
     MSG_DP_ALERT_TEDDY_PARSE_FAILED_BY_JOIN_JOINTYPE(            "msg.dp.alert.teddy.parse.failed.by.join.jointype"),
+    MSG_DP_ALERT_TEDDY_PARSE_FAILED_BY_WINDOW_VALUE(             "msg.dp.alert.teddy.parse.failed.by.window.value"),
     MSG_DP_ALERT_TEDDY_COLUMN_NOT_FOUND(                         "msg.dp.alert.teddy.column.not.found"),
     MSG_DP_ALERT_TEDDY_NOT_SUPPORTED_TYPE(                       "msg.dp.alert.teddy.not.supported.type"),
     MSG_DP_ALERT_TEDDY_QUERY_FAILED(                             "msg.dp.alert.teddy.query.failed"),

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformRuleService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformRuleService.java
@@ -289,15 +289,18 @@ public class PrepTransformRuleService {
         break;
       case "split":
         on = ((Map) mapRule.get("on")).get("value");
+        col = ((Map) mapRule.get("col")).get("value");
         limit = ((Integer) (mapRule.get("limit"))).intValue();
         strCount = combineCountAndUnit(limit + 1, "column");      // split N times, produces N + 1 columns
-        shortRuleString = String.format(FMTSTR_SPLIT, mapRule.get("col"), strCount, nodeToString(on));
+
+        shortRuleString = String.format(FMTSTR_SPLIT, shortenColumnList(col), strCount, nodeToString(on));
         break;
       case "extract":
         on = ((Map) mapRule.get("on")).get("value");
+        col = ((Map) mapRule.get("col")).get("value");
         limit = ((Integer) (mapRule.get("limit"))).intValue();
         strCount = combineCountAndUnit(limit, "time");            // extract N times, produces just N columns
-        shortRuleString = String.format(FMTSTR_EXTRACT, nodeToString(on), strCount, mapRule.get("col"));
+        shortRuleString = String.format(FMTSTR_EXTRACT, nodeToString(on), strCount, shortenColumnList(col));
         break;
       case "flatten":
         shortRuleString = String.format(FMTSTR_FLATTEN, mapRule.get("col"));

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
@@ -1624,7 +1624,7 @@ public class PrepTransformService {
         }
       } else if( rule.getName().equals( "extract"  ) ) {
         Extract extract = (Extract)rule;
-        String col = extract.getCol();
+        Expression col = extract.getCol();
         Boolean IgnoreCase = extract.getIgnoreCase();
         Integer limit = extract.getLimit();
         Expression on = extract.getOn();
@@ -1655,7 +1655,7 @@ public class PrepTransformService {
         }
       } else if( rule.getName().equals( "split"  ) ) {
         Split split = (Split)rule;
-        String col = split.getCol();
+        Expression col = split.getCol();
         Boolean ignoreCase = split.getIgnoreCase();
         Integer limit = split.getLimit();
         Expression on = split.getOn();
@@ -1740,7 +1740,7 @@ public class PrepTransformService {
         Expression value = window.getValue();
         if (null == value) {
           LOGGER.error("confirmRuleStringForException(): aggregate value is null");
-          throw PrepException.create(PrepErrorCodes.PREP_TRANSFORM_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_TEDDY_PARSE_FAILED_BY_AGGREGATE_VALUE);
+          throw PrepException.create(PrepErrorCodes.PREP_TRANSFORM_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_TEDDY_PARSE_FAILED_BY_WINDOW_VALUE);
         }
       } else {
         LOGGER.error("confirmRuleStringForException(): ruleName is wrong - "+rule.getName());
@@ -1749,7 +1749,7 @@ public class PrepTransformService {
     } catch (PrepException e) {
       throw e;
     } catch (RuleException e) {
-      throw PrepException.create(PrepErrorCodes.PREP_TRANSFORM_ERROR_CODE, e);
+      throw PrepException.create(PrepErrorCodes.PREP_TRANSFORM_ERROR_CODE, TeddyException.fromRuleException(e));
     } catch (Exception e) {
       LOGGER.error("confirmRuleStringForException(): caught an exception: ", e);
       throw PrepException.create(PrepErrorCodes.PREP_TRANSFORM_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_TEDDY_PARSE_FAILED, e.getMessage());


### PR DESCRIPTION
### Description
Currently, split and extract rules can be applied to only one column at a time.
Allow multiple column as a target column parameter for split/extract rules.
Delete original columns after split rule applied.

**Related Issue** : <!--- Please link to the issue here. -->
https://github.com/metatron-app/metatron-discovery/issues/790


### How Has This Been Tested?
Do multi column split and extract.
Edit applied split and extract rule.
Check result.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
