### PR TITLE
#1047 Map chart => Remove legend size change from Chart modify view

### DIFF
--- a/discovery-frontend/src/app/common/component/chart/type/map-chart/map-chart.component.html
+++ b/discovery-frontend/src/app/common/component/chart/type/map-chart/map-chart.component.html
@@ -23,12 +23,12 @@
          (click)="changeFoldLegend()">
       <!-- size 축소 -->
       <div class="ddp-remark-size-s">
-        <a href="javascript:" class="ddp-btn-size-s"></a>
+        <a *ngIf="!isPage" href="javascript:" class="ddp-btn-size-s"></a>
       </div>
       <!-- //size 축소 -->
       <!-- size 확대 -->
       <div class="ddp-remark-size-b">
-        <a href="javascript:" class="ddp-btn-size"></a>
+        <a *ngIf="!isPage" href="javascript:" class="ddp-btn-size"></a>
         <!-- layer -->
         <div *ngFor="let layer of legendInfo.layer; let index = index" class="ddp-ui-layer">
           <span class="ddp-label">{{layer.name}}</span>


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
맵차트 편집화면에서 범례 축소 기능을 제거합니다.

**Related Issue** : #1047 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
맵차트 편집화면에서 차트를 그렸을때 범례 축소 아이콘이 등장하지 않는것을 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
