### PR TITLE
#970 Legend selection (selection through dimension of color setting) is not possible when there are two dimension values.

### DIFF
--- a/discovery-frontend/src/app/common/component/chart/base-chart.ts
+++ b/discovery-frontend/src/app/common/component/chart/base-chart.ts
@@ -1696,35 +1696,37 @@ export abstract class BaseChart extends AbstractComponent implements OnInit, OnD
 
     let shelve: any = this.pivot;
 
-    // 선반값에서 해당 타입에 해당하는값만 name string값으로 리턴
-    const getShelveReturnString = ((shelve: any, typeList: ShelveFieldType[]): string[] => {
-      const resultList: string[] = [];
-      _.forEach(shelve, (value, key) => {
-        shelve[key].map((item) => {
-          if (_.eq(item.type, typeList[0]) || _.eq(item.type, typeList[1])) {
-            resultList.push(item.name);
-          }
+    if( shelve ) {
+      // 선반값에서 해당 타입에 해당하는값만 name string값으로 리턴
+      const getShelveReturnString = ((shelve: any, typeList: ShelveFieldType[]): string[] => {
+        const resultList: string[] = [];
+        _.forEach(shelve, (value, key) => {
+          shelve[key].map((item) => {
+            if (_.eq(item.type, typeList[0]) || _.eq(item.type, typeList[1])) {
+              resultList.push(item.name);
+            }
+          });
         });
+        return resultList;
       });
-      return resultList;
-    });
 
-    // 색상지정 기준 필드리스트 설정, 기본 필드 설정
-    this.uiOption.fieldList = getShelveReturnString(shelve, [ShelveFieldType.DIMENSION, ShelveFieldType.TIMESTAMP]);
+      // 색상지정 기준 필드리스트 설정, 기본 필드 설정
+      this.uiOption.fieldList = getShelveReturnString(shelve, [ShelveFieldType.DIMENSION, ShelveFieldType.TIMESTAMP]);
 
-    if (this.uiOption.color) {
-      // targetField 설정
-      const targetField = (<UIChartColorByDimension>this.uiOption.color).targetField;
+      if (this.uiOption.color) {
+        // targetField 설정
+        const targetField = (<UIChartColorByDimension>this.uiOption.color).targetField;
 
-      // targetField가 있을때
-      if (!_.isEmpty(targetField)) {
-        if (this.uiOption.fieldList.indexOf(targetField) < 0) (<UIChartColorByDimension>this.uiOption.color).targetField = _.last(this.uiOption.fieldList);
+        // targetField가 있을때
+        if (!_.isEmpty(targetField)) {
+          if (this.uiOption.fieldList.indexOf(targetField) < 0) (<UIChartColorByDimension>this.uiOption.color).targetField = _.last(this.uiOption.fieldList);
 
-      // targetField가 없을때
-      } else {
+          // targetField가 없을때
+        } else {
 
-        // 마지막 필드를 타겟필드로 잡기
-        (<UIChartColorByDimension>this.uiOption.color).targetField = _.last(this.uiOption.fieldList);
+          // 마지막 필드를 타겟필드로 잡기
+          (<UIChartColorByDimension>this.uiOption.color).targetField = _.last(this.uiOption.fieldList);
+        }
       }
     }
 


### PR DESCRIPTION
### Description
차원값이 2개인 경우 차원값에 따른 색상 설정을 할 경우 원복이 되는 문제 있습니다.

**Related Issue** : #970 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
1. 대시보드에서 2개의 dimension을 이용하여 차트를 생성합니다. 
2. Color Setting 에서 dimension 으로 변경하고 선반의 dimension 을 선택합니다.
3. 차트를 저장하고 대시보드 편집화면으로 이동하였을 때 dimension 에 따른 색상 설정이 유지되는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
