### PR TITLE
H#1046 dataprep migration

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepMonitorService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepMonitorService.java
@@ -709,9 +709,7 @@ public class PrepMonitorService implements ApplicationListener<ApplicationReadyE
       String tblCheckQuery = String.format("SELECT * FROM %s", tblName);
       stmt.executeQuery(tblCheckQuery);
     } catch (SQLException e) {
-      // It probably be TABLE NOT FOUND.
-      e.printStackTrace();
-      LOGGER.info("checkOldTableExists(): no old table: {}", tblName);
+      // It will probably be TABLE NOT FOUND: just suppress
       return false;
     }
 


### PR DESCRIPTION
### Description
I have enhanced the processing for cases where there is no tables to migrate.
In other words, if the old entity group can not be found, it has to be passed without any critical log generation.
In fact, the absence of entity groups will increasingly become a major case very soon.

_아예 migration 할 것이 없는 경우에 대한 처리를 보완하였습니다.
즉, old entity group을 찾을 수 없는 경우, 아무 critical log 생성 없이 그냥 지나가도록 하였습니다.
사실, entity group이 없는 것이 점점 더 major case가 될 것입니다._

**Related Issue** : https://github.com/metatron-app/metatron-discovery/issues/1046

### How Has This Been Tested?
Locally. With H2 and MySQL.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

