### PR TITLE
#175 Combine chart => fix secondary axis range error

### DIFF
--- a/discovery-frontend/src/app/common/component/chart/option/converter/axis-option-converter.ts
+++ b/discovery-frontend/src/app/common/component/chart/option/converter/axis-option-converter.ts
@@ -41,7 +41,8 @@ export class AxisOptionConverter {
 
   public static axisMinMax: Object = {
     xAxis: {min: 0, max: 0},
-    yAxis: {min: 0, max: 0}
+    yAxis: {min: 0, max: 0},
+    subAxis: {min: 0, max: 0}
   };
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/discovery-frontend/src/app/common/component/chart/option/define/common.ts
+++ b/discovery-frontend/src/app/common/component/chart/option/define/common.ts
@@ -100,7 +100,8 @@ export enum AxisType {
   VALUE = <any>'value',
   LOG = <any>'log',
   X = <any>'xAxis',
-  Y = <any>'yAxis'
+  Y = <any>'yAxis',
+  SUB = <any>'subAxis'
 }
 
 /**

--- a/discovery-frontend/src/app/common/component/chart/type/combine-chart/combine-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/combine-chart/combine-chart.component.ts
@@ -231,55 +231,88 @@ export class CombineChartComponent extends BaseChart implements OnInit, OnDestro
       if ((<UIChartAxisLabelValue>axisOption[index].label) && _.eq((<UIChartAxisLabelValue>axisOption[index].label).type, AxisType.VALUE)
         && axisOption[index].grid) {
 
-        // Min / Max값을 다시 구한다.
-        let min = null;
-        let max = null;
-        let calculateMin = null;
-        this.data.columns.map((column, index) => {
-          if( index % 2 == 0 ) {
-            column.value.map((value) => {
-              if (min == null || value < min) {
-                min = value;
-              }
-              if (max == null || value > max) {
-                max = value;
-              }
-            });
+        // Sub Axis
+        if( index % 2 != 0 ) {
+
+          // Min / Max값을 다시 구한다.
+          let min = null;
+          let max = null;
+          let calculateMin = null;
+          this.data.columns.map((column, index) => {
+            if( index % 2 != 0 ) {
+              column.value.map((value) => {
+                if (min == null || value < min) {
+                  min = value;
+                }
+                if (max == null || value > max) {
+                  max = value;
+                }
+              });
+            }
+          });
+
+          calculateMin = Math.ceil(min - ((max - min) * 0.05));
+          max = max;
+
+          // Min / Max 업데이트
+          AxisOptionConverter.axisMinMax[AxisType.SUB].min = min;
+          AxisOptionConverter.axisMinMax[AxisType.SUB].max = max;
+
+          // 오토스케일 적용시
+          if( axisOption[index].grid.autoScaled ) {
+            delete option.min;
+            delete option.max;
+            option.scale = true;
           }
-        });
-
-        calculateMin = Math.ceil(min - ((max - min) * 0.05));
-        // min = min > 0
-        //   ? calculateMin >= 0 ? calculateMin : min
-        //   : min;
-        max = max;
-
-        // Min / Max 업데이트
-        AxisOptionConverter.axisMinMax[AxisType.Y].min = min;
-        AxisOptionConverter.axisMinMax[AxisType.Y].max = max;
-
-        // 기준선 변경시
-        let baseline = 0;
-        if( axisOption[index].baseline && axisOption[index].baseline != 0 ) {
-          baseline = <number>axisOption[index].baseline;
+          else {
+            delete option.scale;
+          }
         }
-
-        // 축 범위 자동설정이 설정되지 않았고
-        // 오토스케일 적용시
-        if( baseline == 0 && axisOption[index].grid.autoScaled ) {
-          // // 적용
-          // option.min = min > 0
-          //   ? Math.ceil(min - ((max - min) * 0.05))
-          //   : min;
-          // option.max = max;
-
-          delete option.min;
-          delete option.max;
-          option.scale = true;
-        }
+        // Main Axis
         else {
-          delete option.scale;
+
+          // Min / Max값을 다시 구한다.
+          let min = null;
+          let max = null;
+          let calculateMin = null;
+          this.data.columns.map((column, index) => {
+            if( index % 2 == 0 ) {
+              column.value.map((value) => {
+                if (min == null || value < min) {
+                  min = value;
+                }
+                if (max == null || value > max) {
+                  max = value;
+                }
+              });
+            }
+          });
+
+          calculateMin = Math.ceil(min - ((max - min) * 0.05));
+          max = max;
+
+          // Min / Max 업데이트
+          AxisOptionConverter.axisMinMax[AxisType.Y].min = min;
+          AxisOptionConverter.axisMinMax[AxisType.Y].max = max;
+
+          // 기준선 변경시
+          let baseline = 0;
+          if( axisOption[index].baseline && axisOption[index].baseline != 0 ) {
+            baseline = <number>axisOption[index].baseline;
+          }
+
+          // 축 범위 자동설정이 설정되지 않았고
+          // 오토스케일 적용시
+          if( baseline == 0 && axisOption[index].grid.autoScaled ) {
+            delete option.min;
+            delete option.max;
+            option.scale = true;
+          }
+          else {
+            delete option.scale;
+          }
         }
+
       }
     });
 

--- a/discovery-frontend/src/app/page/chart-style/axis-value-option.component.html
+++ b/discovery-frontend/src/app/page/chart-style/axis-value-option.component.html
@@ -65,7 +65,7 @@
         </div>
         <div class="ddp-col-7">
           <input [(ngModel)]="axisTemp.grid.max" (keyup.enter)="changeMax()" type="text" class="ddp-input-typebasic"
-                 [attr.placeholder]="getDecimalRoundNumber(AxisOptionConverter.axisMinMax[(axis.mode == 'row' ? 'xAxis' : 'yAxis')].max)"
+                 [attr.placeholder]="getDecimalRoundNumber(AxisOptionConverter.axisMinMax[(axis.mode == 'sub_column' ? 'subAxis' : axis.mode == 'row' ? 'xAxis' : 'yAxis')].max)"
                  [disabled]="axis?.grid?.autoScaled">
         </div>
       </div>
@@ -76,7 +76,7 @@
         <div class="ddp-col-7">
           <!-- error 일때 ddp-error 추가 -->
           <input [(ngModel)]="axisTemp.grid.min" (keyup.enter)="changeMin()" type="text" class="ddp-input-typebasic"
-                 [attr.placeholder]="getDecimalRoundNumber(AxisOptionConverter.axisMinMax[(axis.mode == 'row' ? 'xAxis' : 'yAxis')].min)"
+                 [attr.placeholder]="getDecimalRoundNumber(AxisOptionConverter.axisMinMax[(axis.mode == 'sub_column' ? 'subAxis' : axis.mode == 'row' ? 'xAxis' : 'yAxis')].min)"
                  [disabled]="axis?.grid?.autoScaled">
         </div>
       </div>


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
컴바인차트 보조축 Set Axis Range의 min/max 예시값이 보조축 데이터와 다른 부분을 수정합니다.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#175 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 컴바인 차트를 그린 후 보조축 옵션의 Set axis range를 on으로 설정합니다.
2. Max / Min value의 placeholder값이 보조축 데이터와 맞는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
