### PR TITLE
F#761 timestamp histogram error

### DIFF
--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/edit-rule-grid.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/edit-rule-grid.component.ts
@@ -659,6 +659,10 @@ export class EditRuleGridComponent extends AbstractComponent implements OnInit, 
       gridResponse: _.cloneDeep(this._apiGridData)
     };
 
+    if (data.timestampStyle) {
+      currentContextMenuInfo['timestampStyle'] = data.timestampStyle;
+    }
+
     Object.keys(this._clickedSeries).forEach((key, index) => {
       if (this._clickedSeries[key].length >= 1 && index === data.index) {
         param['clickable']= true;
@@ -1837,6 +1841,12 @@ export class EditRuleGridComponent extends AbstractComponent implements OnInit, 
     headerMenu.buttons = [{
       cssClass: 'slick-header-menubutton', command: field.name, index: field.seq, type: field.type
     }];
+
+
+    // if timestamp type -> include timestamp style
+    if (field.type === 'TIMESTAMP') {
+      headerMenu.buttons[0]['timestampStyle'] = this._getHistogramInfo(field.seq).timestampFormat;
+    }
     return headerMenu;
   } // function - _getHeaderMenu
 

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/scroll-loading-grid.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/scroll-loading-grid.component.ts
@@ -482,14 +482,22 @@ export class ScrollLoadingGridComponent implements OnInit, AfterViewInit, OnDest
       // Header menu plugin
       let headerButtonsPlugin = new Slick.Plugins.HeaderButtons();
       headerButtonsPlugin.onCommand.subscribe((e, args) => {
-        this.onContextMenuClick.emit({
+
+        const contextMenuParam = {
           columnName: args.button.command,
           index: args.button.index,
           left: e.pageX,
           top: e.pageY,
           columnType: args.button.type
-        });
+        };
+
+        if (args.button.timestampStyle){ // only if column is timestamp type
+          contextMenuParam['timestampStyle'] = args.button.timestampStyle;
+        }
+
+        this.onContextMenuClick.emit(contextMenuParam);
         grid.invalidate();
+
       });
       grid.registerPlugin(headerButtonsPlugin);
     }

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/rule-context-menu.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/rule-context-menu.component.ts
@@ -298,6 +298,11 @@ export class RuleContextMenuComponent extends AbstractComponent implements OnIni
                 let idx = this.labelsForNumbers.indexOf(item);
                 result += this.histogramData.length-1 !== index ? `${selCol} >= ${item} && ${this.contextInfo.columnName} < ${this.labelsForNumbers[idx+1]} || ` : `${selCol} >= ${item} && ${selCol} < ${this.labelsForNumbers[idx+1]}`;
               })
+            } else if (this.contextInfo.columnType === 'TIMESTAMP') {
+              this.histogramData.forEach((item,index) => {
+                let idx = this.labelsForNumbers.indexOf(item);
+                result += this.histogramData.length-1 !== index ? `time_diff(timestamp('${item}','${this.contextInfo.timestampStyle}'),${selCol}) >= 0 && time_diff(timestamp('${this.labelsForNumbers[idx+1]}','${this.contextInfo.timestampStyle}'), ${selCol}) < 0 || ` : `time_diff(timestamp('${item}','${this.contextInfo.timestampStyle}'),${selCol}) >= 0 && time_diff(timestamp('${this.labelsForNumbers[idx+1]}','${this.contextInfo.timestampStyle}'), ${selCol}) < 0`;
+              });
             } else {
               this.histogramData.forEach((item,index) => {
                 result += this.histogramData.length-1 !== index ? selCol + ' == ' +'\''+ item +'\''+ ' || ' : selCol + ' == ' +'\''+ item +'\'';

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/Histogram.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/Histogram.java
@@ -67,6 +67,7 @@ public class Histogram implements Serializable {
   public int matched;
 
   public Granule bestGranularity;
+  public String timestampFormat;
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Constructors
@@ -80,6 +81,7 @@ public class Histogram implements Serializable {
     mismatchedRows = new ArrayList<>();
     matchedRows = new ArrayList<>();
     bestGranularity = NOT_USED;
+    timestampFormat = "NOT_USED";
   }
 
   public Histogram(int colWidth) {
@@ -436,46 +438,62 @@ public class Histogram implements Serializable {
       case NOT_USED:
         assert false;
       case YEAR:
+        timestampFormat = "yyyy";
         return DateTimeFormat.forPattern("yyyy");
       case MONTH:
+        timestampFormat = "yyyy-MM";
         return DateTimeFormat.forPattern("yyyy-MM");
       case DAY:
         if (min.getYear() == max.getYear()) {                   // 연도가 같으면 월부터만
+          timestampFormat = "MM-dd";
           return DateTimeFormat.forPattern("MM-dd");
         }
+        timestampFormat = "yyyy-MM-dd";
         return DateTimeFormat.forPattern("yyyy-MM-dd");
       case HOUR:
         if (min.getYear() == max.getYear()) {
           if (min.getMonthOfYear() == max.getMonthOfYear()) {   // 월이 같으면 일부터만
+            timestampFormat = "dd\\'T\\'hh";
             return DateTimeFormat.forPattern("dd'T'hh");
           }
+          timestampFormat = "MM-dd\\'T\\'hh";
           return DateTimeFormat.forPattern("MM-dd'T'hh");
         }
+        timestampFormat = "yyyy-MM-dd\\'T\\'hh";
         return DateTimeFormat.forPattern("yyyy-MM-dd'T'hh");
       case MINUTE:
         if (min.getYear() == max.getYear()) {
           if (min.getMonthOfYear() == max.getMonthOfYear()) {
             if (min.getDayOfMonth() == max.getDayOfMonth()) {
+              timestampFormat = "hh:mm";
               return DateTimeFormat.forPattern("hh:mm");        // 일이 같으면 시부터만
             }
+            timestampFormat = "dd\\'T\\'hh:mm";
             return DateTimeFormat.forPattern("dd'T'hh:mm");
           }
+          timestampFormat = "MM-dd\\'T\\'hh:mm";
           return DateTimeFormat.forPattern("MM-dd'T'hh:mm");
         }
+        timestampFormat = "yyyy-MM-dd\\'T\\'hh:mm";
         return DateTimeFormat.forPattern("yyyy-MM-dd'T'hh:mm");
       case SECOND:
         if (min.getYear() == max.getYear()) {
           if (min.getMonthOfYear() == max.getMonthOfYear()) {
             if (min.getDayOfMonth() == max.getDayOfMonth()) {
               if (min.getHourOfDay() == max.getDayOfMonth()) {  // 시가 같으면 분부터만
+                timestampFormat = "mm:ss";
                 return DateTimeFormat.forPattern("mm:ss");
               }
+              timestampFormat = "hh:mm:ss";
               return DateTimeFormat.forPattern("hh:mm:ss");
             }
+            timestampFormat = "dd\\'T\\'hh:mm:ss";
             return DateTimeFormat.forPattern("dd'T'hh:mm:ss");
           }
+          timestampFormat = "MM-dd\\'T\\'hh:mm:ss";
           return DateTimeFormat.forPattern("MM-dd'T'hh:mm:ss");
         }
+        timestampFormat = "yyyy-MM-dd\\'T\\'hh:mm:ss";
         return DateTimeFormat.forPattern("yyyy-MM-dd'T'hh:mm:ss");
       case MILLIS:
         if (min.getYear() == max.getYear()) {
@@ -483,16 +501,22 @@ public class Histogram implements Serializable {
             if (min.getDayOfMonth() == max.getDayOfMonth()) {
               if (min.getHourOfDay() == max.getDayOfMonth()) {
                 if (min.getMinuteOfHour() == max.getDayOfMonth()) {
+                  timestampFormat = "ss.SSS";
                   return DateTimeFormat.forPattern("ss.SSS");   // 분이 같으면 초부터만
                 }
+                timestampFormat = "mm:ss.SSS";
                 return DateTimeFormat.forPattern("mm:ss.SSS");
               }
+              timestampFormat = "hh:mm:ss.SSS";
               return DateTimeFormat.forPattern("hh:mm:ss.SSS");
             }
+            timestampFormat = "dd\\'T\\'hh:mm:ss.SSS";
             return DateTimeFormat.forPattern("dd'T'hh:mm:ss.SSS");
           }
+          timestampFormat = "MM-dd\\'T\\'hh:mm:ss.SSS";
           return DateTimeFormat.forPattern("MM-dd'T'hh:mm:ss.SSS");
         }
+        timestampFormat = "yyyy-MM-dd\\'T\\'hh:mm:ss.SSS";
         return DateTimeFormat.forPattern("yyyy-MM-dd'T'hh:mm:ss.SSS");
     }
     assert false;


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Allow Keep and delete from context menu by clicking the histogram when column type is timestamp

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#761 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Dataflow main grid -> click timestamp type histogram bar -> keep/ delete -> check if keep and delete works.
See screenshot
![image](https://user-images.githubusercontent.com/42233517/49073924-e6615000-f276-11e8-9b30-ec25e9a0b3c1.png)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
