### PR TITLE
Fix expiration time in datasource detail information

### DIFF
--- a/discovery-frontend/src/app/data-storage/data-source-list/component/ingestion-setting.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/component/ingestion-setting.component.ts
@@ -109,7 +109,7 @@ export class IngestionSettingComponent extends AbstractComponent {
   public isShowQueryGranularityList: boolean = false;
 
   // expiration list (only linked source type)
-  public expirationTimeList: any[];
+  public expirationTimeList: any[] = [];
   // selected expiration (only linked source type)
   public selectedExpirationTime: any;
   // expiration list show flag (only linked source type)
@@ -632,7 +632,7 @@ export class IngestionSettingComponent extends AbstractComponent {
     ];
     this.selectedPartitionType = this.partitionTypeList[0];
     // init expiration time list
-    this.expirationTimeList = this._getExpirationTimeList();
+    this._setExpirationTimeList(this.expirationTimeList);
     this.selectedExpirationTime = this.expirationTimeList[0];
     // init ingestion type list
     this.ingestionTypeList = [
@@ -869,23 +869,21 @@ export class IngestionSettingComponent extends AbstractComponent {
   }
 
   /**
-   * Get expiration time list
-   * @returns {Array}
+   * Set expiration time list
+   * @param {Array} expirationTimeList
    * @private
    */
-  private _getExpirationTimeList() {
-    const result = [];
+  private _setExpirationTimeList(expirationTimeList: any[]): void {
     const TIME = 1800;
     for (let i = 1; i < 49; i++) {
       if (i === 1) {
-        result.push({label: this.translateService.instant('msg.storage.li.dsource.expire-minutes',{minute:30}), value: TIME});
+        expirationTimeList.push({label: this.translateService.instant('msg.storage.li.dsource.expire-minutes',{minute:30}), value: TIME});
       } else{
-        result.push (i % 2 === 0
+        expirationTimeList.push (i % 2 === 0
           ? {label: this.translateService.instant('msg.storage.li.dsource.expire-hour',{hour: i / 2}), value: TIME * i}
           : {label: this.translateService.instant('msg.storage.li.dsource.expire-hour-minutes',{hour: Math.floor(i / 2), minute:30}), value: TIME * i});
       }
     }
-    return result;
   }
 
   /**

--- a/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/information-dats-source/information-data-source.component.html
+++ b/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/information-dats-source/information-data-source.component.html
@@ -476,7 +476,7 @@
               <!-- Link 형 -->
               <ul class="ddp-list-sub" *ngIf="getConnType.toString() === 'LINK'">
                 <li>
-                  {{'msg.storage.th.time-interval' | translate}} : {{getIngestionExpired}}
+                  {{'msg.storage.th.time-interval' | translate}} : {{getIngestionExpired()}}
                 </li>
               </ul>
               <!-- //Link 형 -->

--- a/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/information-dats-source/information-data-source.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/information-dats-source/information-data-source.component.ts
@@ -97,6 +97,8 @@ export class InformationDataSourceComponent extends AbstractPopupComponent imple
 
   // ingestionProgress
   private _ingestionProgress: any;
+  // expiration time list
+  private _expirationTimeList: any[] = [];
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
   | Protected Variables
@@ -406,11 +408,11 @@ export class InformationDataSourceComponent extends AbstractPopupComponent imple
   }
 
   /**
-   * ingestion expired
-   * @returns {number}
+   * Get ingestion expired
+   * @returns {string}
    */
-  public get getIngestionExpired(): number {
-    return this.getIngestion.expired;
+  public getIngestionExpired(): string {
+    return this._expirationTimeList.find(obj => obj.value === this.getIngestion.expired).label;
   }
 
   /**
@@ -729,6 +731,24 @@ export class InformationDataSourceComponent extends AbstractPopupComponent imple
   }
 
   /**
+   * Set expiration time list
+   * @param {Array} expirationTimeList
+   * @private
+   */
+  private _setExpirationTimeList(expirationTimeList: any[]): void {
+    const TIME = 1800;
+    for (let i = 1; i < 49; i++) {
+      if (i === 1) {
+        expirationTimeList.push({label: this.translateService.instant('msg.storage.li.dsource.expire-minutes',{minute:30}), value: TIME});
+      } else{
+        expirationTimeList.push (i % 2 === 0
+          ? {label: this.translateService.instant('msg.storage.li.dsource.expire-hour',{hour: i / 2}), value: TIME * i}
+          : {label: this.translateService.instant('msg.storage.li.dsource.expire-hour-minutes',{hour: Math.floor(i / 2), minute:30}), value: TIME * i});
+      }
+    }
+  }
+
+  /**
    * ui init
    */
   private initView() {
@@ -758,6 +778,8 @@ export class InformationDataSourceComponent extends AbstractPopupComponent imple
       { label: this.translateService.instant('msg.storage.li.dsource.date-sat'), value: 'SAT', checked: true },
       { label: this.translateService.instant('msg.storage.li.dsource.date-sun'), value: 'SUN', checked: true }
     ];
+    // init expiration time list
+    this._setExpirationTimeList(this._expirationTimeList);
 
     // bar option
     this.barOption = {

--- a/discovery-frontend/src/assets/css/polaris.v2.page.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.page.css
@@ -751,7 +751,7 @@ ul.ddp-list-board-thumbview li.ddp-selected a span.ddp-data-name {color:#4b515b;
 .ddp-wrap-widget.ddp-box-full {position:fixed; left:290px; top:165px; bottom:0; right:0; height:auto; background-color:#fff; z-index:130}
 .ddp-wrap-widget.ddp-box-full .ddp-loading-part {z-index:130;}
 
-.ddp-box-widget {position:relative; background-color:#fff; cursor:pointer; border:1px solid #fff; box-sizing:border-box;}
+.ddp-box-widget {position:relative; background-color:#fff; border:1px solid #fff; box-sizing:border-box;}
 .ddp-box-widget .ddp-ui-graph-name {position:relative; padding:4px 5px 4px 10px; color:#4b515b; font-size:14px; box-sizing:border-box;z-index:30;}
 .ddp-box-widget .ddp-ui-graph-name .ddp-data-name {display:block; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
 .ddp-box-widget .ddp-ui-graph-name .ddp-ui-tooltip-info {display:none; position:absolute; top:35px; left:10px;}


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
연결형 데이터소스 상세화면에서 expiration 이 생성시처럼 시간과 분 표시가 나타나지 않아 사용자가 어떤 값인지 인지하기 어려운 현상을 수정함
![2018-12-20 1 17 31](https://user-images.githubusercontent.com/42233627/50263672-4e601c00-045a-11e9-9775-cdd1ff7ad556.png)


**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
3.1.1 release test

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 데이터소스 생성 > DB 생성 > 연결형으로 데이터소스 생성
2. 데이터소스 상세화면 > information tab > 1에서 생성할때 선택한 expiration time이 생성할때와 마찬가지로 읽기 쉬운 형태로 표기되는지 확인

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project. _it will be added soon_
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
