### PR TITLE
F#1118 bugfix dataprep undo

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepMetaDBMigrationService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepMetaDBMigrationService.java
@@ -422,10 +422,11 @@ public class PrepMetaDBMigrationService implements ApplicationListener<Applicati
     copySameCol("modified_by",            colVals, rs);
     copySameCol("modified_time",          colVals, rs);
     copySameCol("version",                colVals, rs);
+    colVals.put("delimiter",              ",");                       // add new column
     copySameCol("ds_desc",                colVals, rs);
     copySameCol("ds_name",                colVals, rs);
     copySameCol("ds_type",                colVals, rs);
-    colVals.put("file_format",            "CSV");                     // add new column
+    colVals.put("file_format",            "EXCEL");                   // add new column
     colVals.put("filename_before_upload", rs.getObject("filename"));  // change column name
     colVals.put("import_type",            "UPLOAD");                  // change enum
     colVals.put("sheet_name",             sheetName);                 // add new column

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
@@ -1362,7 +1362,7 @@ public class PrepTransformService {
 
     //wrangledDataset.setDsName(importedDataset.getDsName() + " [W]");
     String dsName = importedDataset.getDsName();
-    String newDsName = dsName.replaceFirst(" \\((EXCEL|CSV|STAGING|MYSQL|ORACLE|TIBERO|HIVE|POSTGRESQL|MSSQL|PRESTO)\\)$","");
+    String newDsName = dsName.replaceFirst(" \\((EXCEL|CSV|JSON|STAGING|MYSQL|ORACLE|TIBERO|HIVE|POSTGRESQL|MSSQL|PRESTO)\\)$","");
     wrangledDataset.setDsName(newDsName);
     wrangledDataset.setDsType(WRANGLED);
     wrangledDataset.setCreatorDfId(dfId);

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
@@ -797,7 +797,7 @@ public class PrepTransformService {
     assert dataset != null : dsId;
 
     // dataset이 loading되지 않았으면 loading
-    load_internal(dsId, true);    // do compaction if necessary
+    load_internal(dsId);      // TODO: do compaction (only when UI requested explicitly)
 
     PrepTransformResponse response = null;
     int origStageIdx = teddyImpl.getCurStageIdx(dsId);


### PR DESCRIPTION
### Description
불필요한 룰 적용(룰 삭제, 삽입 등이 반복되었을 경우)을 by-pass하기 위해 룰 compaction 기능이 있는데, 이것이 잘못 적용이 되어서 문제를 일으켰었습니다. 차후 W.DS에 대해 exclusive lock을 구현할 때까진 compaction을 하지 않기로 했습니다.

**Related Issue** : https://github.com/metatron-app/metatron-discovery/issues/1118


### How Has This Been Tested?
Run locally.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
