### PR TITLE
#904 Need to fix displaying list of Text widget

### DIFF
--- a/discovery-frontend/src/assets/css/polaris.v2.page.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.page.css
@@ -1010,7 +1010,9 @@ ul.ddp-list-text li a .ddp-data-info span {display:block; color:#4b515b; font-si
 	text-overflow: ellipsis;
 	display: -webkit-box;
 	-webkit-line-clamp: 2; /* 라인수 */
-	-webkit-box-orient: vertical;
+  /* autoprefixer: off */
+  -webkit-box-orient: vertical;
+  /* autoprefixer: on */
 	word-wrap:break-word;}
 
 /**********************************************************************************


### PR DESCRIPTION
### Description
대시보드 내 텍스트 위젯 목록에서 텍스트 위젯의 내용이 그대로 표시되어 목록이 정상적으로 표시되지 않습니다.

**Related Issue** : #904 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 대시보드를 생성하고 편집화면으로 이동합니다.
2. 텍스트 위젯 생성 버튼을 클릭하여 생성 팝업을 띄웁니다.
3. 아주 긴 내용을 입력한 후 저장합니다.
4. 우측 목록에서 위젯의 내용이 최대 두 줄만 표시되는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
