### PR TITLE
#1141 added_preparation_custom_patch_controller

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetJdbcService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetJdbcService.java
@@ -297,7 +297,7 @@ public class PrepDatasetJdbcService {
                 dataFrame.rows.add(readRows++,row);
                 if( limitSize < readRows ) { break; }
             }
-//                dataset.setTotalLines(-1);    // FIXME: 이것을 설정하면 callable에서 하는 일과 lock이 겹침. 추후, callback으로 REST API를 쓰도록 수정하면 해결될 듯.
+            dataset.setTotalLines(-1L);
             dataset.setTotalBytes(-1L);
 
             JdbcUtils.closeResultSet(rs);

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/service/PrDatasetService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/service/PrDatasetService.java
@@ -14,6 +14,7 @@
 
 package app.metatron.discovery.domain.dataprep.service;
 
+import app.metatron.discovery.common.GlobalObjectMapper;
 import app.metatron.discovery.domain.dataprep.*;
 import app.metatron.discovery.domain.dataprep.entity.PrDataset;
 import app.metatron.discovery.domain.dataprep.exceptions.PrepErrorCodes;
@@ -22,6 +23,8 @@ import app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey;
 import app.metatron.discovery.domain.dataprep.teddy.DataFrame;
 import app.metatron.discovery.domain.datasource.connection.DataConnection;
 import app.metatron.discovery.domain.datasource.connection.DataConnectionRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -37,8 +40,8 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
-
 import java.io.File;
+import java.util.List;
 import java.util.Map;
 
 
@@ -293,6 +296,37 @@ public class PrDatasetService {
             dataset.setDcUrl(dataConnection.getUrl());
             //dataset.setDcConnectUrl(dataConnection.getConnectUrl());
             dataset.setDcPublished(dataConnection.getPublished());
+        }
+    }
+
+    public void patchAllowedOnly(PrDataset dataset, PrDataset patchDataset) {
+        // Dataset editing is not yet supported.
+        // Only a few fields are allowed to be changed.
+        // It can be changed.
+
+        List<String> allowKeys = Lists.newArrayList();
+        allowKeys.add("dsName");
+        allowKeys.add("dsDesc");
+        allowKeys.add("totalLines");
+        allowKeys.add("totalBytes");
+
+        List<String> ignoreKeys = Lists.newArrayList();
+        ignoreKeys.add("dsId");
+        ignoreKeys.add("refDfCount");
+
+        if(patchDataset.getDsName()!=null) { dataset.setDsName(patchDataset.getDsName()); }
+        if(patchDataset.getDsDesc()!=null) { dataset.setDsDesc(patchDataset.getDsDesc()); }
+        if(patchDataset.getTotalBytes()!=null) { dataset.setTotalBytes(patchDataset.getTotalBytes()); }
+        if(patchDataset.getTotalLines()!=null) { dataset.setTotalLines(patchDataset.getTotalLines()); }
+
+        ObjectMapper objectMapper = GlobalObjectMapper.getDefaultMapper();
+        Map<String, Object> mapDataset = objectMapper.convertValue(patchDataset, Map.class);
+        for(String key : mapDataset.keySet()) {
+            if( false==ignoreKeys.contains(key) ) { continue; }
+
+            if( false==allowKeys.contains(key) ) {
+                LOGGER.debug("'" + key + "' of pr-dataset is an attribute to which patch is not applied");
+            }
         }
     }
 }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
preparation API uses custom controller for PrDataset and PrDataflow.
GET and POST are already served.
now PATCH controller was added.

**Related Issue** : [#1141](https://github.com/metatron-app/metatron-discovery/issues/1141)
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. create a dataset for JDBC
2. see the details of the dataset
3. totalBytes is a positive number not -1.
totalBytes is set by PATCH API
 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
