### PR TITLE
F#1072 do not loop dataprep meta-db migration

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepMetaDBMigrationService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepMetaDBMigrationService.java
@@ -72,6 +72,10 @@ public class PrepMetaDBMigrationService implements ApplicationListener<Applicati
   public void onApplicationEvent(ApplicationReadyEvent event) {
     Connection conn;
 
+    if (prepProperties.isMigrateMetaDB() == false) {
+      return;
+    }
+
     LOGGER.info("PrepMetaDBMigrationService: started");
 
     try {

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepProperties.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepProperties.java
@@ -62,6 +62,20 @@ public class PrepProperties {
   public SamplingInfo sampling;
   public EtlInfo etl;
 
+  // temporary for 2 sprints
+  public Boolean migrateMetaDB;
+
+  public boolean isMigrateMetaDB() {
+    if (migrateMetaDB == null) {
+      return false;
+    }
+    return migrateMetaDB;
+  }
+
+  public void setMigrateMetaDB(boolean migrateMetaDB) {
+    this.migrateMetaDB = migrateMetaDB;
+  }
+
   // Commonly, only below getters will be used
 
   public String getLocalBaseDir() {


### PR DESCRIPTION
### Description
Changed the dataprep meta-db migration to run only once so that JUnit tests run without being blocked.

_JUnit 테스트가 잘 돌 수 있도록, dataprep meta-db migration이 단 한 번만 돌도록 수정하였습니다._

**Related Issue** : https://github.com/metatron-app/metatron-discovery/issues/1072


### How Has This Been Tested?
Run locally.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
