### PR TITLE
Apply static resource caching

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/config/ApiResourceConfig.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/config/ApiResourceConfig.java
@@ -64,6 +64,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.hibernate5.Hibernate5Module;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
+import java.util.concurrent.TimeUnit;
 import org.springframework.beans.factory.annotation.Autowire;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -77,6 +78,7 @@ import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
 import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurer;
 import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurerAdapter;
 import org.springframework.data.rest.webmvc.config.RepositoryRestMvcConfiguration;
+import org.springframework.http.CacheControl;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.ByteArrayHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
@@ -112,6 +114,16 @@ import static com.fasterxml.jackson.core.JsonParser.Feature.ALLOW_SINGLE_QUOTES;
 @Import(RepositoryRestMvcConfiguration.class)
 @EnableWebMvc
 public class ApiResourceConfig extends WebMvcConfigurerAdapter {
+
+    private static final String RESOURCE_PATH = "/resource/";
+    private static final String CHUNK_JS = RESOURCE_PATH + "*.*.chunk.js";
+    private static final String BUNDLE_JS = RESOURCE_PATH + "*.*.bundle.js";
+    private static final String BUNDLE_CSS = RESOURCE_PATH + "*.*.bundle.css";
+    private static final String PNG = RESOURCE_PATH + "*.*.png";
+    private static final String JPG = RESOURCE_PATH + "*.*.jpg";
+    private static final String WOFF = RESOURCE_PATH + "*.*.woff";
+    private static final String EOF = RESOURCE_PATH + "*.*.eot";
+    private static final String TTF = RESOURCE_PATH + "*.*.ttf";
 
     public final static String APP_UI_ROUTE_PREFIX = "/app/v2/";
     public final static String API_PREFIX = "/api";
@@ -152,9 +164,15 @@ public class ApiResourceConfig extends WebMvcConfigurerAdapter {
 
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
-        registry.addResourceHandler("/resource/**").addResourceLocations("classpath:resource/");
-        registry.addResourceHandler("/assets/**").addResourceLocations("classpath:resource/assets/");
-        registry.addResourceHandler("/webjars/**").addResourceLocations("classpath:/META-INF/resources/webjars/");
+        registry.addResourceHandler("/resource/**")
+            .addResourceLocations("classpath:resource/");
+        registry.addResourceHandler(CHUNK_JS, BUNDLE_JS, BUNDLE_CSS, PNG, JPG, WOFF, EOF, TTF)
+            .addResourceLocations("classpath:resource/")
+            .setCacheControl(CacheControl.maxAge(7, TimeUnit.DAYS).cachePublic());
+        registry.addResourceHandler("/assets/**")
+            .addResourceLocations("classpath:resource/assets/");
+        registry.addResourceHandler("/webjars/**")
+            .addResourceLocations("classpath:/META-INF/resources/webjars/");
     }
 
     @Override

--- a/discovery-server/src/main/java/app/metatron/discovery/config/ApiResourceConfig.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/config/ApiResourceConfig.java
@@ -184,7 +184,7 @@ public class ApiResourceConfig extends WebMvcConfigurerAdapter {
                     .addResourceLocations("classpath:resource/")
                     .setCacheControl(CacheControl.maxAge(value, TimeUnit.SECONDS).cachePublic());
             } catch (Exception e) {
-                LOGGER.debug("Please check the value of \"polaris.resources.cache.cachecontrol.max-age\" in application.yaml. Resource caching is not enabled.");
+                LOGGER.debug("Please check the value of \"polaris.resources.cache.cacheControl.max-age\" in application.yaml. Resource caching is not enabled.");
             }
         });
 

--- a/discovery-server/src/main/java/app/metatron/discovery/config/ApiResourceConfig.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/config/ApiResourceConfig.java
@@ -70,12 +70,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowire;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.core.env.Environment;
 import org.springframework.core.type.filter.AnnotationTypeFilter;
 import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
 import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
@@ -140,8 +140,8 @@ public class ApiResourceConfig extends WebMvcConfigurerAdapter {
     @Autowired
     MetatronProperties metatronProperties;
 
-    @Autowired
-    private Environment environment;
+    @Value("${polaris.resources.cache.cacheControl.max-age: 604800}")
+    private Integer cacheControlMaxAge;
 
     /**
      * Maps all AngularJS routes to index so that they work with direct linking.
@@ -178,12 +178,11 @@ public class ApiResourceConfig extends WebMvcConfigurerAdapter {
         registry.addResourceHandler("/resource/**")
             .addResourceLocations("classpath:resource/");
 
-        Optional<String> resourceCacheControlMaxAge = ofNullable(environment.getProperty("polaris.resources.cache.cacheControl.max-age"));
-        resourceCacheControlMaxAge.ifPresent(cacheControlMaxAge -> {
+        ofNullable(cacheControlMaxAge).ifPresent(value -> {
             try {
                 registry.addResourceHandler(CHUNK_JS, BUNDLE_JS, BUNDLE_CSS, PNG, JPG, WOFF, EOF, TTF)
                     .addResourceLocations("classpath:resource/")
-                    .setCacheControl(CacheControl.maxAge(Long.valueOf(cacheControlMaxAge), TimeUnit.SECONDS).cachePublic());
+                    .setCacheControl(CacheControl.maxAge(value, TimeUnit.SECONDS).cachePublic());
             } catch (Exception e) {
                 LOGGER.debug("Please check the value of \"polaris.resources.cache.cachecontrol.max-age\" in application.yaml. Resource caching is not enabled.");
             }

--- a/discovery-server/src/main/resources/application.yaml
+++ b/discovery-server/src/main/resources/application.yaml
@@ -181,7 +181,7 @@ polaris:
     configFile: default-configs/default-jgroups-tcp.xml
   # Static resource caching is set to the default value of 7 days (seconds).
   # Setting default value in "metatron-discovery/discovery-server/src/main/java/app/metatron/discovery/config/ApiResourceConfig.java" configuration.
-  # If you want to apply longer caching, You can use the "resources.cache.cacheControl.max-age" attribute value to set the caching time for the static resource.
+  # If you want to apply longer caching, You can use the "resources.cache.cacheControl.max-age" property value to set the caching time for the static resource.
   # resources.cache.cacheControl.max-age: 604888
 #  cors:
 #    -

--- a/discovery-server/src/main/resources/application.yaml
+++ b/discovery-server/src/main/resources/application.yaml
@@ -179,7 +179,10 @@ polaris:
         uri: /druid/coordinator/v1/datasources/{datasourceId}/purge
   cache:
     configFile: default-configs/default-jgroups-tcp.xml
-
+  # Static resource caching is set to the default value of 7 days (seconds).
+  # Setting default value in "metatron-discovery/discovery-server/src/main/java/app/metatron/discovery/config/ApiResourceConfig.java" configuration.
+  # If you want to apply longer caching, You can use the "resources.cache.cacheControl.max-age" attribute value to set the caching time for the static resource.
+  # resources.cache.cacheControl.max-age: 604888
 #  cors:
 #    -
 #      mapping: "/api/**"

--- a/discovery-server/src/main/resources/application.yaml
+++ b/discovery-server/src/main/resources/application.yaml
@@ -179,6 +179,7 @@ polaris:
         uri: /druid/coordinator/v1/datasources/{datasourceId}/purge
   cache:
     configFile: default-configs/default-jgroups-tcp.xml
+  resources.cache.cacheControl.max-age: 604800 # 7 day seconds
 
 #  cors:
 #    -

--- a/discovery-server/src/main/resources/application.yaml
+++ b/discovery-server/src/main/resources/application.yaml
@@ -182,7 +182,7 @@ polaris:
   # Static resource caching is set to the default value of 7 days (seconds).
   # Setting default value in "metatron-discovery/discovery-server/src/main/java/app/metatron/discovery/config/ApiResourceConfig.java" configuration.
   # If you want to apply longer caching, You can use the "resources.cache.cacheControl.max-age" property value to set the caching time for the static resource.
-  # resources.cache.cacheControl.max-age: 604888
+  # resources.cache.cacheControl.max-age: 604800
 #  cors:
 #    -
 #      mapping: "/api/**"

--- a/discovery-server/src/main/resources/application.yaml
+++ b/discovery-server/src/main/resources/application.yaml
@@ -179,7 +179,6 @@ polaris:
         uri: /druid/coordinator/v1/datasources/{datasourceId}/purge
   cache:
     configFile: default-configs/default-jgroups-tcp.xml
-  resources.cache.cacheControl.max-age: 604800 # 7 day seconds
 
 #  cors:
 #    -


### PR DESCRIPTION
 - Resource has been cached
 - Excluded files and directory ( index.html, favicon.ico, assets )

### Description
#897 PR을 이어서 진행합니다.
기존에 `/resource/**` 해당 경로로 캐싱을 할 경우에 다국어 파일까지 캐싱되는 문제가 있었습니다.
인지하지 못하고 있었는데 `index.html`파일도 캐싱되고 있었습니다. 
해당 파일(index.html)이 캐싱되면 패키징되면서 해시가 바뀌어도 바뀐 파일을 불러오지 못합니다.

우선 패키징하면 아래와 같이 파일이 번들링됩니다.

```text
assets
0.315e1847c1f0b9743a14.chunk.js
1.80ae6146d0efc98b6a9f.chunk.js
2.8ca93f1afa72e48b88f4.chunk.js
3.599fcbba128f6e76be8c.chunk.js
4.da8900252b14296298d9.chunk.js
5.5eb561ad679634cf45ae.chunk.js
6.b639745031306faa43df.chunk.js
7.a9144137563f69cd23b7.chunk.js
8.c4b52a5e4bcca8f04a0a.chunk.js
9.de798d934d28ec1b000f.chunk.js
10.33cd71e402bfec6b0439.chunk.js
11.deeadfe544a46247eb13.chunk.js
12.e7b1d6460dca54445481.chunk.js
13.3d987814706bbcd7bde3.chunk.js
14.1088eb5a0a8d05a0725b.chunk.js
15.45a47daa810469f83f7b.chunk.js
16.f287b8ef57f6f9dbfa56.chunk.js
17.02cf2522d8c1e1ce07d0.chunk.js
18.579d3749eb225d7cf8af.chunk.js
19.e6fb03ed2f4080e1e57c.chunk.js
20.cb5411fb4e70455bc51f.chunk.js
21.1e30d388328b9bb74461.chunk.js
bg_error.3814017f3c06eb75f6ec.png
data_arrow.a9738dad63b291031687.png
favicon.ico
file.72e5460c886df4667b9c.png
icon_boxbtn.97253b678f7443356575.png
icon_checkbox2.ba3de82d7568e0458f59.png
icon_dbtype.509732aff9c6c102320b.png
icon_dbtype_dim.4f7de2e63584f699cf73.png
icon_depth.58633467f310d3aadbb3.png
icon_guide_arrow.564e5556c7f2fc143718.png
icon_outline.bbcebad039878f921f7d.png
icon_presentation.db26c41625ce562404bd.png
icon_sidemenu.9e4c486aabee305e07ed.png
img_chartnodata.8cbf6618210395bc4b78.png
img_color_02.10c97b144393edbf0257.png
img_color_03.81150bd1fccf61c194ba.png
img_color_04.63fe3a75c967a0a63a46.png
img_graph.fc8a479b5a1e503b1d0b.png
img_graph_s.538350d3794efb4e4266.png
img_network.f66963632a0c0907a099.png
img_randar.12b06cfb88ff4b1ca49f.png
img_scatter.9b65b64e412996fdb3c3.png
index.html
inline.61803bdbf990809a8d86.bundle.js
login.c729b1a2e4a85cffbb0c.jpg
logo_login.dff556e746ecff4c55da.png
main.fcd3ffc9b15f10e4979c.bundle.js
monaco-webfont.179f96cc364e3710a261.woff
monaco-webfont.08304a749ecd0a94cc29.eot
polyfills.99d8f7986da226fa91e2.bundle.js
query.6073f28bc230fa93719f.png
scripts.10a2fa5908cf53f73c34.bundle.js
SpoqaHanSans-Bold.1b37d90b132291f1acbe.ttf
SpoqaHanSans-Bold.1f7521e7db160fd4182a.eot
SpoqaHanSans-Bold.a6b79ce32080d32b0d85.woff
SpoqaHanSans-Regular.1c56ae0a92b76330dfd8.ttf
SpoqaHanSans-Regular.3e019a62f664fb2e711e.eot
SpoqaHanSans-Regular.a0421d301d2d7796e0e0.woff
SpoqaHanSans-Thin.0d6b107cbb512ff7e297.ttf
SpoqaHanSans-Thin.75b1ef766eabb77c70bf.eot
SpoqaHanSans-Thin.f0c07e7d12e24bdb0357.woff
styles.8d6d886984e303b95b2d.bundle.css
styles.ec7b70d80cb9ecc7ce6e.bundle.js
vendor.750afd4584a5324760eb.bundle.js
workflow.cc3c0aa115ffc9417fb8.png
```

여기서 `index.html`, `favicon.ico`, `assets`을  제외하고 캐싱을 적용했습니다.

```java
    private static final String RESOURCE_PATH = "/resource/";
    private static final String CHUNK_JS = RESOURCE_PATH + "*.*.chunk.js";
    private static final String BUNDLE_JS = RESOURCE_PATH + "*.*.bundle.js";
    private static final String BUNDLE_CSS = RESOURCE_PATH + "*.*.bundle.css";
    private static final String PNG = RESOURCE_PATH + "*.*.png";
    private static final String JPG = RESOURCE_PATH + "*.*.jpg";
    private static final String WOFF = RESOURCE_PATH + "*.*.woff";
    private static final String EOF = RESOURCE_PATH + "*.*.eot";
    private static final String TTF = RESOURCE_PATH + "*.*.ttf"; 

   registry.addResourceHandler("/resource/**")
            .addResourceLocations("classpath:resource/");
   registry.addResourceHandler(CHUNK_JS, BUNDLE_JS, BUNDLE_CSS, PNG, JPG, WOFF, EOF, TTF)
            .addResourceLocations("classpath:resource/")
            .setCacheControl(CacheControl.maxAge(7, TimeUnit.DAYS).cachePublic());
```

정확하게 확인하기 위해서는 **http://localhost:8180/app/v2/index.html** URL을 입력해서 확인해야 합니다. 
아래 스크린샷을 보면 의도한 바와 같이 `index.html`, `favicon.ico`, `다국어 파일(en.json, ko.json)`은 캐싱이 되지 않은 것을 확인할 수 있습니다.
해싱되지 않는 파일은 캐싱 처리하지 않는 것이 안전하다고 생각합니다.
그래서 `다국어`파일을 포함 `index.html`, `favicon.ico`은 캐싱하지 않는 방향으로 수정했습니다.
@kyungtaak 확인 부탁드립니다.

**Related PR** : #897 #1163
**Related Issue** : #1162

### How Has This Been Tested?
브라우저 개발자 도구에서 리소스가 캐싱이 되고 있는지 확인하면 됩니다.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [X] My code follows the code style of this project. _it will be added soon_
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document. _it will be added soon_
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
<img width="1680" alt="2019-01-03 3 01 37" src="https://user-images.githubusercontent.com/41019113/50605492-c4a65900-0f05-11e9-8c86-f94fe6e24495.png">