### PR TITLE
#1056 Fixed error message display failure when data ingestion failed

### DIFF
--- a/discovery-frontend/src/app/dashboard/filters/essential-filter/essential-filter.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/essential-filter/essential-filter.component.ts
@@ -478,8 +478,10 @@ export class EssentialFilterComponent extends AbstractFilterPopupComponent imple
         tempDsInfo.progressTopic, (data: { progress: number, message: string }) => {
           if (-1 === data.progress) {
             this.ingestionStatus = data;
+            this.ingestionStatus.step = -1;
             Alert.error(data.message);
             this.safelyDetectChanges();
+            CommonConstant.stomp.unsubscribe(subscription);     // Socket 응답 해제
           } else if (100 === data.progress) {
             this.ingestionStatus = data;
             this.safelyDetectChanges();
@@ -532,7 +534,7 @@ export class EssentialFilterComponent extends AbstractFilterPopupComponent imple
     this.fields = [];
     this.fields = this.fields
       .concat(fieldList.filter(item => item.role !== FieldRole.MEASURE))
-      .concat(fieldList.filter(item => item.role === FieldRole.MEASURE))
+      .concat(fieldList.filter(item => item.role === FieldRole.MEASURE));
   } // function - _setFields
 
   /**


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
연결형 데이터소스로 대시보드 생성 시 적재 과정에서 실패할 경우 오류 메시지 없이 dimmed 상태가 남아 있는 현상이 있습니다.

**Related Issue** : #1056 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. linked로 데이터소스 생성 후 필수필터 지정
2. 대시보드에서 해당 소스 불러와 필수필터 설정
3. Done버튼 클릭시 ingestion되다가 에러 발생
4. 에러 발생하면 재적재 시도 메시지가 나타나는지 확인합니다. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
