### PR TITLE
#1079 rollback edit filter validation in column detail datasource

### DIFF
--- a/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/column-detail-data-source/column-detail-data-source.component.html
+++ b/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/column-detail-data-source/column-detail-data-source.component.html
@@ -99,10 +99,10 @@
             <thead>
             <tr>
               <th>{{'msg.metadata.th.physical.name' | translate}}
-                <a href="javascript:" class="ddp-link-filter" *ngIf="!isExistMetaData() && !isDisableEditFilter()" (click)="onClickEditFilters()">{{'msg.storage.ui.edit.filters' | translate}} ></a>
+                <a href="javascript:" class="ddp-link-filter" *ngIf="!isExistMetaData()" (click)="onClickEditFilters()">{{'msg.storage.ui.edit.filters' | translate}} ></a>
               </th>
               <th *ngIf="isExistMetaData()">{{'msg.metadata.th.name' | translate}}
-                <a href="javascript:" class="ddp-link-filter" (click)="onClickEditFilters()" *ngIf="!isDisableEditFilter()">{{'msg.storage.ui.edit.filters' | translate}} ></a>
+                <a href="javascript:" class="ddp-link-filter" (click)="onClickEditFilters()">{{'msg.storage.ui.edit.filters' | translate}} ></a>
               </th>
             </tr>
             </thead>

--- a/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/column-detail-data-source/column-detail-data-source.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/column-detail-data-source/column-detail-data-source.component.ts
@@ -172,14 +172,6 @@ export class ColumnDetailDataSourceComponent extends AbstractComponent implement
   }
 
   /**
-   * is disable edit filter
-   * @returns {boolean}
-   */
-  public isDisableEditFilter(): boolean {
-    return this.datasource.ingestion && this.datasource.ingestion.type === 'link' && this.datasource.ingestion.dataType === 'QUERY';
-  }
-
-  /**
    * Is exist metadata
    * @returns {boolean}
    */


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
데이터소스 중, `연결형`이고 데이터베이스가 `QUERY` 형태인 데이터소스의 상세화면에서 **edit filter** 버튼을 hide시킨것을 다시 보이도록 수정
![2018-12-14 1 21 30](https://user-images.githubusercontent.com/42233627/49983029-81f6fe00-ffa3-11e8-8daa-44b02b7032f9.png)
![2018-12-14 1 21 15](https://user-images.githubusercontent.com/42233627/49983030-81f6fe00-ffa3-11e8-82d7-30cd7cfba1fd.png)


**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#1079

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 데이터소스 > 데이터소스 생성(DB)
2. 연결형 선택, database table 선택 단계에서 QUERY로 테이블을 선택 후 데이터소스 생성
3. 2에서 생성한 상세화면의 Column detail tab에서 **edit filter** 버튼이 제대로 보이는지 확인

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project. _it will be added soon_
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
