### PR TITLE
#1019 Fix delete error in context menu when column name has white space

### DIFF
--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/rule-context-menu.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/rule-context-menu.component.ts
@@ -292,12 +292,12 @@ export class RuleContextMenuComponent extends AbstractComponent implements OnIni
             } else if (this.contextInfo.columnType === 'DOUBLE' || this.contextInfo.columnType === 'LONG') {
               this.histogramData.forEach((item,index) => {
                 let idx = this.labelsForNumbers.indexOf(item);
-                result += this.histogramData.length-1 !== index ? `${selCol} >= ${item} && ${this.contextInfo.columnName} < ${this.labelsForNumbers[idx+1]} || ` : `${selCol} >= ${item} && ${selCol} < ${this.labelsForNumbers[idx+1]}`;
+                result += this.histogramData.length-1 !== index ? `${selCol} >= ${item} && ${selCol} < ${this.labelsForNumbers[idx+1]} || ` : `${selCol} >= ${item} && ${selCol} < ${this.labelsForNumbers[idx+1]}`;
               })
             } else if (this.contextInfo.columnType === 'TIMESTAMP') {
               this.histogramData.forEach((item,index) => {
                 let idx = this.labelsForNumbers.indexOf(item);
-                result += this.histogramData.length-1 !== index ? `time_between(${this.contextInfo.columnName},'${this.contextInfo.timestampStyle[idx]}','${this.contextInfo.timestampStyle[idx+1]}') || ` : `time_between(${this.contextInfo.columnName},'${this.contextInfo.timestampStyle[idx]}','${this.contextInfo.timestampStyle[idx+1]}')`;
+                result += this.histogramData.length-1 !== index ? `time_between(${selCol},'${this.contextInfo.timestampStyle[idx]}','${this.contextInfo.timestampStyle[idx+1]}') || ` : `time_between(${selCol},'${this.contextInfo.timestampStyle[idx]}','${this.contextInfo.timestampStyle[idx+1]}')`;
               });
             } else {
               this.histogramData.forEach((item,index) => {


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Error applying delete/ keep with context menu when column type is timestamp and column name has a whitespace

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#1019 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Dataflow main grid -> change timestamp type column name to `Rename Column` -> try delete/keep with context menu by clicking histogram 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
