### PR TITLE
#725 fix partition keys in source detail

### DIFF
--- a/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/staging-db-component/staging-db-complete/staging-db-complete.component.html
+++ b/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/staging-db-component/staging-db-complete/staging-db-complete.component.html
@@ -47,8 +47,7 @@
             <th>
               {{'msg.storage.ui.dsource.create.partition.keys' | translate}}
             </th>
-            <td>
-              {{getIngestionData.selectedPartitionType.value === 'ENABLE' ? getPartitionsEnabledLabel() :('msg.storage.ui.set.disable' | translate)}}
+            <td [innerHTML]="getPartitionKeys()">
             </td>
           </tr>
           <!-- //partition -->

--- a/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/staging-db-component/staging-db-complete/staging-db-complete.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/staging-db-component/staging-db-complete/staging-db-complete.component.ts
@@ -41,6 +41,9 @@ export class StagingDbCompleteComponent extends AbstractPopupComponent implement
   // datasource data
   private _sourceData: DatasourceInfo;
 
+  // partition key list
+  private _partitionKey: any = [];
+
   @ViewChild(ConfirmModalComponent)
   private _confirmModal: ConfirmModalComponent;
 
@@ -88,6 +91,8 @@ export class StagingDbCompleteComponent extends AbstractPopupComponent implement
     super.ngOnInit();
     // ui init
     this._initView();
+    // set partition key
+    this._partitionKey = this.getIngestionData.selectedPartitionType.value === 'ENABLE' ? this._getPartitionParams() : [];
     // if createData is exist, load createData
     if (this._sourceData.hasOwnProperty('createData')) {
       this._loadData(this._sourceData.createData);
@@ -181,11 +186,27 @@ export class StagingDbCompleteComponent extends AbstractPopupComponent implement
   }
 
   /**
-   * Get partition key label
+   * partition keys label
    * @returns {string}
    */
-  public getPartitionsEnabledLabel(): string {
-    return this.translateService.instant('msg.storage.ui.partition.enable.count.label', {value: this._getPartitionFields.length});
+  public getPartitionKeys(): string {
+    // if exist partition keys in ingestion data
+    if (this._partitionKey && this._partitionKey.length !== 0) {
+      return this._partitionKey.reduce((acc, partition) => {
+        acc += acc === ''
+          ? Object.keys(partition).reduce((line, key) => {
+            StringUtil.isNotEmpty(partition[key]) && (line += line === '' ? `${key}=${partition[key]}` : `/${key}=${partition[key]}`);
+            return line;
+          }, '')
+          : '<br>' + Object.keys(partition).reduce((line, key) => {
+          StringUtil.isNotEmpty(partition[key]) && (line += line === '' ? `${key}=${partition[key]}` : `/${key}=${partition[key]}`);
+          return line;
+        }, '');
+        return acc;
+      }, '');
+    } else { // if not exist partition keys
+      return this.translateService.instant('msg.storage.ui.set.false');
+    }
   }
 
 

--- a/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/information-dats-source/information-data-source.component.html
+++ b/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/information-dats-source/information-data-source.component.html
@@ -503,8 +503,7 @@
               <label class="ddp-label-type">{{'msg.storage.th.partition-keys' | translate}}
               </label>
               <!-- edit option -->
-              <div class="ddp-ui-edit-option">
-                {{getPartitionKeys()}}
+              <div class="ddp-ui-edit-option" [innerHTML]="getPartitionKeys()">
               </div>
               <!-- //edit option -->
             </div>

--- a/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/information-dats-source/information-data-source.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/information-dats-source/information-data-source.component.ts
@@ -460,46 +460,18 @@ export class InformationDataSourceComponent extends AbstractPopupComponent imple
    * @returns {string}
    */
   public getPartitionKeys(): string {
-    const test = [
-      {
-        "ym":"201704",
-        "dd":"20"
-      },
-      {
-        "ym":"201704",
-        "dd":"21",
-        "mm":"3131",
-      },
-      {
-        "ym":"201704",
-      }
-    ]
     // data range 가 있다면
-    // if (this.getIngestion.partitions && this.getIngestion.partitions.length !== 0) {
-    //   return this.getIngestion.partitions.reduce((acc, partition) => {
-    //     acc = acc === '' ? Object.keys(partition).reduce((line, key) => {
-    //       line = line === '' ? `${key}=${partition[key]}` : `/${key}=${partition[key]}`;
-    //       return line;
-    //     }, '') : '<br>' + Object.keys(partition).reduce((line, key) => {
-    //       line = line === '' ? `${key}=${partition[key]}` : `/${key}=${partition[key]}`;
-    //       return line;
-    //     }, '');
-    //     return acc;
-    //   }, '');
-    // } else {
-    //   return this.translateService.instant('msg.storage.ui.set.false');
-    // }
-    if (test && test.length !== 0) {
-      return test.reduce((acc, partition) => {
+    if (this.getIngestion.partitions && this.getIngestion.partitions.length !== 0) {
+      return this.getIngestion.partitions.reduce((acc, partition) => {
         acc += acc === ''
           ? Object.keys(partition).reduce((line, key) => {
             line += line === '' ? `${key}=${partition[key]}` : `/${key}=${partition[key]}`;
             return line;
           }, '')
           : '<br>' + Object.keys(partition).reduce((line, key) => {
-            line += line === '' ? `${key}=${partition[key]}` : `/${key}=${partition[key]}`;
-            return line;
-          }, '');
+          line += line === '' ? `${key}=${partition[key]}` : `/${key}=${partition[key]}`;
+          return line;
+        }, '');
         return acc;
       }, '');
     } else {

--- a/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/information-dats-source/information-data-source.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/information-dats-source/information-data-source.component.ts
@@ -460,7 +460,7 @@ export class InformationDataSourceComponent extends AbstractPopupComponent imple
    * @returns {string}
    */
   public getPartitionKeys(): string {
-    // data range 가 있다면
+    // if exist partition keys in ingestion data
     if (this.getIngestion.partitions && this.getIngestion.partitions.length !== 0) {
       return this.getIngestion.partitions.reduce((acc, partition) => {
         acc += acc === ''
@@ -474,7 +474,7 @@ export class InformationDataSourceComponent extends AbstractPopupComponent imple
         }, '');
         return acc;
       }, '');
-    } else {
+    } else { // if not exist partition keys
       return this.translateService.instant('msg.storage.ui.set.false');
     }
   }

--- a/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/information-dats-source/information-data-source.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/information-dats-source/information-data-source.component.ts
@@ -465,12 +465,12 @@ export class InformationDataSourceComponent extends AbstractPopupComponent imple
       return this.getIngestion.partitions.reduce((acc, partition) => {
         acc += acc === ''
           ? Object.keys(partition).reduce((line, key) => {
-            line += line === '' ? `${key}=${partition[key]}` : `/${key}=${partition[key]}`;
+            StringUtil.isNotEmpty(partition[key]) && (line += line === '' ? `${key}=${partition[key]}` : `/${key}=${partition[key]}`);
             return line;
           }, '')
           : '<br>' + Object.keys(partition).reduce((line, key) => {
-          line += line === '' ? `${key}=${partition[key]}` : `/${key}=${partition[key]}`;
-          return line;
+            StringUtil.isNotEmpty(partition[key]) && (line += line === '' ? `${key}=${partition[key]}` : `/${key}=${partition[key]}`);
+            return line;
         }, '');
         return acc;
       }, '');

--- a/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/information-dats-source/information-data-source.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/information-dats-source/information-data-source.component.ts
@@ -448,25 +448,63 @@ export class InformationDataSourceComponent extends AbstractPopupComponent imple
    * @returns {string}
    */
   public getDataRangeLabel(): string {
-    const range = this.getIngestion.intervals;
     // data range 가 있다면
-    if (range) {
-      return range[0].split('/').join(' ~ ').replace(/T/g, ' ');
+    if (this.getIngestion.intervals) {
+      return this.getIngestion.intervals[0].split('/').join(' ~ ').replace(/T/g, ' ');
     }
-    return 'None';
+    return this.translateService.instant('msg.storage.ui.set.false');
   }
 
   /**
-   * TODO partition keys label
+   * partition keys label
    * @returns {string}
    */
   public getPartitionKeys(): string {
-    const partitions = this.getIngestion.partitions;
+    const test = [
+      {
+        "ym":"201704",
+        "dd":"20"
+      },
+      {
+        "ym":"201704",
+        "dd":"21",
+        "mm":"3131",
+      },
+      {
+        "ym":"201704",
+      }
+    ]
     // data range 가 있다면
-    if (partitions.length !== 0) {
-      return '';
+    // if (this.getIngestion.partitions && this.getIngestion.partitions.length !== 0) {
+    //   return this.getIngestion.partitions.reduce((acc, partition) => {
+    //     acc = acc === '' ? Object.keys(partition).reduce((line, key) => {
+    //       line = line === '' ? `${key}=${partition[key]}` : `/${key}=${partition[key]}`;
+    //       return line;
+    //     }, '') : '<br>' + Object.keys(partition).reduce((line, key) => {
+    //       line = line === '' ? `${key}=${partition[key]}` : `/${key}=${partition[key]}`;
+    //       return line;
+    //     }, '');
+    //     return acc;
+    //   }, '');
+    // } else {
+    //   return this.translateService.instant('msg.storage.ui.set.false');
+    // }
+    if (test && test.length !== 0) {
+      return test.reduce((acc, partition) => {
+        acc += acc === ''
+          ? Object.keys(partition).reduce((line, key) => {
+            line += line === '' ? `${key}=${partition[key]}` : `/${key}=${partition[key]}`;
+            return line;
+          }, '')
+          : '<br>' + Object.keys(partition).reduce((line, key) => {
+            line += line === '' ? `${key}=${partition[key]}` : `/${key}=${partition[key]}`;
+            return line;
+          }, '');
+        return acc;
+      }, '');
+    } else {
+      return this.translateService.instant('msg.storage.ui.set.false');
     }
-    return 'None';
   }
 
   /**


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
파티션키가 있는 데이터소스인 경우 데이터소스 상세화면에서 설정된 파티션이 제대로 보이지 않던 현상수정
![2019-01-07 11 29 22](https://user-images.githubusercontent.com/42233627/50751063-522dd400-128b-11e9-9286-86d545bd7fd2.png)


**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#725 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 데이터소스 > stagingDB로 데이터소스 생성 > 파티션 키가 있는 데이터로 생성
2. 1에서 생성한 소스의 상세화면으로 이동
3. information tab의 타임스탬프 설정에서 파티션키가 제대로 표시되는지 확인

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project. _it will be added soon_
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
