### PR TITLE
Fixed input check error on user profile popup and join popup

### DIFF
--- a/discovery-frontend/src/app/admin/workspace-management/component/workspace-permission-schemas/create-permission-schema.component.ts
+++ b/discovery-frontend/src/app/admin/workspace-management/component/workspace-permission-schemas/create-permission-schema.component.ts
@@ -81,6 +81,7 @@ export class CreatePermissionSchemaComponent extends AbstractPopupComponent impl
    * 컴포넌트 실행
    */
   public init() {
+    this.addBodyScrollHidden();
     const roleSet: RoleSet = new RoleSet();
     roleSet.scope = RoleSetScope.PUBLIC;
     this.roleSet = roleSet;
@@ -91,6 +92,7 @@ export class CreatePermissionSchemaComponent extends AbstractPopupComponent impl
    * 화면 종료
    */
   public close() {
+    this.removeBodyScrollHidden();
     this.isShow = false;
   } // function - close
 

--- a/discovery-frontend/src/app/admin/workspace-management/component/workspace-permission-schemas/permission-schemas.component.ts
+++ b/discovery-frontend/src/app/admin/workspace-management/component/workspace-permission-schemas/permission-schemas.component.ts
@@ -82,7 +82,9 @@ export class PermissionSchemasComponent extends AbstractComponent implements OnI
   | Override Method
   |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
 
-  // Init
+  /**
+   * 컴포넌트 초기 실행
+   */
   public ngOnInit() {
     super.ngOnInit();
     // ui 초기화
@@ -91,7 +93,17 @@ export class PermissionSchemasComponent extends AbstractComponent implements OnI
     this._getRoleSetList();
   }
 
-  // Destroy
+  /**
+   * 화면 초기화
+   */
+  public ngAfterViewInit() {
+    super.ngAfterViewInit();
+    this.removeBodyScrollHidden();
+  }
+
+  /**
+   * 컴포넌트 제거
+   */
   public ngOnDestroy() {
     super.ngOnDestroy();
   }

--- a/discovery-frontend/src/app/common/component/abstract-popup.component.ts
+++ b/discovery-frontend/src/app/common/component/abstract-popup.component.ts
@@ -14,7 +14,6 @@
 
 import { ElementRef, EventEmitter, Injector, Output } from '@angular/core';
 import { AbstractComponent } from './abstract.component';
-import * as $ from 'jquery';
 
 export class AbstractPopupComponent extends AbstractComponent {
 
@@ -51,17 +50,17 @@ export class AbstractPopupComponent extends AbstractComponent {
 
   public ngOnInit() {
     super.ngOnInit();
-    $('body').removeClass('body-hidden').addClass('body-hidden');
+    this.addBodyScrollHidden();
   }
 
 
   public ngOnDestroy() {
-    $('body').removeClass('body-hidden');
+    this.removeBodyScrollHidden();
     super.ngOnDestroy();
   }
 
   public close() {
-    $('body').removeClass('body-hidden');
+    this.removeBodyScrollHidden();
     this.closeEvent.emit();
   }
 

--- a/discovery-frontend/src/app/common/component/abstract.component.ts
+++ b/discovery-frontend/src/app/common/component/abstract.component.ts
@@ -166,6 +166,19 @@ export class AbstractComponent implements OnInit, AfterViewInit, OnDestroy, CanC
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Public Method
    |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
+  /**
+   * add body scroll hidden class
+   */
+  public addBodyScrollHidden() {
+    $('body').removeClass('body-hidden').addClass('body-hidden');
+  } // function - addBodyScrollHidden
+
+  /**
+   * remove body scroll hidden class
+   */
+  public removeBodyScrollHidden() {
+    $('body').removeClass('body-hidden');
+  } // function - removeBodyScrollHidden
 
   // noinspection JSMethodCanBeStatic
   /**

--- a/discovery-frontend/src/app/user/login/component/join/join.component.html
+++ b/discovery-frontend/src/app/user/login/component/join/join.component.html
@@ -22,14 +22,14 @@
 
       <!-- contents -->
       <div class="ddp-ui-user-contet">
-        <!-- input form -->
-        <!-- error 일때 ddp-type-error 추가 -->
-        <div class="ddp-ui-input-form" [ngClass]="{'ddp-type-error': joinValidation.username == false}">
+        <!-- User Name 입력 -->
+        <div [ngClass]="{'ddp-type-ok': '' !== user.username && joinValidation.username, 'ddp-type-error': false === joinValidation.username}"
+             class="ddp-ui-input-form" >
           <label class="ddp-label-type">{{'msg.login.join.name' | translate}} </label>
           <div class="ddp-input-check">
             <input type="text" class="ddp-input-type" placeholder="{{'msg.login.join.name.ph' | translate}}"  (keydown)="joinValidation.usernameMessage? hideError('username') :null" [(ngModel)]="user.username" (blur)="validation('username')">
             <em class="ddp-icon-ok" *ngIf="joinValidation.username"></em>
-            <em class="ddp-icon-error" *ngIf="joinValidation.username == false"></em>
+            <em class="ddp-icon-error" *ngIf="joinValidation.username == false" (click)="user.username = ''; joinValidation.username = undefined;"></em>
           </div>
           <!-- error 메시지 -->
           <span class="ddp-ui-error" *ngIf="joinValidation.username == false">
@@ -37,10 +37,9 @@
           </span>
           <!-- //error 메시지 -->
         </div>
-        <!-- //input form -->
+        <!-- // User Name 입력 -->
 
-        <!-- input form -->
-        <!-- error 일때 ddp-type-error 추가 -->
+        <!-- Full Name 입력 -->
         <div class="ddp-ui-input-form">
           <label class="ddp-label-type">{{'msg.login.join.fullname' | translate}}
             <!-- tooltip -->
@@ -61,12 +60,11 @@
           <!-- error 메시지 -->
           <!-- //error 메시지 -->
         </div>
-        <!-- //input form -->
+        <!-- // Full Name 입력 -->
 
-
-        <!-- input form -->
-        <!-- error 일때 ddp-type-error 추가 -->
-        <div class="ddp-ui-input-form" [ngClass]="{'ddp-type-error': joinValidation.email == false}">
+        <!-- E-Mail 입력 -->
+        <div [ngClass]="{'ddp-type-ok': '' !== user.email && joinValidation.email, 'ddp-type-error': false === joinValidation.email }"
+             class="ddp-ui-input-form" >
           <label class="ddp-label-type">{{'msg.login.join.email' | translate}}
             <!-- tooltip -->
             <div class="ddp-ui-tooltip">
@@ -82,7 +80,7 @@
           <div class="ddp-input-check">
             <input type="text" class="ddp-input-type" placeholder="{{'msg.login.join.email.ph' | translate}}" (keydown)="joinValidation.emailMessage? hideError('email') :null" [(ngModel)]="user.email" (blur)="validation('email')">
             <em class="ddp-icon-ok" *ngIf="joinValidation.email"></em>
-            <em class="ddp-icon-error" *ngIf="joinValidation.email == false"></em>
+            <em class="ddp-icon-error" *ngIf="joinValidation.email == false" (click)="user.email = '';joinValidation.email = undefined;"></em>
           </div>
           <!-- error 메시지 -->
           <span class="ddp-ui-error" *ngIf="joinValidation.email == false">
@@ -90,14 +88,14 @@
           </span>
           <!-- //error 메시지 -->
         </div>
-        <!-- //input form -->
+        <!-- // E-Mail 입력 -->
 
-
-        <!-- input form -->
+        <!-- Password 입력 -->
         <div class="ddp-wrap-overflow ddp-clear">
           <div class="ddp-ui-fleft ">
             <!-- error 일때 ddp-type-error 추가 -->
-            <div class="ddp-ui-input-form" [ngClass]="{'ddp-type-error': joinValidation.password == false}">
+            <div [ngClass]="{'ddp-type-ok': '' !== user.password && joinValidation.password, 'ddp-type-error': false === joinValidation.password }"
+                 class="ddp-ui-input-form" >
               <label class="ddp-label-type">{{'msg.login.join.passwd' | translate}}
                 <!-- tooltip -->
                 <div class="ddp-ui-tooltip">
@@ -108,13 +106,12 @@
                   </div>
                 </div>
                 <!-- //tooltip -->
-
               </label>
 
               <div class="ddp-input-check">
                 <input type="password" class="ddp-input-type" placeholder="{{'msg.login.join.passwd.ph' | translate}}" [(ngModel)]="user.password" (keydown)="joinValidation.passwordMessage? hideError('password') :null" (blur)="validation('password')">
                 <em class="ddp-icon-ok" *ngIf="joinValidation.password"></em>
-                <em class="ddp-icon-error" *ngIf="joinValidation.password == false"></em>
+                <em class="ddp-icon-error" *ngIf="joinValidation.password == false" (click)="user.password = ''; joinValidation.password = undefined;"></em>
               </div>
               <!-- error 메시지 -->
               <span class="ddp-ui-error" *ngIf="joinValidation.password == false">
@@ -126,13 +123,14 @@
           </div>
           <div class="ddp-ui-fright">
             <!-- error 일때 ddp-type-error 추가 -->
-            <div class="ddp-ui-input-form" [ngClass]="{'ddp-type-error': joinValidation.confirmPassword == false}">
+            <div [ngClass]="{'ddp-type-ok': '' !== user.confirmPassword && joinValidation.confirmPassword, 'ddp-type-error': false === joinValidation.confirmPassword }"
+                 class="ddp-ui-input-form" >
               <label class="ddp-label-type">{{'msg.login.join.confirm-passwd' | translate}} </label>
 
               <div class="ddp-input-check">
                 <input type="password" class="ddp-input-type" placeholder="{{'msg.login.join.confirm-passwd.ph' | translate}}" (keydown)="joinValidation.confirmPasswordMessage? hideError('confirmPassword') :null" [(ngModel)]="user.confirmPassword" (blur)="validation('confirmPassword')">
                 <em class="ddp-icon-ok" *ngIf="joinValidation.confirmPassword"></em>
-                <em class="ddp-icon-error" *ngIf="joinValidation.confirmPassword == false"></em>
+                <em class="ddp-icon-error" *ngIf="joinValidation.confirmPassword == false" (click)="user.confirmPassword = ''; joinValidation.confirmPassword = undefined;"></em>
               </div>
               <!-- error 메시지 -->
               <span class="ddp-ui-error" *ngIf="joinValidation.confirmPassword == false">
@@ -143,7 +141,7 @@
 
           </div>
         </div>
-        <!-- //input form -->
+        <!-- // Password 입력 -->
 
         <!-- input form -->
         <!--<div class="ddp-ui-input-form">-->

--- a/discovery-frontend/src/app/user/login/component/join/join.component.ts
+++ b/discovery-frontend/src/app/user/login/component/join/join.component.ts
@@ -289,13 +289,12 @@ export class JoinComponent extends AbstractComponent implements OnInit, OnDestro
           this.joinValidation.username = true;
         }
       }).catch((error) => {
-
         this.joinValidation.username = false;
         this.joinValidation.usernameMessage
           = this.translateService.instant('LOGIN_JOIN_VALID_ID');
         return;
-
       });
+      this.joinValidation.username = true;
     }
     // Email validation
     else if ('email' === type) {
@@ -326,6 +325,7 @@ export class JoinComponent extends AbstractComponent implements OnInit, OnDestro
           = this.translateService.instant('LOGIN_JOIN_VALID_ID');
         return;
       });
+      this.joinValidation.email = true;
     }
     // password confirm validation
     else if ('password' === type || 'confirmPassword' === type) {
@@ -344,14 +344,16 @@ export class JoinComponent extends AbstractComponent implements OnInit, OnDestro
       if (this.user.password !== this.user.confirmPassword) {
         this.joinValidation.confirmPassword = false;
         this.joinValidation.confirmPasswordMessage = this.translateService.instant('LOGIN_JOIN_NOMATCH_PASSWORD');
+        return;
+      } else {
+        this.joinValidation.confirmPassword = true;
       }
     }
 
     // 검증 통과시 validation true로 변경
     this.joinValidation[type] = true;
 
-
-  }
+  } // function - validation
 
   // 입력값 검증 결과
   private isValid() {

--- a/discovery-frontend/src/app/user/profile/profile.component.html
+++ b/discovery-frontend/src/app/user/profile/profile.component.html
@@ -21,8 +21,9 @@
             </span>
 
       <div class="ddp-ui-pop-buttons">
-        <a href="javascript:" class="ddp-btn-pop" (click)="close()">{{'msg.comm.btn.cancl' | translate}}</a>
-        <a href="javascript:" class="ddp-btn-pop ddp-bg-black" (click)="done()">{{'msg.comm.btn.done' | translate}}</a>
+        <a (click)="close()" href="javascript:" class="ddp-btn-pop" >{{'msg.comm.btn.close' | translate}}</a>
+        <a (click)="done()" [class.ddp-disabled]="!isPhoneChanged && !isEmailChanged && !isFullNameChanged"
+           href="javascript:" class="ddp-btn-pop ddp-bg-black" >{{'msg.comm.btn.save' | translate}}</a>
       </div>
     </div>
 
@@ -76,20 +77,18 @@
 
           </div>
 
-          <!-- input form -->
+          <!-- User Name -->
           <div class="ddp-ui-input-form">
             <label class="ddp-label-type">{{'msg.comm.ui.profile.name' | translate}}</label>
             <div class="ddp-data-form">
               {{user.username}}
             </div>
           </div>
-          <!-- //input form -->
-          <!-- input form -->
-          <!--
-              error 일때 ddp-type-error 추가
-              ok 일 경우 ddp-type-ok 추가
-           -->
-          <div class="ddp-ui-input-form" [class.ddp-type-error]="resultEmail === false">
+          <!-- // User Name -->
+
+          <!-- E-Mail -->
+          <div [ngClass]="{'ddp-type-ok' : isEmailChanged && true === resultEmail, 'ddp-type-error' : false === resultEmail}"
+               class="ddp-ui-input-form" >
             <label class="ddp-label-type">{{'msg.comm.ui.profile.email' | translate}}
               <!-- tooltip -->
               <div class="ddp-ui-tooltip">
@@ -114,10 +113,11 @@
             <span class="ddp-ui-error">{{emailMessage}}</span>
             <!-- //error 메시지 -->
           </div>
-          <!-- //input form -->
-          <!-- input form -->
-          <!-- error 일때 ddp-type-error 추가 -->
-          <div class="ddp-ui-input-form" [class.ddp-type-error]="resultName === false">
+          <!-- // E-Mail -->
+
+          <!-- Full Name -->
+          <div [ngClass]="{'ddp-type-ok' : isFullNameChanged && true === resultName, 'ddp-type-error' : false === resultName}"
+               class="ddp-ui-input-form" >
             <label class="ddp-label-type">{{'msg.comm.ui.profile.fullname' | translate}}
               <!-- tooltip -->
               <div class="ddp-ui-tooltip">
@@ -142,7 +142,9 @@
             <span class="ddp-ui-error">{{nameMessage}}</span>
             <!-- //error 메시지 -->
           </div>
-          <!-- //input form -->
+          <!-- // Full Name -->
+
+          <!-- Password -->
           <div class="ddp-ui-input-form">
             <label class="ddp-label-type">{{'msg.login.join.passwd' | translate}}</label>
             <div class="ddp-data-form">
@@ -150,11 +152,9 @@
               <a href="javascript:" class="ddp-btn-selection ddp-line" (click)="onClickChangePassword()"><em class="ddp-icon-key"></em>{{'msg.comm.btn.profile.password.change' | translate}}</a>
             </div>
           </div>
-          <!-- input form -->
-          <!--
-              error 일때 ddp-type-error 추가
-              ok 일 경우 ddp-type-ok 추가
-           -->
+          <!-- // Password -->
+
+          <!-- Phone -->
           <div class="ddp-ui-input-form">
             <label class="ddp-label-type">{{'msg.comm.ui.profile.phone' | translate}}
               <!-- tooltip -->
@@ -171,10 +171,11 @@
             <div class="ddp-input-check">
               <input type="text" class="ddp-input-type" placeholder="{{'msg.comm.ph.profile.phone' | translate}}"
                      input-mask="number"
-                     [(ngModel)]="user.tel"/>
+                     [(ngModel)]="user.tel" />
             </div>
           </div>
-          <!-- //input form -->
+          <!-- // Phone -->
+
           <!-- permission -->
           <div class="ddp-ui-input-form">
             <label class="ddp-label-type">
@@ -183,6 +184,7 @@
             </label>
           </div>
           <!-- //permission -->
+
           <!-- input form -->
           <div class="ddp-ui-input-form">
             <label class="ddp-label-type">
@@ -191,10 +193,8 @@
               <!--<span class="ddp-info2" *ngIf="getGroupLength() === 1">{{getGroup()[0].name}}</span>-->
               <!--<span class="ddp-info2" *ngIf="getGroupLength() > 1">{{'msg.comm.ui.profile.groups.detail' | translate: {group: getGroup()[0].name, etc: getGroupLength() - 1} }}</span>-->
             </label>
-
           </div>
           <!-- //input form -->
-
 
           <!-- Workspace -->
           <div class="ddp-ui-input-form">

--- a/discovery-frontend/src/app/user/profile/profile.component.ts
+++ b/discovery-frontend/src/app/user/profile/profile.component.ts
@@ -22,12 +22,11 @@ import { CommonConstant } from '../../common/constant/common.constant';
 import { Alert } from '../../common/util/alert.util';
 import { User } from '../../domain/user/user';
 import { UserService } from '../service/user.service';
-import { isUndefined } from 'util';
+import {isNullOrUndefined, isUndefined} from 'util';
 import { CommonUtil } from '../../common/util/common.util';
 import { StringUtil } from '../../common/util/string.util';
 import { ChangePasswordComponent } from './change-password/change-password.component';
 import { Group } from '../../domain/user/group';
-import { SYSTEM_PERMISSION } from '../../common/permission/permission';
 import { WorkspaceService } from '../../workspace/service/workspace.service';
 import { Workspace } from '../../domain/workspace/workspace';
 import { CookieConstant } from '../../common/constant/cookie.constant';
@@ -81,9 +80,9 @@ export class ProfileComponent extends AbstractComponent implements OnInit, OnDes
   public isShow = false;
 
   // email flag
-  public resultEmail: boolean = true;
+  public resultEmail: boolean;
   // name flag
-  public resultName: boolean = true;
+  public resultName: boolean;
 
   // email error message
   public emailMessage: string;
@@ -149,21 +148,44 @@ export class ProfileComponent extends AbstractComponent implements OnInit, OnDes
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
   | Public Method
   |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
+  /**
+   * Phone 변경 여부
+   */
+  public get isPhoneChanged():boolean {
+    const userTel = isNullOrUndefined( this.user.tel ) ? '' : this.user.tel.trim();
+    return this._userTel !== userTel;
+  } // function - isPhoneChanged
+
+  /**
+   * E-Mail 변경 여부
+   */
+  public get isEmailChanged():boolean {
+    const userEmail = isNullOrUndefined( this.user.email ) ? '' : this.user.email.trim();
+    return this._userEmail !== userEmail;
+  } // function - isEmailChanged
+
+  /**
+   * Full Name 변경 여부
+   */
+  public get isFullNameChanged():boolean {
+    const userName = isNullOrUndefined( this.user.fullName ) ? '' : this.user.fullName.trim();
+    return this._userName !== userName;
+  } // function - isFullNameChanged
 
   /** Init */
   public init(user: User) {
     // ui init
     this._initView();
     // user ID
-    this._userId = user.username;
+    this._userId = isNullOrUndefined( user.username ) ? '' : user.username.trim();
     // user email
-    this._userEmail = user.email;
+    this._userEmail = isNullOrUndefined( user.email ) ? '' : user.email.trim();
     // user name
-    this._userName = user.fullName;
+    this._userName = isNullOrUndefined( user.fullName ) ? '' : user.fullName.trim();
     // user tel
-    this._userTel = user.tel;
+    this._userTel = isNullOrUndefined( user.tel ) ? '' : user.tel.trim();
     // user image
-    this._imageUrl = user.imageUrl;
+    this._imageUrl = isNullOrUndefined( user.imageUrl ) ? '' : user.imageUrl.trim();
     // 팝업 show
     this.isShow = true;
     // 팝업시 하단 스크롤 hide
@@ -384,9 +406,9 @@ export class ProfileComponent extends AbstractComponent implements OnInit, OnDes
     // 초기화
     this.user = new User();
     // email flag
-    this.resultEmail = true;
+    this.resultEmail = undefined;
     // name flag
-    this.resultName = true;
+    this.resultName = undefined;
   }
 
   /**
@@ -476,7 +498,7 @@ export class ProfileComponent extends AbstractComponent implements OnInit, OnDes
     };
 
     // 에러 처리
-    this.uploader.onErrorItem = (item, response, status, headers) => {
+    this.uploader.onErrorItem = () => {
       // TODO 이미지 업로드 에러 처리
       console.log('error');
       this.loadingHide();


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
회원 가입 화면 및 사용자 프로필 화면에서의 입력 체크 오류를 수정합니다.
퍼미션 스키마 화면에서의 스크롤 문제를 수정합니다. 

**Related Issue** : MT-12, MT-13, MT-22, MT-23, MT-48 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 사용자 등록화면에서 정상적으로 입력하였을 때 validation check 아이콘이 표시되는지 확인합니다.
2.사용자 등록화면에서 비밀번호 체크를 비밀번호와 다르게 입력하였을 때 정상적으로 체크하는지 확인합니다.
3. GNB > 사용자 프로필 관리 화면에서 Email, Full Name 관련하여 Validation check 가 표시되는지 확인합니다.
4. GNB > 사용자 프로필 관리 화면에서 내용이 수정되었을 때만 저장 버튼이 활성화 되는지 확인합니다.
5. administration > 퍼미션 스키마 화면에서 목록이 많을 경우 상하 스크롤이 정상적으로 동작하는지 확인합니다. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
