### PR TITLE
#901 Missing checking catalog name duplication when creating the catalog

### DIFF
--- a/discovery-frontend/src/app/meta-data-management/catalog/catalog.component.ts
+++ b/discovery-frontend/src/app/meta-data-management/catalog/catalog.component.ts
@@ -327,6 +327,10 @@ export class CatalogComponent extends AbstractComponent implements OnInit, OnDes
    */
   public editCatalog(catalog) {
     catalog.editing = true;
+    this.safelyDetectChanges();
+    this.catalogInput.nativeElement.value = catalog.name; // 현재 값 적용
+    this.catalogInput.nativeElement.focus();
+
     this.selectedCatalog = new Catalog();
     this.isEditCatalogName = true;
   }
@@ -346,7 +350,10 @@ export class CatalogComponent extends AbstractComponent implements OnInit, OnDes
           this.initView();
           this.inProcess = false;
         }).catch((error) => {
-          Alert.warning(error);
+          if( error && error.message ) {
+            Alert.warning(error.message);
+          }
+          this.inProcess = false;
         })
       }
     } else {

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/MetadataErrorCodes.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/MetadataErrorCodes.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.metatron.discovery.domain.mdm;
+
+import app.metatron.discovery.common.exception.ErrorCodes;
+
+public enum MetadataErrorCodes implements ErrorCodes {
+
+  METADATA_COMMON_ERROR("MD001"),
+  DUPLICATED_CATALOG_NAME("MD002");
+
+  String errorCode;
+
+  MetadataErrorCodes(String errorCode) {
+    this.errorCode = errorCode;
+  }
+
+  @Override
+  public String getCode() {
+    return errorCode;
+  }
+}

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/catalog/CatalogEventHandler.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/catalog/CatalogEventHandler.java
@@ -37,10 +37,16 @@ public class CatalogEventHandler {
   
   @HandleBeforeCreate
   public void handleBeforeCreate(Catalog catalog) {
-    if ( catalogRepository.countByCatalogName(catalog.getName()) > 0 ){
-      throw new CatalogException(DUPLICATED_CATALOG_NAME, "Duplicated Catalog Name");
-    }
 
+    if ( catalog.getParentId() == null ){
+      if ( catalogRepository.countByCatalogName(catalog.getName()) > 0 ){
+        throw new CatalogException(DUPLICATED_CATALOG_NAME, "Duplicated Catalog Name");
+      }
+    }else{
+      if ( catalogRepository.countByCatalogNameAndParentId(catalog.getName(), catalog.getParentId()) > 0 ){
+        throw new CatalogException(DUPLICATED_CATALOG_NAME, "Duplicated Catalog Name");
+      }
+    }
   }
 
   @HandleAfterCreate

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/catalog/CatalogEventHandler.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/catalog/CatalogEventHandler.java
@@ -21,6 +21,8 @@ import org.springframework.data.rest.core.annotation.HandleBeforeDelete;
 import org.springframework.data.rest.core.annotation.HandleBeforeSave;
 import org.springframework.data.rest.core.annotation.RepositoryEventHandler;
 
+import static app.metatron.discovery.domain.mdm.MetadataErrorCodes.DUPLICATED_CATALOG_NAME;
+
 /**
  * Catalog event handler
  */
@@ -29,9 +31,16 @@ public class CatalogEventHandler {
 
   @Autowired
   CatalogTreeService catalogTreeService;
+
+  @Autowired
+  CatalogRepository catalogRepository;
   
   @HandleBeforeCreate
   public void handleBeforeCreate(Catalog catalog) {
+    if ( catalogRepository.countByCatalogName(catalog.getName()) > 0 ){
+      throw new CatalogException(DUPLICATED_CATALOG_NAME, "Duplicated Catalog Name");
+    }
+
   }
 
   @HandleAfterCreate

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/catalog/CatalogException.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/catalog/CatalogException.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.metatron.discovery.domain.mdm.catalog;
+
+import app.metatron.discovery.common.exception.MetatronException;
+import app.metatron.discovery.domain.mdm.MetadataErrorCodes;
+
+public class CatalogException extends MetatronException {
+
+
+  public CatalogException(MetadataErrorCodes code, String message) {
+    super(code, message);
+  }
+
+  public CatalogException(MetadataErrorCodes code, Throwable cause) {
+    super(code, cause);
+  }
+
+  public CatalogException(MetadataErrorCodes code, String message, Throwable cause) {
+    super(code, message, cause);
+  }
+}

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/catalog/CatalogRepository.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/catalog/CatalogRepository.java
@@ -59,7 +59,10 @@ public interface CatalogRepository extends JpaRepository<Catalog, String>,
    * @return
    */
   @RestResource(exported = false)
+  @Query("SELECT count(c) FROM Catalog c WHERE c.name = :name AND c.parentId = :parentId")
+  Long countByCatalogNameAndParentId(@Param("name") String name, @Param("parentId") String parentId);
+
+  @RestResource(exported = false)
   @Query("SELECT count(c) FROM Catalog c WHERE c.name = :name")
   Long countByCatalogName(@Param("name") String name);
-
 }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/catalog/CatalogRepository.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/catalog/CatalogRepository.java
@@ -52,4 +52,14 @@ public interface CatalogRepository extends JpaRepository<Catalog, String>,
   @Query("SELECT c FROM Catalog c, CatalogTree ct WHERE c.id = ct.id.ancestor AND ct.id.descendant = :catalogId ORDER BY ct.depth desc")
   List<Catalog> findAllAncestors(@Param("catalogId") String catalogId);
 
+  /**
+   * Check duplicated catalog name
+   *
+   * @param name
+   * @return
+   */
+  @RestResource(exported = false)
+  @Query("SELECT count(c) FROM Catalog c WHERE c.name = :name")
+  Long countByCatalogName(@Param("name") String name);
+
 }


### PR DESCRIPTION
### Description
메타데이터 카탈로그 생성시 동일 레벨에서 이름을 중복해서 입력하면 등록이 되고 있습니다. 반면에 중복된 이름으로 수정하려고 하면 입력오류를 발생시킵니다.

**Related Issue** : #901 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 메타데이터 관리 > 카탈로그 메뉴로 이동합니다.
2. 카탈로그를 생성합니다. 
4. 동일한 이름의 카탈로그로 생성 시도 합니다. -> 생성되지 않고 경고창이 나타나는지 확인합니다.
5. 다른 이름으로 생성된 카탈로그 중 하나의 이름을 다른 카탈로그와 같은 이름으로 수정 시도 합니다. -> 수정되지 않고 경고창에 나타나는지 확인합니다. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
