### PR TITLE
#762 stop execute time when using retry button

### DIFF
--- a/discovery-frontend/src/app/workbench/workbench.component.ts
+++ b/discovery-frontend/src/app/workbench/workbench.component.ts
@@ -2473,6 +2473,7 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
       const runningResultTab: ResultTab = this._getResultTab(this.runningResultTabId);
       runningResultTab.showLog = true;
       runningResultTab.setResultStatus( 'CANCEL' );
+      runningResultTab.doneTimer();
       if (isSuccess) {
         runningResultTab.name = this._genResultTabName(runningResultTab.queryEditor.name, 'RESULT', runningResultTab.order);
         if (isNullOrUndefined(runningResultTab.message)) {


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
쿼리 실행 취소 후, 재실행을 할 경우 완료 이후에도 실행 시간이 계속 증가합니다. 

**Related Issue** : #762 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 워크벤치로 이동합니다. 
2. 쿼리 실행 후 취소를 시도합니다. 
3. 취소 성공 후 재실행을 할경우, 정상적으로 조회가 완료된 이후에도 실행 시간이 계속 증가 되지 않는지 확인합니다. 


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
