### PR TITLE
#740 remove url link in connection list

### DIFF
--- a/discovery-frontend/src/app/data-storage/data-connection/data-connection.component.html
+++ b/discovery-frontend/src/app/data-storage/data-connection/data-connection.component.html
@@ -99,7 +99,7 @@
         </td>
         <td>
           <span *ngIf="isDefaultType(connection)">{{connection.hostname}} / {{connection.port}}</span>
-          <a href="javascript:" class="ddp-link" *ngIf="!isDefaultType(connection)">{{connection.url}}</a>
+          <a href="javascript:" *ngIf="!isDefaultType(connection)">{{connection.url}}</a>
         </td>
         <td class="ddp-data-last">
           {{connection.createdTime | mdate: 'YYYY-MM-DD HH:mm'}}  <em class="ddp-icon-by">{{'msg.storage.ui.by' | translate}}</em>{{connection.createdBy.fullName}}

--- a/discovery-frontend/src/app/data-storage/data-connection/data-connection.component.html
+++ b/discovery-frontend/src/app/data-storage/data-connection/data-connection.component.html
@@ -98,8 +98,7 @@
           {{getConnectionImplementorLabel(connection.implementor)}}
         </td>
         <td>
-          <span *ngIf="isDefaultType(connection)">{{connection.hostname}} / {{connection.port}}</span>
-          <a href="javascript:" *ngIf="!isDefaultType(connection)">{{connection.url}}</a>
+          <span>{{isDefaultType(connection) ? connection.hostname + ' / ' + connection.port : connection.url}}</span>
         </td>
         <td class="ddp-data-last">
           {{connection.createdTime | mdate: 'YYYY-MM-DD HH:mm'}}  <em class="ddp-icon-by">{{'msg.storage.ui.by' | translate}}</em>{{connection.createdBy.fullName}}

--- a/discovery-frontend/src/app/workbench/component/detail-workbench/detail-workbench-dataconnection-info/detail-workbench-dataconnection-info.html
+++ b/discovery-frontend/src/app/workbench/component/detail-workbench/detail-workbench-dataconnection-info/detail-workbench-dataconnection-info.html
@@ -45,7 +45,7 @@
           {{'msg.storage.ui.conn.url'|translate}}
         </th>
         <td>
-          <a href="javascript:" class="ddp-link">{{dataconnection.url}}</a>
+          {{dataconnection.url}}
         </td>
       </tr>
       </tbody>

--- a/discovery-frontend/src/app/workbench/component/detail-workbench/detail-workbench-schema-browser/detail-workbench-schema-browser.component.html
+++ b/discovery-frontend/src/app/workbench/component/detail-workbench/detail-workbench-schema-browser/detail-workbench-schema-browser.component.html
@@ -311,7 +311,7 @@
                     {{'msg.storage.ui.conn.url'|translate}}
                   </th>
                   <td>
-                    <a href="javascript:" class="ddp-link">{{dataConnection.url}}</a>
+                    {{dataConnection.url}}
                   </td>
                 </tr>
                 </tbody>


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
커넥션 목록에서 connection type이 URL인 경우 파란색 텍스트로 보이던것을 수정
![2019-01-07 2 33 51](https://user-images.githubusercontent.com/42233627/50750746-b8195c00-1289-11e9-9132-383763737ec9.png)

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#740 


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 데이터 저장소 > 커넥션 > 커넥션 생성 > URL타입으로 커넥션 생성
2. 데이터 커넥션 목록에서 1에서 생성한 커넥션의 url이 검정 텍스트로 보이는지 확인

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project. _it will be added soon_
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
