### PR TITLE
Fail to add / edit short name in column dictionary

### DIFF
--- a/discovery-frontend/src/app/domain/meta-data-management/column-dictionary.ts
+++ b/discovery-frontend/src/app/domain/meta-data-management/column-dictionary.ts
@@ -24,7 +24,7 @@ export class ColumnDictionary extends AbstractHistoryEntity {
   // 컬럼 물리 명
   public name: string;
   // 컬럼 축약 명
-  public shortName: string;
+  public suggestionShortName: string;
   // 컬럼 논리 명
   public logicalName: string;
   // 컬럼 설명

--- a/discovery-frontend/src/app/meta-data-management/column-dictionary/create-column-dictionary/create-column-dictionary.component.ts
+++ b/discovery-frontend/src/app/meta-data-management/column-dictionary/create-column-dictionary/create-column-dictionary.component.ts
@@ -360,7 +360,7 @@ export class CreateColumnDictionaryComponent extends AbstractComponent implement
   private _getCreateColumnDictionaryParams(): object {
     const params = {
       name: this.columnName.trim(),
-      shortName: this.shortName.trim(),
+      suggestionShortName: this.shortName.trim(),
       logicalName: this.logicalName.trim(),
       description: this.description.trim(),
       logicalType: this.selectedType,

--- a/discovery-frontend/src/app/meta-data-management/column-dictionary/detail-column-dictionary/detail-column-dictionary.component.html
+++ b/discovery-frontend/src/app/meta-data-management/column-dictionary/detail-column-dictionary/detail-column-dictionary.component.html
@@ -155,7 +155,7 @@
             <div class="ddp-txt-edit" [class.ddp-selected]="shortNameEditFl" (clickOutside)="shortNameEditFl = false">
               <!-- data -->
               <span class="ddp-data-name" (click)="onChangeShortNameMode()">
-              {{columnDictionary.shortName}}
+              {{columnDictionary.suggestionShortName}}
               <em class="ddp-icon-edit2"></em>
             </span>
               <!-- //data -->

--- a/discovery-frontend/src/app/meta-data-management/column-dictionary/detail-column-dictionary/detail-column-dictionary.component.ts
+++ b/discovery-frontend/src/app/meta-data-management/column-dictionary/detail-column-dictionary/detail-column-dictionary.component.ts
@@ -247,7 +247,7 @@ export class DetailColumnDictionaryComponent extends AbstractComponent implement
    */
   public onChangeShortNameMode(): void {
     this.shortNameEditFl = true;
-    this.reShortName = this.columnDictionary.shortName;
+    this.reShortName = this.columnDictionary.suggestionShortName;
   }
 
   /**
@@ -386,7 +386,7 @@ export class DetailColumnDictionaryComponent extends AbstractComponent implement
     // blur
     this.shortNameElement.nativeElement.blur();
     // 컬럼 사전 업데이트
-    this._updateColumnDictionary({shortName: this.reShortName.trim()});
+    this._updateColumnDictionary({suggestionShortName: this.reShortName.trim()});
   }
 
   /**


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Add/ edit Short Column Name in column dictionary

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
MT-58

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

Metadata -> column dictionary -> create new column dictionary 

![image](https://user-images.githubusercontent.com/42233517/49427728-70fdfe00-f7e7-11e8-8855-142fbbffcd58.png)

Add column dictionary with short colum name -> 
Go to column dictionary detail -> check if you can see the short column name -> Try editing short column name 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
