### PR TITLE
#1122 remove semicolon when query ends with semicolon

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcConnectionService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcConnectionService.java
@@ -890,7 +890,12 @@ public class JdbcConnectionService {
     // int totalRows = countOfSelectQuery(connection, ingestion);
     JdbcQueryResultResponse queryResultSet = null;
 
-    LOGGER.debug("selectQuery : {} ", query);
+    String queryString = query;
+    while(StringUtils.endsWith(queryString.trim(), ";")){
+      queryString = StringUtils.substring(queryString, 0, StringUtils.lastIndexOf(queryString, ";"));
+    }
+
+    LOGGER.debug("selectQuery : {} ", queryString);
 
     Connection conn = null;
     Statement stmt = null;
@@ -902,7 +907,7 @@ public class JdbcConnectionService {
       if (limit > 0)
         stmt.setMaxRows(limit);
 
-      rs = stmt.executeQuery(query);
+      rs = stmt.executeQuery(queryString);
 
       queryResultSet = getJdbcQueryResult(rs, extractColumnName);
       // queryResultSet.setTotalRows(totalRows);


### PR DESCRIPTION
### Description
When creating a data source with Hive as the source, an error occurs when the query ends with ";".
so remove semicolon when query ends with semicolon

**Related Issue** : 
#1122 

### How Has This Been Tested?
1. Create DataSource with Hive or Create DataSet with Hive
2. select query tab
3. input simple query ends with ';'
ex) select * from default sales limit 10;
4. query executed without error.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
