### PR TITLE
#1056 Problem with settings the mandatory filter in the link-type datasource

### DIFF
--- a/discovery-frontend/src/app/common/component/abstract.component.ts
+++ b/discovery-frontend/src/app/common/component/abstract.component.ts
@@ -93,6 +93,8 @@ export class AbstractComponent implements OnInit, AfterViewInit, OnDestroy, CanC
   // 로그인 아이디
   public loginUserId: string;
 
+  public compUUID:string;
+
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Constructor
    |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
@@ -123,6 +125,7 @@ export class AbstractComponent implements OnInit, AfterViewInit, OnDestroy, CanC
 
     // 웹소켓 연결
     // this.checkAndConnectWebSocket().then();
+    this.compUUID = CommonUtil.getUUID();
   }
 
   ngAfterViewInit() {

--- a/discovery-frontend/src/app/dashboard/component/create-dashboard/create-board-ds-network.component.ts
+++ b/discovery-frontend/src/app/dashboard/component/create-dashboard/create-board-ds-network.component.ts
@@ -81,9 +81,9 @@ export class CreateBoardDsNetworkComponent extends AbstractComponent implements 
   public isPossibleSettingRel: boolean = false;  // 연계 정보 설정 가능 여부
 
   // Data Ingestion
-  public candidateIngestionList: BoardDataSource[] = []; // 데이터적재 후보 데이터소스 목록
-  public ingestionTargetDatasource: BoardDataSource;     // 데이터적재 대상 데이터소스
-  public isShowDataIngestion: boolean = false;           // 데이터적재 팝업 표시 여부
+  public candidateIngestionList: BoardDataSource[] = [];  // 데이터적재 후보 데이터소스 목록
+  public ingestionTargetDatasource: BoardDataSource;      // 데이터적재 대상 데이터소스
+  public isShowDataIngestion: boolean = false;            // 데이터적재 팝업 표시 여부
 
   // 선택 정보
   public selectedDataSource: BoardDataSource;           // 선택된 데이터소스
@@ -178,11 +178,9 @@ export class CreateBoardDsNetworkComponent extends AbstractComponent implements 
     this.subscriptions.push(
       this.broadCaster.on('CREATE_BOARD_RE_INGESTION').subscribe((data: { dataSource: BoardDataSource }) => {
         this._clearSelection();
-        // const dataSource: BoardDataSource = BoardDataSource.convertDsToMetaDs(data.dataSource.metaDataSource);
-        // dataSource.temporary = false;
-        // dataSource.engineName = dataSource.name;
-        // dataSource.type = 'default';
-        this.candidateIngestionList.push(data.dataSource['orgDataSource']);
+        const targetDs:BoardDataSource = data.dataSource['orgDataSource'];
+        targetDs.uiFilters = data.dataSource.uiFilters;
+        this.candidateIngestionList.push(targetDs);
         this._showDataIngestion();
       })
     );

--- a/discovery-frontend/src/app/dashboard/component/create-dashboard/create-board-ds-network.component.ts
+++ b/discovery-frontend/src/app/dashboard/component/create-dashboard/create-board-ds-network.component.ts
@@ -133,8 +133,6 @@ export class CreateBoardDsNetworkComponent extends AbstractComponent implements 
     this.subscriptions.push(
       this.broadCaster.on('CREATE_BOARD_REMOVE_DS').subscribe((data: { dataSourceId: string }) => {
         this.selectedDataSource = null;
-        const removeIdx: number = this._dataSources.findIndex(item => item.id === data.dataSourceId);
-        this._dataSources.splice(removeIdx, 1);
         this._removeDataSource(data.dataSourceId);
       })
     );
@@ -180,11 +178,11 @@ export class CreateBoardDsNetworkComponent extends AbstractComponent implements 
     this.subscriptions.push(
       this.broadCaster.on('CREATE_BOARD_RE_INGESTION').subscribe((data: { dataSource: BoardDataSource }) => {
         this._clearSelection();
-        const dataSource: BoardDataSource = BoardDataSource.convertDsToMetaDs(data.dataSource.metaDataSource);
-        dataSource.temporary = false;
-        dataSource.engineName = dataSource.name;
-        dataSource.type = 'default';
-        this.candidateIngestionList.push(dataSource);
+        // const dataSource: BoardDataSource = BoardDataSource.convertDsToMetaDs(data.dataSource.metaDataSource);
+        // dataSource.temporary = false;
+        // dataSource.engineName = dataSource.name;
+        // dataSource.type = 'default';
+        this.candidateIngestionList.push(data.dataSource['orgDataSource']);
         this._showDataIngestion();
       })
     );
@@ -397,8 +395,6 @@ export class CreateBoardDsNetworkComponent extends AbstractComponent implements 
 
     if (data.remove) {
       data.remove.forEach(id => {
-        const removeIdx: number = this._dataSources.findIndex(item => item.id === id);
-        this._dataSources.splice(removeIdx, 1);
         this._removeDataSource(id);
       });
     }
@@ -481,8 +477,14 @@ export class CreateBoardDsNetworkComponent extends AbstractComponent implements 
     dataSource.metaDataSource = tempDatasource.info;
     dataSource.uiFilters = tempDatasource.filters;
     dataSource['temporaryId'] = tempDatasource.id;
+    dataSource['orgDataSource'] = this.ingestionTargetDatasource;
 
-    this._dataSources.push(tempDatasource.info);
+    const targetIdx: number = this._dataSources.findIndex(item => item.id === dataSource.id);
+    if( -1 < targetIdx ) {
+      this._dataSources[targetIdx] = tempDatasource.info;
+    } else {
+      this._dataSources.push(tempDatasource.info);
+    }
     this._addDataSource(dataSource);
 
     // 다음 예정 데이터소스 표시
@@ -672,10 +674,15 @@ export class CreateBoardDsNetworkComponent extends AbstractComponent implements 
    * @private
    */
   private _removeDataSource(dataSourceId: string) {
+
+    // 데이터소스 삭제
+    const dsRemoveIdx: number = this._dataSources.findIndex(item => item.id === dataSourceId);
+    ( dsRemoveIdx ) && (this._dataSources.splice(dsRemoveIdx, 1));
+
     // 네트워크 노드 삭제
     this._nodes.remove({ id: dataSourceId });
 
-    // 데이터 소스 삭제
+    // 보드 데이터 소스 삭제
     const removeIdx = this._boardDataSources.findIndex(item => item.id === dataSourceId);
     (-1 < removeIdx) && (this._boardDataSources.splice(removeIdx, 1));
 

--- a/discovery-frontend/src/app/dashboard/dashboard.component.ts
+++ b/discovery-frontend/src/app/dashboard/dashboard.component.ts
@@ -385,6 +385,11 @@ export class DashboardComponent extends DashboardLayoutComponent implements OnIn
 
               if (ds.temporary && TempDsStatus.ENABLE === ds.temporary.status) {
                 boardDsInfo.metaDataSource = ds;
+                if( dashboard.configuration.filters ) {
+                  dashboard.configuration.filters = ds.temporary.filters.concat( dashboard.configuration.filters);
+                } else {
+                  dashboard.configuration.filters = ds.temporary.filters;
+                }
                 // if( 'multi' === dashboard.configuration.dataSource.type ) {
                 //   dashboard.configuration.dataSource.dataSources.some( item => {
                 //     if( DashboardUtil.isSameDataSource( item, ds ) ) {

--- a/discovery-frontend/src/app/dashboard/filters/abstract-filter-panel.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/abstract-filter-panel.component.ts
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-import { AbstractComponent } from '../../common/component/abstract.component';
+import {AbstractComponent} from '../../common/component/abstract.component';
 import {
   ElementRef,
   EventEmitter,
@@ -24,11 +24,11 @@ import {
   SimpleChange,
   SimpleChanges
 } from '@angular/core';
-import { Filter } from '../../domain/workbook/configurations/filter/filter';
-import { Dashboard } from '../../domain/dashboard/dashboard';
-import { Datasource, Field } from '../../domain/datasource/datasource';
-import { DashboardUtil } from '../util/dashboard.util';
-import { FilterUtil } from '../util/filter.util';
+import {Filter} from '../../domain/workbook/configurations/filter/filter';
+import {Dashboard} from '../../domain/dashboard/dashboard';
+import {ConnectionType, Datasource, Field} from '../../domain/datasource/datasource';
+import {DashboardUtil} from '../util/dashboard.util';
+import {FilterUtil} from '../util/filter.util';
 
 export class AbstractFilterPanelComponent extends AbstractComponent implements OnInit, OnDestroy {
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
@@ -204,7 +204,7 @@ export class AbstractFilterPanelComponent extends AbstractComponent implements O
 
     this.dataSource = FilterUtil.getDataSourceForFilter(filter, this.dashboard);
 
-    if( this.dataSource ) {
+    if (this.dataSource) {
       // 대시보드 필터 여부
       this.isBoardFilter = !filter.ui.widgetId;
 
@@ -212,13 +212,13 @@ export class AbstractFilterPanelComponent extends AbstractComponent implements O
       this.field = DashboardUtil.getFieldByName(this.dashboard, filter.dataSource, filter.field, filter.ref);
 
       // 타임스탬프, 필수필터, 추천필터일 경우에도 변경 불가능
-      if ( 'recommended' === filter.ui.importanceType || 'timestamp' === filter.ui.importanceType  ) {
+      if ('recommended' === filter.ui.importanceType || 'timestamp' === filter.ui.importanceType) {
         this.isChangeable = false;
       }
 
       // 기능 버튼 활성 여부
       this.isDeletable = this.isChangeable && (this.isDashboardMode === this.isBoardFilter);
-      this.isEditable = (this.isDashboardMode === this.isBoardFilter);
+      this.isEditable = (this.isDashboardMode === this.isBoardFilter) && !(ConnectionType.LINK === this.dataSource.connType && 'recommended' === filter.ui.importanceType);
     } else {
       this.isDeletable = true;
     }

--- a/discovery-frontend/src/app/dashboard/filters/essential-filter/essential-filter.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/essential-filter/essential-filter.component.ts
@@ -123,7 +123,8 @@ export class EssentialFilterComponent extends AbstractFilterPopupComponent imple
     this._dataSource = new BoardDataSource();
     const mainDs: BoardDataSource = this.inputDatasource;
 
-    // console.info('>>>>>>> mainDs : ', mainDs);
+    // 필드 나눔
+    this._setFields(mainDs.uiFields);
 
     if (mainDs.temporary) {
       // 재설정인 경우
@@ -133,6 +134,10 @@ export class EssentialFilterComponent extends AbstractFilterPopupComponent imple
       this._dataSource.name = mainDs.metaDataSource.name;
       this._dataSource.engineName = mainDs.metaDataSource.engineName;
       this._dataSourceId = mainDs.id;
+
+      if( mainDs.metaDataSource['filters'] ) {
+        this.essentialFilters = mainDs.metaDataSource['filters'];   // 필수 필터 설정
+      }
     } else {
       // 초기 설정인 경우
       this._dataSource.type = 'default';
@@ -140,13 +145,12 @@ export class EssentialFilterComponent extends AbstractFilterPopupComponent imple
       this._dataSource.name = mainDs.name;
       this._dataSource.engineName = mainDs.engineName;
       this._dataSourceId = mainDs.id;
+      if( mainDs.uiFilters && 0 < mainDs.uiFilters.length ) {
+        this.essentialFilters = mainDs.uiFilters;
+      } else {
+        this.essentialFilters = this._setEssentialFilters(mainDs.uiFields);   // 필수 필터 설정
+      }
     }
-
-    // 필드 나눔
-    this._setFields(mainDs.uiFields);
-
-    // 필수 필터 설정
-    this.essentialFilters = this._setEssentialFilters(mainDs.uiFields);
 
     // UI에서 표현할 수 있는 데이터로 Convert
     if (0 < this.essentialFilters.length) {
@@ -155,7 +159,7 @@ export class EssentialFilterComponent extends AbstractFilterPopupComponent imple
 
       this._convertServerSpecToUISpec(this.essentialFilters);
       // this._originalFilters = _.cloneDeep(this.essentialFilters);
-
+/*
       this.loadingShow();
       this._setEssentialFilter([], 0).then(() => {
         // console.info(this.essentialFilters);
@@ -165,6 +169,7 @@ export class EssentialFilterComponent extends AbstractFilterPopupComponent imple
         this.commonExceptionHandler(error, this.translateService.instant('msg.board.alert.fail.load.essential'));
         this.loadingHide();
       });
+*/
     }
 
     this._pseudoDashboard = new Dashboard();

--- a/discovery-frontend/src/app/dashboard/filters/inclusion-filter/configure-filters-inclusion.component.html
+++ b/discovery-frontend/src/app/dashboard/filters/inclusion-filter/configure-filters-inclusion.component.html
@@ -346,3 +346,5 @@
     <!-- // 아이템 목록 영역 -->
   </div>
 </div>
+
+<div *ngIf="isNoData && isNoData" class="ddp-ui-empty">{{'msg.board.filter.ui.no-data' | translate}}</div>

--- a/discovery-frontend/src/app/dashboard/filters/inclusion-filter/configure-filters-inclusion.component.html
+++ b/discovery-frontend/src/app/dashboard/filters/inclusion-filter/configure-filters-inclusion.component.html
@@ -272,7 +272,7 @@
 
       <!-- 후보값 목록 표시 -->
       <ul class="ddp-list-checktype ddp-type-list">
-        <li class="ddp-list-all">
+        <li *ngIf="useAll" class="ddp-list-all">
           <label *ngIf="!isSingleSelect(targetFilter)" class="ddp-label-checkbox">
             <input (click)="candidateSelectAll($event)" [checked]="isCheckedAllItem()" type="checkbox">
             <i class="ddp-icon-checkbox"></i>
@@ -280,7 +280,7 @@
           </label>
           <label *ngIf="isSingleSelect(targetFilter)" class="ddp-label-radio">
             <input (click)="candidateSelectAll($event)" [checked]="isCheckedAllItem()"
-                   type="radio" name="candidateSingle" >
+                   type="radio" name="candidateSingle_{{compUUID}}" >
             <i class="ddp-icon-radio"></i>
             <span class="ddp-txt-radio">({{'msg.board.filter.ui.all' | translate}})</span>
           </label>
@@ -299,7 +299,7 @@
           </label>
           <!-- radio -->
           <label class="ddp-label-radio" *ngIf="isSingleSelect(targetFilter)">
-            <input type="radio" name="candidateSingle"
+            <input type="radio" name="candidateSingle_{{compUUID}}"
                    (click)="candidateSelect(item, $event)"
                    [checked]="isCheckedItem(item)">
             <i class="ddp-icon-radio"></i>

--- a/discovery-frontend/src/app/dashboard/filters/inclusion-filter/configure-filters-inclusion.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/inclusion-filter/configure-filters-inclusion.component.ts
@@ -104,8 +104,10 @@ export class ConfigureFiltersInclusionComponent extends AbstractFilterPopupCompo
   | Public Variables
   |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
 
-  public isShow: boolean = false;   // 컴포넌트 표시 여부
-  public isOnlyShowCandidateValues: boolean = false;   // 표시할 후보값만 표시 여부
+  public isShow: boolean = false; // 컴포넌트 표시 여부
+  public isOnlyShowCandidateValues: boolean = false;  // 표시할 후보값만 표시 여부
+  public useAll:boolean = false;  // 전체 선택 표시 여부
+  public isNoData:boolean = false;  // 데이터 없음 표시 여부
 
   // 수정 대상
   public targetFilter: InclusionFilter;
@@ -129,8 +131,6 @@ export class ConfigureFiltersInclusionComponent extends AbstractFilterPopupCompo
 
   @Output()
   public goToSelectField: EventEmitter<any> = new EventEmitter();
-
-  public useAll:boolean = false;
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
   | Constructor
@@ -771,6 +771,7 @@ export class ConfigureFiltersInclusionComponent extends AbstractFilterPopupCompo
     result.forEach((item) => this._candidateList.push(this._objToCandidate(item, targetField)));
     this.totalItemCnt = this._candidateList.length;
     (targetFilter.candidateValues) || (targetFilter.candidateValues = []);
+    this.isNoData = ( 0 === this.totalItemCnt );
 
     // 정렬
     this.sortCandidateValues(targetFilter);

--- a/discovery-frontend/src/app/dashboard/filters/inclusion-filter/configure-filters-inclusion.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/inclusion-filter/configure-filters-inclusion.component.ts
@@ -130,6 +130,8 @@ export class ConfigureFiltersInclusionComponent extends AbstractFilterPopupCompo
   @Output()
   public goToSelectField: EventEmitter<any> = new EventEmitter();
 
+  public useAll:boolean = false;
+
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
   | Constructor
   |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
@@ -224,6 +226,13 @@ export class ConfigureFiltersInclusionComponent extends AbstractFilterPopupCompo
       this.targetFilter = targetFilter;
       this._targetField = targetField;
       this._board = board;
+
+      // 전체 선택 기능 체크 및 전체 선택 기능이 비활성 일떄, 초기값 기본 선택 - for Essential Filter
+      this.useAll = !( -1 < targetField.filteringSeq );
+      if( false === this.useAll && 0 === this._selectedValues.length ) {
+        this._selectedValues.push( this._candidateList[0] );
+      }
+
       this.isShow = true;
       this.safelyDetectChanges();
       this.loadingHide();
@@ -592,7 +601,7 @@ export class ConfigureFiltersInclusionComponent extends AbstractFilterPopupCompo
    * @return {boolean}
    */
   public isCheckedAllItem(): boolean {
-    if (this.isSingleSelect(this.targetFilter)) {
+    if (this.useAll && this.isSingleSelect(this.targetFilter)) {
       return 0 === this._selectedValues.length
     } else {
       return this._candidateList.length === this._selectedValues.length;

--- a/discovery-frontend/src/app/dashboard/filters/inclusion-filter/inclusion-filter-panel.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/inclusion-filter/inclusion-filter-panel.component.ts
@@ -34,9 +34,7 @@ import { PopupService } from '../../../common/service/popup.service';
 import { AbstractFilterPanelComponent } from '../abstract-filter-panel.component';
 import { Field } from '../../../domain/datasource/datasource';
 import { StringUtil } from '../../../common/util/string.util';
-import { FilterUtil } from '../../util/filter.util';
 import { DIRECTION } from '../../../domain/workbook/configurations/sort';
-import { DashboardUtil } from '../../util/dashboard.util';
 import { EventBroadcaster } from '../../../common/event/event.broadcaster';
 import { FilterWidget } from '../../../domain/dashboard/widget/filter-widget';
 
@@ -351,7 +349,11 @@ export class InclusionFilterPanelComponent extends AbstractFilterPanelComponent 
     const currFilter: InclusionFilter = _.cloneDeep(filter);
 
     // Selector 설정
-    this.isMultiSelector = (currFilter.selector === InclusionSelectorType.MULTI_COMBO || currFilter.selector === InclusionSelectorType.MULTI_LIST);
+    if( currFilter.valueList && 1 < currFilter.valueList.length ) {
+      this.isMultiSelector = true;
+    } else {
+      this.isMultiSelector = (currFilter.selector === InclusionSelectorType.MULTI_COMBO || currFilter.selector === InclusionSelectorType.MULTI_LIST);
+    }
 
     this.filter = currFilter;
 

--- a/discovery-frontend/src/app/dashboard/filters/time-filter/time-list-filter.component.html
+++ b/discovery-frontend/src/app/dashboard/filters/time-filter/time-list-filter.component.html
@@ -75,7 +75,7 @@
   <!-- 후보값 목록 표시 -->
   <ul class="ddp-list-checktype"
       [ngClass]="{'ddp-type-list' : 'CHANGE' === mode, 'ddp-list-padd' : 'CHANGE' !== mode }">
-    <li class="ddp-list-all">
+    <li *ngIf="useAll" class="ddp-list-all">
       <label class="ddp-label-checkbox">
         <input (click)="candidateSelectAll($event)" [checked]="isCheckedAllItem()" type="checkbox">
         <i class="ddp-icon-checkbox"></i>

--- a/discovery-frontend/src/app/dashboard/filters/time-filter/time-list-filter.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/time-filter/time-list-filter.component.ts
@@ -57,6 +57,7 @@ export class TimeListFilterComponent extends AbstractFilterPopupComponent implem
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
   | Public Variables
   |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
+  public useAll:boolean = false;
 
   public isOnlyShowCandidateValues: boolean = false;   // 표시할 후보값만 표시 여부
 
@@ -372,6 +373,16 @@ export class TimeListFilterComponent extends AbstractFilterPopupComponent implem
       this._setCandidateResult(result, filter, sortBy);
       this.targetFilter = filter;
       this.safelyDetectChanges();
+
+      // 전체 선택 기능 체크 및 전체 선택 기능이 비활성 일떄, 초기값 기본 선택 - for Essential Filter
+      if( this.targetField ) {
+        this.useAll = !( -1 < this.targetField.filteringSeq );
+      } else {
+        this.useAll = true;
+      }
+      if( false === this.useAll && 0 === this._selectedValues.length ) {
+        this._selectedValues.push( this._candidateList[0] );
+      }
 
       // 변경사항 전파
       ( isBroadcast ) && ( this.changeEvent.emit(this.getData()) );

--- a/discovery-frontend/src/app/dashboard/service/dashboard.service.ts
+++ b/discovery-frontend/src/app/dashboard/service/dashboard.service.ts
@@ -191,6 +191,7 @@ export class DashboardService extends AbstractService {
           delete boardConf.dataSource.engineName;
           delete boardConf.dataSource.uiFields;
           delete boardConf.dataSource.metaDataSource;
+          delete boardConf.dataSource['orgDataSource'];
           if (boardConf.dataSource.dataSources) {
             boardConf.dataSource.dataSources.forEach(item => {
               delete item.uiFields;

--- a/discovery-frontend/src/app/dashboard/service/dashboard.service.ts
+++ b/discovery-frontend/src/app/dashboard/service/dashboard.service.ts
@@ -190,6 +190,7 @@ export class DashboardService extends AbstractService {
           delete boardConf.dataSource.connType;
           delete boardConf.dataSource.engineName;
           delete boardConf.dataSource.uiFields;
+          delete boardConf.dataSource.uiFilters;
           delete boardConf.dataSource.metaDataSource;
           delete boardConf.dataSource['orgDataSource'];
           if (boardConf.dataSource.dataSources) {
@@ -209,7 +210,14 @@ export class DashboardService extends AbstractService {
           });
         }
         if (boardConf.filters) {
-          boardConf.filters = boardConf.filters.map(item => FilterUtil.convertToServerSpecForDashboard(item));
+          boardConf.filters
+            = boardConf.filters.filter( item => {
+              if( boardConf.dataSource.temporary ) {
+                return 'recommended' !== item.ui.importanceType;
+              } else {
+                return true;
+              }
+            }).map(item => FilterUtil.convertToServerSpecForDashboard(item));
         }
         delete boardConf.layout;
         delete boardConf.fields;

--- a/discovery-frontend/src/app/dashboard/update-dashboard.component.ts
+++ b/discovery-frontend/src/app/dashboard/update-dashboard.component.ts
@@ -1515,7 +1515,7 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
     this.showBoardLoading();
 
     // 대시보드 설정
-    this.dashboardService.getDashboard(dashboardId).then((boardInfo) => {
+    this.dashboardService.getDashboard(dashboardId).then((boardInfo:Dashboard) => {
 
       boardInfo.workBook = this.workbook;
       // Linked Datasource 인지 그리고 데이터소스가 적재되었는지 여부를 판단함
@@ -1535,6 +1535,12 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
               const boardDsInfo: BoardDataSource = DashboardUtil.getBoardDataSourceFromDataSource(boardInfo, dsInfo);
               this.datasourceService.getDatasourceDetail(boardDsInfo['temporaryId']).then((ds: Datasource) => {
                 boardDsInfo.metaDataSource = ds;
+                if( boardInfo.configuration.filters ) {
+                  boardInfo.configuration.filters = ds.temporary.filters.concat( boardInfo.configuration.filters);
+                } else {
+                  boardInfo.configuration.filters = ds.temporary.filters;
+                }
+
                 res();
               }).catch(err => rej(err));
             }));

--- a/discovery-frontend/src/app/dashboard/util/filter.util.ts
+++ b/discovery-frontend/src/app/dashboard/util/filter.util.ts
@@ -18,37 +18,37 @@ import {
   InclusionSelectorType,
   InclusionSortBy
 } from '../../domain/workbook/configurations/filter/inclusion-filter';
-import { BoundFilter } from '../../domain/workbook/configurations/filter/bound-filter';
+import {BoundFilter} from '../../domain/workbook/configurations/filter/bound-filter';
 import {
   InequalityType,
   MeasureInequalityFilter
 } from '../../domain/workbook/configurations/filter/measure-inequality-filter';
-import { AggregationType } from '../../domain/workbook/configurations/field/measure-field';
+import {AggregationType} from '../../domain/workbook/configurations/field/measure-field';
 import {
   MeasurePositionFilter,
   PositionType
 } from '../../domain/workbook/configurations/filter/measure-position-filter';
-import { ContainsType, WildCardFilter } from '../../domain/workbook/configurations/filter/wild-card-filter';
-import { Datasource, Field } from '../../domain/datasource/datasource';
-import { BoardDataSource, Dashboard } from '../../domain/dashboard/dashboard';
-import { Filter } from '../../domain/workbook/configurations/filter/filter';
-import { ByTimeUnit, TimeUnit } from '../../domain/workbook/configurations/field/timestamp-field';
-import { TimeFilter } from '../../domain/workbook/configurations/filter/time-filter';
-import { isNullOrUndefined } from 'util';
-import { TimeListFilter } from '../../domain/workbook/configurations/filter/time-list-filter';
-import { TimeAllFilter } from '../../domain/workbook/configurations/filter/time-all-filter';
-import { TimeRangeFilter } from '../../domain/workbook/configurations/filter/time-range-filter';
+import {ContainsType, WildCardFilter} from '../../domain/workbook/configurations/filter/wild-card-filter';
+import {Datasource, Field} from '../../domain/datasource/datasource';
+import {BoardDataSource, Dashboard} from '../../domain/dashboard/dashboard';
+import {Filter} from '../../domain/workbook/configurations/filter/filter';
+import {ByTimeUnit, TimeUnit} from '../../domain/workbook/configurations/field/timestamp-field';
+import {TimeFilter} from '../../domain/workbook/configurations/filter/time-filter';
+import {isNullOrUndefined} from 'util';
+import {TimeListFilter} from '../../domain/workbook/configurations/filter/time-list-filter';
+import {TimeAllFilter} from '../../domain/workbook/configurations/filter/time-all-filter';
+import {TimeRangeFilter} from '../../domain/workbook/configurations/filter/time-range-filter';
 import {
   TimeRelativeFilter,
   TimeRelativeTense
 } from '../../domain/workbook/configurations/filter/time-relative-filter';
-import { DashboardUtil } from './dashboard.util';
+import {DashboardUtil} from './dashboard.util';
 import {
   IntervalFilter,
   IntervalRelativeTimeType,
   IntervalSelectorType
 } from '../../domain/workbook/configurations/filter/interval-filter';
-import { DIRECTION } from '../../domain/workbook/configurations/sort';
+import {DIRECTION} from '../../domain/workbook/configurations/sort';
 
 declare let moment;
 
@@ -120,6 +120,26 @@ export class FilterUtil {
   } // function - getBoardDataSourceForFilter
 
   /**
+   * 필수 필터 목록 조회
+   * @param {Dashboard} board
+   * @param {Filter} filter
+   */
+  public static getEssentialFilters(board: Dashboard, filter?:Filter): Filter[] {
+    let essentialFilters: Filter[] = [];
+    if (board.configuration.dataSource.temporary) {
+      essentialFilters = board.configuration.filters.filter(item => {
+        const filterField = DashboardUtil.getFieldByName(board, item.dataSource, item.field);
+        if( filter && filter.ui && filter.ui.filteringSeq) {
+          return filter.ui.filteringSeq < filterField.filteringSeq;
+        } else {
+          return -1 < filterField.filteringSeq;
+        }
+      });
+    }
+    return essentialFilters;
+  } // function - getEssentialFilters
+
+  /**
    * 필터에 대한 데이터소스 반환
    * @param {Filter} filter
    * @param {Dashboard} board
@@ -148,7 +168,7 @@ export class FilterUtil {
     inclusionFilter.preFilters.push(this.getBasicPositionFilter(preFilterData));
     inclusionFilter.preFilters.push(this.getBasicWildCardFilter(field.name, preFilterData));
 
-    inclusionFilter.sort = new InclusionItemSort( InclusionSortBy.TEXT, DIRECTION.ASC );
+    inclusionFilter.sort = new InclusionItemSort(InclusionSortBy.TEXT, DIRECTION.ASC);
 
     (importanceType) && (inclusionFilter.ui.importanceType = importanceType);
     (-1 < field.filteringSeq) && (inclusionFilter.ui.filteringSeq = field.filteringSeq + 1);
@@ -257,7 +277,7 @@ export class FilterUtil {
           'locale', 'format', 'rrule', 'relValue', 'timeUnit'];
         break;
       case 'include' :
-        keyMap = ['valueList', 'candidateValues','sort'];
+        keyMap = ['selector', 'valueList', 'candidateValues', 'sort'];
         break;
       case 'timestamp' :
         keyMap = ['selectedTimestamps', 'timeFormat'];
@@ -335,7 +355,7 @@ export class FilterUtil {
           'minTime', 'maxTime', 'valueList', 'candidateValues', 'discontinuous', 'granularity'];
         break;
       case 'include' :
-        keyMap = ['selector', 'preFilters', 'valueList', 'candidateValues', 'definedValues','sort'];
+        keyMap = ['selector', 'preFilters', 'valueList', 'candidateValues', 'definedValues', 'sort'];
         break;
       case 'timestamp' :
         keyMap = ['selectedTimestamps', 'timeFormat'];

--- a/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/edit-filter-data-source.component.html
+++ b/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/edit-filter-data-source.component.html
@@ -8,7 +8,7 @@
       </span>
       <div class="ddp-ui-pop-buttons">
         <a href="javascript:" class="ddp-btn-pop" (click)="onClickCancel()">{{'msg.comm.btn.cancl' | translate}}</a>
-        <a href="javascript:" class="ddp-btn-pop ddp-bg-black" (click)="onClickDone()">{{'msg.comm.btn.done' | translate}}</a>
+        <a href="javascript:" class="ddp-btn-pop ddp-bg-black" (click)="updateColumnList()">{{'msg.comm.btn.done' | translate}}</a>
       </div>
     </div>
     <!-- //title -->
@@ -177,5 +177,3 @@
     </div>
   </div>
 </div>
-
-<app-confirm-modal (confirm)="updateColumnList()"></app-confirm-modal>

--- a/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/edit-filter-data-source.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/edit-filter-data-source.component.ts
@@ -18,8 +18,6 @@ import * as _ from 'lodash';
 import { DatasourceService } from '../../../datasource/service/datasource.service';
 import { Alert } from '../../../common/util/alert.util';
 import { FilteringOptions, FilteringOptionType } from '../../../domain/workbook/configurations/filter/filter';
-import { ConfirmModalComponent } from '../../../common/component/modal/confirm/confirm.component';
-import { Modal } from '../../../common/domain/modal';
 
 /**
  * Edit recommend and essential filter in datasource
@@ -36,9 +34,6 @@ export class EditFilterDataSourceComponent extends AbstractComponent implements 
   private _columnList: any[];
   // origin recommend filtered column list
   private _originFilteringColumnList: any[];
-
-  @ViewChild(ConfirmModalComponent)
-  private _confirmModalComponent: ConfirmModalComponent;
 
   // filtered column list
   public filteredColumnList: any[];
@@ -195,14 +190,6 @@ export class EditFilterDataSourceComponent extends AbstractComponent implements 
   }
 
   /**
-   * Click done button
-   */
-  public onClickDone(): void {
-    // If the datasource type is LINKED, show confirm popup
-    this.isLinkedType ? this._openConfirmModal() : this.updateColumnList();
-  }
-
-  /**
    * Click search keyword
    * @param {KeyboardEvent} event
    */
@@ -306,18 +293,6 @@ export class EditFilterDataSourceComponent extends AbstractComponent implements 
     this.isShowOnlyFilterColumnList = false;
     // show flag
     this.isShowComponent = true;
-  }
-
-  /**
-   * Open confirm popup modal
-   * @private
-   */
-  private _openConfirmModal(): void {
-    const modal = new Modal();
-    modal.name = this.isLinkedType ? this.translateService.instant('msg.storage.ui.essential.filter.save.title') : this.translateService.instant('msg.storage.ui.recommendation.filter.save.title');
-    modal.description = this.translateService.instant('msg.storage.ui.ingestion.desc');
-    modal.btnName = this.translateService.instant('msg.storage.btn.re.ingestion');
-    this._confirmModalComponent.init(modal);
   }
 
   /**

--- a/discovery-frontend/src/app/datasource/service/datasource.service.ts
+++ b/discovery-frontend/src/app/datasource/service/datasource.service.ts
@@ -160,7 +160,7 @@ export class DatasourceService extends AbstractService {
     param.dataSource = DashboardUtil.getDataSourceForApi(
       _.cloneDeep(FilterUtil.getBoardDataSourceForFilter(filter, board))
     );
-    param.filters = (filters) ? _.cloneDeep(filters) : [];
+    param.filters = (filters && 0 < filters.length) ? _.cloneDeep(filters) : FilterUtil.getEssentialFilters(board, filter);
     param.filters = param.filters
       .map(item => FilterUtil.convertToServerSpec(item))
       .filter(item => !(item.type === 'bound' && item['min'] == null));
@@ -244,7 +244,6 @@ export class DatasourceService extends AbstractService {
           param.targetField.aggregationType = 'NONE';
           param.targetField.type = 'measure';
         }
-        param.filters = [];
       }
 
     }

--- a/discovery-frontend/src/assets/css/polaris.v2.page.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.page.css
@@ -1583,6 +1583,7 @@ ul.ddp-list-text li a .ddp-data-info span {display:block; color:#4b515b; font-si
 
 .ddp-type-setup .ddp-ui-top .ddp-ui-tags {float:right; }
 .ddp-setup-contents {position:relative; padding:17px 0;}
+.ddp-setup-contents .ddp-ui-empty {margin:-18px 0; padding:20px 16px; font-size:13px;}
 .ddp-setup-contents .ddp-box-item-search {position:relative;}
 .ddp-setup-contents .ddp-box-item-search .ddp-list-checktype {position:relative; top:0; padding-bottom:10px;max-height:225px;}
 .ddp-setup-contents .ddp-box-item-search .ddp-data-result,

--- a/discovery-frontend/src/assets/i18n/en.json
+++ b/discovery-frontend/src/assets/i18n/en.json
@@ -1464,6 +1464,7 @@
   "msg.board.filter.sel.data" : "Please select data.",
   "msg.board.filter.placeholder.search-field" : "Search by field name",
   "msg.board.filter.ui.select-measure" : "Select Measure",
+  "msg.board.filter.ui.no-data" : "No Data",
   "msg.custom.filter.popup.change.aggregation.title" : "Do you want to continue to change?",
   "msg.custom.filter.popup.change.aggregation.description" : "If you change the condition including aggregations, it can affect all of charts using these columns.",
   "msg.board.ordering,tooltip" : "Ordering",

--- a/discovery-frontend/src/assets/i18n/ko.json
+++ b/discovery-frontend/src/assets/i18n/ko.json
@@ -1462,6 +1462,7 @@
   "msg.board.filter.sel.data" : "데이터를 선택해 주세요",
   "msg.board.filter.placeholder.search-field" : "필드 이름 검색",
   "msg.board.filter.ui.select-measure" : "측정값 선택",
+  "msg.board.filter.ui.no-data" : "선택할 수 있는 값이 없습니다",
   "msg.custom.filter.popup.change.aggregation.title" : "조건식 변경을 계속 진행하시겠습니까?",
   "msg.custom.filter.popup.change.aggregation.description" : "집계 함수가 포함된 조건식 변경 시, 해당 컬럼이 사용된 차트에 영향을 줄 수 있습니다",
   "msg.board.ordering,tooltip" : "순서지정",

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourceService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourceService.java
@@ -14,6 +14,27 @@
 
 package app.metatron.discovery.domain.datasource;
 
+import com.google.common.collect.Lists;
+
+import com.querydsl.core.types.Predicate;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import app.metatron.discovery.common.criteria.ListCriterion;
 import app.metatron.discovery.common.criteria.ListCriterionType;
 import app.metatron.discovery.common.criteria.ListFilter;
@@ -35,24 +56,6 @@ import app.metatron.discovery.domain.workspace.WorkspaceRepository;
 import app.metatron.discovery.domain.workspace.WorkspaceService;
 import app.metatron.discovery.util.AuthUtils;
 import app.metatron.discovery.util.PolarisUtils;
-import com.google.common.collect.Lists;
-import com.querydsl.core.types.Predicate;
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.joda.time.DateTime;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import static app.metatron.discovery.domain.datasource.DataSourceTemporary.ID_PREFIX;
 
@@ -136,13 +139,13 @@ public class DataSourceService {
     for (DataSourceTemporary temporary : temporaries) {
       List<Filter> originalFilters = temporary.getFilterList();
       // Filter 설정을 비교대상 모두 하지 않은 경우, matched
-      if (CollectionUtils.isEmpty(originalFilters) == CollectionUtils.isEmpty(filters)) {
+      if (CollectionUtils.isEmpty(originalFilters) && CollectionUtils.isEmpty(filters)) {
         matchedTempories.add(temporary);
         continue;
       }
 
       // Filter 설정이 둘중 한쪽이 없는 경우, pass
-      if (!(CollectionUtils.isNotEmpty(originalFilters) == CollectionUtils.isNotEmpty(filters))) {
+      if (originalFilters == null || filters == null) {
         continue;
       }
 
@@ -152,7 +155,7 @@ public class DataSourceService {
       }
 
       boolean compareResult = true;
-      for (int i = 0; originalFilters.size() > 0; i++) {
+      for (int i = 0; i < originalFilters.size(); i++) {
         Filter originalFilter = originalFilters.get(i);
         Filter reqFilter = filters.get(i);
 
@@ -265,136 +268,136 @@ public class DataSourceService {
 
     return dataSources;
   }
-  
-  public List<ListCriterion> getListCriterion(){
+
+  public List<ListCriterion> getListCriterion() {
 
     List<ListCriterion> criteria = new ArrayList<>();
-    
+
     //Status
     criteria.add(new ListCriterion(DataSourceListCriterionKey.STATUS,
-            ListCriterionType.CHECKBOX, "msg.storage.ui.criterion.status"));
+                                   ListCriterionType.CHECKBOX, "msg.storage.ui.criterion.status"));
 
     //Publish
     criteria.add(new ListCriterion(DataSourceListCriterionKey.PUBLISH,
-            ListCriterionType.CHECKBOX, "msg.storage.ui.criterion.publish", true));
+                                   ListCriterionType.CHECKBOX, "msg.storage.ui.criterion.publish", true));
 
     //Creator
     criteria.add(new ListCriterion(DataSourceListCriterionKey.CREATOR,
-            ListCriterionType.CHECKBOX, "msg.storage.ui.criterion.creator", true));
+                                   ListCriterionType.CHECKBOX, "msg.storage.ui.criterion.creator", true));
 
     //CreatedTime
     ListCriterion createdTimeCriterion
-            = new ListCriterion(DataSourceListCriterionKey.CREATED_TIME,
-            ListCriterionType.RANGE_DATETIME, "msg.storage.ui.criterion.created-time");
+        = new ListCriterion(DataSourceListCriterionKey.CREATED_TIME,
+                            ListCriterionType.RANGE_DATETIME, "msg.storage.ui.criterion.created-time");
     createdTimeCriterion.addFilter(new ListFilter(DataSourceListCriterionKey.CREATED_TIME,
-            "createdTimeFrom", "createdTimeTo", "", "",
-            "msg.storage.ui.criterion.created-time"));
+                                                  "createdTimeFrom", "createdTimeTo", "", "",
+                                                  "msg.storage.ui.criterion.created-time"));
     criteria.add(createdTimeCriterion);
 
     //DateTime
-//    criteria.add(new ListCriterion(DataSourceListCriterionKey.DATETIME,
-//            ListCriterionType.RADIO, "msg.storage.ui.criterion.datetime"));
+    //    criteria.add(new ListCriterion(DataSourceListCriterionKey.DATETIME,
+    //            ListCriterionType.RADIO, "msg.storage.ui.criterion.datetime"));
 
     //more
     ListCriterion moreCriterion = new ListCriterion(DataSourceListCriterionKey.MORE,
-            ListCriterionType.CHECKBOX, "msg.storage.ui.criterion.more");
-//    DateTime currentDateTime = DateTime.now();
-//    DateTime recentlyDateTime = currentDateTime.minusDays(7);
-//    String fromStr = recentlyDateTime.toString();
-//    String toStr = currentDateTime.toString();
-//    moreCriterion.addFilter(new ListFilter(DataSourceListCriterionKey.MODIFIED_TIME,
-//            "modifiedTimeFrom", "modifiedTimeTo", "", "",
-//            "msg.storage.ui.criterion.modified-time"));
-//    moreCriterion.addFilter(new ListFilter(DataSourceListCriterionKey.CREATED_TIME,
-//            "createdTimeFrom", "createdTimeTo", fromStr, toStr,
-//            "msg.storage.ui.criterion.recently-created-time"));
+                                                    ListCriterionType.CHECKBOX, "msg.storage.ui.criterion.more");
+    //    DateTime currentDateTime = DateTime.now();
+    //    DateTime recentlyDateTime = currentDateTime.minusDays(7);
+    //    String fromStr = recentlyDateTime.toString();
+    //    String toStr = currentDateTime.toString();
+    //    moreCriterion.addFilter(new ListFilter(DataSourceListCriterionKey.MODIFIED_TIME,
+    //            "modifiedTimeFrom", "modifiedTimeTo", "", "",
+    //            "msg.storage.ui.criterion.modified-time"));
+    //    moreCriterion.addFilter(new ListFilter(DataSourceListCriterionKey.CREATED_TIME,
+    //            "createdTimeFrom", "createdTimeTo", fromStr, toStr,
+    //            "msg.storage.ui.criterion.recently-created-time"));
 
     moreCriterion.addSubCriterion(new ListCriterion(DataSourceListCriterionKey.MODIFIED_TIME,
-            ListCriterionType.RANGE_DATETIME, "msg.storage.ui.criterion.modified-time"));
+                                                    ListCriterionType.RANGE_DATETIME, "msg.storage.ui.criterion.modified-time"));
     moreCriterion.addSubCriterion(new ListCriterion(DataSourceListCriterionKey.CONNECTION_TYPE,
-            ListCriterionType.CHECKBOX, "msg.storage.ui.criterion.connection-type"));
-//    moreCriterion.addSubCriterion(new ListCriterion(DataSourceListCriterionKey.DATASOURCE_TYPE,
-//            ListCriterionType.CHECKBOX, "msg.storage.ui.criterion.ds-type"));
+                                                    ListCriterionType.CHECKBOX, "msg.storage.ui.criterion.connection-type"));
+    //    moreCriterion.addSubCriterion(new ListCriterion(DataSourceListCriterionKey.DATASOURCE_TYPE,
+    //            ListCriterionType.CHECKBOX, "msg.storage.ui.criterion.ds-type"));
     moreCriterion.addSubCriterion(new ListCriterion(DataSourceListCriterionKey.SOURCE_TYPE,
-            ListCriterionType.CHECKBOX, "msg.storage.ui.criterion.source-type"));
+                                                    ListCriterionType.CHECKBOX, "msg.storage.ui.criterion.source-type"));
     criteria.add(moreCriterion);
 
     //description
-//    ListCriterion descriptionCriterion
-//            = new ListCriterion(DataSourceListCriterionKey.CONTAINS_TEXT,
-//            ListCriterionType.TEXT, "msg.storage.ui.criterion.contains-text");
-//    descriptionCriterion.addFilter(new ListFilter(DataSourceListCriterionKey.CONTAINS_TEXT,
-//            "containsText", "", "msg.storage.ui.criterion.contains-text"));
-//    criteria.add(descriptionCriterion);
+    //    ListCriterion descriptionCriterion
+    //            = new ListCriterion(DataSourceListCriterionKey.CONTAINS_TEXT,
+    //            ListCriterionType.TEXT, "msg.storage.ui.criterion.contains-text");
+    //    descriptionCriterion.addFilter(new ListFilter(DataSourceListCriterionKey.CONTAINS_TEXT,
+    //            "containsText", "", "msg.storage.ui.criterion.contains-text"));
+    //    criteria.add(descriptionCriterion);
 
     return criteria;
   }
 
-  public ListCriterion getListCriterionByKey(DataSourceListCriterionKey criterionKey){
+  public ListCriterion getListCriterionByKey(DataSourceListCriterionKey criterionKey) {
     ListCriterion criterion = new ListCriterion();
     criterion.setCriterionKey(criterionKey);
 
-    switch (criterionKey){
+    switch (criterionKey) {
       case STATUS:
         DataSource.Status[] statuses = {
-                DataSource.Status.ENABLED,
-                DataSource.Status.PREPARING,
-                DataSource.Status.FAILED,
-                DataSource.Status.DISABLED
+            DataSource.Status.ENABLED,
+            DataSource.Status.PREPARING,
+            DataSource.Status.FAILED,
+            DataSource.Status.DISABLED
         };
-        for(DataSource.Status status : statuses){
+        for (DataSource.Status status : statuses) {
           String filterName = status.toString();
           criterion.addFilter(new ListFilter(criterionKey, "status", status.toString(), filterName));
         }
         break;
       case DATASOURCE_TYPE:
-        for(DataSource.DataSourceType dataSourceType : DataSource.DataSourceType.values()){
+        for (DataSource.DataSourceType dataSourceType : DataSource.DataSourceType.values()) {
           String filterName = dataSourceType.toString();
           criterion.addFilter(new ListFilter(criterionKey, "dataSourceType",
-                  dataSourceType.toString(), filterName));
+                                             dataSourceType.toString(), filterName));
         }
         break;
       case SOURCE_TYPE:
         DataSource.SourceType[] srcTypes = {
-                DataSource.SourceType.FILE,
-                DataSource.SourceType.HDFS,
-                DataSource.SourceType.HIVE,
-                DataSource.SourceType.JDBC,
-                DataSource.SourceType.REALTIME,
-                DataSource.SourceType.IMPORT,
-                DataSource.SourceType.SNAPSHOT
+            DataSource.SourceType.FILE,
+            DataSource.SourceType.HDFS,
+            DataSource.SourceType.HIVE,
+            DataSource.SourceType.JDBC,
+            DataSource.SourceType.REALTIME,
+            DataSource.SourceType.IMPORT,
+            DataSource.SourceType.SNAPSHOT
         };
 
-        for(DataSource.SourceType sourceType : srcTypes){
+        for (DataSource.SourceType sourceType : srcTypes) {
           String filterName = sourceType.toString();
           criterion.addFilter(new ListFilter(criterionKey, "sourceType",
-                  sourceType.toString(), filterName));
+                                             sourceType.toString(), filterName));
         }
         break;
       case CONNECTION_TYPE:
-        for(DataSource.ConnectionType connectionType : DataSource.ConnectionType.values()){
+        for (DataSource.ConnectionType connectionType : DataSource.ConnectionType.values()) {
           String filterName = connectionType.toString();
           criterion.addFilter(new ListFilter(criterionKey, "connectionType",
-                  connectionType.toString(), filterName));
+                                             connectionType.toString(), filterName));
         }
         break;
       case PUBLISH:
         //allow search
         criterion.setSearchable(true);
 
-        criterion.addFilter(new ListFilter(criterionKey, "published",  "true", "msg.storage.ui.criterion.open-data"));
+        criterion.addFilter(new ListFilter(criterionKey, "published", "true", "msg.storage.ui.criterion.open-data"));
 
         //my private workspace
         Workspace myWorkspace = workspaceRepository.findPrivateWorkspaceByOwnerId(AuthUtils.getAuthUserName());
         criterion.addFilter(new ListFilter(criterionKey, "workspace",
-                myWorkspace.getId(), myWorkspace.getName()));
+                                           myWorkspace.getId(), myWorkspace.getName()));
 
         //my public workspace
         List<Workspace> publicWorkspaces
-                = workspaceService.getPublicWorkspaces(false, false, false, null);
-        for(Workspace workspace : publicWorkspaces){
+            = workspaceService.getPublicWorkspaces(false, false, false, null);
+        for (Workspace workspace : publicWorkspaces) {
           criterion.addFilter(new ListFilter(criterionKey, "workspace",
-                  workspace.getId(), workspace.getName()));
+                                             workspace.getId(), workspace.getName()));
         }
         break;
       case CREATOR:
@@ -412,15 +415,15 @@ public class DataSourceService {
 
         //me
         userCriterion.addFilter(new ListFilter("createdBy", userName,
-                user.getFullName() + " (me)"));
+                                               user.getFullName() + " (me)"));
 
         //datasource created users
         List<String> creatorIdList = dataSourceRepository.findDistinctCreatedBy();
         List<User> creatorUserList = userRepository.findByUsernames(creatorIdList);
-        for(User creator : creatorUserList){
-          if(!creator.getUsername().equals(userName)){
+        for (User creator : creatorUserList) {
+          if (!creator.getUsername().equals(userName)) {
             ListFilter filter = new ListFilter("createdBy", creator.getUsername(),
-                    creator.getFullName());
+                                               creator.getFullName());
             userCriterion.addFilter(filter);
           }
         }
@@ -432,78 +435,78 @@ public class DataSourceService {
 
         //my group
         List<Map<String, Object>> groupList = groupService.getJoinedGroupsForProjection(userName, false);
-        if(groupList != null && !groupList.isEmpty()){
-          for(Map<String, Object> groupMap : groupList){
+        if (groupList != null && !groupList.isEmpty()) {
+          for (Map<String, Object> groupMap : groupList) {
             ListFilter filter = new ListFilter("userGroup", groupMap.get("id").toString(),
-                    groupMap.get("name").toString() + " (my)");
+                                               groupMap.get("name").toString() + " (my)");
             groupCriterion.addFilter(filter);
           }
         }
 
         //data manager group
         List<RoleDirectory> roleDirectoryList
-                = roleDirectoryRepository.findByTypeAndRoleId(DirectoryProfile.Type.GROUP, "ROLE_SYSTEM_DATA_MANAGER");
-        if(roleDirectoryList != null && !roleDirectoryList.isEmpty()){
-          for(RoleDirectory roleDirectory : roleDirectoryList){
+            = roleDirectoryRepository.findByTypeAndRoleId(DirectoryProfile.Type.GROUP, "ROLE_SYSTEM_DATA_MANAGER");
+        if (roleDirectoryList != null && !roleDirectoryList.isEmpty()) {
+          for (RoleDirectory roleDirectory : roleDirectoryList) {
             //duplicate group check
             boolean duplicated = false;
-            if(groupList != null && !groupList.isEmpty()){
+            if (groupList != null && !groupList.isEmpty()) {
               long duplicatedCnt = groupList.stream()
-                      .filter(groupMap -> roleDirectory.getDirectoryId().equals(groupMap.get("id").toString()))
-                      .count();
+                                            .filter(groupMap -> roleDirectory.getDirectoryId().equals(groupMap.get("id").toString()))
+                                            .count();
               duplicated = duplicatedCnt > 0;
             }
 
-            if(!duplicated){
+            if (!duplicated) {
               ListFilter filter = new ListFilter("userGroup", roleDirectory.getDirectoryId(),
-                      roleDirectory.getDirectoryName());
+                                                 roleDirectory.getDirectoryName());
               groupCriterion.addFilter(filter);
             }
           }
         }
-//
-//        //data manager group member
-//        List<GroupMember> memberResults = groupMemberRepository.findByGroupId("ID_GROUP_DATA_MANAGER");
-//        if(memberResults != null && !memberResults.isEmpty()){
-//          List<String> memberUserNameList = memberResults.stream()
-//                  .map(member -> member.getMemberId())
-//                  .collect(Collectors.toList());
-//          List<User> dataManagerUserList = userRepository.findByUsernames(memberUserNameList);
-//          for(User member : dataManagerUserList){
-//            ListFilter filter = new ListFilter("createdBy", member.getUsername(),
-//                    member.getFullName() + "(" + member.getUsername() + ")");
-//            groupCriterion.addFilter(filter);
-//          }
-//        }
+        //
+        //        //data manager group member
+        //        List<GroupMember> memberResults = groupMemberRepository.findByGroupId("ID_GROUP_DATA_MANAGER");
+        //        if(memberResults != null && !memberResults.isEmpty()){
+        //          List<String> memberUserNameList = memberResults.stream()
+        //                  .map(member -> member.getMemberId())
+        //                  .collect(Collectors.toList());
+        //          List<User> dataManagerUserList = userRepository.findByUsernames(memberUserNameList);
+        //          for(User member : dataManagerUserList){
+        //            ListFilter filter = new ListFilter("createdBy", member.getUsername(),
+        //                    member.getFullName() + "(" + member.getUsername() + ")");
+        //            groupCriterion.addFilter(filter);
+        //          }
+        //        }
         break;
       case DATETIME:
         //created_time
         ListCriterion createdTimeCriterion = new ListCriterion();
         createdTimeCriterion.setCriterionName("msg.storage.ui.criterion.created-time");
         createdTimeCriterion.addFilter(new ListFilter(DataSourceListCriterionKey.CREATED_TIME,
-                "createdTimeFrom", "createdTimeTo", "", "",
-                "msg.storage.ui.criterion.created-time"));
+                                                      "createdTimeFrom", "createdTimeTo", "", "",
+                                                      "msg.storage.ui.criterion.created-time"));
         criterion.addSubCriterion(createdTimeCriterion);
 
         //modified_time
         ListCriterion modifiedTimeCriterion = new ListCriterion();
         modifiedTimeCriterion.setCriterionName("msg.storage.ui.criterion.modified-time");
         modifiedTimeCriterion.addFilter(new ListFilter(DataSourceListCriterionKey.MODIFIED_TIME,
-                "modifiedTimeFrom", "modifiedTimeTo", "", "",
-                "msg.storage.ui.criterion.modified-time"));
+                                                       "modifiedTimeFrom", "modifiedTimeTo", "", "",
+                                                       "msg.storage.ui.criterion.modified-time"));
         criterion.addSubCriterion(modifiedTimeCriterion);
         break;
       case CREATED_TIME:
         //created_time
         criterion.addFilter(new ListFilter(DataSourceListCriterionKey.CREATED_TIME,
-                "createdTimeFrom", "createdTimeTo", "", "",
-                "msg.storage.ui.criterion.created-time"));
+                                           "createdTimeFrom", "createdTimeTo", "", "",
+                                           "msg.storage.ui.criterion.created-time"));
         break;
       case MODIFIED_TIME:
         //modified_time
         criterion.addFilter(new ListFilter(DataSourceListCriterionKey.MODIFIED_TIME,
-                "modifiedTimeFrom", "modifiedTimeTo", "", "",
-                "msg.storage.ui.criterion.modified-time"));
+                                           "modifiedTimeFrom", "modifiedTimeTo", "", "",
+                                           "msg.storage.ui.criterion.modified-time"));
         break;
       default:
         break;
@@ -512,25 +515,25 @@ public class DataSourceService {
     return criterion;
   }
 
-  public List<ListFilter> getDefaultFilter(){
+  public List<ListFilter> getDefaultFilter() {
     List<DataSourceProperties.DefaultFilter> defaultFilters = dataSourceProperties.getDefaultFilters();
 
     List<ListFilter> defaultCriteria = new ArrayList<>();
 
-    if(defaultFilters != null){
-      for(DataSourceProperties.DefaultFilter defaultFilter : defaultFilters){
+    if (defaultFilters != null) {
+      for (DataSourceProperties.DefaultFilter defaultFilter : defaultFilters) {
         //me
-        if(defaultFilter.getFilterValue().equals("me")){
+        if (defaultFilter.getFilterValue().equals("me")) {
           String userName = AuthUtils.getAuthUserName();
           User user = userRepository.findByUsername(userName);
 
           ListFilter meFilter = new ListFilter(DataSourceListCriterionKey.valueOf(defaultFilter.getCriterionKey())
-                  , "createdBy", null, userName, null, user.getFullName() + " (me)");
+              , "createdBy", null, userName, null, user.getFullName() + " (me)");
           defaultCriteria.add(meFilter);
         } else {
           ListFilter listFilter = new ListFilter(DataSourceListCriterionKey.valueOf(defaultFilter.getCriterionKey())
-                  , defaultFilter.getFilterKey(), null, defaultFilter.getFilterValue(), null
-                  , defaultFilter.getFilterName());
+              , defaultFilter.getFilterKey(), null, defaultFilter.getFilterValue(), null
+              , defaultFilter.getFilterName());
           defaultCriteria.add(listFilter);
         }
       }
@@ -539,36 +542,36 @@ public class DataSourceService {
   }
 
   public Page<DataSource> findDataSourceListByFilter(
-          List<DataSource.Status> statuses,
-          List<String> workspaces,
-          List<String> createdBys,
-          List<String> userGroups,
-          DateTime createdTimeFrom,
-          DateTime createdTimeTo,
-          DateTime modifiedTimeFrom,
-          DateTime modifiedTimeTo,
-          String containsText,
-          List<DataSource.DataSourceType> dataSourceTypes,
-          List<DataSource.SourceType> sourceTypes,
-          List<DataSource.ConnectionType> connectionTypes,
-          List<Boolean> published,
-          Pageable pageable){
+      List<DataSource.Status> statuses,
+      List<String> workspaces,
+      List<String> createdBys,
+      List<String> userGroups,
+      DateTime createdTimeFrom,
+      DateTime createdTimeTo,
+      DateTime modifiedTimeFrom,
+      DateTime modifiedTimeTo,
+      String containsText,
+      List<DataSource.DataSourceType> dataSourceTypes,
+      List<DataSource.SourceType> sourceTypes,
+      List<DataSource.ConnectionType> connectionTypes,
+      List<Boolean> published,
+      Pageable pageable) {
 
     //add userGroups member to createdBy
     List<GroupMember> groupMembers = groupMemberRepository.findByGroupIds(userGroups);
-    if(groupMembers != null && !groupMembers.isEmpty()){
-      if(createdBys == null)
+    if (groupMembers != null && !groupMembers.isEmpty()) {
+      if (createdBys == null)
         createdBys = new ArrayList<>();
 
-      for(GroupMember groupMember : groupMembers){
+      for (GroupMember groupMember : groupMembers) {
         createdBys.add(groupMember.getMemberId());
       }
     }
 
     // Get Predicate
     Predicate searchPredicated = DataSourcePredicate.searchList(statuses, workspaces, createdBys, createdTimeFrom,
-            createdTimeTo, modifiedTimeFrom, modifiedTimeTo, containsText, dataSourceTypes, sourceTypes, connectionTypes,
-            published);
+                                                                createdTimeTo, modifiedTimeFrom, modifiedTimeTo, containsText, dataSourceTypes, sourceTypes, connectionTypes,
+                                                                published);
 
     // Find by predicated
     Page<DataSource> dataSources = dataSourceRepository.findAll(searchPredicated, pageable);

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/Field.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/Field.java
@@ -245,7 +245,8 @@ public class Field implements MetatronDomain<Long> {
   private Field mapper;
 
   /**
-   * Related field information, When you configure a new field by mapping an existing physical field
+   * Related field information, When you configure a new field by mapping an existing physical
+   * field
    */
   @OneToMany(mappedBy = "mapper")
   @JsonBackReference
@@ -280,7 +281,6 @@ public class Field implements MetatronDomain<Long> {
     this.role = SearchParamValidator.enumUpperValue(FieldRole.class, patch.getValue("role"), "role");
     this.logicalType = SearchParamValidator.enumUpperValue(LogicalType.class, patch.getValue("logicalType"), "logicalType");
     this.aggrType = SearchParamValidator.enumUpperValue(MeasureField.AggregationType.class, patch.getValue("aggrType"), "aggrType");
-    this.format = patch.getValue("format");
     this.seq = patch.getLongValue("seq");
 
     this.filtering = patch.getValue("filtering");
@@ -289,15 +289,21 @@ public class Field implements MetatronDomain<Long> {
       this.filteringSeq = patch.getLongValue("filteringSeq");
       setFilteringOptions(patch.getObjectValue("filteringOptions"));
     }
+
+    setFormat(patch.getObjectValue("format"));
   }
 
   public void updateField(CollectionPatch patch) {
     // if(patch.hasProperty("name")) this.name = patch.getValue("name");
     if (patch.hasProperty("alias")) this.alias = patch.getValue("alias");
+
     if (patch.hasProperty("description")) this.description = patch.getValue("description");
+
     if (patch.hasProperty("logicalType"))
       this.logicalType = SearchParamValidator.enumUpperValue(LogicalType.class, patch.getValue("logicalType"), "logicalType");
-    if (patch.hasProperty("format")) this.format = patch.getValue("format");
+
+    if (patch.hasProperty("format")) setFormat(patch.getObjectValue("format"));
+
     if (patch.hasProperty("seq")) this.seq = patch.getLongValue("seq");
 
     if (patch.hasProperty("filtering")) this.filtering = patch.getValue("filtering");
@@ -319,8 +325,8 @@ public class Field implements MetatronDomain<Long> {
   @JsonIgnore
   public Aggregation getAggregation(boolean isRelay) {
 
-    if(isRelay) {
-      return new RelayAggregation(name,logicalType.toEngineMetricType());
+    if (isRelay) {
+      return new RelayAggregation(name, logicalType.toEngineMetricType());
     }
 
     if (aggrType == null) {
@@ -596,6 +602,15 @@ public class Field implements MetatronDomain<Long> {
     }
 
     return format;
+  }
+
+  public void setFormat(Object object) {
+    if (object == null) {
+      this.format = null;
+    } else {
+      FieldFormat format = GlobalObjectMapper.getDefaultMapper().convertValue(object, FieldFormat.class);
+      this.format = GlobalObjectMapper.writeValueAsString(format);
+    }
   }
 
   public void setFormat(String format) {

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/datasource/DataSourceRestIntegrationTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/datasource/DataSourceRestIntegrationTest.java
@@ -93,6 +93,7 @@ import app.metatron.discovery.domain.scheduling.engine.DataSourceCheckJobIntegra
 import app.metatron.discovery.domain.workbook.configurations.datasource.DefaultDataSource;
 import app.metatron.discovery.domain.workbook.configurations.field.DimensionField;
 import app.metatron.discovery.domain.workbook.configurations.field.MeasureField;
+import app.metatron.discovery.domain.workbook.configurations.format.CustomDateTimeFormat;
 import app.metatron.discovery.domain.workbook.configurations.format.GeoPointFormat;
 import app.metatron.discovery.domain.workbook.configurations.format.TemporaryTimeFormat;
 import app.metatron.discovery.domain.workbook.configurations.format.UnixTimeFormat;
@@ -272,6 +273,7 @@ public class DataSourceRestIntegrationTest extends AbstractRestIntegrationTest {
     TestUtils.printTestTitle("1. add DataSource with Fields include filteringOption property");
 
     Field f1 = new Field("filtering field1", DataType.TIMESTAMP, TIMESTAMP, 0L);
+    f1.setFormat(GlobalObjectMapper.writeValueAsString(new CustomDateTimeFormat("yyyy-MM-dd")));
     f1.setFiltering(true);
     f1.setFilteringSeq(0L);
     f1.setFilteringOptions(new Field.FilterOption("time", "relative", Lists.newArrayList("range", "relative")));
@@ -326,7 +328,11 @@ public class DataSourceRestIntegrationTest extends AbstractRestIntegrationTest {
     updateField.put("id", field1Id);
     updateField.put("alias", "update field name");
     updateField.put("description", "update description");
-    //    updateField.put("filtering", false);
+
+    Map<String, Object> formatMap = Maps.newHashMap();
+    formatMap.put("type", "time_format");
+    formatMap.put("format", "yyyy-MM-dd");
+    updateField.put("format", formatMap);
     updateField.put("filteringOptions", new Field.FilterOption("time", "range", Lists.newArrayList("range", "relative")));
 
     Map<String, Object> removeField = Maps.newHashMap();


### PR DESCRIPTION
### Description
링크 형태의 데이터 소스를 대시보드 연결시 필수 필터 편집 화면에 필수 필터 내 항목을 가져오는데서 오류가 발생합니다.

**Related Issue** : #1056 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
(기존에 DB > Linked datasource 가 생성되었다고 가정합니다.)

1. 대시보드 생성시 링크 데이터 소스 연결 > 링크 데이터 소스 적재 작업 수행 완료
2. 연결된 데이터 소스를 클릭하면 하단에 데이터 소스 정보가 나타나는데 "필수 필터" 탭 선택
3. 탭 화면내 "수정" 버튼클릭
4. 정상적으로 목록을 가져와야 합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
