### PR TITLE
#1086-fix Use original column type of hive table when generating json file

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/json/PrepJsonUtil.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/json/PrepJsonUtil.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
+import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
@@ -214,6 +215,7 @@ public class PrepJsonUtil {
       ResultSetMetaData rsmd = rs.getMetaData();
       int columnCount = rsmd.getColumnCount();
       String[] columnNames = new String[columnCount+1];
+      int[] columnTypes = new int[columnCount+1];
       StringBuffer sb;
       for (int columnIdx = 1; columnIdx <= columnCount; columnIdx++) {
         String colName = rsmd.getColumnName(columnIdx);
@@ -221,8 +223,10 @@ public class PrepJsonUtil {
           colName = colName.substring(dbName.length() + 1);
         }
         colName = "\""+colName.replaceAll("\"","\\\"")+"\"";
-
         columnNames[columnIdx] = colName;
+
+        int colType = rsmd.getColumnType(columnIdx);
+        columnTypes[columnIdx] = colType;
       }
 
       while (rs.next()) {
@@ -235,7 +239,7 @@ public class PrepJsonUtil {
           }
           sb.append(columnNames[columnIdx]);
           sb.append(":");
-          sb.append(escapeForJSON(columnValue));
+          sb.append(escapeForJSON(columnValue, columnTypes[columnIdx]));
         }
         sb.append("}\n");
         outputStream.write(sb.toString().getBytes());
@@ -246,15 +250,12 @@ public class PrepJsonUtil {
     }
   }
 
-  private static String escapeForJSON(String value) {
+  private static String escapeForJSON(String value, int colType) {
+    if(colType == Types.DOUBLE || colType == Types.BIGINT || colType == Types.BOOLEAN) {
+      return value;
+    }
     if(value.contains("\"")) {
       value = value.replaceAll("\"","\\\\\"");
-    }
-    if(value.equalsIgnoreCase("null") || value.equalsIgnoreCase("true") || value.equalsIgnoreCase("false")) {
-      return value;
-    }
-    if(value.matches("-?\\d+(\\.\\d+)?")) {
-      return value;
     }
 
     return "\"" + value + "\"";


### PR DESCRIPTION
### Description
Generating JSON file from hive type snapshot has some issue.
Thus, Sometimes I can not create a new dataset with downloaded json file from hive type snapshot.
This commit will fix that problem.

**Related Issue** : <!--- Please link to the issue here. -->
https://github.com/metatron-app/metatron-discovery/issues/1119


### How Has This Been Tested?
1. Open any dataflow and dataset
2. Set some column's value as '01' or '02'
3. Create a Staging DB(Hive) type snapshot
4. Download it as a json file.
5. Create a dataset with the json file.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
