### PR TITLE
Datepicker input change to readonly

### DIFF
--- a/discovery-frontend/src/app/common/component/period/period.component.html
+++ b/discovery-frontend/src/app/common/component/period/period.component.html
@@ -53,11 +53,11 @@
     <div class="ddp-ui-calen ddp-clear" style="width:320px;">
 
       <div class="ddp-box-calen">
-        <input #startPickerInput type="text" class="ddp-input-typebasic ddp-data-calen" placeholder="yyyy-MM-dd hh:mm"/>
+        <input #startPickerInput type="text" class="ddp-input-typebasic ddp-data-calen" placeholder="yyyy-MM-dd hh:mm" readonly/>
       </div>
       <span class="ddp-bar">~</span>
       <div class="ddp-box-calen">
-        <input #endPickerInput type="text" class="ddp-input-typebasic ddp-data-calen" placeholder="yyyy-MM-dd hh:mm"/>
+        <input #endPickerInput type="text" class="ddp-input-typebasic ddp-data-calen" placeholder="yyyy-MM-dd hh:mm" readonly/>
       </div>
     </div>
     <a href="javascript:" class="ddp-btn-line-s" (click)="done()">{{'msg.page.btn.apply' | translate}}</a>
@@ -68,10 +68,10 @@
 <div class="ddp-ui-calen" *ngIf="!isShowButtons">
 
   <div class="ddp-box-calen" [ngClass]="{'ddp-disabled' : disabled}">
-    <input #startPickerInput type="text" class="ddp-input-typebasic ddp-data-calen" placeholder="yyyy-MM-dd hh:mm"/>
+    <input #startPickerInput type="text" class="ddp-input-typebasic ddp-data-calen" placeholder="yyyy-MM-dd hh:mm" readonly/>
   </div>
   <span class="ddp-bar">~</span>
   <div class="ddp-box-calen" [ngClass]="{'ddp-disabled' : disabled}">
-    <input #endPickerInput type="text" class="ddp-input-typebasic ddp-data-calen" placeholder="yyyy-MM-dd hh:mm"/>
+    <input #endPickerInput type="text" class="ddp-input-typebasic ddp-data-calen" placeholder="yyyy-MM-dd hh:mm" readonly/>
   </div>
 </div>


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
datepicker의 input이 입력되어 지정된 포맷과 다르게 보이는 현상 수정
input이 입력되지 않도록 readonly로 변경

적용 화면 : 데이터소스, 데이터모니터링, 어드민관리

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
MT-24

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 데이터소스 > 데이터소스 상세화면 > 모니터링 > 하단의 쿼리 탭의 datepicker에 값이 입력이 안되는것 확인
2. 데이터 모니터링 > 로그 통계, 잡 로그 탭의 datepicker에 값이 입력이 안되는것 확인
3. 어드민 > 사용자관리 > 멤버쉽 승인, 멤버, 그룹 탭의 datepicker에 값이 입력이 안되는것 확인

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project. _it will be added soon_
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
