### PR TITLE
F#841 create dataset with json file

### DIFF
--- a/discovery-frontend/src/app/data-preparation/component/create-snapshot-popup.component.ts
+++ b/discovery-frontend/src/app/data-preparation/component/create-snapshot-popup.component.ts
@@ -478,18 +478,13 @@ export class CreateSnapshotPopup extends AbstractPopupComponent implements OnIni
 
     this.fileFormat = [
       { value: 'CSV', label: 'CSV' },
-      { value: 'JSON', label: 'JSON' }
+      // { value: 'JSON', label: 'JSON' }
     ];
 
     this.ssName = '';
     this.fileLocations = [];
     this.fileUris = [];
-    /*
-    this.fileLocations = [
-      { value: 'WAS', label: 'WAS' },
-      { value: 'HDFS', label: 'HDFS' }
-    ];
-    */
+
 
     // -------------------
     // Hive

--- a/discovery-frontend/src/app/data-preparation/component/create-snapshot-popup.component.ts
+++ b/discovery-frontend/src/app/data-preparation/component/create-snapshot-popup.component.ts
@@ -478,7 +478,7 @@ export class CreateSnapshotPopup extends AbstractPopupComponent implements OnIni
 
     this.fileFormat = [
       { value: 'CSV', label: 'CSV' },
-      // { value: 'JSON', label: 'JSON' }
+      { value: 'JSON', label: 'JSON' }
     ];
 
     this.ssName = '';

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/dataset-info-popup/dataset-info-popup.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/dataset-info-popup/dataset-info-popup.component.ts
@@ -707,9 +707,10 @@ export class DatasetInfoPopupComponent extends AbstractComponent implements OnIn
       let extension = new RegExp(/^.*\.(csv|xls|txt|xlsx|json)$/).exec(fileName)[1];
       if(extension.toUpperCase() === 'XLSX' || extension.toUpperCase() === 'XLS') {
         result =  'EXCEL'
-      } else if (extension.toUpperCase() === 'CSV') {
-        result =  'CSV'
-      }
+      } else {
+        result = extension.toUpperCase()
+       }
+
     }
 
     return result;

--- a/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-name.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-name.component.ts
@@ -301,8 +301,7 @@ export class CreateDatasetNameComponent extends AbstractPopupComponent implement
       } else if(extension.toUpperCase() === 'CSV') {
         this.name = `${fileName} (CSV)`;
       } else {
-        // 불명의 확장자는 CSV로 간주함
-        this.name = `${fileName} (CSV)`;
+        this.name = `${fileName} (${extension.toUpperCase()})`;
       }
     } else if ('DB' === type) {
       if( !isUndefined(this.datasetJdbc.dataconnection.connection) ) {

--- a/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-selectfile.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-selectfile.component.ts
@@ -81,6 +81,7 @@ export class CreateDatasetSelectfileComponent extends AbstractPopupComponent imp
           value: this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN_TYPE) + ' ' + this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN)
         }
       ],
+      allowedMimeType: ['application/vnd.ms-excel','text/csv','text/plain','application/json'],
     });
 
     // add 가 처음
@@ -99,7 +100,7 @@ export class CreateDatasetSelectfileComponent extends AbstractPopupComponent imp
 
     // add 할때 에러난다면
     this.uploader.onWhenAddingFileFailed = (item: FileLikeObject, filter: any, options: any) => {
-      Alert.error(item.name + this.translateService.instant('msg.dp.alert.file.format.wrong'));
+      Alert.error(item.name + ' ' + this.translateService.instant('msg.dp.alert.file.format.wrong'));
     };
 
     // 업로드 전 ..

--- a/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-selectsheet.component.html
+++ b/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-selectsheet.component.html
@@ -78,7 +78,8 @@
       </div>
       <div class="ddp-wrap-edit-form" >
         <div class="ddp-clear">
-          <div class="ddp-col-6" *ngIf="!datasetFile.sheets || 0 == datasetFile.sheets.length">
+          <!--<div class="ddp-col-6" *ngIf="!datasetFile.sheets || 0 == datasetFile.sheets.length">  this.isCSV = true-->
+          <div class="ddp-col-6" *ngIf="isCSV">
             <div class="ddp-wrap-edit3 ddp-type">
               <label class="ddp-label-type">{{'msg.dp.th.col.delimiter' | translate}}</label>
               <!-- edit option -->

--- a/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-selectsheet.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-selectsheet.component.ts
@@ -120,18 +120,23 @@ export class CreateDatasetSelectsheetComponent extends AbstractPopupComponent im
           value: this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN_TYPE) + ' ' + this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN)
         }
       ],
+      allowedMimeType: ['application/vnd.ms-excel','text/csv','text/plain','application/json'],
     });
 
     // add 가 처음
     this.uploader.onAfterAddingFile = (item) => {
       this.loadingShow();
-
       if(!new RegExp(/^.*\.(csv|xls|txt|xlsx|json)$/).test( item.file.name )) { // check file extension
         this.uploader.clearQueue();
         this.fileUploadChange.nativeElement.value = ''; // 같은 파일은 연속으로 올리면 잡지 못해서 초기화
         Alert.error(this.translateService.instant('msg.dp.alert.file.format.wrong'));
         this.loadingHide();
       } else{
+        if( item.file.type === 'text/csv' || item.file.type === 'text/plain' ) {
+          this.isCSV = true;
+        } else {
+          this.isCSV = false;
+        }
         this.uploader.setOptions({ additionalParameter: { dest: `${this.uploadLocation}`}});
         this.uploader.uploadAll();
       }
@@ -139,7 +144,7 @@ export class CreateDatasetSelectsheetComponent extends AbstractPopupComponent im
 
     // add 할때 에러난다면
     this.uploader.onWhenAddingFileFailed = (item: FileLikeObject, filter: any, options: any) => {
-      Alert.error(item.name + this.translateService.instant('msg.dp.alert.file.format.wrong'));
+      Alert.error(item.name + ' ' + this.translateService.instant('msg.dp.alert.file.format.wrong'));
     };
 
     // 업로드 전 ..

--- a/discovery-frontend/src/app/data-preparation/dataset/dataset-detail.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataset/dataset-detail.component.ts
@@ -496,8 +496,8 @@ export class DatasetDetailComponent extends AbstractComponent implements OnInit,
       let extension = new RegExp(/^.*\.(csv|xls|txt|xlsx|json)$/).exec(fileName)[1];
       if(extension.toUpperCase() === 'XLSX' || extension.toUpperCase() === 'XLS') {
         result =  'EXCEL'
-      } else if (extension.toUpperCase() === 'CSV') {
-        result =  'CSV'
+      } else {
+        result = extension.toUpperCase()
       }
     }
     return result;

--- a/discovery-frontend/src/assets/i18n/en.json
+++ b/discovery-frontend/src/assets/i18n/en.json
@@ -1028,7 +1028,7 @@
   "msg.dp.ui.fail": "Fail",
   "msg.dp.ui.file.drop" :"or drop file here",
   "msg.dp.ui.file.import" : "Import",
-  "msg.dp.ui.file.upload.description" : "Excel, CSV files are allowed.",
+  "msg.dp.ui.file.upload.description" : ".xls, .xlsx, .txt, .csv and .json formats are allowed.",
   "msg.dp.ui.file.upload.location" : "Upload Location",
   "msg.dp.ui.flows": "Dataflows",
   "msg.dp.ui.grid.view": "Grid view",

--- a/discovery-frontend/src/assets/i18n/ko.json
+++ b/discovery-frontend/src/assets/i18n/ko.json
@@ -1027,7 +1027,7 @@
   "msg.dp.ui.fail": "실패",
   "msg.dp.ui.file.drop" :"or drop file here",
   "msg.dp.ui.file.import" : "Import",
-  "msg.dp.ui.file.upload.description" : "Excel, CSV 형식의 파일이 허용됩니다.",
+  "msg.dp.ui.file.upload.description" : ".xls, .xlsx, .txt, .csv 및 .json 형식이 허용됩니다.",
   "msg.dp.ui.file.upload.location" : "업로드 위치",
   "msg.dp.ui.flows": "데이터플로우",
   "msg.dp.ui.grid.view": "그리드 뷰",

--- a/discovery-server/pom.xml
+++ b/discovery-server/pom.xml
@@ -957,12 +957,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.googlecode.json-simple</groupId>
-            <artifactId>json-simple</artifactId>
-            <version>1.1.1</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.orc</groupId>
             <artifactId>orc-core</artifactId>
             <version>${orc-core.version}</version>

--- a/discovery-server/pom.xml
+++ b/discovery-server/pom.xml
@@ -957,6 +957,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.googlecode.json-simple</groupId>
+            <artifactId>json-simple</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.orc</groupId>
             <artifactId>orc-core</artifactId>
             <version>${orc-core.version}</version>

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetService.java
@@ -106,6 +106,13 @@ public class PrepDatasetService {
             String newFileKey = csvFileName.substring(lastIdx+1);
             dataset.setFilekey(newFileKey);
             filekey = newFileKey;
+        } else if(true==dataset.isJSON()) {
+            String csvFileName = this.datasetFilePreviewService.moveJsonToCsv(filekey, null, delimiter);
+            dataset.putCustomValue("filePath", csvFileName);
+            int lastIdx = csvFileName.lastIndexOf(File.separator);
+            String newFileKey = csvFileName.substring(lastIdx+1);
+            dataset.setFilekey(newFileKey);
+            filekey = newFileKey;
         }
 
         if(dataset.getFileTypeEnum() == PrepDataset.FILE_TYPE.HDFS) {

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
@@ -1318,7 +1318,7 @@ public class PrepTransformService {
     if (importedDataset.getImportType().equalsIgnoreCase("FILE")) {
       String path = importedDataset.getCustomValue("filePath"); // datasetFileService.getPath2(importedDataset);
       LOGGER.debug(wrangledDsId + " path=[" + path + "]");
-      if (importedDataset.isDSV() || importedDataset.isEXCEL()) {
+      if (importedDataset.isDSV() || importedDataset.isEXCEL() || importedDataset.isJSON()) {
         gridResponse = teddyImpl.loadFileDataset(wrangledDsId, path, importedDataset.getDelimiter(), wrangledDataset.getDsName());
       }
       /* excel type dataset has csv file
@@ -1327,10 +1327,6 @@ public class PrepTransformService {
         throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_FILE_FORMAT_WRONG);
       }
       */
-      else if (importedDataset.isJSON()) {
-        LOGGER.error("createStage0(): EXCEL not supported: " + path);
-        throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_FILE_FORMAT_WRONG);
-      }
       else {
         throw new IllegalArgumentException("invalid flie type: createWrangledDataset\nimportedDataset: " + importedDataset.toString());
       }
@@ -1749,7 +1745,7 @@ public class PrepTransformService {
     } catch (PrepException e) {
       throw e;
     } catch (RuleException e) {
-      throw PrepException.create(PrepErrorCodes.PREP_TRANSFORM_ERROR_CODE, e);
+      throw PrepException.create(PrepErrorCodes.PREP_TRANSFORM_ERROR_CODE, TeddyException.fromRuleException(e));
     } catch (Exception e) {
       LOGGER.error("confirmRuleStringForException(): caught an exception: ", e);
       throw PrepException.create(PrepErrorCodes.PREP_TRANSFORM_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_TEDDY_PARSE_FAILED, e.getMessage());


### PR DESCRIPTION
### Description
Currently, we support dataset creation with excel, csv and txt files.
Let's also support json files.

**Related Issue** : <!--- Please link to the issue here. -->
https://github.com/metatron-app/metatron-discovery/issues/841


### How Has This Been Tested?
1. Go datapreparation
2. Go Dataset and Create new dataset
3. Import JSON file
4. Check preview and result dataset
5. Try import generated dataset into dataflow


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
