### PR TITLE
#603 Sometimes filter disappear when combining filters

### DIFF
--- a/discovery-frontend/src/app/dashboard/component/create-dashboard/create-board-ds-network.component.ts
+++ b/discovery-frontend/src/app/dashboard/component/create-dashboard/create-board-ds-network.component.ts
@@ -354,7 +354,7 @@ export class CreateBoardDsNetworkComponent extends AbstractComponent implements 
    */
   public offEditRelationMode() {
     this.isRelationEditMode = false;
-    this._network.disableEditMode();
+    ( this._network ) && ( this._network.disableEditMode() );
     this.toggleGuide( 'HIDE' );
     this.safelyDetectChanges();
 

--- a/discovery-frontend/src/app/dashboard/component/create-dashboard/create-board.component.ts
+++ b/discovery-frontend/src/app/dashboard/component/create-dashboard/create-board.component.ts
@@ -49,7 +49,7 @@ export class CreateBoardComponent extends AbstractPopupComponent implements OnIn
   @Input()
   public workspaceId: string;
 
-  public isDenyNext: boolean = false;
+  public isDenyNext: boolean = true;
   public isShowButtons: boolean = true;
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/discovery-frontend/src/app/meta-data-management/code-table/detail-code-table/detail-code-table.component.ts
+++ b/discovery-frontend/src/app/meta-data-management/code-table/detail-code-table/detail-code-table.component.ts
@@ -12,20 +12,20 @@
  * limitations under the License.
  */
 
-import { AbstractComponent } from '../../../common/component/abstract.component';
-import { Component, ElementRef, Injector, OnDestroy, OnInit, ViewChild } from '@angular/core';
-import { DeleteModalComponent } from '../../../common/component/modal/delete/delete.component';
-import { CodeTableService } from '../service/code-table.service';
-import { ActivatedRoute } from '@angular/router';
-import { CodeTable } from '../../../domain/meta-data-management/code-table';
-import { CodeValuePair } from '../../../domain/meta-data-management/code-value-pair';
-import { Alert } from '../../../common/util/alert.util';
-import { Modal } from '../../../common/domain/modal';
+import {AbstractComponent} from '../../../common/component/abstract.component';
+import {Component, ElementRef, Injector, OnDestroy, OnInit, ViewChild} from '@angular/core';
+import {DeleteModalComponent} from '../../../common/component/modal/delete/delete.component';
+import {CodeTableService} from '../service/code-table.service';
+import {ActivatedRoute} from '@angular/router';
+import {CodeTable} from '../../../domain/meta-data-management/code-table';
+import {CodeValuePair} from '../../../domain/meta-data-management/code-value-pair';
+import {Alert} from '../../../common/util/alert.util';
+import {Modal} from '../../../common/domain/modal';
 import * as _ from 'lodash';
-import { CommonUtil } from '../../../common/util/common.util';
-import { ConfirmModalComponent } from '../../../common/component/modal/confirm/confirm.component';
-import { LinkedColumnDictionaryComponent } from '../../component/linked-column-dictionary/linked-column-dictionary.component';
-import { ColumnDictionary } from '../../../domain/meta-data-management/column-dictionary';
+import {CommonUtil} from '../../../common/util/common.util';
+import {ConfirmModalComponent} from '../../../common/component/modal/confirm/confirm.component';
+import {LinkedColumnDictionaryComponent} from '../../component/linked-column-dictionary/linked-column-dictionary.component';
+import {ColumnDictionary} from '../../../domain/meta-data-management/column-dictionary';
 
 @Component({
   selector: 'app-detail-code-table',
@@ -176,7 +176,7 @@ export class DetailCodeTableComponent extends AbstractComponent implements OnIni
    * @returns {ColumnDictionary[]}
    */
   public getLinkedColumnDictionaryList(): ColumnDictionary[] {
-    return this.linkedDictionaryList.slice(0,3);
+    return this.linkedDictionaryList.slice(0, 3);
   }
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
@@ -197,7 +197,7 @@ export class DetailCodeTableComponent extends AbstractComponent implements OnIni
   public onClickDeleteCodeTable(): void {
     const modal = new Modal();
     modal.name = this.translateService.instant('msg.metadata.ui.codetable.delete.title');
-    modal.description =  this._originCodeTable.name;
+    modal.description = this._originCodeTable.name;
     modal.btnName = this.translateService.instant('msg.comm.ui.del');
     this._deleteComp.init(modal);
   }
@@ -409,7 +409,12 @@ export class DetailCodeTableComponent extends AbstractComponent implements OnIni
         // 중복
         if (result['duplicated']) {
           // alert
-          Alert.warning(this.translateService.instant('msg.metadata.ui.codetable.create.valid.table.name.duplicated' , {value: this.codeTable.name.trim()}));
+          Alert.warning(
+            this.translateService.instant(
+              'msg.metadata.ui.codetable.create.valid.table.name.duplicated',
+              {value: this.reName.trim()}
+            )
+          );
           // 로딩 hide
           this.loadingHide();
         } else {
@@ -484,7 +489,11 @@ export class DetailCodeTableComponent extends AbstractComponent implements OnIni
     // 로딩 show
     this.loadingShow();
     // 컬럼 사전 목록 조회
-    this._codeTableService.getColumnDictionaryInCodeTable(this._codeTableId, {size: 15, page: 0, sort: 'logicalName,asc'})
+    this._codeTableService.getColumnDictionaryInCodeTable(this._codeTableId, {
+      size: 15,
+      page: 0,
+      sort: 'logicalName,asc'
+    })
       .then((result) => {
         // 수
         this.linkedDictionaryTotalCount = result['page'].totalElements;
@@ -523,12 +532,12 @@ export class DetailCodeTableComponent extends AbstractComponent implements OnIni
     this._originCodeList.forEach((origin) => {
       _.findIndex(this.codeList, (code) => {
         return origin.id && origin.id === code.id;
-      }) === -1  && params.push({id: origin.id, op: 'remove'});
+      }) === -1 && params.push({id: origin.id, op: 'remove'});
     });
     // add | replace
     this.codeList.forEach((code) => {
       // origin index
-      const originIndex =  _.findIndex(this._originCodeList, (origin) => {
+      const originIndex = _.findIndex(this._originCodeList, (origin) => {
         return origin.id && code.id === origin.id;
       });
 


### PR DESCRIPTION
### Description
필터를 복합적으로 적용하였을 때 센키차트가 그려지지 않는 경우가 있습니다.

**Related Issue** : #603 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 센키차트를 생성하고 대시보드에 배치합니다.
2. 측정값 필터 위젯을 두가지 생성하여 대시보드에 배치합니다.
3. 대시보드를 저장하고 열람화면에서 여러개의 필터값을 수정합니다.
4. 차트가 정상적으로 표시되는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

### Additional Context<!-- if not appropriate, remove this topic. -->
대시보드 초기 버튼 문제와 코드테이블 alert 문제도 같이 처리 하였습니다.