### PR TITLE
Fixed a problem where data summary information was not initialized in the data preview screen

### DIFF
--- a/discovery-frontend/src/app/common/component/data-preview/data.preview.component.ts
+++ b/discovery-frontend/src/app/common/component/data-preview/data.preview.component.ts
@@ -132,9 +132,9 @@ export class DataPreviewComponent extends AbstractPopupComponent implements OnIn
   public roles: any = {};
 
   // Datasource
+  public datasources: Datasource[] = [];
   public mainDatasource: Datasource;
   public joinMappings: JoinMapping[] = [];
-  public datasources: Datasource[] = [];
   public joinDataSources: Datasource[] = [];
 
   // 메인 그리드 rows 개수
@@ -1044,6 +1044,13 @@ export class DataPreviewComponent extends AbstractPopupComponent implements OnIn
     // seletedfield init
     this.selectedField = null;
     this.timestampField = null;
+    this.columns = [];
+    this.colTypes = [];
+    this.roles = {};
+
+    this.joinMappings = [];
+    this.joinDataSources = [];
+
     this.safelyDetectChanges();
 
     // set columns info


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
데이터 미리보기 화면에서 데이터 요약 정보가 초기화 되지 않는 문제를 수정합니다.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 멀티데이터소스로 대시보드를 생성합니다.
2. 데이터 미리보기를 띄운 후 데이터소스의 요약 정보를 확인합니다.
3. 데이터소스를 변경한 후, 데이터소스 요약정보가 누적되지 않고 정상적으로 표시되는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
