### PR TITLE
Fix missing "get only the first" option on db ingestion stage

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcConnectionService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcConnectionService.java
@@ -17,6 +17,20 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specic language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -28,34 +42,12 @@
 
 package app.metatron.discovery.domain.datasource.connection.jdbc;
 
-import app.metatron.discovery.common.datasource.DataType;
-import app.metatron.discovery.common.datasource.LogicalType;
-import app.metatron.discovery.common.exception.ResourceNotFoundException;
-import app.metatron.discovery.domain.datasource.Field;
-import app.metatron.discovery.domain.datasource.connection.ConnectionRequest;
-import app.metatron.discovery.domain.datasource.connection.DataConnection;
-import app.metatron.discovery.domain.datasource.connection.jdbc.query.NativeCriteria;
-import app.metatron.discovery.domain.datasource.connection.jdbc.query.expression.*;
-import app.metatron.discovery.domain.datasource.connection.jdbc.query.utils.VarGenerator;
-import app.metatron.discovery.domain.datasource.data.CandidateQueryRequest;
-import app.metatron.discovery.domain.datasource.ingestion.jdbc.BatchIngestionInfo;
-import app.metatron.discovery.domain.datasource.ingestion.jdbc.JdbcIngestionInfo;
-import app.metatron.discovery.domain.datasource.ingestion.jdbc.LinkIngestionInfo;
-import app.metatron.discovery.domain.datasource.ingestion.jdbc.SelectQueryBuilder;
-import app.metatron.discovery.domain.engine.EngineProperties;
-import app.metatron.discovery.domain.user.CachedUserService;
-import app.metatron.discovery.domain.user.User;
-import app.metatron.discovery.domain.workbench.util.WorkbenchDataSource;
-import app.metatron.discovery.domain.workbench.util.WorkbenchDataSourceUtils;
-import app.metatron.discovery.domain.workbook.configurations.filter.Filter;
-import app.metatron.discovery.domain.workbook.configurations.filter.InclusionFilter;
-import app.metatron.discovery.domain.workbook.configurations.filter.IntervalFilter;
-import app.metatron.discovery.util.AuthUtils;
-import app.metatron.discovery.util.PolarisUtils;
-import com.facebook.presto.jdbc.PrestoArray;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+
+import com.facebook.presto.jdbc.PrestoArray;
+
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.expression.DateValue;
 import net.sf.jsqlparser.expression.Expression;
@@ -68,10 +60,15 @@ import net.sf.jsqlparser.expression.operators.relational.GreaterThanEquals;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.schema.Table;
-import net.sf.jsqlparser.statement.select.*;
+import net.sf.jsqlparser.statement.select.Limit;
+import net.sf.jsqlparser.statement.select.PlainSelect;
+import net.sf.jsqlparser.statement.select.Select;
+import net.sf.jsqlparser.statement.select.SelectExpressionItem;
+import net.sf.jsqlparser.statement.select.SelectItem;
 import net.sf.jsqlparser.util.SelectUtils;
 import net.sf.jsqlparser.util.cnfexpression.MultiAndExpression;
 import net.sf.jsqlparser.util.cnfexpression.MultiOrExpression;
+
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -90,27 +87,66 @@ import org.springframework.jdbc.support.JdbcUtils;
 import org.springframework.stereotype.Component;
 import org.supercsv.prefs.CsvPreference;
 
-import javax.sql.DataSource;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.sql.*;
+import java.sql.Connection;
 import java.sql.Date;
-import java.util.*;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 import java.util.stream.Collectors;
+
+import javax.sql.DataSource;
+
+import app.metatron.discovery.common.datasource.DataType;
+import app.metatron.discovery.common.datasource.LogicalType;
+import app.metatron.discovery.common.exception.ResourceNotFoundException;
+import app.metatron.discovery.domain.datasource.Field;
+import app.metatron.discovery.domain.datasource.connection.ConnectionRequest;
+import app.metatron.discovery.domain.datasource.connection.DataConnection;
+import app.metatron.discovery.domain.datasource.connection.jdbc.query.NativeCriteria;
+import app.metatron.discovery.domain.datasource.connection.jdbc.query.expression.NativeCurrentDatetimeExp;
+import app.metatron.discovery.domain.datasource.connection.jdbc.query.expression.NativeDateFormatExp;
+import app.metatron.discovery.domain.datasource.connection.jdbc.query.expression.NativeEqExp;
+import app.metatron.discovery.domain.datasource.connection.jdbc.query.expression.NativeOrderExp;
+import app.metatron.discovery.domain.datasource.connection.jdbc.query.expression.NativeProjection;
+import app.metatron.discovery.domain.datasource.connection.jdbc.query.utils.VarGenerator;
+import app.metatron.discovery.domain.datasource.data.CandidateQueryRequest;
+import app.metatron.discovery.domain.datasource.data.QueryTimeExcetpion;
+import app.metatron.discovery.domain.datasource.ingestion.jdbc.BatchIngestionInfo;
+import app.metatron.discovery.domain.datasource.ingestion.jdbc.JdbcIngestionInfo;
+import app.metatron.discovery.domain.datasource.ingestion.jdbc.LinkIngestionInfo;
+import app.metatron.discovery.domain.datasource.ingestion.jdbc.SelectQueryBuilder;
+import app.metatron.discovery.domain.engine.EngineProperties;
+import app.metatron.discovery.domain.user.CachedUserService;
+import app.metatron.discovery.domain.user.User;
+import app.metatron.discovery.domain.workbench.util.WorkbenchDataSource;
+import app.metatron.discovery.domain.workbench.util.WorkbenchDataSourceUtils;
+import app.metatron.discovery.domain.workbook.configurations.filter.Filter;
+import app.metatron.discovery.domain.workbook.configurations.filter.InclusionFilter;
+import app.metatron.discovery.domain.workbook.configurations.filter.IntervalFilter;
+import app.metatron.discovery.util.AuthUtils;
+import app.metatron.discovery.util.PolarisUtils;
 
 import static app.metatron.discovery.domain.datasource.connection.jdbc.JdbcDataConnection.CURRENT_DATE_FORMAT;
 import static java.util.stream.Collectors.toList;
 
 /**
- * Created by kyungtaak on 2016. 6. 16..
+ *
  */
 @Component
 public class JdbcConnectionService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(JdbcConnectionService.class);
-
-  private static final int MAX_FETCH_SIZE = 100000;
 
   private static final String RESULTSET_COLUMN_PREFIX = SelectQueryBuilder.TEMP_TABLE_NAME + ".";
 
@@ -670,7 +706,7 @@ public class JdbcConnectionService {
       return searchTablesWithQueryPageable(connection, dataSource, schema, tableNamePattern, pageable);
     } else if (connection instanceof HiveMetastoreConnection && ((HiveMetastoreConnection) connection).includeMetastoreInfo()) {
       return searchTablesWithHiveMetastore(connection, dataSource, schema, tableNamePattern, pageable);
-    } else if (connection instanceof HiveConnection || connection instanceof PrestoConnection){
+    } else if (connection instanceof HiveConnection || connection instanceof PrestoConnection) {
       return searchTablesWithQuery(connection, dataSource, schema, tableNamePattern);
     } else {
       return searchTablesWithMetadata(connection, dataSource, schema, tableNamePattern);
@@ -711,7 +747,7 @@ public class JdbcConnectionService {
   }
 
   public Map<String, Object> searchTablesWithQuery(JdbcDataConnection connection, DataSource dataSource,
-                                                           String schema, String tableNamePattern) {
+                                                   String schema, String tableNamePattern) {
     JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
 
     String tableListQuery = connection.getShowTableQuery(schema);
@@ -724,31 +760,31 @@ public class JdbcConnectionService {
     } catch (Exception e) {
       LOGGER.error("Fail to get list of table : {}", e.getMessage());
       throw new JdbcDataConnectionException(JdbcDataConnectionErrorCodes.INVALID_QUERY_ERROR_CODE,
-              "Fail to get list of database : " + e.getMessage());
+                                            "Fail to get list of database : " + e.getMessage());
     }
 
     tableNames.stream()
-            .forEach(tableMap -> {
-              tableMap.put("name", tableMap.get(connection.getTableNameColumn()));
-              tableMap.remove(connection.getTableNameColumn());
-            });
+              .forEach(tableMap -> {
+                tableMap.put("name", tableMap.get(connection.getTableNameColumn()));
+                tableMap.remove(connection.getTableNameColumn());
+              });
 
     //exclude table
     List<String> excludeTables = connection.getExcludeTables();
-    if(excludeTables != null){
+    if (excludeTables != null) {
       tableNames = tableNames.stream()
-              .filter(tableInfoMap -> excludeTables.indexOf(tableInfoMap.get("name").toString()) < 0)
-              .collect(toList());
+                             .filter(tableInfoMap -> excludeTables.indexOf(tableInfoMap.get("name").toString()) < 0)
+                             .collect(toList());
     }
 
     Map<String, Object> databaseMap = new LinkedHashMap<>();
-    if(StringUtils.isEmpty(tableNamePattern)){
+    if (StringUtils.isEmpty(tableNamePattern)) {
       databaseMap.put("tables", tableNames);
       databaseMap.put("page", createPageInfoMap(tableNames.size(), tableNames.size(), 0));
     } else {
       List filteredList = tableNames.stream()
-              .filter(tableMap -> tableMap.get("name").toString().contains(tableNamePattern))
-              .collect(Collectors.toList());
+                                    .filter(tableMap -> tableMap.get("name").toString().contains(tableNamePattern))
+                                    .collect(Collectors.toList());
       databaseMap.put("tables", filteredList);
       databaseMap.put("page", createPageInfoMap(filteredList.size(), filteredList.size(), 0));
     }
@@ -857,10 +893,10 @@ public class JdbcConnectionService {
     Map<String, Object> tableMap = new LinkedHashMap<>();
 
     List<String> excludeTables = connection.getExcludeTables();
-    if(excludeTables != null){
+    if (excludeTables != null) {
       tableInfos = tableInfos.stream()
-              .filter(tableInfoMap -> excludeTables.indexOf(tableInfoMap.get("name")) >= 0)
-              .collect(toList());
+                             .filter(tableInfoMap -> excludeTables.indexOf(tableInfoMap.get("name")) >= 0)
+                             .collect(toList());
     }
 
     int tableCount = tableInfos.size();
@@ -897,9 +933,9 @@ public class JdbcConnectionService {
       // queryResultSet.setTotalRows(totalRows);
     } catch (SQLException e) {
       LOGGER.error("Fail to query for select : SQLState({}), ErrorCode({}), Message : {}"
-              , e.getSQLState(), e.getErrorCode(), e.getMessage());
+          , e.getSQLState(), e.getErrorCode(), e.getMessage());
       throw new JdbcDataConnectionException(JdbcDataConnectionErrorCodes.PREVIEW_TABLE_SQL_ERROR,
-              "Fail to query : " + e.getSQLState() + ", "  + e.getErrorCode() + ", " + e.getMessage());
+                                            "Fail to query : " + e.getSQLState() + ", " + e.getErrorCode() + ", " + e.getMessage());
     } catch (Exception e) {
       LOGGER.error("Fail to query for select :  {}", e.getMessage());
       throw new JdbcDataConnectionException(JdbcDataConnectionErrorCodes.INVALID_QUERY_ERROR_CODE,
@@ -938,10 +974,10 @@ public class JdbcConnectionService {
       nativeCriteria.addTable(tableName, table);
 
       //add projection for partition
-      if(partitionList != null && !partitionList.isEmpty()){
+      if (partitionList != null && !partitionList.isEmpty()) {
 
-        for(Map<String, Object> partitionMap : partitionList){
-          for(String keyStr : partitionMap.keySet()){
+        for (Map<String, Object> partitionMap : partitionList) {
+          for (String keyStr : partitionMap.keySet()) {
             nativeCriteria.add(new NativeEqExp(keyStr, partitionMap.get(keyStr)));
           }
         }
@@ -1045,32 +1081,31 @@ public class JdbcConnectionService {
     // Get JDBC Connection and set database
     JdbcDataConnection realConnection = connection == null ? ingestionInfo.getConnection() : connection;
     if (connection instanceof MySQLConnection
-            || connection instanceof HiveConnection
-            || connection instanceof PrestoConnection) {
+        || connection instanceof HiveConnection
+        || connection instanceof PrestoConnection) {
       if (ingestionInfo.getDatabase() != null) {
         realConnection.setDatabase(ingestionInfo.getDatabase());
       }
     }
 
     DataSource dataSource = getDataSource(Preconditions.checkNotNull(realConnection, "connection info. required."),
-            true);
+                                          true);
 
     List<String> tempCsvFiles = Lists.newArrayList();
 
     String queryString;
     Select select = null;
     PlainSelect selectBody;
-    try{
+    try {
       select = createSelect(ingestionInfo);
       selectBody = (PlainSelect) select.getSelectBody();
       addFields(selectBody, fields, realConnection);
       addFilter(selectBody, filters);
-      if(limit != null)
-        addLimit(selectBody, maxLimit);
-    } catch (JSQLParserException e){
-      e.printStackTrace();
+      addLimit(selectBody, maxLimit);
+    } catch (JSQLParserException e) {
+      LOGGER.error("Fail to build SQL", e);
+      throw new QueryTimeExcetpion("Fail to build SQL", e);
     }
-
 
     queryString = select.toString();
 
@@ -1078,7 +1113,7 @@ public class JdbcConnectionService {
 
     // 쿼리 결과 저장
     String tempFileName = getTempFileName(baseDir, EngineProperties.TEMP_CSV_PREFIX + "_"
-            + dataSourceName + "_" + System.currentTimeMillis());
+        + dataSourceName + "_" + System.currentTimeMillis());
     JdbcCSVWriter jdbcCSVWriter = null;
     try {
       jdbcCSVWriter = new JdbcCSVWriter(new FileWriter(tempFileName), CsvPreference.STANDARD_PREFERENCE);
@@ -1107,7 +1142,7 @@ public class JdbcConnectionService {
 
   }
 
-  public Select createSelect(JdbcIngestionInfo ingestionInfo) throws JSQLParserException{
+  public Select createSelect(JdbcIngestionInfo ingestionInfo) throws JSQLParserException {
     Select select;
     if (ingestionInfo.getDataType() == JdbcIngestionInfo.DataType.TABLE) {
       String database = ingestionInfo.getDatabase();
@@ -1116,7 +1151,7 @@ public class JdbcConnectionService {
       select = SelectUtils.buildSelectFromTable(new Table(tableName));
     } else {
       net.sf.jsqlparser.statement.Statement parsedStmt = CCJSqlParserUtil.parse(ingestionInfo.getQuery());
-      if(!(parsedStmt instanceof Select)){
+      if (!(parsedStmt instanceof Select)) {
         throw new JSQLParserException("query is not select");
       }
 
@@ -1125,13 +1160,13 @@ public class JdbcConnectionService {
     return select;
   }
 
-  public PlainSelect addFields(PlainSelect selectBody, List<Field> fields, DataConnection realConnection){
+  public PlainSelect addFields(PlainSelect selectBody, List<Field> fields, DataConnection realConnection) {
     if (CollectionUtils.isNotEmpty(fields)) {
       //change projection
       List<SelectItem> newSelectItems = Lists.newArrayList();
-      for(Field field : fields){
+      for (Field field : fields) {
         //
-        if(field.isNotPhysicalField()) {
+        if (field.isNotPhysicalField()) {
           continue;
         }
 
@@ -1141,8 +1176,8 @@ public class JdbcConnectionService {
           NativeCurrentDatetimeExp nativeCurrentDatetimeExp = new NativeCurrentDatetimeExp(field.getName());
           columnName = nativeCurrentDatetimeExp.toSQL(implementor);
         } else if (StringUtils.isEmpty(field.getTimeFormat()) &&
-                (field.getRole() == Field.FieldRole.TIMESTAMP ||
-                        (field.getRole() == Field.FieldRole.DIMENSION && field.getType() == DataType.TIMESTAMP))) {
+            (field.getRole() == Field.FieldRole.TIMESTAMP ||
+                (field.getRole() == Field.FieldRole.DIMENSION && field.getType() == DataType.TIMESTAMP))) {
           NativeDateFormatExp nativeDateFormatExp = new NativeDateFormatExp(field.getName(), null);
           columnName = nativeDateFormatExp.toSQL(implementor);
           field.setFormat(NativeDateFormatExp.COMMON_DEFAULT_DATEFORMAT);
@@ -1151,7 +1186,7 @@ public class JdbcConnectionService {
         }
 
         SelectExpressionItem selectExpressionItem = new SelectExpressionItem(new Column(columnName));
-//          selectExpressionItem.setAlias(new Alias(field.getAlias()));
+        //          selectExpressionItem.setAlias(new Alias(field.getAlias()));
         newSelectItems.add(selectExpressionItem);
       }
       selectBody.setSelectItems(newSelectItems);
@@ -1160,7 +1195,7 @@ public class JdbcConnectionService {
     return selectBody;
   }
 
-  public PlainSelect addFilter(PlainSelect selectBody, List<Filter> filters){
+  public PlainSelect addFilter(PlainSelect selectBody, List<Filter> filters) {
     if (filters != null && !filters.isEmpty()) {
       List<Expression> andExprList = new ArrayList<>();
       for (Filter filter : filters) {
@@ -1226,7 +1261,7 @@ public class JdbcConnectionService {
         }
       }
 
-      if(selectBody.getWhere() != null){
+      if (selectBody.getWhere() != null) {
         selectBody.setWhere(new AndExpression(selectBody.getWhere(), new MultiAndExpression(andExprList)));
       } else {
         selectBody.setWhere(new MultiAndExpression(andExprList));
@@ -1235,7 +1270,7 @@ public class JdbcConnectionService {
     return selectBody;
   }
 
-  public PlainSelect addLimit(PlainSelect selectBody, int maxLimit){
+  public PlainSelect addLimit(PlainSelect selectBody, int maxLimit) {
     Limit limitExpression = new Limit();
     limitExpression.setRowCount(new LongValue(maxLimit));
     selectBody.setLimit(limitExpression);
@@ -1275,7 +1310,7 @@ public class JdbcConnectionService {
     NativeProjection nativeProjection = new NativeProjection();
 
     String targetFieldName = targetField.getName();
-    if(StringUtils.contains(targetFieldName, ".")){
+    if (StringUtils.contains(targetFieldName, ".")) {
       targetFieldName = StringUtils.split(targetFieldName, ".")[1];
     }
 
@@ -1351,18 +1386,18 @@ public class JdbcConnectionService {
     List<String> tempCsvFiles = Lists.newArrayList();
 
     // 증분 Query 작성
-//    String queryString = new SelectQueryBuilder(realConnection)
-//        .projection(fields)
-//        .query(batchIngestionInfo)
-//        .incremental(timestampField, incrementalTime.toString(CURRENT_DATE_FORMAT))
-//        .limit(0, maxLimit)
-//        .build();
-//
-//    LOGGER.debug("Generated incremental query : {} ", queryString);
+    //    String queryString = new SelectQueryBuilder(realConnection)
+    //        .projection(fields)
+    //        .query(batchIngestionInfo)
+    //        .incremental(timestampField, incrementalTime.toString(CURRENT_DATE_FORMAT))
+    //        .limit(0, maxLimit)
+    //        .build();
+    //
+    //    LOGGER.debug("Generated incremental query : {} ", queryString);
 
     Select select = null;
     PlainSelect selectBody;
-    try{
+    try {
 
       select = createSelect(ingestionInfo);
       selectBody = (PlainSelect) select.getSelectBody();
@@ -1378,7 +1413,7 @@ public class JdbcConnectionService {
         String rightExprStr = realConnection.getCharToDateStmt(incrementalTime.toString(CURRENT_DATE_FORMAT), JdbcDataConnection.DEFAULT_FORMAT);
         greaterThanEquals.setRightExpression(new Column(rightExprStr));
 
-        if(selectBody.getWhere() != null){
+        if (selectBody.getWhere() != null) {
           AndExpression andExpression = new AndExpression(selectBody.getWhere(), greaterThanEquals);
           selectBody.setWhere(andExpression);
         } else {
@@ -1393,7 +1428,7 @@ public class JdbcConnectionService {
         limitExpression.setRowCount(new LongValue(maxLimit));
         selectBody.setLimit(limitExpression);
       }
-    } catch (JSQLParserException e){
+    } catch (JSQLParserException e) {
       throw new RuntimeException(e.getMessage());
     }
 
@@ -1488,8 +1523,8 @@ public class JdbcConnectionService {
     long duplicated = fieldList.stream()
                                .filter(field -> field.getName().equals(fieldName))
                                .count();
-    if(duplicated > 0){
-      if(StringUtils.contains(fieldName, ".")){
+    if (duplicated > 0) {
+      if (StringUtils.contains(fieldName, ".")) {
         return StringUtils.split(fieldName, ".")[0] + "." + VarGenerator.gen(fieldName);
       } else {
         return VarGenerator.gen(fieldName);
@@ -1574,11 +1609,11 @@ public class JdbcConnectionService {
     }
 
     List<String> excludeSchemas = connection.getExcludeSchemas();
-    if(excludeSchemas != null){
+    if (excludeSchemas != null) {
       //filter after query execute for hive
       databaseNames = databaseNames.stream()
-              .filter(databaseName -> excludeSchemas.indexOf(databaseName) < 0)
-              .collect(toList());
+                                   .filter(databaseName -> excludeSchemas.indexOf(databaseName) < 0)
+                                   .collect(toList());
     }
 
     databaseCount = databaseNames.size();
@@ -1604,10 +1639,10 @@ public class JdbcConnectionService {
     }
 
     List<String> excludeSchemas = connection.getExcludeSchemas();
-    if(excludeSchemas != null){
+    if (excludeSchemas != null) {
       filteredList = filteredList.stream()
-              .filter(schema -> excludeSchemas.indexOf(schema) < 0)
-              .collect(toList());
+                                 .filter(schema -> excludeSchemas.indexOf(schema) < 0)
+                                 .collect(toList());
     }
 
     schemaMap.put("databases", filteredList);
@@ -1623,7 +1658,7 @@ public class JdbcConnectionService {
   public Map<String, Object> searchDatabases(JdbcDataConnection connection, DataSource dataSource,
                                              String databaseNamePattern, Pageable pageable) {
     if (
-            connection instanceof MySQLConnection ||
+        connection instanceof MySQLConnection ||
             connection instanceof MssqlConnection) {
       return searchDatabasesWithQueryPageable(connection, dataSource, databaseNamePattern, pageable);
     } else if (connection instanceof PostgresqlConnection) {
@@ -1820,9 +1855,9 @@ public class JdbcConnectionService {
     properties.setProperty("password", password);
 
     //add native properties
-    if(connection.getPropertiesMap() != null){
-      for(String propertyKey : connection.getPropertiesMap().keySet()){
-        if(StringUtils.startsWith(propertyKey, JdbcDataConnection.JDBC_PROPERTY_PREFIX)){
+    if (connection.getPropertiesMap() != null) {
+      for (String propertyKey : connection.getPropertiesMap().keySet()) {
+        if (StringUtils.startsWith(propertyKey, JdbcDataConnection.JDBC_PROPERTY_PREFIX)) {
           String nativePropertyKey = StringUtils.replaceFirst(propertyKey, JdbcDataConnection.JDBC_PROPERTY_PREFIX, "");
           properties.setProperty(nativePropertyKey, connection.getPropertiesMap().get(propertyKey));
         }
@@ -1843,14 +1878,14 @@ public class JdbcConnectionService {
     JdbcUtils.closeConnection(connection);
   }
 
-  public int writeResultSetToCSV(ResultSet resultSet, String tempCsvFilePath, List<String> headers) throws SQLException{
+  public int writeResultSetToCSV(ResultSet resultSet, String tempCsvFilePath, List<String> headers) throws SQLException {
     JdbcCSVWriter jdbcCSVWriter = null;
     int rowNumber = 0;
     try {
       jdbcCSVWriter = new JdbcCSVWriter(new FileWriter(tempCsvFilePath), CsvPreference.STANDARD_PREFERENCE);
 
       //write header from list if exist
-      if(headers != null && !headers.isEmpty()){
+      if (headers != null && !headers.isEmpty()) {
         jdbcCSVWriter.setWithHeader(false);
         jdbcCSVWriter.writeHeaders(headers);
       }
@@ -1859,10 +1894,11 @@ public class JdbcConnectionService {
     } catch (IOException e) {
       LOGGER.error("writeResultSetToCSV error", e);
     } finally {
-      try{
-        if(jdbcCSVWriter != null)
+      try {
+        if (jdbcCSVWriter != null)
           jdbcCSVWriter.close();
-      }catch (IOException e){}
+      } catch (IOException e) {
+      }
     }
     return rowNumber;
   }
@@ -1880,12 +1916,12 @@ public class JdbcConnectionService {
       String fieldName;
       String tableName;
 
-      if(extractColumnName){
+      if (extractColumnName) {
         fieldName = extractColumnName(columnLabel);
       } else {
         fieldName = removeDummyPrefixColumnName(columnLabel);
         //useOldAliasMetadataBehavior=true
-        if(metaData instanceof com.mysql.jdbc.ResultSetMetaData){
+        if (metaData instanceof com.mysql.jdbc.ResultSetMetaData) {
           tableName = metaData.getTableName(i);
           fieldName = tableName + "." + fieldName;
         }
@@ -1912,10 +1948,10 @@ public class JdbcConnectionService {
       for (int i = 1; i <= colNum; i++) {
         String fieldName = fields.get(i - 1).getName();
         //@TODO require Oracle JDBC configuartion
-//        if (rs.getObject(i) instanceof TIMESTAMP) { // Oracle Timestamp Case
-//          TIMESTAMP timestamp = (TIMESTAMP) rs.getObject(i);
-//          rowMap.put(fieldName, timestamp.timestampValue().toString());
-//        } else
+        //        if (rs.getObject(i) instanceof TIMESTAMP) { // Oracle Timestamp Case
+        //          TIMESTAMP timestamp = (TIMESTAMP) rs.getObject(i);
+        //          rowMap.put(fieldName, timestamp.timestampValue().toString());
+        //        } else
         if (rs.getObject(i) instanceof Timestamp) {
           rowMap.put(fieldName, rs.getObject(i).toString());
         } else if (rs.getObject(i) instanceof PgArray || rs.getObject(i) instanceof PGobject) {
@@ -1931,60 +1967,60 @@ public class JdbcConnectionService {
     return dataList;
   }
 
-  public List<Map<String, Object>> getPartitionList(HiveMetastoreConnection connection, ConnectionRequest connectionRequest){
+  public List<Map<String, Object>> getPartitionList(HiveMetastoreConnection connection, ConnectionRequest connectionRequest) {
     HiveMetaStoreJdbcClient hiveMetaStoreJdbcClient = new HiveMetaStoreJdbcClient(
-            connection.getMetastoreURL(),
-            connection.getMetastoreUserName(),
-            connection.getMetastorePassword(),
-            connection.getMetastoreDriverName());
+        connection.getMetastoreURL(),
+        connection.getMetastoreUserName(),
+        connection.getMetastorePassword(),
+        connection.getMetastoreDriverName());
 
     List partitionInfoList = hiveMetaStoreJdbcClient.getPartitionList(connectionRequest.getDatabase(), connectionRequest.getQuery(), null);
     return partitionInfoList;
   }
 
-  public List<Map<String, Object>> validatePartition(HiveMetastoreConnection connection, ConnectionRequest connectionRequest){
+  public List<Map<String, Object>> validatePartition(HiveMetastoreConnection connection, ConnectionRequest connectionRequest) {
     HiveMetaStoreJdbcClient hiveMetaStoreJdbcClient = new HiveMetaStoreJdbcClient(
-            connection.getMetastoreURL(),
-            connection.getMetastoreUserName(),
-            connection.getMetastorePassword(),
-            connection.getMetastoreDriverName());
+        connection.getMetastoreURL(),
+        connection.getMetastoreUserName(),
+        connection.getMetastorePassword(),
+        connection.getMetastoreDriverName());
 
     List<String> partitionNameList = new ArrayList<>();
-    for(Map<String, Object> partitionNameMap : connectionRequest.getPartitions()){
+    for (Map<String, Object> partitionNameMap : connectionRequest.getPartitions()) {
       partitionNameList.addAll(PolarisUtils.mapWithRangeExpressionToList(partitionNameMap));
     }
     //1. partition info 가져오기
     List<Map<String, Object>> partitionInfoList = new ArrayList<>();
-    try{
+    try {
       partitionInfoList = hiveMetaStoreJdbcClient.getPartitionList(connectionRequest.getDatabase(), connectionRequest.getQuery(), partitionNameList);
-    } catch (Exception e){
+    } catch (Exception e) {
       throw new JdbcDataConnectionException(JdbcDataConnectionErrorCodes.PARTITION_NOT_EXISTED, e.getCause().getMessage());
     }
 
     //2. partition parameter가 모두 존재하는지 여부
-    for(String partitionNameParam : partitionNameList){
+    for (String partitionNameParam : partitionNameList) {
       //must exist partition exclude asterisk
       boolean isPartitionExist = false;
-      if(partitionNameParam.contains("{*}")){
+      if (partitionNameParam.contains("{*}")) {
         isPartitionExist = true;
       } else {
-        for(Map<String, Object> existPartition : partitionInfoList){
+        for (Map<String, Object> existPartition : partitionInfoList) {
           String existPartName = existPartition.get("PART_NAME").toString();
-          if(partitionNameParam.equals(existPartName)){
+          if (partitionNameParam.equals(existPartName)) {
             isPartitionExist = true;
             break;
           }
         }
       }
 
-      if(!isPartitionExist)
+      if (!isPartitionExist)
         throw new JdbcDataConnectionException(JdbcDataConnectionErrorCodes.PARTITION_NOT_EXISTED,
-                "partition (" + partitionNameParam + ") is not exists in " + connectionRequest.getQuery() + ".");
+                                              "partition (" + partitionNameParam + ") is not exists in " + connectionRequest.getQuery() + ".");
     }
 
-    if(partitionInfoList == null || partitionInfoList.isEmpty())
+    if (partitionInfoList == null || partitionInfoList.isEmpty())
       throw new JdbcDataConnectionException(JdbcDataConnectionErrorCodes.PARTITION_NOT_EXISTED,
-              "partition is not exists in " + connectionRequest.getQuery() + ".");
+                                            "partition is not exists in " + connectionRequest.getQuery() + ".");
 
     return partitionInfoList;
   }

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/datasource/DataSourceRestIntegrationTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/datasource/DataSourceRestIntegrationTest.java
@@ -3,6 +3,20 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specic language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -2207,6 +2221,8 @@ public class DataSourceRestIntegrationTest extends AbstractRestIntegrationTest {
     singleJdbcInfo.setDataType(JdbcIngestionInfo.DataType.TABLE);
     singleJdbcInfo.setDatabase("polaris_datasources");
     singleJdbcInfo.setQuery("sample_ingestion");
+    singleJdbcInfo.setMaxLimit(3);
+    singleJdbcInfo.setRollup(false);
 
     dataSource.setIngestion(GlobalObjectMapper.writeValueAsString(singleJdbcInfo));
 


### PR DESCRIPTION
### Description
DB 데이터 소스 적재 단계에서 옵션중  "Get first option" 이 제대로 동작하지 않아 이를 수정합니다.

**Related Issue** : #832 

### How Has This Been Tested?
(사전에 데이터 베이스의 연결정보가 저장되어 있고, 특정 테이블이 준비되어있다고 가정합니다.)

1. 데이터소스 관리자 권한이 있는 사용자로 로그인합니다.
2. LNB 영역에 관리 > 데이터 스토리지 > 데이터 소스 로 이동하여 "새로운 데이터 소스 생성" 버튼을 클릭하여 데이터 소스 생성 단계로 진입합니다.
3. 소스 타입을 데이터 베이스로 선택합니다.
4. 임의의 데이터 커넥션, 테이블을 선택합니다. 
5. 수집 설정에서 "get only the first" 옵션에서 적재하려는 테이블의 총건수 보다 낮은 ROW 로 입력합니다.
   (Roll up 설정을 설정안함으로 지정합니다.)
6. 데이터 소스 수정을 마친 후 상세 페이지에서 건수정보를 확인합니다. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project. _it will be added soon_
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. _it will be added soon_
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

### Additional Context<!-- if not appropriate, remove this topic. -->
