### PR TITLE
F#953 close resultset first before cancel statement

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/scheduling/workbench/TimeoutConnectionCloseJob.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/scheduling/workbench/TimeoutConnectionCloseJob.java
@@ -57,21 +57,6 @@ public class TimeoutConnectionCloseJob extends QuartzJobBean {
 
     LOGGER.info("## Start batch job for checking time out websocket.");
 
-    System.out.println("Session Stats info " +webSocketMessageBrokerStats.getWebSocketSessionStatsInfo());
-
-    System.out.println("userRegistry.getUsers() = " + userRegistry.getUsers());
-
-    for(SimpUser simpUser : userRegistry.getUsers()){
-      System.out.println("simpUser = " + simpUser.getName());
-      for(SimpSession simpSession : simpUser.getSessions()){
-        System.out.println("simpSession.getId() = " + simpSession.getId());
-        for(SimpSubscription simpSubscription : simpSession.getSubscriptions()){
-          System.out.println("simpSubscription.getId() = " + simpSubscription.getId());
-          System.out.println("simpSubscription.getDestination() = " + simpSubscription.getDestination());
-        }
-      }
-    }
-
     //1. getting connect websocket session
     List<String> subscribedWebsocketId = new ArrayList<>();
     for(SimpUser simpUser : userRegistry.getUsers()){

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/scheduling/workbench/TimeoutConnectionCloseJob.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/scheduling/workbench/TimeoutConnectionCloseJob.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.metatron.discovery.domain.scheduling.workbench;
+
+import app.metatron.discovery.domain.workbench.util.WorkbenchDataSource;
+import app.metatron.discovery.domain.workbench.util.WorkbenchDataSourceUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.messaging.simp.user.SimpSession;
+import org.springframework.messaging.simp.user.SimpSubscription;
+import org.springframework.messaging.simp.user.SimpUser;
+import org.springframework.messaging.simp.user.SimpUserRegistry;
+import org.springframework.scheduling.quartz.QuartzJobBean;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.socket.config.WebSocketMessageBrokerStats;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+@Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+public class TimeoutConnectionCloseJob extends QuartzJobBean {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TimeoutConnectionCloseJob.class);
+
+  @Autowired
+  WebSocketMessageBrokerStats webSocketMessageBrokerStats;
+
+  @Autowired
+  private SimpUserRegistry userRegistry;
+  
+  public TimeoutConnectionCloseJob() {
+  }
+
+  @Override
+  public void executeInternal(JobExecutionContext jobExecutionContext) throws JobExecutionException {
+
+    LOGGER.info("## Start batch job for checking time out websocket.");
+
+    System.out.println("Session Stats info " +webSocketMessageBrokerStats.getWebSocketSessionStatsInfo());
+
+    System.out.println("userRegistry.getUsers() = " + userRegistry.getUsers());
+
+    for(SimpUser simpUser : userRegistry.getUsers()){
+      System.out.println("simpUser = " + simpUser.getName());
+      for(SimpSession simpSession : simpUser.getSessions()){
+        System.out.println("simpSession.getId() = " + simpSession.getId());
+        for(SimpSubscription simpSubscription : simpSession.getSubscriptions()){
+          System.out.println("simpSubscription.getId() = " + simpSubscription.getId());
+          System.out.println("simpSubscription.getDestination() = " + simpSubscription.getDestination());
+        }
+      }
+    }
+
+    //1. getting connect websocket session
+    List<String> subscribedWebsocketId = new ArrayList<>();
+    for(SimpUser simpUser : userRegistry.getUsers()){
+      for(SimpSession simpSession : simpUser.getSessions()){
+        for(SimpSubscription simpSubscription : simpSession.getSubscriptions()){
+          if(StringUtils.startsWith(simpSubscription.getDestination(), "/user/queue/workbench")){
+            subscribedWebsocketId.add(simpSession.getId());
+          }
+        }
+      }
+    }
+    LOGGER.info("Current subscribed queue from workbench : {}", subscribedWebsocketId);
+
+    //2. getting workbench datasource
+    Map<String, WorkbenchDataSource> workbenchDataSourceList = WorkbenchDataSourceUtils.getCurrentConnection();
+    LOGGER.info("Current connected workbench DataSource : {}", workbenchDataSourceList.keySet());
+
+    //3. filter workbench datasource not in queue
+    List<WorkbenchDataSource> dataSourceList
+            = workbenchDataSourceList.entrySet().stream()
+            .filter(workbenchMap -> !subscribedWebsocketId.contains(workbenchMap.getKey()))
+            .map(workbenchMap -> workbenchMap.getValue())
+            .collect(Collectors.toList());
+    LOGGER.info("Workbench DataSource not in ws queue : {}",
+            dataSourceList.stream().map(workbenchDataSource -> workbenchDataSource.getWebSocketId()));
+
+    //4. destroy DataSource
+    for(WorkbenchDataSource workbenchDataSource : dataSourceList){
+      if(workbenchDataSource.getSingleConnectionDataSource() != null){
+        workbenchDataSource.getSingleConnectionDataSource().destroy();
+        LOGGER.info("Destroy workbench DataSource : {}", workbenchDataSource.getWebSocketId());
+      }
+    }
+
+    LOGGER.info("## End batch job for checking time out websocket.");
+  }
+
+}

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/scheduling/workbench/TimeoutConnectionCloseJob.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/scheduling/workbench/TimeoutConnectionCloseJob.java
@@ -81,7 +81,7 @@ public class TimeoutConnectionCloseJob extends QuartzJobBean {
             .map(workbenchMap -> workbenchMap.getValue())
             .collect(Collectors.toList());
     LOGGER.info("Workbench DataSource not in ws queue : {}",
-            dataSourceList.stream().map(workbenchDataSource -> workbenchDataSource.getWebSocketId()));
+            dataSourceList.stream().map(workbenchDataSource -> workbenchDataSource.getWebSocketId()).collect(Collectors.toList()));
 
     //4. destroy DataSource
     for(WorkbenchDataSource workbenchDataSource : dataSourceList){

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/QueryEditorService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/QueryEditorService.java
@@ -54,10 +54,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
+import java.sql.*;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -475,11 +472,20 @@ public class QueryEditorService {
         
         LOGGER.debug("Removed remain query all");
         stmt = dataSourceInfo.getCurrentStatement();
-        if(stmt != null)
+        if(stmt != null){
+          ResultSet rs = stmt.getResultSet();
+          if(rs != null){
+            LOGGER.debug("ResultSet is not null");
+            JdbcUtils.closeResultSet(rs);
+          }
           stmt.cancel();
+        }
+
         LOGGER.debug("Statement is canceled");
       }
-    } catch (SQLException sqle) {
+    } catch (SQLFeatureNotSupportedException e) {
+      LOGGER.debug("Presto not Support cancel...");
+    } catch (SQLException e) {
     } finally {
       JdbcUtils.closeStatement(stmt);
     }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/WorkbenchController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/WorkbenchController.java
@@ -15,16 +15,16 @@
 package app.metatron.discovery.domain.workbench;
 
 import app.metatron.discovery.common.exception.BadRequestException;
-import app.metatron.discovery.common.exception.GlobalErrorCodes;
-import app.metatron.discovery.common.exception.MetatronException;
+import app.metatron.discovery.common.exception.ResourceNotFoundException;
 import app.metatron.discovery.domain.datasource.connection.DataConnection;
 import app.metatron.discovery.domain.datasource.connection.jdbc.HiveConnection;
 import app.metatron.discovery.domain.workbench.dto.ImportFile;
 import app.metatron.discovery.domain.workbench.hive.WorkbenchHiveService;
+import app.metatron.discovery.domain.workbench.util.WorkbenchDataSource;
+import app.metatron.discovery.domain.workbench.util.WorkbenchDataSourceUtils;
+import app.metatron.discovery.domain.workspace.Workspace;
 import app.metatron.discovery.util.HibernateUtils;
 import org.apache.commons.lang.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -34,13 +34,7 @@ import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.io.IOException;
 import java.util.Map;
-
-import app.metatron.discovery.common.exception.ResourceNotFoundException;
-import app.metatron.discovery.domain.workbench.util.WorkbenchDataSource;
-import app.metatron.discovery.domain.workbench.util.WorkbenchDataSourceUtils;
-import app.metatron.discovery.domain.workspace.Workspace;
 
 @RepositoryRestController
 public class WorkbenchController {
@@ -74,24 +68,11 @@ public class WorkbenchController {
     return ResponseEntity.ok(this.pagedResourcesAssembler.toResource(workbenches, resourceAssembler));
   }
 
-  @RequestMapping(value = "/workbenchs/connection", method = RequestMethod.GET, produces = "application/json")
+  @RequestMapping(value = "/workbenchs/connection", method = RequestMethod.GET)
   @ResponseBody
   public ResponseEntity<?> currentConnection() {
     Map<String, WorkbenchDataSource> dataSourceMap = WorkbenchDataSourceUtils.getCurrentConnection();
-    return ResponseEntity.ok(
-            dataSourceMap.entrySet().stream()
-                    .map(e -> e.getValue().toString())
-                    .toArray());
-  }
-
-  @RequestMapping(value = "/workbenchdatasource", method = RequestMethod.GET, produces = "application/json")
-  @ResponseBody
-  public ResponseEntity<?> workbenchdatasource() {
-    Map<String, WorkbenchDataSource> dataSourceMap = WorkbenchDataSourceUtils.getCurrentConnection();
-    return ResponseEntity.ok(
-            dataSourceMap.entrySet().stream()
-                    .map(e -> e.getValue().toString())
-                    .toArray());
+    return ResponseEntity.ok(dataSourceMap);
   }
 
   @RequestMapping(value = "/workbenchs/{id}/import", method = RequestMethod.POST)

--- a/discovery-server/src/main/resources/application.yaml
+++ b/discovery-server/src/main/resources/application.yaml
@@ -240,7 +240,7 @@ polaris:
   workbench:
     defaultResultSize: 1000
     maxResultSize: 1000000
-    maxFetchSize: 10000
+    maxFetchSize: 1000
     tempHdfsPath: /tmp/hive
     tempCSVPath: /tmp
   geoserver:

--- a/discovery-server/src/main/resources/application.yaml
+++ b/discovery-server/src/main/resources/application.yaml
@@ -4,7 +4,7 @@
 # --polaris.analyze.pivot=false --polaris.analyze.forward=JSON
 spring:
   profiles:
-    active: local,mysql-default-db,logging-console-debug,spark-local-yarn,scheduling # cloud-local #, initial #, bcrypt-encoder, encode-password-initial
+    active: local,h2-default-db,logging-console-debug,spark-local-yarn,scheduling # cloud-local #, initial #, bcrypt-encoder, encode-password-initial
   application:
     name: ${METATRON_NAME:metatron}
   datasource:

--- a/discovery-server/src/main/resources/application.yaml
+++ b/discovery-server/src/main/resources/application.yaml
@@ -4,7 +4,7 @@
 # --polaris.analyze.pivot=false --polaris.analyze.forward=JSON
 spring:
   profiles:
-    active: local,h2-default-db,logging-console-debug,spark-local-yarn,scheduling # cloud-local #, initial #, bcrypt-encoder, encode-password-initial
+    active: local,mysql-default-db,logging-console-debug,spark-local-yarn,scheduling # cloud-local #, initial #, bcrypt-encoder, encode-password-initial
   application:
     name: ${METATRON_NAME:metatron}
   datasource:

--- a/discovery-server/src/main/resources/logback-console.xml
+++ b/discovery-server/src/main/resources/logback-console.xml
@@ -54,6 +54,10 @@
 
     <logger name="app.metatron.discovery" level="debug"/>
 
+    <logger name="org.springframework.jdbc" level="debug"/>
+    <logger name="org.apache.hive" level="debug"/>
+    <logger name="java.sql" level="debug"/>
+
     <root level="WARN">
         <appender-ref ref="CONSOLE"/>
     </root>

--- a/discovery-server/src/main/resources/logback-console.xml
+++ b/discovery-server/src/main/resources/logback-console.xml
@@ -54,10 +54,6 @@
 
     <logger name="app.metatron.discovery" level="debug"/>
 
-    <logger name="org.springframework.jdbc" level="debug"/>
-    <logger name="org.apache.hive" level="debug"/>
-    <logger name="java.sql" level="debug"/>
-
     <root level="WARN">
         <appender-ref ref="CONSOLE"/>
     </root>


### PR DESCRIPTION
### Description
If canceling the query, close the resultset first if it exists before canceling the statement.
This is a similar implementation of the cancel () method of an unimplemented PrestoStatement.

**Related Issue** : <!--- Please link to the issue here. -->
#953 

### How Has This Been Tested?
1. goto Presto workbench.
2. execute query
3. click cancel button
4. See if the cancellation is done.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
