### PR TITLE
Use datasketch query to COUNTD function

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/AbstractQueryBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/AbstractQueryBuilder.java
@@ -226,7 +226,7 @@ public abstract class AbstractQueryBuilder {
   /**
    * 엔진에 질의할 때 필요한 추가 정보
    */
-  protected Map<String, Object> context;
+  protected Map<String, Object> context = Maps.newHashMap();
 
   /**
    * 질의할 queryId, 캔슬시 활용
@@ -715,12 +715,11 @@ public abstract class AbstractQueryBuilder {
 
     // TODO: 파라미터도 추가해야함, 일단 기존 로직 유지
     Map<String, String> exprMap = userFieldsMap.values().stream()
-                                               .filter(userDefinedField -> userDefinedField instanceof ExpressionField)
-                                               .collect(Collectors.toMap(UserDefinedField::getName, f -> ((ExpressionField) f).getExpr()));
+        .filter(userDefinedField -> userDefinedField instanceof ExpressionField)
+        .collect(Collectors.toMap(UserDefinedField::getName, f -> ((ExpressionField) f).getExpr()));
 
-    ComputationalField.makeAggregationFunctionsIn(field.getAlias(), curExpr,
-                                                  aggregations, postAggregations, windowingSpecs,
-                                                  exprMap);
+    ComputationalField.makeAggregationFunctionsIn(field.getAlias(), curExpr, aggregations
+        , postAggregations, windowingSpecs, context, exprMap);
 
   }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/Aggregation.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/Aggregation.java
@@ -32,6 +32,7 @@ import app.metatron.discovery.query.druid.aggregations.*;
     @JsonSubTypes.Type(value = JavaScriptAggregation.class, name = "javascript"),
     @JsonSubTypes.Type(value = CardinalityAggregation.class, name = "cardinality"),
     @JsonSubTypes.Type(value = SketchAggregation.class, name = "sketch"),
+    @JsonSubTypes.Type(value = DistinctSketchAggregation.class, name = "thetaSketch"),
     @JsonSubTypes.Type(value = ApproxHistogramAggregation.class, name = "approxHistogram"),
     @JsonSubTypes.Type(value = ApproxHistogramFoldAggregation.class, name = "approxHistogramFold"),
     @JsonSubTypes.Type(value = FilteredAggregation.class, name = "filtered")

--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/aggregations/DistinctSketchAggregation.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/aggregations/DistinctSketchAggregation.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.metatron.discovery.query.druid.aggregations;
+
+
+import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import app.metatron.discovery.query.druid.Aggregation;
+
+@JsonTypeName("thetaSketch")
+public class DistinctSketchAggregation implements Aggregation {
+
+  @NotNull
+  String name;
+
+  @NotNull
+  String fieldName;
+
+  Long size;
+
+  Boolean shouldFinalize;
+
+  public DistinctSketchAggregation() {
+  }
+
+  public DistinctSketchAggregation(String name, String fieldName, Long size, Boolean shouldFinalize) {
+    this.name = name;
+    this.fieldName = fieldName;
+    this.size = size;
+    this.shouldFinalize = shouldFinalize;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getFieldName() {
+    return fieldName;
+  }
+
+  public void setFieldName(String fieldName) {
+    this.fieldName = fieldName;
+  }
+
+  public Long getSize() {
+    return size;
+  }
+
+  public void setSize(Long size) {
+    this.size = size;
+  }
+
+  public Boolean getShouldFinalize() {
+    return shouldFinalize;
+  }
+
+  public void setShouldFinalize(Boolean shouldFinalize) {
+    this.shouldFinalize = shouldFinalize;
+  }
+}

--- a/discovery-server/src/main/java/app/metatron/discovery/query/polaris/ComputationalField.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/polaris/ComputationalField.java
@@ -657,7 +657,8 @@ public class ComputationalField {
       } else if ("countof".equals(context.IDENTIFIER().getText().toLowerCase())) {
         aggregations.add(new CountAggregation(paramName));
       } else if ("countd".equals(context.IDENTIFIER().getText().toLowerCase())) {
-        aggregations.add(new DistinctSketchAggregation(fieldName, fieldExpression.replaceAll("^\"|\"$", ""), 65536L, false));
+        // if you shouldFinalize to false, this route's return includes .estimation value. So you may need to modify UI code.
+        aggregations.add(new DistinctSketchAggregation(fieldName, fieldExpression.replaceAll("^\"|\"$", ""), 65536L, true));
         paramName = null;
         Map<String, Object> processingMap = Maps.newHashMap();
         processingMap.put("type", "sketch.estimate");

--- a/discovery-server/src/test/java/app/metatron/discovery/query/polaris/ComputationalFieldTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/query/polaris/ComputationalFieldTest.java
@@ -256,7 +256,7 @@ public class ComputationalFieldTest extends AbstractIntegrationTest {
         partitionColumns.add( "abc" );
         ans_windowingSpecs.add( new WindowingSpec( partitionColumns, null, Arrays.asList( "ac_sum_recu = 1.01*if($prev(ac_sum_recu)==null,1,$prev(ac_sum_recu))")));
 
-        ComputationalField.makeAggregationFunctions3(fieldName, input, aggregations, postAggregations, windowingSpecs);
+        ComputationalField.makeAggregationFunctions3(fieldName, input, aggregations, postAggregations, windowingSpecs, Maps.newHashMap());
 
         Assert.assertTrue( compareAggregations( ans_aggregations, ans_postAggregations, ans_windowingSpecs, aggregations, postAggregations, windowingSpecs ) );
 
@@ -273,7 +273,7 @@ public class ComputationalFieldTest extends AbstractIntegrationTest {
         ans_aggregations.add(new DoubleSumAggregation( "aggregationfunc_000", null, "count"));
         ans_windowingSpecs.add( new WindowingSpec( null, null, Arrays.asList( "ac_sum_recu = aggregationfunc_000+if($prev(ac_sum_recu)==null,0,$prev(ac_sum_recu))")));
 
-        ComputationalField.makeAggregationFunctions3(fieldName, input, aggregations, postAggregations, windowingSpecs);
+        ComputationalField.makeAggregationFunctions3(fieldName, input, aggregations, postAggregations, windowingSpecs, Maps.newHashMap());
 
         Assert.assertTrue( compareAggregations( ans_aggregations, ans_postAggregations, ans_windowingSpecs, aggregations, postAggregations, windowingSpecs ) );
 
@@ -289,7 +289,7 @@ public class ComputationalFieldTest extends AbstractIntegrationTest {
         ans_aggregations.add(new DoubleSumAggregation( "aggregationfunc_000", null, "profit+1"));
         ans_postAggregations.add( new MathPostAggregator("fieldname", "(aggregationfunc_000/count)", null ));
 
-        ComputationalField.makeAggregationFunctions3(fieldName, input, aggregations, postAggregations, windowingSpecs);
+        ComputationalField.makeAggregationFunctions3(fieldName, input, aggregations, postAggregations, windowingSpecs, Maps.newHashMap());
 
         Assert.assertTrue( compareAggregations( ans_aggregations, ans_postAggregations, ans_windowingSpecs, aggregations, postAggregations, windowingSpecs ) );
 
@@ -304,7 +304,7 @@ public class ComputationalFieldTest extends AbstractIntegrationTest {
         ans_aggregations.add(new DoubleSumAggregation( "aggregationfunc_000", null, "z"));
         ans_postAggregations.add( new MathPostAggregator("fieldName01", "x+y+aggregationfunc_000", null ));
 
-        ComputationalField.makeAggregationFunctions3( fieldName, input, aggregations, postAggregations, windowingSpecs);
+        ComputationalField.makeAggregationFunctions3( fieldName, input, aggregations, postAggregations, windowingSpecs, Maps.newHashMap());
 
         Assert.assertTrue( compareAggregations( ans_aggregations, ans_postAggregations, ans_windowingSpecs, aggregations, postAggregations, windowingSpecs ) );
 
@@ -320,7 +320,7 @@ public class ComputationalFieldTest extends AbstractIntegrationTest {
         ans_aggregations.add(new DoubleSumAggregation( "aggregationfunc_000", null, "log(z)"));
         ans_postAggregations.add( new MathPostAggregator("fieldName01", "x+y+(aggregationfunc_000/count)", null ));
 
-        ComputationalField.makeAggregationFunctions3( fieldName, input, aggregations, postAggregations, windowingSpecs);
+        ComputationalField.makeAggregationFunctions3( fieldName, input, aggregations, postAggregations, windowingSpecs, Maps.newHashMap());
 
         Assert.assertTrue( compareAggregations( ans_aggregations, ans_postAggregations, ans_windowingSpecs, aggregations, postAggregations, windowingSpecs ) );
 
@@ -386,7 +386,7 @@ public class ComputationalFieldTest extends AbstractIntegrationTest {
         fieldName = "avg_per_city";
         input = "$mean( sumof(Profit), {City,Category})";
         ComputationalField.checkComputationalFieldIn( input, mapFieldNames );
-        ComputationalField.makeAggregationFunctionsIn( fieldName, input, aggregations, postAggregations, windowingSpecs, mapFieldNames );
+        ComputationalField.makeAggregationFunctionsIn( fieldName, input, aggregations, postAggregations, windowingSpecs, Maps.newHashMap(), mapFieldNames );
 
         return;
     }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Changed query method to datasketch mode to improve result of COUNT function.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#967 


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Add custom measure using COUNTD function at chart editing page.
2. Create chart with this custom measure.
3. Result's accuracy might be enhanced.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
http://druid.io/docs/latest/development/extensions-core/datasketches-aggregators.html