### PR TITLE
#1168 remove value validation in dataconnection custom prop.

### DIFF
--- a/discovery-frontend/src/app/data-storage/data-connection/handler-data-connection/create-data-connection/create-connection.component.html
+++ b/discovery-frontend/src/app/data-storage/data-connection/handler-data-connection/create-data-connection/create-connection.component.html
@@ -518,7 +518,7 @@
                       </div>
                       <div class="ddp-col-7">
                         <input type="text" class="ddp-input-typebasic ddp-full" placeholder="{{'msg.storage.ph.custom.property.value' | translate}}"
-                               [(ngModel)]="property.value" (ngModelChange)="property.valueError = false" (focusout)="propertyValueValidation(property)">
+                               [(ngModel)]="property.value" (ngModelChange)="property.valueError = false">
                         <span class="ddp-data-error" *ngIf="property.valueError"> {{property.valueValidMessage}}</span>
                       </div>
                       <a href="javascript:" class="ddp-icon-del" (click)="onClickRemoveProperty(i)"></a>

--- a/discovery-frontend/src/app/data-storage/data-connection/handler-data-connection/create-data-connection/create-connection.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-connection/handler-data-connection/create-data-connection/create-connection.component.ts
@@ -368,14 +368,15 @@ export class CreateConnectionComponent extends AbstractPopupComponent implements
       property.valueError = true;
       return;
     }
+    // #1168 - removed valid
     // check special characters, and korean (enable .dot)
-    if (property.value.trim().match(/[ㄱ-ㅎ|ㅏ-ㅣ|가-힣|\{\}\[\]\/?,;:|\)*~`!^\-_+<>@\#$%&\\\=\(\'\"]/gi)) {
-      // set duplicate message
-      property.valueValidMessage = this.translateService.instant('msg.storage.ui.custom.property.special.char.disable');
-      // set error flag
-      property.valueError = true;
-      return;
-    }
+    // if (property.value.trim().match(/[ㄱ-ㅎ|ㅏ-ㅣ|가-힣|\{\}\[\]\/?,;:|\)*~`!^\-_+<>@\#$%&\\\=\(\'\"]/gi)) {
+    //   // set duplicate message
+    //   property.valueValidMessage = this.translateService.instant('msg.storage.ui.custom.property.special.char.disable');
+    //   // set error flag
+    //   property.valueError = true;
+    //   return;
+    // }
   }
 
   /**

--- a/discovery-frontend/src/app/data-storage/data-connection/handler-data-connection/create-data-connection/create-connection.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-connection/handler-data-connection/create-data-connection/create-connection.component.ts
@@ -490,7 +490,7 @@ export class CreateConnectionComponent extends AbstractPopupComponent implements
         // check key empty
         this.propertyKeyValidation(property);
         // check value empty
-        this.propertyValueValidation(property);
+        // this.propertyValueValidation(property);
       });
       // if exist connection properties
       return !_.some(this.properties, property => property.keyError || property.valueError);

--- a/discovery-frontend/src/app/data-storage/data-connection/handler-data-connection/update-data-connection/update-connection.component.html
+++ b/discovery-frontend/src/app/data-storage/data-connection/handler-data-connection/update-data-connection/update-connection.component.html
@@ -554,7 +554,7 @@
                       </div>
                       <div class="ddp-col-7">
                         <input type="text" class="ddp-input-typebasic ddp-full" placeholder="{{'msg.storage.ph.custom.property.value' | translate}}"
-                               [(ngModel)]="property.value" (ngModelChange)="property.valueError = false" (focusout)="propertyValueValidation(property)">
+                               [(ngModel)]="property.value" (ngModelChange)="property.valueError = false">
                         <span class="ddp-data-error" *ngIf="property.valueError"> {{property.valueValidMessage}}</span>
                       </div>
                       <a href="javascript:" class="ddp-icon-del" (click)="onClickRemoveProperty(i)"></a>

--- a/discovery-frontend/src/app/data-storage/data-connection/handler-data-connection/update-data-connection/update-connection.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-connection/handler-data-connection/update-data-connection/update-connection.component.ts
@@ -599,7 +599,7 @@ export class UpdateConnectionComponent extends AbstractPopupComponent implements
         // check key empty
         this.propertyKeyValidation(property);
         // check value empty
-        this.propertyValueValidation(property);
+        // this.propertyValueValidation(property);
       });
       // if exist connection properties
       return !_.some(this.properties, property => property.keyError || property.valueError);

--- a/discovery-frontend/src/app/data-storage/data-connection/handler-data-connection/update-data-connection/update-connection.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-connection/handler-data-connection/update-data-connection/update-connection.component.ts
@@ -415,14 +415,15 @@ export class UpdateConnectionComponent extends AbstractPopupComponent implements
       property.valueError = true;
       return;
     }
+    // #1168 - removed valid
     // check special characters, and korean (enable .dot)
-    if (property.value.trim().match(/[ㄱ-ㅎ|ㅏ-ㅣ|가-힣|\{\}\[\]\/?,;:|\)*~`!^\-_+<>@\#$%&\\\=\(\'\"]/gi)) {
-      // set duplicate message
-      property.valueValidMessage = this.translateService.instant('msg.storage.ui.custom.property.special.char.disable');
-      // set error flag
-      property.valueError = true;
-      return;
-    }
+    // if (property.value.trim().match(/[ㄱ-ㅎ|ㅏ-ㅣ|가-힣|\{\}\[\]\/?,;:|\)*~`!^\-_+<>@\#$%&\\\=\(\'\"]/gi)) {
+    //   // set duplicate message
+    //   property.valueValidMessage = this.translateService.instant('msg.storage.ui.custom.property.special.char.disable');
+    //   // set error flag
+    //   property.valueError = true;
+    //   return;
+    // }
   }
 
   /**

--- a/discovery-frontend/src/app/data-storage/data-source-list/component/advanced-setting.component.html
+++ b/discovery-frontend/src/app/data-storage/data-source-list/component/advanced-setting.component.html
@@ -50,7 +50,7 @@
           <!-- value -->
           <div class="ddp-col-7">
             <input type="text" class="ddp-input-typebasic ddp-full" placeholder="{{option.ph || ('msg.storage.ph.config.value' | translate)}}"
-                   [(ngModel)]="option.value" (ngModelChange)="option.valueError = false" (focusout)="configValueValidation(option)">
+                   [(ngModel)]="option.value" (ngModelChange)="option.valueError = false">
             <span class="ddp-data-error" *ngIf="option.valueError"> {{option.valueValidMessage}}</span>
           </div>
           <!-- value -->
@@ -99,7 +99,7 @@
           <!-- value -->
           <div class="ddp-col-7">
             <input type="text" class="ddp-input-typebasic ddp-full" placeholder="{{option.ph || ('msg.storage.ph.config.value' | translate)}}"
-                   [(ngModel)]="option.value" (ngModelChange)="option.valueError = false" (focusout)="configValueValidation(option)">
+                   [(ngModel)]="option.value" (ngModelChange)="option.valueError = false">
             <span class="ddp-data-error" *ngIf="option.valueError"> {{option.valueValidMessage}}</span>
           </div>
           <!-- value -->

--- a/discovery-frontend/src/app/data-storage/data-source-list/component/advanced-setting.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/component/advanced-setting.component.ts
@@ -127,6 +127,7 @@ export class AdvancedSettingComponent extends AbstractComponent {
 
   /**
    * Property value validation
+   * #1168 remove validation
    * @param property
    */
   public configValueValidation(option: any): void {


### PR DESCRIPTION
### Description
remove value validation in dataconnection custom prop.

**Related Issue** : #1168 


### How Has This Been Tested?
1. create data connection

2. input special character in custom properties
(Advanced Settings > Custom Properties)

3. save data connection without invalid error.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
