### PR TITLE
#618 Map chart does not re-draw after resizing

### DIFF
--- a/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
+++ b/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
@@ -71,6 +71,7 @@ import {GridComponent} from "../../../common/component/grid/grid.component";
 import {header, SlickGridHeader} from "../../../common/component/grid/grid.header";
 import {GridOption} from "../../../common/component/grid/grid.option";
 import {Pivot} from "../../../domain/workbook/configurations/pivot";
+import {MapChartComponent} from "../../../common/component/chart/type/map-chart/map-chart.component";
 
 declare let $;
 
@@ -423,8 +424,9 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
             const lineChart: LineChartComponent = this.chart['lineChart'];
             barChart.chart.resize();
             lineChart.chart.resize();
-          } else if (this.chart.uiOption.type === ChartType.LABEL || this.chart.uiOption.type === ChartType.MAP) {
-
+          } else if (this.chart.uiOption.type === ChartType.LABEL) {
+          } else if (this.chart.uiOption.type === ChartType.MAP) {
+            (<MapChartComponent>this.chart).draw();
           } else if (this.chart.uiOption.type === ChartType.NETWORK) {
             (<NetworkChartComponent>this.chart).draw();
           } else {


### PR DESCRIPTION
### Description
위젯 리사이즈 시 맵차트가 다시 그려지지 않습니다.

**Related Issue** : #618 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 대시보드를 생성한 후 맵 차트를 생성합니다.
2. 다른 차트를 여러개 생성 한 후, 대시보드에 배치합니다.
3. 맵 차트 위젯의 크기를 조정하여 맵 차트가 위젯 크기에 맞게 다시 그려지는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
