### PR TITLE
#1081 add '_' for duplicated column

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcConnectionService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcConnectionService.java
@@ -1649,9 +1649,9 @@ public class JdbcConnectionService {
                                .count();
     if (duplicated > 0) {
       if (StringUtils.contains(fieldName, ".")) {
-        return StringUtils.split(fieldName, ".")[0] + "." + VarGenerator.gen(fieldName);
+        return StringUtils.split(fieldName, ".")[0] + "." + VarGenerator.gen(fieldName + "_");
       } else {
-        return VarGenerator.gen(fieldName);
+        return VarGenerator.gen(fieldName + "_");
       }
     }
     return fieldName;


### PR DESCRIPTION
### Description
If there are duplicate column names in the result of the query, add a random number to avoid duplicate column names.
Add a separator(`_`) before the random number.
ex) a4501_ -> a`_`4501_

**Related Issue** :
 #1081 

### How Has This Been Tested?
1. goto mysql workbench
2. execute query with duplicated column
ex) select 'a' as id, 'b' as id;
3. see changed column name;

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
