### PR TITLE
Can set retry option for ingestion job

### DIFF
--- a/discovery-server/pom.xml
+++ b/discovery-server/pom.xml
@@ -1,5 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specic language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!--
  ~ Licensed under the Apache License, Version 2.0 (the "License");
  ~ you may not use this file except in compliance with the License.
  ~ You may obtain a copy of the License at
@@ -589,9 +603,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.evanlennick</groupId>
-            <artifactId>retry4j</artifactId>
-            <version>0.15.0</version>
+            <groupId>net.jodah</groupId>
+            <artifactId>failsafe</artifactId>
+            <version>1.1.1</version>
         </dependency>
 
         <!-- Spec 관련 Library -->

--- a/discovery-server/pom.xml
+++ b/discovery-server/pom.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specic language governing permissions and
-  ~ limitations under the License.
-  -->
-
-<!--
  ~ Licensed under the Apache License, Version 2.0 (the "License");
  ~ you may not use this file except in compliance with the License.
  ~ You may obtain a copy of the License at

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSource.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSource.java
@@ -17,20 +17,6 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specic language governing permissions and
- * limitations under the License.
- */
-
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSource.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSource.java
@@ -17,6 +17,20 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specic language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -271,6 +285,13 @@ public class DataSource extends AbstractHistoryEntity implements MetatronDomain<
   @Column(name = "ds_fields_matched")
   @FieldBridge(impl = BooleanBridge.class)
   Boolean fieldsMatched;
+
+  /**
+   * Whether to check data source that failed during ingestion process
+   */
+  @Column(name = "ds_fail_on_engine")
+  @FieldBridge(impl = BooleanBridge.class)
+  Boolean failOnEngine;
 
   /**
    * Spring data rest 제약으로 인한 Dummy Property. - Transient 어노테이션 구성시 HandleBeforeSave 에서 인식 못하는 문제
@@ -856,6 +877,14 @@ public class DataSource extends AbstractHistoryEntity implements MetatronDomain<
 
   public void setFieldsMatched(Boolean fieldsMatched) {
     this.fieldsMatched = fieldsMatched;
+  }
+
+  public Boolean getFailOnEngine() {
+    return failOnEngine;
+  }
+
+  public void setFailOnEngine(Boolean failOnEngine) {
+    this.failOnEngine = failOnEngine;
   }
 
   public boolean isFieldMatchedByNames(final List<String> matchingFieldNames) {

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourceRepository.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourceRepository.java
@@ -3,20 +3,6 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specic language governing permissions and
- * limitations under the License.
- */
-
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourceRepository.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourceRepository.java
@@ -3,6 +3,20 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specic language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -31,28 +45,25 @@ import app.metatron.discovery.domain.context.ContextDomainRepository;
  * DataSourceRepository
  */
 @RepositoryRestResource(path = "datasources", itemResourceRel = "datasource"
-        , collectionResourceRel = "datasources", excerptProjection = DataSourceProjections.DefaultProjection.class)
+    , collectionResourceRel = "datasources", excerptProjection = DataSourceProjections.DefaultProjection.class)
 public interface DataSourceRepository extends JpaRepository<DataSource, String>,
-                                              QueryDslPredicateExecutor<DataSource>,
-                                              ContextDomainRepository<DataSource>,
-                                              DataSourceRepositoryExtends,
-                                              DataSourceSearchRepository {
+    QueryDslPredicateExecutor<DataSource>,
+    ContextDomainRepository<DataSource>,
+    DataSourceRepositoryExtends,
+    DataSourceSearchRepository {
 
   /**
    * fake!! http://stackoverflow.com/questions/25201306/implementing-custom-methods-of-spring-data-repository-and-exposing-them-through
    *
    * for search
-   *
-   * @param keywords
-   * @param pageable
-   * @return
    */
   @RestResource(path = "keyword")
   @Query("select ds from DataSource ds where ds.id= :q")
   Page<DataSource> searchByKeyword(@Param("q") String keywords, Pageable pageable);
 
   @RestResource(path = "query")
-  @Query("select ds from DataSource ds where ds.id= :q")  // fake!!
+  @Query("select ds from DataSource ds where ds.id= :q")
+    // fake!!
   Page<DataSource> searchByQuery(@Param("q") String query, Pageable pageable);
 
   @RestResource(exported = false)
@@ -76,12 +87,6 @@ public interface DataSourceRepository extends JpaRepository<DataSource, String>,
 
   /**
    * Size History 배치잡에서 활용 용도
-   *
-   * @param dsType
-   * @param connType
-   * @param status
-   * @param page
-   * @return
    */
   @RestResource(exported = false)
   Page<DataSource> findByDsTypeAndConnTypeAndStatus(DataSource.DataSourceType dsType,
@@ -93,7 +98,7 @@ public interface DataSourceRepository extends JpaRepository<DataSource, String>,
   @Query("SELECT ds FROM DataSource ds " +
       "WHERE ds.dsType <> 'JOIN' " +
       "AND ds.connType <> 'LINK' " +
-      "AND (ds.status <> 'FAILED' OR ds.status <> 'FAILED')" +
+      "AND ds.status <> 'PREPARING' " +
       "AND ds.srcType IS NOT NULL")
   Page<DataSource> findByDataSourceForCheck(Pageable page);
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourceService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourceService.java
@@ -3,6 +3,20 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specic language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -80,9 +94,10 @@ public class DataSourceService {
     return dataSourceRepository.saveAndFlush(dataSource);
   }
 
-  public void setDataSourceStatus(String datasourceId, DataSource.Status status, DataSourceSummary summary) {
+  public void setDataSourceStatus(String datasourceId, DataSource.Status status, DataSourceSummary summary, Boolean failOnEngine) {
     DataSource dataSource = dataSourceRepository.findOne(datasourceId);
     dataSource.setStatus(status);
+    dataSource.setFailOnEngine(failOnEngine);
     dataSource.setSummary(summary);
   }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourceService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourceService.java
@@ -3,20 +3,6 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specic language governing permissions and
- * limitations under the License.
- */
-
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/ingestion/job/IngestionJobRunner.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/ingestion/job/IngestionJobRunner.java
@@ -40,22 +40,43 @@
  * limitations under the License.
  */
 
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specic language governing permissions and
+ * limitations under the License.
+ */
+
 package app.metatron.discovery.domain.datasource.ingestion.job;
 
 import com.google.common.collect.Maps;
+
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.RetryPolicy;
 
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionException;
 import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.web.client.ResourceAccessException;
 
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 
 import javax.annotation.PostConstruct;
 
@@ -90,7 +111,6 @@ import static app.metatron.discovery.domain.datasource.DataSourceErrorCodes.INGE
 import static app.metatron.discovery.domain.datasource.DataSourceErrorCodes.INGESTION_ENGINE_TASK_ERROR;
 import static app.metatron.discovery.domain.datasource.ingestion.IngestionHistory.IngestionStatus.FAILED;
 import static app.metatron.discovery.domain.datasource.ingestion.IngestionHistory.IngestionStatus.SUCCESS;
-import static app.metatron.discovery.domain.datasource.ingestion.IngestionHistory.IngestionStatus.UNKNOWN;
 import static app.metatron.discovery.domain.datasource.ingestion.job.IngestionProgress.END_INGESTION_JOB;
 import static app.metatron.discovery.domain.datasource.ingestion.job.IngestionProgress.ENGINE_INIT_TASK;
 import static app.metatron.discovery.domain.datasource.ingestion.job.IngestionProgress.ENGINE_REGISTER_DATASOURCE;
@@ -149,7 +169,14 @@ public class IngestionJobRunner {
 
   private TransactionTemplate transactionTemplate;
 
-  private Long interval = 5000L;
+  @Value("${polaris.datasource.ingestion.retries.delay:3}")
+  private Long delay;
+
+  @Value("${polaris.datasource.ingestion.retries.maxDelay:60}")
+  private Long maxDelay;
+
+  @Value("${polaris.datasource.ingestion.retries.maxDuration:3600}")
+  private Long maxDuration;
 
   public IngestionJobRunner() {
     // Empty Constructor
@@ -217,7 +244,7 @@ public class IngestionJobRunner {
       }
 
       // registering geoserver
-      if(BooleanUtils.isTrue(dataSource.getIncludeGeo())) {
+      if (BooleanUtils.isTrue(dataSource.getIncludeGeo())) {
         sendTopic(sendTopicUri, new ProgressResponse(95, GEOSERVER_REGISTER_DATASTORE));
         history = updateHistoryProgress(history.getId(), GEOSERVER_REGISTER_DATASTORE);
         ingestionJob.setDataStoreOnGeoserver();
@@ -247,10 +274,9 @@ public class IngestionJobRunner {
         if (history.getProgress() == GEOSERVER_REGISTER_DATASTORE) {
           engineMetaRepository.purgeDataSource(dataSource.getEngineName());
         }
-      }catch (Exception ex) {
+      } catch (Exception ex) {
         LOGGER.warn("Fail to delete datasource on engine during fail process : {}", ex.getMessage());
       }
-
 
       try {
         history = setFailProgress(history.getId(), ie);
@@ -300,7 +326,7 @@ public class IngestionJobRunner {
       history.setStatus(SUCCESS);
       history.setProgress(END_INGESTION_JOB);
 
-      dataSourceService.setDataSourceStatus(history.getDataSourceId(), DataSource.Status.ENABLED, summary);
+      dataSourceService.setDataSourceStatus(history.getDataSourceId(), DataSource.Status.ENABLED, summary, null);
 
       return historyRepository.save(history);
     });
@@ -311,7 +337,9 @@ public class IngestionJobRunner {
       IngestionHistory history = historyRepository.findOne(historyId);
       history.setStatus(FAILED, ie);
 
-      dataSourceService.setDataSourceStatus(history.getDataSourceId(), DataSource.Status.FAILED, null);
+      dataSourceService.setDataSourceStatus(history.getDataSourceId(), DataSource.Status.FAILED,
+                                            null,
+                                            history.getProgress() == ENGINE_REGISTER_DATASOURCE);
 
       return historyRepository.save(history);
     });
@@ -384,71 +412,67 @@ public class IngestionJobRunner {
 
   public SegmentMetaDataResponse checkDataSource(String engineName) {
 
-    SegmentMetaDataResponse segmentMetaData = null;
-    int checkCount = 0;
+    // @formatter:off
+    RetryPolicy retryPolicy = new RetryPolicy()
+        .retryOn(ResourceAccessException.class)
+        .retryOn(Exception.class)
+        .retryIf(result -> result == null)
+        .withBackoff(delay, maxDelay, TimeUnit.SECONDS)
+        .withMaxDuration(maxDuration, TimeUnit.SECONDS);
+		// @formatter:on
 
-    do {
-      if (checkCount == 20) {
-        LOGGER.info("Not Find datasource({}) in 20 times", engineName);
-        break;
-      }
+    Callable<SegmentMetaDataResponse> callable = () -> queryService.segmentMetadata(engineName);
 
-      try {
-        Thread.sleep(interval);
-      } catch (InterruptedException e) {
-      }
+    // @formatter:off
+    SegmentMetaDataResponse response = Failsafe.with(retryPolicy)
+            .onRetriesExceeded((o, throwable) -> {
+              throw new DataSourceIngestionException("Retries exceed for checking datasource : " + engineName);
+            })
+            .onComplete((o, throwable, ctx) -> {
+              if(ctx != null) {
+                LOGGER.debug("Completed checking datasource({}). {} tries. Take time {} seconds.", engineName, ctx.getExecutions(), ctx.getElapsedTime().toSeconds());
+              }
+            })
+            .get(callable);
+    // @formatter:on
 
-      try {
-        segmentMetaData = queryService.segmentMetadata(engineName);
-      } catch (Exception e) {
-        LOGGER.debug("{} : Check ingested datasource({}) : {}", checkCount, engineName, e.getMessage());
-        checkCount++;
-      }
-
-      if (segmentMetaData != null) {
-        LOGGER.debug("{} : Find datasource({})!!", checkCount, engineName);
-        break;
-      }
-
-    } while (true);
-
-    return segmentMetaData;
+    return response;
   }
 
   public IngestionStatusResponse checkIngestion(String taskId) {
 
-    IngestionStatusResponse statusResponse;
-    int unknownCount = 0;
+    // @formatter:off
+    RetryPolicy retryPolicy = new RetryPolicy()
+        .retryOn(ResourceAccessException.class)
+        .retryOn(Exception.class)
+        .retryIf(result -> {
+          if(result instanceof IngestionStatusResponse) {
+            IngestionStatusResponse response = (IngestionStatusResponse) result;
+            if(response.getStatus() == SUCCESS || response.getStatus() == FAILED) {
+              return false;
+            }
+          }
+          return true;
+        })
+        .withBackoff(delay, maxDelay, TimeUnit.SECONDS)
+        .withMaxDuration(maxDuration, TimeUnit.SECONDS);
+		// @formatter:on
 
-    do {
-      try {
-        Thread.sleep(interval);
-      } catch (InterruptedException e) {
-      }
 
-      try {
-        statusResponse = ingestionService.doCheckResult(taskId);
-      } catch (Exception e) {
-        LOGGER.warn("Keep task({}) status cause by engine error : {}", taskId, e.getMessage());
-        statusResponse = IngestionStatusResponse.unknownResponse(taskId, e);
-      }
+    Callable<IngestionStatusResponse> callable = () -> ingestionService.doCheckResult(taskId);
 
-      LOGGER.debug("Check Task({}) : {}", taskId, statusResponse);
-
-      if (statusResponse.getStatus() == SUCCESS
-          || statusResponse.getStatus() == FAILED) {
-        break;
-      } else if (statusResponse.getStatus() == UNKNOWN) {
-        // If an unrecognized server error occurs consistently, the failure is handled.
-        unknownCount++;
-        if (unknownCount == 10) {
-          LOGGER.info("Unknown error occurred over 10 time. It will mark 'fail'.");
-          statusResponse.setStatus(FAILED);
-          break;
-        }
-      }
-
-    } while (true);
+    // @formatter:off
+    IngestionStatusResponse statusResponse = Failsafe.with(retryPolicy)
+            .onRetriesExceeded((o, throwable) -> {
+              throw new DataSourceIngestionException("Retries exceed for ingestion task : " + taskId);
+            })
+            .onComplete((o, throwable, ctx) -> {
+              if(ctx != null) {
+                LOGGER.debug("Completed checking task ({}). {} tries. Take time {} seconds.", taskId, ctx.getExecutions(), ctx.getElapsedTime().toSeconds());
+              }
+            })
+            .get(callable);
+    // @formatter:on
 
     return statusResponse;
   }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/ingestion/job/IngestionJobRunner.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/ingestion/job/IngestionJobRunner.java
@@ -40,20 +40,6 @@
  * limitations under the License.
  */
 
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specic language governing permissions and
- * limitations under the License.
- */
-
 package app.metatron.discovery.domain.datasource.ingestion.job;
 
 import com.google.common.collect.Maps;

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/scheduling/engine/DataSourceCheckJob.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/scheduling/engine/DataSourceCheckJob.java
@@ -3,20 +3,6 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specic language governing permissions and
- * limitations under the License.
- */
-
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software

--- a/discovery-server/src/main/resources/application.yaml
+++ b/discovery-server/src/main/resources/application.yaml
@@ -212,6 +212,12 @@ polaris:
       - 'dd/MM/yyyy'
   chart:
     profile: default
+  datasource:
+    ingestion:
+      retries:
+        delay: 6
+        maxDelay: 90
+        maxDuration : 3600
   engine:
     hostname:
       broker: http://localhost:8082

--- a/discovery-server/src/test/java/app/metatron/discovery/util/FailSafeTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/util/FailSafeTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specic language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specic language governing permissions and
+ * limitations under the License.
+ */
+
+package app.metatron.discovery.util;
+
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.RetryPolicy;
+
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+public class FailSafeTest {
+
+  @Test
+  public void basicSample() {
+    SomeApi api = new SomeApi();
+
+    Callable<String> callable = () -> api.call();
+
+    // @formatter:off
+    RetryPolicy retryPolicy = new RetryPolicy()
+        .retryOn(ApiException.class)
+        .withBackoff(3, 60, TimeUnit.SECONDS)
+        .withMaxRetries(20)
+        .withMaxDuration(30, TimeUnit.MINUTES);
+		// @formatter:on
+
+    try {
+      String result = Failsafe.with(retryPolicy)
+                              .onComplete((o, throwable, ctx) -> {
+                                System.out.println(ctx);
+                                if(ctx != null) {
+                                  System.out.println(ctx.getElapsedTime().toSeconds());
+                                  System.out.println(ctx.getExecutions());
+                                }
+                              })
+                              .get(callable);
+      System.out.println(result);
+
+    } catch (Exception ree) {
+      System.err.println("retries exhausted..");
+    }
+
+  }
+
+  static class ApiException extends Exception {
+  }
+
+  static class SomeApi {
+    private int count = 1;
+
+    public String call() throws ApiException {
+      System.out.println("API call #" + count);
+      count++;
+      if (count < 5) {
+        System.out.println(DateTime.now() + ": throwing exception..");
+        throw new ApiException();
+      }
+
+      return UUID.randomUUID().toString().toUpperCase();
+    }
+  }
+}

--- a/discovery-server/src/test/java/app/metatron/discovery/util/FailSafeTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/util/FailSafeTest.java
@@ -12,20 +12,6 @@
  * limitations under the License.
  */
 
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specic language governing permissions and
- * limitations under the License.
- */
-
 package app.metatron.discovery.util;
 
 import net.jodah.failsafe.Failsafe;


### PR DESCRIPTION
### Description
적재 단계 내에서 2가지의 재시도 로직이 존재합니다. 이 재시도 로직에서 옵션을 3가지 설정할수 있도록 조정합니다.
기본적인 재시도 정책은 expornatial backoff 이며, 설정할수 있는 속성은 아래와 같습니다. 
- delay : 최초 딜레이 시간 (초)
- maxDelay : 최대 딜레이 시간 (초)
- maxDuration : 전체 재시도 최대 시간 (초)

**Related Issue** : #887 

### How Has This Been Tested?
1. 아래와 같이 설정을 조정하여 실제 딜레이 시간을 조정 또는 확인 합니다.
```
polaris:
  datasource:
    ingestion:
      retries:
        delay: 3
        maxDelay: 90
        maxDuration : 3600
```

2. 실제 설정에 맞게 잘 동작하는지 확인 합니다. 
- UI 를 통한 적재 테스트가 잘동작하는지 확인합니다.
- 상세 결과는 어플리케이션 로그를 통해 확인합니다.
`Completed checking task (index_localfileingestion_gedvo_2018-12-01T15:02:20.658Z). 3 tries. Take time 8 seconds.`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project. _it will be added soon_
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. _it will be added soon_
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
