### PR TITLE
Use backticks with column in dataprep

### DIFF
--- a/discovery-frontend/src/app/data-preparation/data-snapshot/data-snapshot.component.html
+++ b/discovery-frontend/src/app/data-preparation/data-snapshot/data-snapshot.component.html
@@ -116,7 +116,7 @@
       </colgroup>
       <thead>
       <tr>
-        <th (click)="changeOrder('ssName')">
+        <th (click)="changeOrder('ssName')" class="ddp-cursor">
           {{'msg.dp.th.ss' | translate}}
           <em class="ddp-icon-array-default2" *ngIf="selectedContentSort.key !== 'ssName' || selectedContentSort.sort === 'default'"></em>
           <em class="ddp-icon-array-asc2" *ngIf="selectedContentSort.key === 'ssName' && selectedContentSort.sort === 'asc'"></em>
@@ -134,7 +134,7 @@
         <th>
           {{'msg.dp.th.et' | translate}}
         </th>
-        <th (click)="changeOrder('createdTime')">
+        <th (click)="changeOrder('createdTime')" class="ddp-cursor">
           {{'msg.comm.th.created' | translate}}
           <em class="ddp-icon-array-default2" *ngIf="selectedContentSort.key !== 'createdTime' || selectedContentSort.sort === 'default'"></em>
           <em class="ddp-icon-array-asc2" *ngIf="selectedContentSort.key === 'createdTime' && selectedContentSort.sort === 'asc'"></em>

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/edit-rule-grid.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/edit-rule-grid.component.ts
@@ -824,8 +824,8 @@ export class EditRuleGridComponent extends AbstractComponent implements OnInit, 
     if (data.more) {
       this._gridComp.columnAllUnSelection();
 
-      const singleSelectionMap: string[] = ['rename', 'unnest', 'extract', 'split',];
-      const multiSelectionMap: string[] = ['merge', 'replace', 'set', 'nest', 'settype', 'setformat', 'move', 'countpattern'];
+      const singleSelectionMap: string[] = ['rename', 'unnest'];
+      const multiSelectionMap: string[] = ['merge', 'replace', 'set', 'nest', 'settype', 'setformat', 'move', 'countpattern', 'extract', 'split'];
 
       if (-1 < singleSelectionMap.indexOf(data.more.command)) {
         this._gridComp.selectColumn(data.more.col.value[0], true);

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-aggregate.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-aggregate.component.ts
@@ -103,10 +103,7 @@ export class EditRuleAggregateComponent extends EditRuleComponent implements OnI
     }
 
     const columnsStr: string = _.cloneDeep(this.selectedFields).map((item) => {
-      if (-1 !== item.name.indexOf(' ')) {
-        item.name = '`' + item.name + '`';
-      }
-      return item.name
+      return '`' + item.name + '`';
     }).join(', ');
 
     const validFormulaList:string[] = [];

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-countpattern.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-countpattern.component.ts
@@ -19,7 +19,7 @@ import { Alert } from '../../../../../../common/util/alert.util';
 import { StringUtil } from '../../../../../../common/util/string.util';
 import { isUndefined } from "util";
 import { EventBroadcaster } from '../../../../../../common/event/event.broadcaster';
-import { PreparationCommonUtil } from '../../../../../util/preparation-common.util';
+import * as _ from 'lodash';
 
 @Component({
   selector : 'edit-rule-countpattern',
@@ -100,11 +100,8 @@ export class EditRuleCountpatternComponent extends EditRuleComponent implements 
       return undefined;
     }
 
-    const columnsStr: string = this.selectedFields.map((item) => {
-      if (-1 !== item.name.indexOf(' ')) {
-        item.name = '`' + item.name + '`';
-      }
-      return item.name
+    const columnsStr: string = _.cloneDeep(this.selectedFields).map((item) => {
+      return '`' + item.name + '`';
     }).join(', ');
 
     // rule string

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-drop.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-drop.component.ts
@@ -92,10 +92,7 @@ export class EditRuleDropComponent extends EditRuleComponent implements OnInit, 
     }
 
     const columnsStr: string = _.cloneDeep(this.selectedFields).map((item) => {
-      if (-1 !== item.name.indexOf(' ')) {
-        item.name = '`' + item.name + '`';
-      }
-      return item.name
+      return '`' + item.name + '`';
     }).join(', ');
 
     return {

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-extract.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-extract.component.ts
@@ -122,10 +122,7 @@ export class EditRuleExtractComponent extends EditRuleComponent implements OnIni
     }
 
     const columnsStr: string = _.cloneDeep(this.selectedFields).map((item) => {
-      if (-1 !== item.name.indexOf(' ')) {
-        item.name = '`' + item.name + '`';
-      }
-      return item.name
+      return '`' + item.name + '`';
     }).join(', ');
 
     let ruleString = 'extract col: ' + columnsStr

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-flatten.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-flatten.component.ts
@@ -94,10 +94,7 @@ export class EditRuleFlattenComponent extends EditRuleComponent implements OnIni
     }
 
     const columnsStr: string = _.cloneDeep(this.selectedFields).map((item) => {
-      if (-1 !== item.name.indexOf(' ')) {
-        item.name = '`' + item.name + '`';
-      }
-      return item.name
+      return '`' + item.name + '`';
     }).join(', ');
 
     let ruleString = 'flatten col: ' + columnsStr;

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-merge.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-merge.component.ts
@@ -21,7 +21,7 @@ import {isNullOrUndefined, isUndefined} from "util";
 import { EventBroadcaster } from '../../../../../../common/event/event.broadcaster';
 import { PreparationCommonUtil } from '../../../../../util/preparation-common.util';
 import * as _ from 'lodash';
- 
+
 @Component({
   selector : 'edit-rule-merge',
   templateUrl : './edit-rule-merge.component.html'
@@ -109,10 +109,7 @@ export class EditRuleMergeComponent extends EditRuleComponent implements OnInit,
     }
 
     const columnsStr: string = _.cloneDeep(this.selectedFields).map((item) => {
-      if (-1 !== item.name.indexOf(' ')) {
-        item.name = '`' + item.name + '`';
-      }
-      return item.name
+      return '`' + item.name + '`';
     }).join(', ');
 
     let ruleString = 'merge col: ' + columnsStr

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-move.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-move.component.ts
@@ -103,10 +103,7 @@ export class EditRuleMoveComponent extends EditRuleComponent implements OnInit, 
     }
 
     const columnsStr: string = _.cloneDeep(this.selectedFields).map((item) => {
-      if (-1 !== item.name.indexOf(' ')) {
-        item.name = '`' + item.name + '`';
-      }
-      return item.name
+      return '`' + item.name + '`';
     }).join(', ');
 
     if (isNullOrUndefined(this.beforeOrAfter) || this.beforeOrAfter === '') {
@@ -127,7 +124,7 @@ export class EditRuleMoveComponent extends EditRuleComponent implements OnInit, 
     return {
       command: 'move',
       col: columnsStr,
-      ruleString: `move col: ${columnsStr} ${this.beforeOrAfter}: ${this.selectedStandardField.indexOf(' ') === -1 ? this.selectedStandardField : '`' + this.selectedStandardField + '`'}`
+      ruleString: `move col: ${columnsStr} ${this.beforeOrAfter}: ${'`' + this.selectedStandardField + '`'}`
     };
 
   } // function - getRuleData

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-nest.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-nest.component.ts
@@ -117,10 +117,7 @@ export class EditRuleNestComponent extends EditRuleComponent implements OnInit, 
     }
 
     const columnsStr: string = _.cloneDeep(this.selectedFields).map((item) => {
-      if (-1 !== item.name.indexOf(' ')) {
-        item.name = '`' + item.name + '`';
-      }
-      return item.name
+      return '`' + item.name + '`';
     }).join(', ');
 
     return {

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-pivot.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-pivot.component.ts
@@ -104,10 +104,7 @@ export class EditRulePivotComponent extends EditRuleComponent implements OnInit,
 
     let selFields = _.cloneDeep(this.selectedFields);
     const columnsStr: string = selFields.map((item) => {
-      if (-1 !== item.name.indexOf(' ')) {
-        item.name = '`' + item.name + '`';
-      }
-      return item.name
+      return '`' + item.name + '`';
     }).join(', ');
 
     const validFormulaList:string[] = [];
@@ -136,10 +133,7 @@ export class EditRulePivotComponent extends EditRuleComponent implements OnInit,
     }
     let selGroupFields = _.cloneDeep(this.selectedGroupFields);
     const groupStr: string = selGroupFields.map((item) => {
-      if (-1 !== item.name.indexOf(' ')) {
-        item.name = '`' + item.name + '`';
-      }
-      return item.name
+      return '`' + item.name + '`';
     }).join(', ');
 
     return {

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-rename.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-rename.component.ts
@@ -114,15 +114,12 @@ export class EditRuleRenameComponent extends EditRuleComponent implements OnInit
     }
 
     let selectedFieldName:string = this.selectedFields[0].name;
-    if (-1 !== this.selectedFields[0].name.indexOf(' ')) {
-      selectedFieldName = '`' + selectedFieldName + '`';
-    }
 
     return {
       command: 'rename',
       to: this.newFieldName,
       col: selectedFieldName,
-      ruleString: 'rename col: ' + selectedFieldName + ' to: ' + clonedNewFieldName
+      ruleString: 'rename col: `' + selectedFieldName + '`' + `to: ${clonedNewFieldName}`
     };
 
   } // function - getRuleData

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-replace.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-replace.component.ts
@@ -128,10 +128,7 @@ export class EditRuleReplaceComponent extends EditRuleComponent implements OnIni
     }
 
     const columnsStr: string = _.cloneDeep(this.selectedFields).map((item) => {
-      if (-1 !== item.name.indexOf(' ')) {
-        item.name = '`' + item.name + '`';
-      }
-      return item.name
+      return '`' + item.name + '`'
     }).join(', ');
 
     let ruleString = `replace col: ${columnsStr} with: ${clonedNewValue} on: ${clonedPattern} global: ${this.isGlobal} ignoreCase: ${this.isIgnoreCase}`;

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-set.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-set.component.ts
@@ -92,10 +92,7 @@ export class EditRuleSetComponent extends EditRuleComponent implements OnInit, A
       }
 
       const columnsStr: string = _.cloneDeep(this.selectedFields).map((item) => {
-        if (-1 !== item.name.indexOf(' ')) {
-          item.name = '`' + item.name + '`';
-        }
-        return item.name
+        return '`' + item.name + '`';
       }).join(', ');
 
       // val
@@ -121,6 +118,7 @@ export class EditRuleSetComponent extends EditRuleComponent implements OnInit, A
         ruleString: `set col: ${columnsStr} value: ${val}`
       };
 
+      this.condition = this.ruleConditionInputComponent['_results'][1].getCondition();
       if ('' !== this.condition && !isNullOrUndefined(this.condition)) {
         rules.ruleString += ` row: ${this.condition}`;
       }

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-setformat.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-setformat.component.ts
@@ -139,7 +139,7 @@ export class EditRuleSetformatComponent extends EditRuleComponent implements OnI
         // When at least one column is selected or this.selectedTimestamp is not empty
         this.selectedTimestamp = this.tempTimetampValue;
         if (cols.length > 0 || '' !== this.tempTimetampValue) {
-          if ('' === this.tempTimetampValue) {
+          if ('' === this.tempTimetampValue && this.selectedFields[0]) {
             let idx = this._getFieldNameArray().indexOf(this.selectedFields[0].name);
             if(idx !== undefined && idx >= 0) {this.selectedTimestamp = this.colTypes[idx].timestampStyle;}
           }
@@ -180,15 +180,12 @@ export class EditRuleSetformatComponent extends EditRuleComponent implements OnI
     }
 
     if ('Custom format' === this.selectedTimestamp && '' === this.customTimestamp || '' === this.selectedTimestamp) {
-      Alert.warning('Timestamp format must not be null');
+      Alert.warning(this.translateService.instant('msg.dp.alert.format.error'));
       return undefined;
     }
 
     const columnsStr: string = this.selectedFields.map((item) => {
-      if (-1 !== item.name.indexOf(' ')) {
-        item.name = '`' + item.name + '`';
-      }
-      return item.name
+      return '`' + item.name + '`';
     }).join(', ');
 
     let ruleString = 'setformat col: ' + columnsStr + ' format: ';

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-settype.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-settype.component.ts
@@ -228,10 +228,7 @@ export class EditRuleSettypeComponent extends EditRuleComponent implements OnIni
     }
 
     const columnsStr: string = this.selectedFields.map((item) => {
-      if (-1 !== item.name.indexOf(' ')) {
-        item.name = '`' + item.name + '`';
-      }
-      return item.name
+      return '`' + item.name + '`';
     }).join(', ');
 
     let ruleString = 'settype col: ' + columnsStr + ` type: ${this.selectedType}`;
@@ -320,7 +317,7 @@ export class EditRuleSettypeComponent extends EditRuleComponent implements OnIni
       this.isTimestamp = false;
     }
   }
-
+ 
   /**
    * Show/hide pattern tooltip
    * @param {boolean} isShow

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-sort.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-sort.component.ts
@@ -99,10 +99,7 @@ export class EditRuleSortComponent extends EditRuleComponent implements OnInit, 
     }
 
     const columnsStr: string = _.cloneDeep(this.selectedFields).map((item) => {
-      if (-1 !== item.name.indexOf(' ')) {
-        item.name = '`' + item.name + '`';
-      }
-      return item.name
+      return '`' + item.name + '`';
     }).join(', ');
 
     let rule =  {

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-split.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-split.component.ts
@@ -17,7 +17,7 @@ import { AfterViewInit, Component, ElementRef, Injector, OnDestroy, OnInit } fro
 import { Field } from '../../../../../../domain/data-preparation/dataset';
 import { Alert } from '../../../../../../common/util/alert.util';
 import { StringUtil } from '../../../../../../common/util/string.util';
-import {isNull, isNullOrUndefined, isUndefined} from "util";
+import { isNullOrUndefined, isUndefined} from "util";
 import { EventBroadcaster } from '../../../../../../common/event/event.broadcaster';
 import * as _ from 'lodash';
 
@@ -122,10 +122,7 @@ export class EditRuleSplitComponent extends EditRuleComponent implements OnInit,
     }
 
     const columnsStr: string = _.cloneDeep(this.selectedFields).map((item) => {
-      if (-1 !== item.name.indexOf(' ')) {
-        item.name = '`' + item.name + '`';
-      }
-      return item.name
+      return '`' + item.name + '`';
     }).join(', ');
 
     let ruleString = `split col: ${columnsStr} on: ${clonedPattern} limit: ${this.limit} ignoreCase: ${this.isIgnoreCase}`;

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-unnest.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-unnest.component.ts
@@ -105,10 +105,7 @@ export class EditRuleUnnestComponent extends EditRuleComponent implements OnInit
     }
 
     const columnsStr: string = _.cloneDeep(this.selectedFields).map((item) => {
-      if (-1 !== item.name.indexOf(' ')) {
-        item.name = '`' + item.name + '`';
-      }
-      return item.name
+      return '`' + item.name + '`';
     }).join(', ');
 
     let ruleString = 'unnest col: ' + columnsStr;

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-unpivot.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-unpivot.component.ts
@@ -99,10 +99,7 @@ export class EditRuleUnpivotComponent extends EditRuleComponent implements OnIni
 
     // TODO : condition validation
     const columnsStr: string = _.cloneDeep(this.selectedFields).map((item) => {
-      if (-1 !== item.name.indexOf(' ')) {
-        item.name = '`' + item.name + '`';
-      }
-      return item.name
+      return '`' + item.name + '`';
     }).join(', ');
 
 

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-window.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-window.component.ts
@@ -162,10 +162,7 @@ export class EditRuleWindowComponent extends EditRuleComponent implements OnInit
     if (this.selectedFields.length !== 0) {
       let selFields = _.cloneDeep(this.selectedFields);
       groupStr = selFields.map((item) => {
-        if (-1 !== item.name.indexOf(' ')) {
-          item.name = '`' + item.name + '`';
-        }
-        return item.name
+        return '`' + item.name + '`';
       }).join(', ');
     }
 
@@ -173,10 +170,7 @@ export class EditRuleWindowComponent extends EditRuleComponent implements OnInit
     if (this.selectedSortFields.length !== 0) {
       let selSortFields = _.cloneDeep(this.selectedSortFields);
       sortStr = selSortFields.map((item) => {
-        if (-1 !== item.name.indexOf(' ')) {
-          item.name = '`' + item.name + '`';
-        }
-        return item.name
+        return '`' + item.name + '`';
       }).join(', ');
     }
 

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/multicolumn-rename.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/multicolumn-rename.component.ts
@@ -296,9 +296,7 @@ export class MulticolumnRenameComponent extends AbstractComponent implements OnI
       }
 
       const columnsStr: string = cols.map((item) => {
-        if (-1 !== item.indexOf(' ')) {
-          item = '`' + item + '`';
-        }
+        item = '`' + item + '`';
         return item
       }).join(', ');
 
@@ -327,7 +325,7 @@ export class MulticolumnRenameComponent extends AbstractComponent implements OnI
 
     let rows: any[] = this.gridRows;
 
-    if( 0 === fields.length || 0 === rows.length ) {
+    if( 0 === fields.length) {
       return;
     }
 

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/rule-context-menu.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/rule-context-menu.component.ts
@@ -214,13 +214,10 @@ export class RuleContextMenuComponent extends AbstractComponent implements OnIni
       // change coluuid list to col name list
       let columnNames = this.changeUUIDtoNames(this.originalSelectedColIds);
       const columnsStr: string = columnNames.map((item) => {
-        if (-1 !== item.indexOf(' ')) {
-          item = '`' + item + '`';
-        }
-        return item
+        return '`' + item + '`';
       }).join(', ');
 
-      const selCol = -1 !== this.contextInfo.columnName.indexOf(' ') ?  '`' + this.contextInfo.columnName + '`' : this.contextInfo.columnName;
+      const selCol = '`' + this.contextInfo.columnName + '`';
 
       let rule = {};
       switch(command.command) {
@@ -265,11 +262,10 @@ export class RuleContextMenuComponent extends AbstractComponent implements OnIni
           break;
         case 'move':
           if (command.value === 'first') {
-            let first = -1 !== this.contextInfo.gridResponse.colNames[0].indexOf(' ') ?  '`' + this.contextInfo.gridResponse.colNames[0] + '`' : this.contextInfo.gridResponse.colNames[0];
+            const first = '`' + this.contextInfo.gridResponse.colNames[0] + '`' ;
             rule['ruleString'] = `move col: ${columnsStr} before: ${first}`;
           } else if (command.value === 'last') {
-            let last = this.contextInfo.gridResponse.colNames[this.contextInfo.gridResponse.colNames.length-1];
-            last = -1 !== last.indexOf(' ') ? '`' + last + '`' : last;
+            const last = '`' +this.contextInfo.gridResponse.colNames[this.contextInfo.gridResponse.colNames.length-1] + '`';
             rule['ruleString'] = `move col: ${columnsStr} after: ${last}`;
           } else if (command.value === 'before' || command.value === 'after') {
             rule['more'] = {command : 'move', col : {value : columnNames}};
@@ -318,9 +314,7 @@ export class RuleContextMenuComponent extends AbstractComponent implements OnIni
               break;
             case 'duplicate':
               let newCol = `${this.contextInfo.columnName}_1`;
-              if (this.contextInfo.columnName.indexOf(' ') !== -1) {
-                newCol = '`'+ newCol + '`';
-              }
+              newCol = '`'+ newCol + '`';
               rule['ruleString'] = `derive value: ${selCol} as: ${newCol}`;
               break;
             case 'split':
@@ -342,14 +336,8 @@ export class RuleContextMenuComponent extends AbstractComponent implements OnIni
           switch(command.value) {
 
             case 'direct-mismatch':
-              //  ismismatched(columnName,'column type with single quote surrounded')
               columnNames.forEach((item) => {
-                if (item.indexOf(' ') > -1) {
-                  res.push('ismismatched(' + '`' + item + '`' + `,'${this.contextInfo.columnType}')`);
-                } else {
-                  res.push(`ismismatched(${item},'${this.contextInfo.columnType}')`)
-                }
-
+                res.push('ismismatched(' + '`' + item + '`' + `,'${this.contextInfo.columnType}')`);
               });
 
               rule['ruleString'] += res.join(' || ');
@@ -358,13 +346,7 @@ export class RuleContextMenuComponent extends AbstractComponent implements OnIni
             case 'direct-missing':
               // delete row: isnull(c) || isnull(`space col`)
               columnNames.forEach((item) => {
-
-                if (item.indexOf(' ') > -1) {
-                  res.push('isnull(' + '`' + item + '`' + ')');
-                } else {
-                  res.push(`isnull(${item})`)
-                }
-
+                res.push('isnull(' + '`' + item + '`' + ')');
               });
 
               rule['ruleString'] += res.join(' || ');

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/rule-join-popup/rule-join-popup.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/rule-join-popup/rule-join-popup.component.ts
@@ -807,37 +807,31 @@ export class RuleJoinPopupComponent extends AbstractPopupComponent implements On
     }
 
     const conditions = this.joinList.map((joinInfo) => {
-      return (joinInfo.leftJoinKey.indexOf(' ') === -1 ? joinInfo.leftJoinKey :  '`' + joinInfo.leftJoinKey + '`') + '=' + (joinInfo.rightJoinKey.indexOf(' ') === -1 ? joinInfo.rightJoinKey :  '`' + joinInfo.rightJoinKey + '`')
+      return ('`' + joinInfo.leftJoinKey + '`') + '=' + ('`' + joinInfo.rightJoinKey + '`')
     }).join(' && ');
 
     let ruleStr: string = 'join leftSelectCol: ';
     if (this.leftSelCols.constructor === Array) {
 
       const leftStr: string = this.leftSelCols.map((item) => {
-        if (-1 !== item.indexOf(' ')) {
-          item = '`' + item + '`';
-        }
-        return item
+        return '`' + item + '`';
       }).join(', ');
 
       ruleStr += leftStr
     } else {
-      ruleStr += this.leftSelCols.indexOf(' ') === -1 ? this.leftSelCols  :  '`' + this.leftSelCols + '`';
+      ruleStr += '`' + this.leftSelCols + '`';
     }
     ruleStr += ' rightSelectCol: ';
 
     const rightStr: string = this.rightSelCols.map((item) => {
-      if (-1 !== item.indexOf(' ')) {
-        item = '`' + item + '`';
-      }
-      return item
+      return '`' + item + '`';
     }).join(', ');
 
 
     if (this.rightSelCols.constructor === Array) {
       ruleStr += rightStr
     } else {
-      ruleStr += this.rightSelCols.indexOf(' ') === -1 ? this.rightSelCols  :  '`' + this.rightSelCols + '`';
+      ruleStr += '`' + this.rightSelCols + '`';
     }
 
     ruleStr += ' condition: ' + conditions + ' joinType: \'' + this.selectedJoinType.toLowerCase() + '\' dataset2: \'' + this.rightDataset.dsId + '\'';

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/rule-union-popup/rule-union-popup.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/rule-union-popup/rule-union-popup.component.ts
@@ -241,10 +241,7 @@ export class RuleUnionPopupComponent extends AbstractPopupComponent implements O
     }
 
     const columnsStr: string = this.resultFields.map((item) => {
-      if (-1 !== item.name.indexOf(' ')) {
-        item.name = '`' + item.name + '`';
-      }
-      return item.name
+      return  '`' + item.name + '`';
     }).join(', ');
 
     let ruleStr: string = 'union masterCol: ' + columnsStr

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow.component.html
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow.component.html
@@ -69,7 +69,7 @@
       </colgroup>
       <thead>
       <tr>
-        <th (click)="changeOrder('dfName')">
+        <th (click)="changeOrder('dfName')" class="ddp-cursor">
           {{'msg.comm.ui.name' | translate}}
           <em class="ddp-icon-array-default2" *ngIf="selectedContentSort.key !== 'dfName' || selectedContentSort.sort === 'default'"></em>
           <em class="ddp-icon-array-asc2" *ngIf="selectedContentSort.key === 'dfName' && selectedContentSort.sort === 'asc'"></em>
@@ -78,7 +78,7 @@
         <th>
           {{'msg.comm.menu.manage.prep.set' | translate}}
         </th>
-        <th (click)="changeOrder('createdTime')">
+        <th (click)="changeOrder('createdTime')" class="ddp-cursor">
           {{'msg.comm.th.created' | translate}}
           <em class="ddp-icon-array-default2" *ngIf="selectedContentSort.key !== 'createdTime' || selectedContentSort.sort === 'default'"></em>
           <em class="ddp-icon-array-asc2" *ngIf="selectedContentSort.key === 'createdTime' && selectedContentSort.sort === 'asc'"></em>

--- a/discovery-frontend/src/app/data-preparation/dataset/dataset.component.html
+++ b/discovery-frontend/src/app/data-preparation/dataset/dataset.component.html
@@ -72,13 +72,13 @@
       </colgroup>
       <thead>
       <tr>
-        <th (click)="changeOrder('dsName')" colspan="2">
+        <th (click)="changeOrder('dsName')" colspan="2" class="ddp-cursor">
           {{'msg.comm.menu.manage.prep.set' | translate}}
           <em class="ddp-icon-array-default2" *ngIf="selectedContentSort.key !== 'dsName' || selectedContentSort.sort === 'default'"></em>
           <em class="ddp-icon-array-asc2" *ngIf="selectedContentSort.key === 'dsName' && selectedContentSort.sort === 'asc'"></em>
           <em class="ddp-icon-array-des2" *ngIf="selectedContentSort.key === 'dsName' && selectedContentSort.sort === 'desc'"></em>
         </th>
-        <th (click)="changeOrder('refDfCount')">
+        <th (click)="changeOrder('refDfCount')"  class="ddp-cursor">
           {{'msg.comm.th.used' | translate}}
           <em class="ddp-icon-array-default2" *ngIf="selectedContentSort.key !== 'refDfCount' || selectedContentSort.sort === 'default'"></em>
           <em class="ddp-icon-array-asc2" *ngIf="selectedContentSort.key === 'refDfCount' && selectedContentSort.sort === 'asc'"></em>
@@ -87,7 +87,7 @@
         <th>
           {{'msg.dp.th.source' | translate}}
         </th>
-        <th (click)="changeOrder('createdTime')">
+        <th (click)="changeOrder('createdTime')"  class="ddp-cursor">
           {{'msg.comm.th.created' | translate}}
           <em class="ddp-icon-array-default2" *ngIf="selectedContentSort.key !== 'createdTime' || selectedContentSort.sort === 'default'"></em>
           <em class="ddp-icon-array-asc2" *ngIf="selectedContentSort.key === 'createdTime' && selectedContentSort.sort === 'asc'"></em>

--- a/discovery-frontend/src/app/monitoring/audit/job-log/job-log.component.html
+++ b/discovery-frontend/src/app/monitoring/audit/job-log/job-log.component.html
@@ -140,7 +140,7 @@
 
     <table class="ddp-table-form ddp-table-type3">
       <colgroup>
-        <col width="90px">
+        <col width="100px">
         <col width="*">
         <col width="10%">
         <col width="70px">

--- a/discovery-frontend/src/assets/i18n/en.json
+++ b/discovery-frontend/src/assets/i18n/en.json
@@ -1286,6 +1286,7 @@
   "msg.dp.alert.enter.group.every" : "Please enter group every",
   "msg.dp.ui.join.prev.msg" : "You can check the results after selecting required items",
   "msg.dp.ui.join.key.required" : "At least one join key is required",
+  "msg.dp.alert.format.error" : "Please enter timestamp pattern",
 
   "msg.board.create.add-ds" : "Add datasource",
   "msg.board.create.add-ds.desc" : "Add the data sources you want to visualize and establish relationships",
@@ -1308,7 +1309,7 @@
   "msg.board.download.desc" : "Up to 1 million downloads, <br> Please contact your administrator for more than 1 million data.",
   "msg.board.download.calc-size" : "Calculating data size ...",
   "msg.board.ui.no.widget": "No widgets",
-  "msg.board.ui.show.only": "Shown only",
+  "msg.board.ui.show.only": "Visible only",
   "msg.board.th.allowance": "Show open data only",
   "msg.board.btn.add.datasource.join": "Add datasource to join",
   "msg.board.update-datasource.confirm.title" : "Do you want to save your changes?",

--- a/discovery-frontend/src/assets/i18n/ko.json
+++ b/discovery-frontend/src/assets/i18n/ko.json
@@ -1285,6 +1285,7 @@
   "msg.dp.alert.enter.group.every" : "그룹 수를 입력하세요",
   "msg.dp.ui.join.prev.msg" : "필수 항목을 선택하면 결과를 확인할 수 있습니다",
   "msg.dp.ui.join.key.required" : "하나 이상의 조인 키가 필요합니다",
+  "msg.dp.alert.format.error" : "타임스탬프 패턴을 입력하세요",
 
   "msg.board.create.add-ds" : "데이터소스 추가",
   "msg.board.create.add-ds.desc" : "시각화 할 데이터소스를 추가하고 관계를 설정해 주세요",
@@ -1307,7 +1308,7 @@
   "msg.board.download.desc" : "최대 100만 건까지 다운로드됩니다,<br>100만 건 이상의 데이터는 관리자에게 문의해 주세요.",
   "msg.board.download.calc-size" : "데이터 용량 계산중...",
   "msg.board.ui.no.widget": "위젯이 없습니다",
-  "msg.board.ui.show.only": "보임 화면 보기",
+  "msg.board.ui.show.only": "보임 보드만",
   "msg.board.th.allowance": "오픈 데이터만 보기",
   "msg.board.btn.add.datasource.join": "조인을 위하여 데이터소스를 추가해 주세요",
   "msg.board.update-datasource.confirm.title" : "변경 사항을 저장하시겠습니까?",


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
When sending ruleString to server, colum name must be wrapped with ` .

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
MT-184

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Dataflow maingrid-> rename  one column -> check if column name is wrapped with back tick in request

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
