### PR TITLE
#1058 granularity automation in ingestion

### DIFF
--- a/discovery-frontend/src/app/data-storage/data-source-list/component/ingestion-setting.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/component/ingestion-setting.component.ts
@@ -692,7 +692,7 @@ export class IngestionSettingComponent extends AbstractComponent {
       this.selectedQueryGranularity = this.segmentGranularityList[0];
     } else if (this._format.type === FieldFormatType.DATE_TIME) { // if exist format, DATE_TIME type
       // _automationGranularity
-      this._automationGranularity(this._format.format, this._format.format.length -1);
+      this._automationGranularity(this._format.format, this._format.format.length - 1);
     } else if (this._format.type === FieldFormatType.UNIX_TIME) { // if exist format, UNIX_TIME type
       // set segment granularity HOUR
       this.selectedSegmentGranularity = this.segmentGranularityList[2];

--- a/discovery-frontend/src/app/data-storage/data-source-list/component/ingestion-setting.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/component/ingestion-setting.component.ts
@@ -153,7 +153,7 @@ export class IngestionSettingComponent extends AbstractComponent {
   public dateList: any[];
   // day list show flag (only engine source type)
   public isShowDateList: boolean = false;
-  // seleted time in week (only engine source type)
+  // selected time in week (only engine source type)
   public selectedWeeklyTime: string;
 
   // cron text (only engine source type)
@@ -220,7 +220,7 @@ export class IngestionSettingComponent extends AbstractComponent {
    * Init
    * @param {DatasourceInfo} sourceData
    */
-  public init(sourceData: DatasourceInfo, createType: string, selectedTimestampColumn: Field): void {
+  public init(sourceData: DatasourceInfo, createType: string, selectedTimestampColumn: Field, isChangedTimestampField: boolean = false): void {
     // datasource data
     this._sourceData = sourceData;
     // create datasource type
@@ -232,8 +232,12 @@ export class IngestionSettingComponent extends AbstractComponent {
     // if exist ingestionData
     if (this._sourceData.hasOwnProperty("ingestionData")) {
       this._loadIngestionData(this._sourceData.ingestionData);
+      // if changed timestamp field, init granularity
+      isChangedTimestampField && this._initGranularity();
     } else { // init
       this._setDefaultIngestionOption();
+      // init granularity
+      this._initGranularity();
       // if staging type, set partition key list
       if (this.createType === 'STAGING' && this._sourceData.databaseData.selectedTableDetail.partitionFields.length > 0) {
         // set key list
@@ -609,8 +613,6 @@ export class IngestionSettingComponent extends AbstractComponent {
    * @private
    */
   private _initView(): void {
-    // init granularity setting
-    this._initGranularity();
     // init roll up type list
     this.rollUpTypeList = [
       { label: this.translateService.instant('msg.storage.ui.set.true'), value: true },

--- a/discovery-frontend/src/app/data-storage/data-source-list/component/ingestion-setting.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/component/ingestion-setting.component.ts
@@ -715,7 +715,7 @@ export class IngestionSettingComponent extends AbstractComponent {
    * @private
    */
   private _automationGranularity(format: string, startNum: number) {
-    switch (format.slice(startNum, startNum - 1)) {
+    switch (format.slice(startNum, startNum + 1)) {
       case 'Y':
       case 'y':
         // set segment granularity YEAR

--- a/discovery-frontend/src/app/data-storage/data-source-list/component/ingestion-setting.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/component/ingestion-setting.component.ts
@@ -736,6 +736,13 @@ export class IngestionSettingComponent extends AbstractComponent {
     } else if (this._format.type === FieldFormatType.UNIX_TIME) { // if exist format, UNIX_TIME type
       // set segment granularity HOUR
       this.selectedSegmentGranularity = this.segmentGranularityList[2];
+      // set query granularity SECOND
+      this.selectedQueryGranularity = this.segmentGranularityList[0];
+    } else { // default
+      // set segment granularity HOUR
+      this.selectedSegmentGranularity = this.segmentGranularityList[2];
+      // set query granularity SECOND
+      this.selectedQueryGranularity = this.segmentGranularityList[0];
     }
     // init query granularity list
     this._updateQueryGranularityList(this.selectedSegmentGranularity);

--- a/discovery-frontend/src/app/data-storage/data-source-list/component/ingestion-setting.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/component/ingestion-setting.component.ts
@@ -691,48 +691,8 @@ export class IngestionSettingComponent extends AbstractComponent {
       // set query granularity SECOND
       this.selectedQueryGranularity = this.segmentGranularityList[0];
     } else if (this._format.type === FieldFormatType.DATE_TIME) { // if exist format, DATE_TIME type
-      switch (this._format.format.slice(-1)) {
-        case 'Y':
-        case 'y':
-          // set segment granularity YEAR
-          this.selectedSegmentGranularity = this.segmentGranularityList[5];
-          // set query granularity YEAR
-          this.selectedQueryGranularity = this.segmentGranularityList[5];
-          break;
-        case 'M':
-          // set segment granularity YEAR
-          this.selectedSegmentGranularity = this.segmentGranularityList[5];
-          // set query granularity MONTH
-          this.selectedQueryGranularity = this.segmentGranularityList[4];
-          break;
-        case 'D':
-        case 'd':
-          // set segment granularity YEAR
-          this.selectedSegmentGranularity = this.segmentGranularityList[5];
-          // set query granularity DAY
-          this.selectedQueryGranularity = this.segmentGranularityList[3];
-          break;
-        case 'H':
-        case 'h':
-          // set segment granularity MONTH
-          this.selectedSegmentGranularity = this.segmentGranularityList[4];
-          // set query granularity HOUR
-          this.selectedQueryGranularity = this.segmentGranularityList[2];
-          break;
-        case 'm':
-          // set segment granularity DAY
-          this.selectedSegmentGranularity = this.segmentGranularityList[3];
-          // set query granularity MINUTE
-          this.selectedQueryGranularity = this.segmentGranularityList[1];
-          break;
-        case 'S':
-        case 's':
-          // set segment granularity HOUR
-          this.selectedSegmentGranularity = this.segmentGranularityList[2];
-          // set query granularity SECOND
-          this.selectedQueryGranularity = this.segmentGranularityList[0];
-          break;
-      }
+      // _automationGranularity
+      this._automationGranularity(this._format.format, this._format.format.length -1);
     } else if (this._format.type === FieldFormatType.UNIX_TIME) { // if exist format, UNIX_TIME type
       // set segment granularity HOUR
       this.selectedSegmentGranularity = this.segmentGranularityList[2];
@@ -746,6 +706,61 @@ export class IngestionSettingComponent extends AbstractComponent {
     }
     // init query granularity list
     this._updateQueryGranularityList(this.selectedSegmentGranularity);
+  }
+
+  /**
+   * automation granularity
+   * @param {string} format
+   * @param {number} startNum
+   * @private
+   */
+  private _automationGranularity(format: string, startNum: number) {
+    switch (format.slice(startNum, startNum - 1)) {
+      case 'Y':
+      case 'y':
+        // set segment granularity YEAR
+        this.selectedSegmentGranularity = this.segmentGranularityList[5];
+        // set query granularity YEAR
+        this.selectedQueryGranularity = this.segmentGranularityList[5];
+        break;
+      case 'M':
+        // set segment granularity YEAR
+        this.selectedSegmentGranularity = this.segmentGranularityList[5];
+        // set query granularity MONTH
+        this.selectedQueryGranularity = this.segmentGranularityList[4];
+        break;
+      case 'D':
+      case 'd':
+        // set segment granularity YEAR
+        this.selectedSegmentGranularity = this.segmentGranularityList[5];
+        // set query granularity DAY
+        this.selectedQueryGranularity = this.segmentGranularityList[3];
+        break;
+      case 'H':
+      case 'h':
+        // set segment granularity MONTH
+        this.selectedSegmentGranularity = this.segmentGranularityList[4];
+        // set query granularity HOUR
+        this.selectedQueryGranularity = this.segmentGranularityList[2];
+        break;
+      case 'm':
+        // set segment granularity DAY
+        this.selectedSegmentGranularity = this.segmentGranularityList[3];
+        // set query granularity MINUTE
+        this.selectedQueryGranularity = this.segmentGranularityList[1];
+        break;
+      case 'S':
+      case 's':
+        // set segment granularity HOUR
+        this.selectedSegmentGranularity = this.segmentGranularityList[2];
+        // set query granularity SECOND
+        this.selectedQueryGranularity = this.segmentGranularityList[0];
+        break;
+      default:
+        // if not startNum first index, call _automationGranularity method
+        startNum !== 0 && this._automationGranularity(this._format.format, startNum - 1);
+        break;
+    }
   }
 
   /**

--- a/discovery-frontend/src/app/data-storage/data-source-list/component/ingestion-setting.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/component/ingestion-setting.component.ts
@@ -17,7 +17,13 @@ import {
   Component, ElementRef, EventEmitter, Injector, Output, Renderer2,
   ViewChild
 } from '@angular/core';
-import { DatasourceInfo, FieldFormat, FieldFormatType, FieldFormatUnit } from '../../../domain/datasource/datasource';
+import {
+  DatasourceInfo,
+  Field,
+  FieldFormat,
+  FieldFormatType,
+  FieldFormatUnit
+} from '../../../domain/datasource/datasource';
 import * as _ from 'lodash';
 import { DatasourceService } from '../../../datasource/service/datasource.service';
 import { StringUtil } from '../../../common/util/string.util';
@@ -214,15 +220,15 @@ export class IngestionSettingComponent extends AbstractComponent {
    * Init
    * @param {DatasourceInfo} sourceData
    */
-  public init(sourceData: DatasourceInfo, createType: string, format: FieldFormat): void {
-    // ui init
-    this._initView();
+  public init(sourceData: DatasourceInfo, createType: string, selectedTimestampColumn: Field): void {
     // datasource data
     this._sourceData = sourceData;
     // create datasource type
     this.createType = createType;
     // set format
-    this._format = format;
+    this._format = selectedTimestampColumn ? selectedTimestampColumn.format : null;
+    // ui init
+    this._initView();
     // if exist ingestionData
     if (this._sourceData.hasOwnProperty("ingestionData")) {
       this._loadIngestionData(this._sourceData.ingestionData);
@@ -605,12 +611,6 @@ export class IngestionSettingComponent extends AbstractComponent {
   private _initView(): void {
     // init granularity setting
     this._initGranularity();
-    // init Segment Granularity list
-    // this.segmentGranularityList = _.filter(this._granularityList, item => item.value !== 'NONE');
-    // this.selectedSegmentGranularity = this.segmentGranularityList[3];
-    // // init Query Granularity list
-    // this.queryGranularityList = this._granularityList;
-    // this.selectedQueryGranularity = this.queryGranularityList[4];
     // init roll up type list
     this.rollUpTypeList = [
       { label: this.translateService.instant('msg.storage.ui.set.true'), value: true },

--- a/discovery-frontend/src/app/data-storage/data-source-list/component/ingestion-setting.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/component/ingestion-setting.component.ts
@@ -758,7 +758,14 @@ export class IngestionSettingComponent extends AbstractComponent {
         break;
       default:
         // if not startNum first index, call _automationGranularity method
-        startNum !== 0 && this._automationGranularity(this._format.format, startNum - 1);
+        if (startNum !== 0) {
+          this._automationGranularity(this._format.format, startNum - 1);
+        } else { // set default
+          // set segment granularity HOUR
+          this.selectedSegmentGranularity = this.segmentGranularityList[2];
+          // set query granularity SECOND
+          this.selectedQueryGranularity = this.segmentGranularityList[0];
+        }
         break;
     }
   }

--- a/discovery-frontend/src/app/data-storage/data-source-list/component/ingestion-setting.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/component/ingestion-setting.component.ts
@@ -675,6 +675,8 @@ export class IngestionSettingComponent extends AbstractComponent {
     ];
     // init second list
     this.selectedWeeklyTime = this.selectedDailyTime = this._getCurrentTime();
+    // init segment granularity list
+    this.segmentGranularityList = _.filter(this._granularityList, item => item.value !== 'NONE');
   }
 
   /**
@@ -682,8 +684,6 @@ export class IngestionSettingComponent extends AbstractComponent {
    * @private
    */
   private _initGranularity(): void {
-    // init segment granularity list
-    this.segmentGranularityList = _.filter(this._granularityList, item => item.value !== 'NONE');
     // if not exist format
     if (!this._format) {
       // set segment granularity HOUR
@@ -925,10 +925,10 @@ export class IngestionSettingComponent extends AbstractComponent {
    * @private
    */
   private _loadIngestionData(ingestionData:any): void {
+    // query granularity list
+    this.queryGranularityList = ingestionData.queryGranularityList;
     // load selected segment granularity
     this.selectedSegmentGranularity = ingestionData.selectedSegmentGranularity;
-    // update query granularity list
-    this._updateQueryGranularityList(this.selectedSegmentGranularity);
     // load selected query granularity
     this.selectedQueryGranularity = ingestionData.selectedQueryGranularity;
     // load selected rollup type
@@ -1003,6 +1003,8 @@ export class IngestionSettingComponent extends AbstractComponent {
    */
   private _saveIngestionData(sourceData: DatasourceInfo): void {
     sourceData['ingestionData'] = {
+      // query granularity list
+      queryGranularityList : this.queryGranularityList,
       // save selected segment granularity
       selectedSegmentGranularity : this.selectedSegmentGranularity,
       // save query granularity

--- a/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/db-create-component/db-configure-schema/db-configure-schema.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/db-create-component/db-configure-schema/db-configure-schema.component.ts
@@ -166,8 +166,11 @@ export class DbConfigureSchemaComponent extends AbstractPopupComponent implement
   public next() {
     // validation
     if (this.getNextValidation()) {
+      const isChangedTimestampField: boolean = this._isChangedTimestampField();
       // 기존 스키마정보 삭제후 생성
       this.deleteAndSaveSchemaData();
+      // if changed timestamp field
+      this.sourceData.schemaData['isChangedTimestampField'] = isChangedTimestampField;
       // 다음 step 으로 이동
       this.step = 'db-ingestion-permission';
       this.stepChange.emit(this.step);
@@ -1057,6 +1060,19 @@ export class DbConfigureSchemaComponent extends AbstractPopupComponent implement
     // 초기화
     this.fields = [];
     this.data = [];
+  }
+
+  /**
+   * Is changed TIMESTAMP field
+   * @private
+   */
+  private _isChangedTimestampField(): boolean {
+    if (this.sourceData.schemaData) {
+      return (this.selectedTimestampType !== this.sourceData.schemaData.selectedTimestampType) ||
+        this.selectedTimestampColumn && (this.selectedTimestampColumn.name !== this.sourceData.schemaData.selectedTimestampColumn.name);
+    } else {
+      return false;
+    }
   }
 }
 

--- a/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/db-create-component/db-configure-schema/db-configure-schema.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/db-create-component/db-configure-schema/db-configure-schema.component.ts
@@ -24,7 +24,6 @@ import {
 import { isUndefined } from 'util';
 import { DatasourceService } from '../../../../../datasource/service/datasource.service';
 import * as _ from 'lodash';
-import { StringUtil } from '../../../../../common/util/string.util';
 import { Alert } from '../../../../../common/util/alert.util';
 import { AddColumnComponent } from '../../../component/add-column.component';
 
@@ -127,7 +126,7 @@ export class DbConfigureSchemaComponent extends AbstractPopupComponent implement
     // 현재 페이지 schema 정보가 있다면
     if (this.sourceData.hasOwnProperty('schemaData')) {
       // init data
-      this.initData(this.sourceData.schemaData);
+      this.initData(_.cloneDeep(this.sourceData.schemaData));
     } else {
       // 데이터베이스 상세데이터
       this.initColumnData(this.sourceData.databaseData);
@@ -1064,12 +1063,14 @@ export class DbConfigureSchemaComponent extends AbstractPopupComponent implement
 
   /**
    * Is changed TIMESTAMP field
+   * @returns {boolean}
    * @private
    */
   private _isChangedTimestampField(): boolean {
     if (this.sourceData.schemaData) {
       return (this.selectedTimestampType !== this.sourceData.schemaData.selectedTimestampType) ||
-        this.selectedTimestampColumn && (this.selectedTimestampColumn.name !== this.sourceData.schemaData.selectedTimestampColumn.name);
+        this.selectedTimestampColumn &&
+        (this.selectedTimestampColumn.name !== this.sourceData.schemaData.selectedTimestampColumn.name || this.selectedTimestampColumn.format.type !== this.sourceData.schemaData.selectedTimestampColumn.format.type);
     } else {
       return false;
     }

--- a/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/db-create-component/db-ingestion-permission/db-ingestion-permission.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/db-create-component/db-ingestion-permission/db-ingestion-permission.component.ts
@@ -74,6 +74,8 @@ export class DbIngestionPermissionComponent extends AbstractPopupComponent imple
         this._sourceData.schemaData.selectedTimestampType === 'CURRENT' ? null :  this._sourceData.schemaData.selectedTimestampColumn,
         this._sourceData.schemaData.isChangedTimestampField
       );
+      // remove changed flag
+      delete this._sourceData.schemaData.isChangedTimestampField;
     }
   }
 

--- a/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/db-create-component/db-ingestion-permission/db-ingestion-permission.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/db-create-component/db-ingestion-permission/db-ingestion-permission.component.ts
@@ -37,7 +37,7 @@ export class DbIngestionPermissionComponent extends AbstractPopupComponent imple
   @Input('sourceData')
   public set setSourceData(sourceData: DatasourceInfo) {
     this._sourceData = sourceData;
-    this._ingestionSettingComponent.init(this._sourceData, 'DB');
+    this._ingestionSettingComponent.init(this._sourceData, 'DB', this._sourceData.schemaData.selectedColumn);
   }
 
   @Input()

--- a/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/db-create-component/db-ingestion-permission/db-ingestion-permission.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/db-create-component/db-ingestion-permission/db-ingestion-permission.component.ts
@@ -37,7 +37,7 @@ export class DbIngestionPermissionComponent extends AbstractPopupComponent imple
   @Input('sourceData')
   public set setSourceData(sourceData: DatasourceInfo) {
     this._sourceData = sourceData;
-    this._ingestionSettingComponent.init(this._sourceData, 'DB', this._sourceData.schemaData.selectedColumn);
+    this._ingestionSettingComponent.init(this._sourceData, 'DB', this._sourceData.schemaData.selectedTimestampColumn);
   }
 
   @Input()

--- a/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/db-create-component/db-ingestion-permission/db-ingestion-permission.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/db-create-component/db-ingestion-permission/db-ingestion-permission.component.ts
@@ -13,7 +13,7 @@
  */
 
 import {
-  Component, ElementRef, EventEmitter, Injector, Input, OnDestroy, OnInit, Output, ViewChild
+  Component, ElementRef, EventEmitter, Injector, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges, ViewChild
 } from '@angular/core';
 import { AbstractPopupComponent } from '../../../../../common/component/abstract-popup.component';
 import { DatasourceInfo } from '../../../../../domain/datasource/datasource';
@@ -26,19 +26,14 @@ import { IngestionSettingComponent } from '../../../component/ingestion-setting.
   selector: 'db-ingestion-permission',
   templateUrl: './db-ingestion-permission.component.html'
 })
-export class DbIngestionPermissionComponent extends AbstractPopupComponent implements OnInit, OnDestroy {
+export class DbIngestionPermissionComponent extends AbstractPopupComponent implements OnInit, OnDestroy, OnChanges {
 
   // datasource data
+  @Input('sourceData')
   private _sourceData: DatasourceInfo;
 
   @ViewChild(IngestionSettingComponent)
   private _ingestionSettingComponent: IngestionSettingComponent;
-
-  @Input('sourceData')
-  public set setSourceData(sourceData: DatasourceInfo) {
-    this._sourceData = sourceData;
-    this._ingestionSettingComponent.init(this._sourceData, 'DB', this._sourceData.schemaData.selectedTimestampColumn);
-  }
 
   @Input()
   public step: string;
@@ -64,6 +59,22 @@ export class DbIngestionPermissionComponent extends AbstractPopupComponent imple
    */
   public ngOnDestroy() {
     super.ngOnDestroy();
+  }
+
+  /**
+   * ngOnChanges
+   * @param changes
+   */
+  ngOnChanges(changes: SimpleChanges): void {
+    // if changed source Data
+    if (changes._sourceData) {
+      this._ingestionSettingComponent.init(
+        this._sourceData,
+        'DB',
+        this._sourceData.schemaData.selectedTimestampType === 'CURRENT' ? null :  this._sourceData.schemaData.selectedTimestampColumn,
+        this._sourceData.schemaData.isChangedTimestampField
+      );
+    }
   }
 
   /**

--- a/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/db-create-component/db-select-data/db-select-data.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/db-create-component/db-select-data/db-select-data.component.ts
@@ -186,7 +186,10 @@ export class DbSelectDataComponent extends AbstractPopupComponent implements OnI
     // validation
     if (this.nextValidation()) {
       // 데이터 변경이 일어난경우 스키마 삭제
-      this.deleteSchemaData();
+      if (this.isChangeData()) {
+        this._sourceData.hasOwnProperty('schemaData') && (delete this._sourceData.schemaData);
+        this._sourceData.hasOwnProperty('ingestionData') && (delete this._sourceData.ingestionData);
+      }
       // 기존 데이터베이스 삭제후 생성
       this.deleteAndSaveDatabaseData();
       // 다음페이지로 이동
@@ -456,17 +459,6 @@ export class DbSelectDataComponent extends AbstractPopupComponent implements OnI
    |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
 
   /**
-   * 데이터가 변경이 일어나고 스키마데이터가 있다면 스키마데이터 삭제
-   */
-  private deleteSchemaData() {
-    // 데이터 변경이 일어난경우 스키마 삭제
-    if (this._sourceData.hasOwnProperty('schemaData')
-      && this.isChangeData()) {
-      delete this._sourceData.schemaData;
-    }
-  }
-
-  /**
    * 기존 데이터베이스 삭제후 새로 생성
    */
   private deleteAndSaveDatabaseData() {
@@ -518,16 +510,18 @@ export class DbSelectDataComponent extends AbstractPopupComponent implements OnI
    * @returns {boolean}
    */
   private isChangeData(): boolean {
-    // 데이터 타입이 변경된경우
-    if (this._sourceData.databaseData.selectedType !== this.selectedType) {
-      return true;
-    // 현재 데이터 타입이 TABLE 이고 데이터베이스 이름이나 테이블 이름이 변경된 경우
-    // 현재 데이터 타입이 QUERY 이고 데이터베이스 이름이나 테이블 이름이 변경된 경우
-    } else if ((this.selectedType === 'TABLE'
+    if (this._sourceData.databaseData) {
+      // 데이터 타입이 변경된경우
+      if (this._sourceData.databaseData.selectedType !== this.selectedType) {
+        return true;
+        // 현재 데이터 타입이 TABLE 이고 데이터베이스 이름이나 테이블 이름이 변경된 경우
+        // 현재 데이터 타입이 QUERY 이고 데이터베이스 이름이나 테이블 이름이 변경된 경우
+      } else if ((this.selectedType === 'TABLE'
         && (this._sourceData.databaseData.selectedDatabase !== this.selectedDatabase || this._sourceData.databaseData.selectedTable !== this.selectedTable))
-      || (this.selectedType === 'QUERY'
-        && (this._sourceData.databaseData.selectedDatabaseQuery !== this.selectedDatabaseQuery || this._sourceData.databaseData.queryText !== this.queryText))) {
-      return true;
+        || (this.selectedType === 'QUERY'
+          && (this._sourceData.databaseData.selectedDatabaseQuery !== this.selectedDatabaseQuery || this._sourceData.databaseData.queryText !== this.queryText))) {
+        return true;
+      }
     }
     return false;
   }

--- a/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/file-create-component/file-configure-schema/file-configure-schema.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/file-create-component/file-configure-schema/file-configure-schema.component.ts
@@ -164,8 +164,11 @@ export class FileConfigureSchemaComponent extends AbstractPopupComponent impleme
   public next() {
     // validation
     if (this.getNextValidation()) {
+      const isChangedTimestampField: boolean = this._isChangedTimestampField();
       // 기존 스키마정보 삭제후 생성
       this.deleteAndSaveSchemaData();
+      // if changed timestamp field
+      this.sourceData.schemaData['isChangedTimestampField'] = isChangedTimestampField;
       // 다음 step 으로 이동
       this.step = 'file-ingestion';
       this.stepChange.emit(this.step);
@@ -1046,5 +1049,18 @@ export class FileConfigureSchemaComponent extends AbstractPopupComponent impleme
     // 초기화
     this.fields = [];
     this.data = [];
+  }
+
+  /**
+   * Is changed TIMESTAMP field
+   * @private
+   */
+  private _isChangedTimestampField(): boolean {
+    if (this.sourceData.schemaData) {
+      return (this.selectedTimestampType !== this.sourceData.schemaData.selectedTimestampType) ||
+        this.selectedTimestampColumn && (this.selectedTimestampColumn.name !== this.sourceData.schemaData.selectedTimestampColumn.name);
+    } else {
+      return false;
+    }
   }
 }

--- a/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/file-create-component/file-configure-schema/file-configure-schema.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/file-create-component/file-configure-schema/file-configure-schema.component.ts
@@ -24,7 +24,6 @@ import {
 import { DatasourceService } from '../../../../../datasource/service/datasource.service';
 import { isUndefined } from 'util';
 import * as _ from 'lodash';
-import { StringUtil } from '../../../../../common/util/string.util';
 import { Alert } from '../../../../../common/util/alert.util';
 import { AddColumnComponent } from '../../../component/add-column.component';
 
@@ -125,7 +124,7 @@ export class FileConfigureSchemaComponent extends AbstractPopupComponent impleme
     // 현재 페이지 schema 정보가 있다면
     if (this.sourceData.hasOwnProperty('schemaData')) {
       // init data
-      this.initData(this.sourceData.schemaData);
+      this.initData(_.cloneDeep(this.sourceData.schemaData));
     } else {
       // 파일 데이터 상세데이터
       this.initColumnData(this.sourceData.fileData);
@@ -1053,12 +1052,14 @@ export class FileConfigureSchemaComponent extends AbstractPopupComponent impleme
 
   /**
    * Is changed TIMESTAMP field
+   * @returns {boolean}
    * @private
    */
   private _isChangedTimestampField(): boolean {
     if (this.sourceData.schemaData) {
       return (this.selectedTimestampType !== this.sourceData.schemaData.selectedTimestampType) ||
-        this.selectedTimestampColumn && (this.selectedTimestampColumn.name !== this.sourceData.schemaData.selectedTimestampColumn.name);
+        this.selectedTimestampColumn &&
+        (this.selectedTimestampColumn.name !== this.sourceData.schemaData.selectedTimestampColumn.name || this.selectedTimestampColumn.format.type !== this.sourceData.schemaData.selectedTimestampColumn.format.type);
     } else {
       return false;
     }

--- a/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/file-create-component/file-ingestion/file-ingestion.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/file-create-component/file-ingestion/file-ingestion.component.ts
@@ -38,7 +38,7 @@ export class FileIngestionComponent extends AbstractPopupComponent implements On
   @Input('sourceData')
   public set setSourceData(sourceData: DatasourceInfo) {
     this._sourceData = sourceData;
-    this._ingestionSettingComponent.init(this._sourceData, 'FILE', this._sourceData.schemaData.selectedColumn);
+    this._ingestionSettingComponent.init(this._sourceData, 'FILE', this._sourceData.schemaData.selectedTimestampColumn);
   }
 
   @Input()

--- a/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/file-create-component/file-ingestion/file-ingestion.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/file-create-component/file-ingestion/file-ingestion.component.ts
@@ -38,7 +38,7 @@ export class FileIngestionComponent extends AbstractPopupComponent implements On
   @Input('sourceData')
   public set setSourceData(sourceData: DatasourceInfo) {
     this._sourceData = sourceData;
-    this._ingestionSettingComponent.init(this._sourceData, 'FILE');
+    this._ingestionSettingComponent.init(this._sourceData, 'FILE', this._sourceData.schemaData.selectedColumn);
   }
 
   @Input()

--- a/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/file-create-component/file-ingestion/file-ingestion.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/file-create-component/file-ingestion/file-ingestion.component.ts
@@ -75,6 +75,8 @@ export class FileIngestionComponent extends AbstractPopupComponent implements On
         this._sourceData.schemaData.selectedTimestampType === 'CURRENT' ? null :  this._sourceData.schemaData.selectedTimestampColumn,
         this._sourceData.schemaData.isChangedTimestampField
       );
+      // remove changed flag
+      delete this._sourceData.schemaData.isChangedTimestampField;
     }
   }
 

--- a/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/file-create-component/file-ingestion/file-ingestion.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/file-create-component/file-ingestion/file-ingestion.component.ts
@@ -13,7 +13,7 @@
  */
 
 import {
-  Component, ElementRef, EventEmitter, Injector, Input, OnDestroy, OnInit, Output,
+  Component, ElementRef, EventEmitter, Injector, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges,
   ViewChild
 } from '@angular/core';
 import { AbstractPopupComponent } from '../../../../../common/component/abstract-popup.component';
@@ -27,19 +27,14 @@ import { IngestionSettingComponent } from '../../../component/ingestion-setting.
   selector: 'file-ingestion',
   templateUrl: './file-ingestion.component.html'
 })
-export class FileIngestionComponent extends AbstractPopupComponent implements OnInit, OnDestroy {
+export class FileIngestionComponent extends AbstractPopupComponent implements OnInit, OnDestroy, OnChanges {
 
   // datasource data
+  @Input('sourceData')
   private _sourceData: DatasourceInfo;
 
   @ViewChild(IngestionSettingComponent)
   private _ingestionSettingComponent: IngestionSettingComponent;
-
-  @Input('sourceData')
-  public set setSourceData(sourceData: DatasourceInfo) {
-    this._sourceData = sourceData;
-    this._ingestionSettingComponent.init(this._sourceData, 'FILE', this._sourceData.schemaData.selectedTimestampColumn);
-  }
 
   @Input()
   public step: string;
@@ -66,6 +61,23 @@ export class FileIngestionComponent extends AbstractPopupComponent implements On
   public ngOnDestroy() {
     super.ngOnDestroy();
   }
+
+  /**
+   * ngOnChanges
+   * @param changes
+   */
+  ngOnChanges(changes: SimpleChanges): void {
+    // if changed source Data
+    if (changes._sourceData) {
+      this._ingestionSettingComponent.init(
+        this._sourceData,
+        'FILE',
+        this._sourceData.schemaData.selectedTimestampType === 'CURRENT' ? null :  this._sourceData.schemaData.selectedTimestampColumn,
+        this._sourceData.schemaData.isChangedTimestampField
+      );
+    }
+  }
+
 
   /**
    * Move to previous step

--- a/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/file-create-component/file-select/file-select.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/file-create-component/file-select/file-select.component.ts
@@ -207,8 +207,11 @@ export class FileSelectComponent extends AbstractPopupComponent implements OnIni
   public next() {
     // validation
     if (this.getNextValidation()) {
-      // 데이터 변경이 일어난경우 스키마 삭제
-      this.deleteSchemaData();
+      // 데이터 변경이 일어난경우 스키마 데이터와 적재데이터 제거
+      if (this.isChangeData()) {
+        this.sourceData.hasOwnProperty('schemaData') && (delete this.sourceData.schemaData);
+        this.sourceData.hasOwnProperty('ingestionData') && (delete this.sourceData.ingestionData);
+      }
       // 기존 파일 데이터 삭제후 생성
       this.deleteAndSaveFileData();
       // 다음페이지로 이동
@@ -437,17 +440,6 @@ export class FileSelectComponent extends AbstractPopupComponent implements OnIni
    |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
 
   /**
-   * 데이터가 변경이 일어나고 스키마데이터가 있다면 스키마데이터 삭제
-   */
-  private deleteSchemaData() {
-    // 데이터 변경이 일어난경우 스키마 삭제
-    if (this.sourceData.hasOwnProperty('schemaData')
-      && this.isChangeData()) {
-      delete this.sourceData.schemaData;
-    }
-  }
-
-  /**
    * 기존 파일 삭제후 새로 생성
    */
   private deleteAndSaveFileData() {
@@ -565,28 +557,21 @@ export class FileSelectComponent extends AbstractPopupComponent implements OnIni
    * @returns {boolean}
    */
   private isChangeData(): boolean {
-    // 파일 key 가 변경된 경우
-    if (this.sourceData.fileData.datasourceFile.filekey !== this.datasourceFile.filekey) {
-      return true;
-    }
-    // 파일 시트가 변경된 경우
-    if (!this.isCsvFile() && (this.sourceData.fileData.datasourceFile.selectedSheetName !== this.datasourceFile.selectedSheetName)) {
-      return true;
-    }
-    // 파일 헤더 생성여부가 변경된경우
-    if (this.sourceData.fileData.createHeadColumnFl !== this.createHeadColumnFl){
-      return true;
+    if (this.sourceData.fileData) {
+      // 파일 key 가 변경된 경우
+      if (this.sourceData.fileData.datasourceFile.filekey !== this.datasourceFile.filekey) {
+        return true;
+      }
+      // 파일 시트가 변경된 경우
+      if (!this.isCsvFile() && (this.sourceData.fileData.datasourceFile.selectedSheetName !== this.datasourceFile.selectedSheetName)) {
+        return true;
+      }
+      // 파일 헤더 생성여부가 변경된경우
+      if (this.sourceData.fileData.createHeadColumnFl !== this.createHeadColumnFl){
+        return true;
+      }
     }
     return false;
-  }
-
-  /**
-   * 파일 데이터 조회
-   * @param datasourceFile
-   * @param isCsvFile
-   */
-  private getFile(datasourceFile, isCsvFile) {
-
   }
 
   /**

--- a/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/staging-db-component/staging-db-configure-schema/staging-db-configure-schema.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/staging-db-component/staging-db-configure-schema/staging-db-configure-schema.component.ts
@@ -165,8 +165,11 @@ export class StagingDbConfigureSchemaComponent extends AbstractPopupComponent im
   public next() {
     // validation
     if (this.getNextValidation()) {
+      const isChangedTimestampField: boolean = this._isChangedTimestampField();
       // 기존 스키마정보 삭제후 생성
       this.deleteAndSaveSchemaData();
+      // if changed timestamp field
+      this.sourceData.schemaData['isChangedTimestampField'] = isChangedTimestampField;
       // 다음 step 으로 이동
       this.step = 'staging-db-ingestion';
       this.stepChange.emit(this.step);
@@ -1045,5 +1048,18 @@ export class StagingDbConfigureSchemaComponent extends AbstractPopupComponent im
     // 초기화
     this.fields = [];
     this.data = [];
+  }
+
+  /**
+   * Is changed TIMESTAMP field
+   * @private
+   */
+  private _isChangedTimestampField(): boolean {
+    if (this.sourceData.schemaData) {
+      return (this.selectedTimestampType !== this.sourceData.schemaData.selectedTimestampType) ||
+        this.selectedTimestampColumn && (this.selectedTimestampColumn.name !== this.sourceData.schemaData.selectedTimestampColumn.name);
+    } else {
+      return false;
+    }
   }
 }

--- a/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/staging-db-component/staging-db-configure-schema/staging-db-configure-schema.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/staging-db-component/staging-db-configure-schema/staging-db-configure-schema.component.ts
@@ -23,7 +23,6 @@ import {
   LogicalType
 } from '../../../../../domain/datasource/datasource';
 import * as _ from 'lodash';
-import { StringUtil } from '../../../../../common/util/string.util';
 import { Alert } from '../../../../../common/util/alert.util';
 import { AddColumnComponent } from '../../../component/add-column.component';
 
@@ -126,7 +125,7 @@ export class StagingDbConfigureSchemaComponent extends AbstractPopupComponent im
     // 현재 페이지 schema 정보가 있다면
     if (this.sourceData.hasOwnProperty('schemaData')) {
       // init data
-      this.initData(this.sourceData.schemaData);
+      this.initData(_.cloneDeep(this.sourceData.schemaData));
     } else {
       // 데이터베이스 상세데이터
       this.initColumnData(this.sourceData.databaseData);
@@ -1052,12 +1051,14 @@ export class StagingDbConfigureSchemaComponent extends AbstractPopupComponent im
 
   /**
    * Is changed TIMESTAMP field
+   * @returns {boolean}
    * @private
    */
   private _isChangedTimestampField(): boolean {
     if (this.sourceData.schemaData) {
       return (this.selectedTimestampType !== this.sourceData.schemaData.selectedTimestampType) ||
-        this.selectedTimestampColumn && (this.selectedTimestampColumn.name !== this.sourceData.schemaData.selectedTimestampColumn.name);
+        this.selectedTimestampColumn &&
+        (this.selectedTimestampColumn.name !== this.sourceData.schemaData.selectedTimestampColumn.name || this.selectedTimestampColumn.format.type !== this.sourceData.schemaData.selectedTimestampColumn.format.type);
     } else {
       return false;
     }

--- a/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/staging-db-component/staging-db-ingestion/staging-db-ingestion.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/staging-db-component/staging-db-ingestion/staging-db-ingestion.component.ts
@@ -13,7 +13,7 @@
  */
 
 import {
-  Component, ElementRef, EventEmitter, Injector, Input, OnDestroy, OnInit, Output,
+  Component, ElementRef, EventEmitter, Injector, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges,
   ViewChild
 } from '@angular/core';
 import { AbstractPopupComponent } from '../../../../../common/component/abstract-popup.component';
@@ -27,19 +27,14 @@ import { IngestionSettingComponent } from '../../../component/ingestion-setting.
   selector: 'staging-db-ingestion',
   templateUrl: './staging-db-ingestion.component.html'
 })
-export class StagingDbIngestionComponent extends AbstractPopupComponent implements OnInit, OnDestroy {
+export class StagingDbIngestionComponent extends AbstractPopupComponent implements OnInit, OnDestroy, OnChanges {
 
   // datasource data
+  @Input('sourceData')
   private _sourceData: DatasourceInfo;
 
   @ViewChild(IngestionSettingComponent)
   private _ingestionSettingComponent: IngestionSettingComponent;
-
-  @Input('sourceData')
-  public set setSourceData(sourceData: DatasourceInfo) {
-    this._sourceData = sourceData;
-    this._ingestionSettingComponent.init(this._sourceData, 'STAGING', this._sourceData.schemaData.selectedTimestampColumn);
-  }
 
   @Input()
   public step: string;
@@ -76,6 +71,22 @@ export class StagingDbIngestionComponent extends AbstractPopupComponent implemen
    */
   public ngOnDestroy() {
     super.ngOnDestroy();
+  }
+
+  /**
+   * ngOnChanges
+   * @param changes
+   */
+  ngOnChanges(changes: SimpleChanges): void {
+    // if changed source Data
+    if (changes._sourceData) {
+      this._ingestionSettingComponent.init(
+        this._sourceData,
+        'STAGING',
+        this._sourceData.schemaData.selectedTimestampType === 'CURRENT' ? null :  this._sourceData.schemaData.selectedTimestampColumn,
+        this._sourceData.schemaData.isChangedTimestampField
+      );
+    }
   }
 
   /**

--- a/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/staging-db-component/staging-db-ingestion/staging-db-ingestion.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/staging-db-component/staging-db-ingestion/staging-db-ingestion.component.ts
@@ -86,6 +86,8 @@ export class StagingDbIngestionComponent extends AbstractPopupComponent implemen
         this._sourceData.schemaData.selectedTimestampType === 'CURRENT' ? null :  this._sourceData.schemaData.selectedTimestampColumn,
         this._sourceData.schemaData.isChangedTimestampField
       );
+      // remove changed flag
+      delete this._sourceData.schemaData.isChangedTimestampField;
     }
   }
 

--- a/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/staging-db-component/staging-db-ingestion/staging-db-ingestion.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/staging-db-component/staging-db-ingestion/staging-db-ingestion.component.ts
@@ -38,7 +38,7 @@ export class StagingDbIngestionComponent extends AbstractPopupComponent implemen
   @Input('sourceData')
   public set setSourceData(sourceData: DatasourceInfo) {
     this._sourceData = sourceData;
-    this._ingestionSettingComponent.init(this._sourceData, 'STAGING', this._sourceData.schemaData.selectedColumn);
+    this._ingestionSettingComponent.init(this._sourceData, 'STAGING', this._sourceData.schemaData.selectedTimestampColumn);
   }
 
   @Input()

--- a/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/staging-db-component/staging-db-ingestion/staging-db-ingestion.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/staging-db-component/staging-db-ingestion/staging-db-ingestion.component.ts
@@ -38,7 +38,7 @@ export class StagingDbIngestionComponent extends AbstractPopupComponent implemen
   @Input('sourceData')
   public set setSourceData(sourceData: DatasourceInfo) {
     this._sourceData = sourceData;
-    this._ingestionSettingComponent.init(this._sourceData, 'STAGING');
+    this._ingestionSettingComponent.init(this._sourceData, 'STAGING', this._sourceData.schemaData.selectedColumn);
   }
 
   @Input()

--- a/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/staging-db-component/staging-db-select-data/staging-db-select-data.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/staging-db-component/staging-db-select-data/staging-db-select-data.component.ts
@@ -145,8 +145,11 @@ export class StagingDbSelectDataComponent extends AbstractPopupComponent impleme
   public next() {
     // validation
     if (this.isExistTableDetail()) {
-      // 데이터 변경이 일어난경우 스키마 삭제
-      this.deleteSchemaData();
+      // 데이터 변경이 일어난경우 스키마 데이터와 적재데이터 제거
+      if (this.isChangeData()) {
+        this.sourceData.hasOwnProperty('schemaData') && (delete this.sourceData.schemaData);
+        this.sourceData.hasOwnProperty('ingestionData') && (delete this.sourceData.ingestionData);
+      }
       // 기존 데이터베이스 삭제후 생성
       this.deleteAndSaveDatabaseData();
       // 다음 step 으로 이동
@@ -388,17 +391,6 @@ export class StagingDbSelectDataComponent extends AbstractPopupComponent impleme
   }
 
   /**
-   * 데이터가 변경이 일어나고 스키마데이터가 있다면 스키마데이터, 적재데이터 삭제
-   */
-  private deleteSchemaData() {
-    // 데이터 변경이 일어난경우 스키마 데이터와 적재데이터 제거
-    if (this.sourceData.hasOwnProperty('databaseData') && this.isChangeData()) {
-      delete this.sourceData.schemaData;
-      delete this.sourceData.ingestionData;
-    }
-  }
-
-  /**
    * 현재 페이지의 데이터베이스 데이터 저장
    * @param {DatasourceInfo} sourceData
    */
@@ -590,13 +582,15 @@ export class StagingDbSelectDataComponent extends AbstractPopupComponent impleme
    * @returns {boolean}
    */
   private isChangeData(): boolean {
-    // 데이터베이스 이름이 변경된 경우
-    if (this.sourceData.databaseData.selectedDatabase !== this.selectedDatabase) {
-      return true;
-    }
-    // 테이블 이름이 변경된 경우
-    if (this.sourceData.databaseData.selectedTable !== this.selectedTable) {
-      return true;
+    if (this.sourceData.databaseData) {
+      // 데이터베이스 이름이 변경된 경우
+      if (this.sourceData.databaseData.selectedDatabase !== this.selectedDatabase) {
+        return true;
+      }
+      // 테이블 이름이 변경된 경우
+      if (this.sourceData.databaseData.selectedTable !== this.selectedTable) {
+        return true;
+      }
     }
     return false;
   }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
config 단계에서 지정한 TIMESTAMP 정보에 따라 granularity를 세팅


**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#1058 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 데이터소스 > 데이터소스 생성 > 데이터베이스 선택단계 (FILE생성의 경우는 2번으로 건너뜀)
2. config단계에서 TIMESTAMP 를 설정 
3. ingestion 단계에서 아래의 조건에따라 granularity가 변경되는지 확인
> 1. config단계에서 TIMESTAMP를 `CURRENT_TIME`으로 선택한 경우, `segment granularity`가 HOUR로, `query granularity`가 SECOND로 설정
> 2. config단계에서 `TIMESTAMP`를 FIELD로 선택한 경우, 'format'의 마지막 날짜에 따라 `segment granularity`와 `query granularity`가 아래의 표를 기준으로 설정
![2018-12-12 6 36 06](https://user-images.githubusercontent.com/42233627/49860257-d2a01700-fe3c-11e8-9873-48225404a7d7.png)
> 3. config단계에서 `TIMESTAMP`를 FIELD로 선택하고 'UNIX'를 선택한 경우, `segment granularity`가 HOUR로, `query granularity`가 SECOND로 설정
> 4. ingestion단계에서 이전버튼을 눌르고, config단계에서 `TIMESTAMP`의 변경이 발생한경우 2번과 같이 값이 새로 설정되는지 확인
> 5. database selet 단계에서 변경이 발생한경우 (FILE의 경우 파일교체), 2번과 같이 값이 새로 설정되는지 확인


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project. _it will be added soon_
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
