### PR TITLE
Bugfix in dashboard

### DIFF
--- a/discovery-frontend/src/app/common/component/abstract.component.ts
+++ b/discovery-frontend/src/app/common/component/abstract.component.ts
@@ -147,15 +147,29 @@ export class AbstractComponent implements OnInit, AfterViewInit, OnDestroy, CanC
     }
   }
 
+  /**
+   * unload 전 실행
+   */
+  public execBeforeUnload() {}
+
+  /**
+   * deactive 체크
+   */
   public canDeactivate(): Observable<boolean> | boolean {
+    this.execBeforeUnload();
     if (this.useUnloadConfirm) {
       return this.unloadConfirmSvc.confirm();
     }
     return true;
   } // function - canDeactivate
 
+  /**
+   * unload 체크
+   * @param event
+   */
   @HostListener('window:beforeunload', ['$event'])
   public beforeUnloadHandler(event) {
+    this.execBeforeUnload();
     if (this.useUnloadConfirm) {
       const confirmationMessage: string = this.translateService.instant('msg.comm.ui.beforeunload');
       event.returnValue = confirmationMessage;  // Gecko, Trident, Chrome 34+
@@ -166,6 +180,7 @@ export class AbstractComponent implements OnInit, AfterViewInit, OnDestroy, CanC
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Public Method
    |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
+  // noinspection JSMethodCanBeStatic
   /**
    * add body scroll hidden class
    */
@@ -173,6 +188,7 @@ export class AbstractComponent implements OnInit, AfterViewInit, OnDestroy, CanC
     $('body').removeClass('body-hidden').addClass('body-hidden');
   } // function - addBodyScrollHidden
 
+  // noinspection JSMethodCanBeStatic
   /**
    * remove body scroll hidden class
    */
@@ -314,6 +330,7 @@ export class AbstractComponent implements OnInit, AfterViewInit, OnDestroy, CanC
     return result;
   } // function - getIconClass
 
+  // noinspection JSMethodCanBeStatic
   /**
    * 필드에 맞는 role 타입 아이콘
    * @param {string} roleType
@@ -323,6 +340,7 @@ export class AbstractComponent implements OnInit, AfterViewInit, OnDestroy, CanC
     return roleType === 'MEASURE' ? 'ddp-measure' : 'ddp-dimension' ;
   }
 
+  // noinspection JSMethodCanBeStatic
   /**
    * 필드에 맞는 Dimension 타입의 아이콘
    * @param {string} type
@@ -382,6 +400,7 @@ export class AbstractComponent implements OnInit, AfterViewInit, OnDestroy, CanC
 
   }
 
+  // noinspection JSMethodCanBeStatic
   /**
    * 필드에 맞는 Measure 타입의 아이콘
    * @param {string} type
@@ -638,6 +657,7 @@ export class AbstractComponent implements OnInit, AfterViewInit, OnDestroy, CanC
     });
   } // function - checkAndConnectWebSocket
 
+  // noinspection JSUnusedGlobalSymbols
   /**
    * 웹소켓 연결 해제
    */

--- a/discovery-frontend/src/app/common/component/abstract.component.ts
+++ b/discovery-frontend/src/app/common/component/abstract.component.ts
@@ -158,7 +158,13 @@ export class AbstractComponent implements OnInit, AfterViewInit, OnDestroy, CanC
   public canDeactivate(): Observable<boolean> | boolean {
     this.execBeforeUnload();
     if (this.useUnloadConfirm) {
-      return this.unloadConfirmSvc.confirm();
+      const obConfirm:Observable<boolean>  = this.unloadConfirmSvc.confirm();
+      obConfirm.subscribe( data => {
+        if( !data ) {
+          history.pushState(null, null, this.router.url);
+        }
+      });
+      return obConfirm;
     }
     return true;
   } // function - canDeactivate

--- a/discovery-frontend/src/app/common/gaurd/can.deactivate.guard.ts
+++ b/discovery-frontend/src/app/common/gaurd/can.deactivate.guard.ts
@@ -26,7 +26,6 @@ export class CanDeactivateGuard implements CanDeactivate<CanComponentDeactivate>
                 route: ActivatedRouteSnapshot,
                 state: RouterStateSnapshot) {
     let url: string = state.url;
-    // console.log('>>>>>>> Url: ' + url);
     return component.canDeactivate ? component.canDeactivate() : true;
   }
 }

--- a/discovery-frontend/src/app/dashboard/service/dashboard.service.ts
+++ b/discovery-frontend/src/app/dashboard/service/dashboard.service.ts
@@ -71,7 +71,7 @@ export class DashboardService extends AbstractService {
     (dashboard.temporaryId) && (params['temporaryId'] = dashboard.temporaryId);
 
     // for UI 속성 제거
-    params = this._convertSpecToServer(_.cloneDeep(params));
+    params = this.convertSpecToServer(_.cloneDeep(params));
     return this.post(url, params).then((board: Dashboard) => {
       return new Promise((resolve) => {
         ( callback ) && ( callback( board ) );
@@ -124,7 +124,7 @@ export class DashboardService extends AbstractService {
    */
   public updateDashboard(dashboardId: string, options: any) {
     // for UI 속성 제거
-    const apiParams: any = this._convertSpecToServer(_.cloneDeep(options));
+    const apiParams: any = this.convertSpecToServer(_.cloneDeep(options));
     return this.patch(this.API_URL + 'dashboards/' + dashboardId, apiParams);
   } // function - updateDashboard
 
@@ -170,17 +170,13 @@ export class DashboardService extends AbstractService {
     return this.post(this.API_URL + 'datasources/validate/expr', param);
   }
 
-
-  /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-   | Private Method
-   |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
   /**
    * UI 스펙을 서버 스펙으로 변경
    * @param param
    * @return {any}
    * @private
    */
-  private _convertSpecToServer(param: any) {
+  public convertSpecToServer(param: any) {
     if (param) {
       delete param['selectDatasource'];
       delete param['update'];
@@ -222,7 +218,11 @@ export class DashboardService extends AbstractService {
       }
     }
     return param;
-  } // function - _convertSpecToServer
+  } // function - convertSpecToServer
+
+  /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+   | Private Method
+   |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
 
   /**
    * 대시보드와 데이터소스 연결에 대한 파라메터 생성

--- a/discovery-frontend/src/app/dashboard/update-dashboard.component.ts
+++ b/discovery-frontend/src/app/dashboard/update-dashboard.component.ts
@@ -416,7 +416,7 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
   /**
    * unload 전 실행
    */
-  public execBeforeUnload() {
+  public execBeforeUnload():boolean {
     let orgInfo:Dashboard = _.cloneDeep(this.orgBoardInfo);
     let currInfo:Dashboard = _.cloneDeep(this.dashboard);
 
@@ -445,6 +445,8 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
     currInfo = this.dashboardService.convertSpecToServer( currInfo );
 
     this.useUnloadConfirm = (JSON.stringify(orgInfo) !== JSON.stringify(currInfo));
+
+    return this.useUnloadConfirm;
   } // function - execBeforeUnload
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/discovery-frontend/src/app/dashboard/update-dashboard.component.ts
+++ b/discovery-frontend/src/app/dashboard/update-dashboard.component.ts
@@ -621,20 +621,28 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
    * 대시보드를 변경한다.
    */
   public moveOrNewDashboard(dashboardItem: Dashboard) {
-    const modal = new Modal();
-    modal.name = this.translateService.instant('msg.board.alert.title.change');
-    modal.description = this.translateService.instant('msg.board.alert.desc.move');
-    modal.btnName = this.translateService.instant('msg.comm.btn.mov');
-    modal.data = {type: 'changeDashboard'};
-    modal.afterConfirm = () => {
+    this.execBeforeUnload();
+    if( this.useUnloadConfirm ) {
+      const modal = new Modal();
+      modal.name = this.translateService.instant('msg.board.alert.title.change');
+      modal.description = this.translateService.instant('msg.board.alert.desc.move');
+      modal.btnName = this.translateService.instant('msg.comm.btn.mov');
+      modal.data = {type: 'changeDashboard'};
+      modal.afterConfirm = () => {
+        if (dashboardItem) {
+          this.selectedDashboard.emit(dashboardItem);
+        } else {
+          this.createDashboard.emit();
+        }
+      };
+      CommonUtil.confirm(modal);
+    } else {
       if (dashboardItem) {
         this.selectedDashboard.emit(dashboardItem);
-        this._initViewPage(dashboardItem.id);
       } else {
         this.createDashboard.emit();
       }
-    };
-    CommonUtil.confirm(modal);
+    }
   } // function - moveOrNewDashboard
 
   /**
@@ -1637,6 +1645,7 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
       // 필터 셋팅
       this._organizeAllFilters().then(() => {
         (setInitialBoard) && (this.orgBoardInfo = _.cloneDeep(dashboard));
+        this.hideBoardLoading();
         this.changeDetect.detectChanges();
       });
 

--- a/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
+++ b/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
@@ -1019,7 +1019,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
           .CannotTriggerInsert(true)
           .Resizable(true)
           .Unselectable(true)
-          .Sortable(true)
+          .Sortable(false)
           .build();
       });
 

--- a/discovery-frontend/src/app/workbook/workbook.component.ts
+++ b/discovery-frontend/src/app/workbook/workbook.component.ts
@@ -77,7 +77,7 @@ export class WorkbookComponent extends AbstractComponent implements OnInit, OnDe
 
   // 대시보드 편집 컴포넌트
   @ViewChild(UpdateDashboardComponent)
-  private updateDashboardComponent: UpdateDashboardComponent;
+  private _updateBoardComp: UpdateDashboardComponent;
 
   @ViewChild('srchDashboard')
   private inputSrchDashboard: ElementRef;
@@ -316,6 +316,15 @@ export class WorkbookComponent extends AbstractComponent implements OnInit, OnDe
       this.cookieService.set(userId + this.workbookId, this.comments.comments[0].id + '', 0, '/');
     }
   }
+
+  /**
+   * unload 전 실행
+   */
+  public execBeforeUnload() {
+    if (this.mode === 'UPDATE' && this._updateBoardComp ) {
+      this.useUnloadConfirm = this._updateBoardComp.execBeforeUnload();
+    }
+  } // function - execBeforeUnload
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Public Method - Common

--- a/discovery-frontend/src/app/workbook/workbook.component.ts
+++ b/discovery-frontend/src/app/workbook/workbook.component.ts
@@ -115,7 +115,7 @@ export class WorkbookComponent extends AbstractComponent implements OnInit, OnDe
   public dashboards: Dashboard[];
 
   public workspace: Workspace;            // 워크스페이스 정보
-  public tempLoadBoard:Dashboard;         // 조회용 임시 보드 정보 ( reload를 위한 )
+  public tempLoadBoard: Dashboard;         // 조회용 임시 보드 정보 ( reload를 위한 )
   public selectedDashboard: Dashboard;    // 선택된 대시보드
 
   // 대시보드 편집 시 시작 커맨드 정보
@@ -969,8 +969,10 @@ export class WorkbookComponent extends AbstractComponent implements OnInit, OnDe
 
     this.tempLoadBoard = dashboard;
     if (!this.selectedDashboard || this.selectedDashboard.id !== dashboard.id) {
-      this._boardComp.showBoardLoading();
-      this._boardComp.hideError();
+      if(this._boardComp) {
+        this._boardComp.showBoardLoading();
+        this._boardComp.hideError();
+      }
       this.dashboardService.getDashboard(dashboard.id).then((board: Dashboard) => {
         // save data for selected dashboard
         board.workBook = this.workbook;
@@ -979,11 +981,13 @@ export class WorkbookComponent extends AbstractComponent implements OnInit, OnDe
 
         this.scrollToDashboard(board.id); // scroll to item
 
-        this._boardComp.hideBoardLoading();
+        (this._boardComp) && (this._boardComp.hideBoardLoading());
         this.safelyDetectChanges();
       }).catch(() => {
-        this._boardComp.showError();
-        this._boardComp.hideBoardLoading();
+        if(this._boardComp) {
+          this._boardComp.showError();
+          this._boardComp.hideBoardLoading();
+        }
         this.safelyDetectChanges();
       });
     } else {
@@ -998,7 +1002,7 @@ export class WorkbookComponent extends AbstractComponent implements OnInit, OnDe
    */
   public onDashboardEvent(event: { name: string, data?: any }) {
     if ('RELOAD_BOARD' === event.name) {
-      this.loadAndSelectDashboard( this.tempLoadBoard );
+      this.loadAndSelectDashboard(this.tempLoadBoard);
     }
   } // function - onDashboardEvent
 

--- a/discovery-frontend/src/app/workbook/workbook.component.ts
+++ b/discovery-frontend/src/app/workbook/workbook.component.ts
@@ -575,7 +575,6 @@ export class WorkbookComponent extends AbstractComponent implements OnInit, OnDe
    */
   public changeMode(mode: string, startupCmd?: { cmd: string, id?: string, type?: string }) {
     this.updateDashboardStartupCmd = startupCmd ? startupCmd : {cmd: 'NONE'};
-    this.useUnloadConfirm = ('UPDATE' === mode);
     this.mode = mode;
     this.safelyDetectChanges();
   } // function - changeMode


### PR DESCRIPTION
### Description
차트 위젯의 다운로드에서 동작하지 않는 정렬 기능을 제거합니다. ( MT-162 )
대시보드에서 벗어날 시 수정되었을 때만 경고창을 표시하도록 수정합니다. ( MT-163 )

**Related Issue** : MT-162, MT-163 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 페이지 위젯의 데이터 다운로드에서 미리보기의 그리드에서 정렬 기능이 제거되었는지 확인합니다.
2. 대시보드 편집화면에서 내용을 수정하지 않고 바로 취소 버튼을 눌렀을 때, 경고창 없이 열람화면으로 이동하는지 확인합니다.
3. 대시보드 편집화면에서 내용을 수정하고 취소 버튼을 눌렀을 때, 경고창이 표시되는지 확인합니다.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
