### PR TITLE
#814 The results of the query executed in workbench should be visible when you exit the browser and run it back into the workbench

### DIFF
--- a/discovery-frontend/src/app/workbench/service/workbench.service.ts
+++ b/discovery-frontend/src/app/workbench/service/workbench.service.ts
@@ -155,12 +155,18 @@ export class WorkbenchService extends AbstractService {
    *****************************************/
 
   // 쿼리 실행
-  public runSingleQueryWithInvalidQuery(params: QueryEditor) {
+  public runSingleQueryWithInvalidQuery(params: QueryEditor, additional: any) {
     const id = params.editorId;
     const param = {
       query: params.query,
-      webSocketId: params.webSocketId
+      webSocketId: params.webSocketId,
+      runIndex: additional.runIndex
     };
+
+    if(additional.retryQueryResultOrder) {
+      param['retryQueryResultOrder'] = additional.retryQueryResultOrder;
+    }
+
     return this.post(this.API_URL + `queryeditors/${id}/query/run`, param); // params => query  값만 사용.
   }
 

--- a/discovery-frontend/src/app/workbench/workbench.component.ts
+++ b/discovery-frontend/src/app/workbench/workbench.component.ts
@@ -1287,15 +1287,20 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
    * run query
    * @param {string} resultTabId
    */
-  public runQueries(resultTabId: string) {
-
+  public runQueries(resultTabId: string, retry : boolean = false) {
     const resultTab: ResultTab = this._getResultTab(resultTabId);
+    const additionalParams = {
+      runIndex: this.currentRunningIndex,
+      retryQueryResultOrder: retry ? resultTab.order : null
+    };
+
     resultTab.queryEditor.webSocketId = this.websocketId;
     resultTab.initialize();
     resultTab.executeTimer();
     this.runningResultTabId = resultTab.id;
 
-    this.workbenchService.runSingleQueryWithInvalidQuery(resultTab.queryEditor)
+
+    this.workbenchService.runSingleQueryWithInvalidQuery(resultTab.queryEditor, additionalParams)
       .then((result) => {
         this.loadingBar.hide();
 
@@ -1353,7 +1358,7 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
           this.safelyDetectChanges();
 
           this.executeTabIds = [item.id];
-          this.runQueries(item.id);
+          this.runQueries(item.id, true);
         }
       })
       .catch((error) => {
@@ -1847,7 +1852,7 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
 
           this.isDataManager = CommonUtil.isValidPermission(SYSTEM_PERMISSION.MANAGE_DATASOURCE);
 
-          if(data.dataConnection.supportSaveAsHiveTable) {
+          if (data.dataConnection.supportSaveAsHiveTable) {
             this.supportSaveAsHiveTable = data.dataConnection.supportSaveAsHiveTable;
           }
 
@@ -1859,6 +1864,7 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
           this.openAccessDeniedConfirm();
         }
 
+        this.restoreQueryResultPreviousState(data.queryEditors);
       });
 
     }).catch((error) => {
@@ -1869,6 +1875,81 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
       }
     });
   } // function - _loadInitData
+
+  private restoreQueryResultPreviousState(queryEditors: any[]): void {
+    if (queryEditors && Array.isArray(queryEditors) && queryEditors.length > 0) {
+      const queryResultRequests: Promise<any>[] = this.createQueryResultRequests(queryEditors);
+      this.restoreQueryResults(queryResultRequests);
+    }
+  }
+
+  private createQueryResultRequests(queryEditors: any[]) : Promise<any>[] {
+    const queryResultPromises: Promise<any>[] = [];
+    queryEditors.forEach((editor) => {
+      if (editor.queryResults && Array.isArray(editor.queryResults)) {
+        editor.queryResults.forEach((queryResult, queryResultIndex) => {
+          const promise: Promise<any> = this.workbenchService.runQueryResult(editor.id,
+            queryResult.filePath, queryResult.defaultNumRows, 0,
+            queryResult.fields);
+
+          const queryEditor: QueryEditor = new QueryEditor();
+          queryEditor.editorId = editor.id;
+          queryEditor.name = editor.name;
+          queryEditor.order = editor.order;
+          queryEditor.query = queryResult.query;
+
+          promise['_metadata'] = {
+            queryEditor: queryEditor,
+            queryResult: {
+              order: queryResultIndex + 1,
+              fields: queryResult.fields,
+              filePath: queryResult.filePath,
+              defaultNumRows: queryResult.defaultNumRows,
+              numRows: queryResult.numRows
+            }
+          };
+          queryResultPromises.push(promise);
+        });
+      }
+    });
+
+    return queryResultPromises;
+  }
+
+  private restoreQueryResults(queryResultRequests: Promise<any>[]): void {
+    Promise.all(queryResultRequests.map(p => p.catch(() => undefined)))
+      .then((results) => {
+        results.forEach((result, index) => {
+          const metadata = queryResultRequests[index]['_metadata'];
+          const queryEditor: QueryEditor = metadata.queryEditor;
+          const tab = new ResultTab(queryEditor.editorId, queryEditor, queryEditor.query, metadata.queryResult.order);
+          tab.resultStatus = 'SUCCESS';
+          tab.executeStatus = 'DONE';
+          tab.errorStatus = 'DONE';
+          tab.name = this._genResultTabName(queryEditor.name, 'RESULT', tab.order);
+          tab.showLog = false;
+          tab.log = [];
+
+          if(result === undefined) {
+            const queryResult: QueryResult = new QueryResult();
+            tab.result = queryResult;
+          } else {
+            const queryResult: QueryResult = new QueryResult();
+            queryResult.fields = metadata.queryResult.fields;
+            queryResult.data = result;
+            queryResult.csvFilePath = metadata.queryResult.filePath;
+            queryResult.defaultNumRows = metadata.queryResult.defaultNumRows;
+            queryResult.numRows = metadata.queryResult.numRows;
+            tab.result = queryResult;
+          }
+
+          this._appendResultTab(tab);
+          this.executeTabIds.push(tab.id);
+        });
+
+        this.tabChangeHandler(this.selectedTabNum, false);
+      });
+  }
 
   /**
    * 에디터 슬라이드 버튼 계산

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/scheduling/common/TemporaryCSVFileCleanJob.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/scheduling/common/TemporaryCSVFileCleanJob.java
@@ -59,8 +59,8 @@ public class TemporaryCSVFileCleanJob extends QuartzJobBean {
 
     LOGGER.info("## Start batch job for checking expired temporary csv file.");
 
-    //expire duration 1 day
-    Duration expireDuration = Period.parse("P1D").toStandardDuration();
+    //expire duration
+    Duration expireDuration = Period.parse(String.format("P%sD", workbenchProperties.getTempCSVExpireDuration())).toStandardDuration();
     Long currentDateTime = DateTime.now().getMillis();
 
     List<Path> deleteTargetPathList = new ArrayList<>();

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/QueryEditor.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/QueryEditor.java
@@ -20,9 +20,12 @@ import app.metatron.discovery.domain.MetatronDomain;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.validator.constraints.NotBlank;
+import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.rest.core.annotation.RestResource;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 
@@ -59,6 +62,10 @@ public class QueryEditor extends AbstractHistoryEntity implements MetatronDomain
 	@OrderBy("modifiedTime DESC")
 	@RestResource(path = "queryhistories")
 	Set<QueryHistory> queryHistories;
+
+	@OneToMany(mappedBy = "queryEditor", orphanRemoval = true, cascade = CascadeType.ALL)
+	@OrderBy("id ASC")
+	List<QueryEditorResult> queryResults = new ArrayList<>();
 
 	public String getId() {
 		return id;
@@ -116,7 +123,23 @@ public class QueryEditor extends AbstractHistoryEntity implements MetatronDomain
     this.index = index;
   }
 
-  @Override
+	public void addQueryResult(QueryEditorResult queryEditorResult) {
+		this.queryResults.add(queryEditorResult);
+
+		if(queryEditorResult.getQueryEditor() != this) {
+			queryEditorResult.setQueryEditor(this);
+		}
+	}
+
+	public List<QueryEditorResult> getQueryResults() {
+		return queryResults;
+	}
+
+	public void clearQueryResults() {
+		this.queryResults.clear();
+	}
+
+	@Override
 	public String toString() {
 		return "QueryEditor{" +
 						"id='" + id + '\'' +

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/QueryEditorProjections.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/QueryEditorProjections.java
@@ -18,6 +18,7 @@ import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.rest.core.config.Projection;
 
+import java.util.List;
 import java.util.Set;
 
 import app.metatron.discovery.common.BaseProjections;
@@ -48,6 +49,8 @@ public class QueryEditorProjections extends BaseProjections{
     UserProfile getModifiedBy();
 
     DateTime getModifiedTime();
+
+    List<QueryEditorResult> getQueryResults();
   }
 
   @Projection(name = "forQueryHistory", types = { QueryEditor.class })

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/QueryEditorResult.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/QueryEditorResult.java
@@ -1,0 +1,95 @@
+package app.metatron.discovery.domain.workbench;
+
+import app.metatron.discovery.common.GlobalObjectMapper;
+import app.metatron.discovery.common.KeepAsJsonDeserialzier;
+import app.metatron.discovery.domain.datasource.Field;
+import com.fasterxml.jackson.annotation.JsonRawValue;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import javax.persistence.*;
+import java.util.List;
+
+@Entity
+@Table(name = "queryeditor_result")
+public class QueryEditorResult {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne
+  @JoinColumn(name = "qe_id", referencedColumnName = "id")
+  private QueryEditor queryEditor;
+
+  @Column(name = "file_path")
+  private String filePath;
+
+  @Column(name = "fields", length = 65535, columnDefinition = "TEXT")
+  @JsonRawValue
+  @JsonDeserialize(using = KeepAsJsonDeserialzier.class)
+  private String fields;
+
+  @Lob
+  @Column(name="query")
+  private String query;
+
+  @Column(name="num_rows")
+  private Long numRows;
+
+  @Column(name="default_num_rows")
+  private Long defaultNumRows;
+
+  public QueryEditorResult() {
+  }
+
+  public QueryEditorResult(String query, String filePath, List<Field> fields, Long numRows, Long defaultNumRows) {
+    this.query = query;
+    this.filePath = filePath;
+    this.setFields(fields);
+    this.numRows = numRows;
+    this.defaultNumRows = defaultNumRows;
+  }
+
+  public QueryEditor getQueryEditor() {
+    return queryEditor;
+  }
+
+  public void setQueryEditor(QueryEditor queryEditor) {
+    this.queryEditor = queryEditor;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getFilePath() {
+    return filePath;
+  }
+
+  public void setFields(List<Field> fields) {
+    this.fields = GlobalObjectMapper.writeValueAsString(fields);
+  }
+
+  public String getFields() {
+    return fields;
+  }
+
+  public String getQuery() {
+    return query;
+  }
+
+  public void setFilePath(String filePath) {
+    this.filePath = filePath;
+  }
+
+  public Long getNumRows() {
+    return numRows;
+  }
+
+  public Long getDefaultNumRows() {
+    return defaultNumRows;
+  }
+
+  public void setNumRows(Long numRows) {
+    this.numRows = numRows;
+  }
+}

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/QueryRunRequest.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/QueryRunRequest.java
@@ -20,6 +20,8 @@ public class QueryRunRequest {
   String webSocketId;
   String database;
   int numRows;
+  int runIndex = -1;
+  int retryQueryResultOrder = -1;
 
   public String getQuery() {
     return query;
@@ -53,13 +55,47 @@ public class QueryRunRequest {
     this.numRows = numRows;
   }
 
+  public int getRunIndex() {
+    return runIndex;
+  }
+
+  public int getRetryQueryResultOrder() {
+    return retryQueryResultOrder;
+  }
+
+  public void setRetryQueryResultOrder(int retryQueryResultOrder) {
+    this.retryQueryResultOrder = retryQueryResultOrder;
+  }
+
+  public void setRunIndex(int runIndex) {
+    this.runIndex = runIndex;
+  }
+
+  public boolean isFirstRunInQueryEditor() {
+    if(this.getRunIndex() == 0 && this.getRetryQueryResultOrder() == -1) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  public boolean isRetryRun() {
+    if(this.getRunIndex() == 0 && this.getRetryQueryResultOrder() > -1) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
   @Override
   public String toString() {
     return "QueryRunRequest{" +
-            "query='" + query + '\'' +
-            ", webSocketId='" + webSocketId + '\'' +
-            ", database='" + database + '\'' +
-            ", numRows=" + numRows +
-            '}';
+        "query='" + query + '\'' +
+        ", webSocketId='" + webSocketId + '\'' +
+        ", database='" + database + '\'' +
+        ", numRows=" + numRows +
+        ", runIndex=" + runIndex +
+        ", retryQueryResultOrder=" + retryQueryResultOrder +
+        '}';
   }
 }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/WorkbenchProperties.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/WorkbenchProperties.java
@@ -25,6 +25,7 @@ public class WorkbenchProperties {
   private Integer maxFetchSize = 2000;
   private String tempHdfsPath = "/tmp/hive";
   private String tempCSVPath = "/tmp";
+  private String tempCSVExpireDuration = "1";
   private String tempDataTableHdfsPath = "/tmp/metatron";
 
   public static String TEMP_SCHEMA_PREFIX = "temp_";
@@ -77,5 +78,13 @@ public class WorkbenchProperties {
 
   public void setTempDataTableHdfsPath(String tempDataTableHdfsPath) {
     this.tempDataTableHdfsPath = tempDataTableHdfsPath;
+  }
+
+  public String getTempCSVExpireDuration() {
+    return tempCSVExpireDuration;
+  }
+
+  public void setTempCSVExpireDuration(String tempCSVExpireDuration) {
+    this.tempCSVExpireDuration = tempCSVExpireDuration;
   }
 }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
* 워크벤치 쿼리 에디터에서 쿼리를 실행 할 때 실행한 질의 결과를 데이터베이스에 테이블에 저장합니다.
 * CSV 파일 경로, 쿼리 등
* 워크벤치 화면에 최초 진입할 때 저장한 쿼리 에디터의 질의 결과를 바탕으로 이전 쿼리 결과를 복원합니다.
  * 결과 복원 시 기존에 만들어진 API(`/api/queryeditors/{id}/query/result`)를 사용하여 이전 쿼리 결과를 조회합니다.

**Related Issue** : <!--- Please link to the issue here. -->

<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
* 이전 쿼리 결과 복원시 CSV 데이터 양이 많을 수도 있기 때문에 기본적으로 100 row로  제약 두었습니다.
* 저장된 CSV 파일이 삭제된 경우 쿼리 결과를 복원하지 못합니다. CSV 파일을 삭제하는 TemporaryCSVFileCleanJob에서 하드 코딩으로 되어있던 1일의 만료일을 WorkbenchProperties를 사용하여 사용자가 설정할 수 있도록 변경하였습니다.
