### PR TITLE
#803 need to go to the detail page right after creating the workbench

### DIFF
--- a/discovery-frontend/src/app/notebook/component/create-notebook/create-notebook-name/create-notebook-name.component.ts
+++ b/discovery-frontend/src/app/notebook/component/create-notebook/create-notebook-name/create-notebook-name.component.ts
@@ -211,7 +211,7 @@ export class CreateNotebookNameComponent extends AbstractPopupComponent implemen
 
 
     // 생성 api
-    this.notebookService.createNotebook(param).then((data) => {
+    this.notebookService.createNotebook(param).then((data:NoteBook) => {
 
       if (data) {
         // 로딩 hide
@@ -222,7 +222,7 @@ export class CreateNotebookNameComponent extends AbstractPopupComponent implemen
 
         this.popupService.notiPopup({
           name: 'complete-notebook-create',
-          data: null
+          data: data.id
         });
       }
 

--- a/discovery-frontend/src/app/notebook/component/create-notebook/create-notebook.component.ts
+++ b/discovery-frontend/src/app/notebook/component/create-notebook/create-notebook.component.ts
@@ -83,7 +83,7 @@ export class CreateNotebookComponent extends AbstractComponent implements OnInit
       if (this.step === 'close-notebook-create') {
 
       } else if (this.step === 'complete-notebook-create') {
-        this.createComplete.emit(true);
+        this.createComplete.emit(data.data);
       }
 
     });

--- a/discovery-frontend/src/app/workbench/component/create-workbench/create-workbench-complete/create-workbench-complete.component.ts
+++ b/discovery-frontend/src/app/workbench/component/create-workbench/create-workbench-complete/create-workbench-complete.component.ts
@@ -129,8 +129,7 @@ export class CreateWorkbenchCompleteComponent extends AbstractPopupComponent imp
         params['description'] = this.description.trim();
       }
 
-
-      this.workbenchService.createWorkbench(params).then(() => {
+      this.workbenchService.createWorkbench(params).then(( data:Workbench ) => {
 
         // 로딩 hide
         this.loadingHide();
@@ -139,8 +138,8 @@ export class CreateWorkbenchCompleteComponent extends AbstractPopupComponent imp
 
         // 완료 알림
         this.popupService.notiPopup({
-          name: 'reload-workbench',
-          data: null
+          name: 'create-workbench',
+          data: data.id
         });
 
         // 닫기

--- a/discovery-frontend/src/app/workspace/component/etc/set-notebook-server.component.html
+++ b/discovery-frontend/src/app/workspace/component/etc/set-notebook-server.component.html
@@ -33,7 +33,6 @@
     <div class="ddp-ui-popup-contents">
       <div class="ddp-ui-notebook-server">
 
-
         <!-- tab -->
         <div class="ddp-wrap-tab">
           <ul class="ddp-ui-tab ddp-clear">
@@ -125,7 +124,7 @@
                   <tr *ngFor="let server of jupyter.servers" (click)="selectedJupyter = server" style="cursor:pointer">
                     <td class="ddp-txt-center">
                       <div class="ddp-ui-radio">
-                        <input type="radio" [checked]="selectedJupyter.id === server.id">
+                        <input name="notebookServer" type="radio" [checked]="selectedJupyter.id === server.id">
                         <i class="ddp-icon-radio"></i>
                       </div>
                     </td>
@@ -159,7 +158,7 @@
                   <tr *ngFor="let server of zeppelin.servers" (click)="selectedZeppelin = server" style="cursor:pointer">
                     <td class="ddp-txt-center">
                       <div class="ddp-ui-radio">
-                        <input type="radio" [checked]="selectedZeppelin.id === server.id">
+                        <input name="notebookServer" type="radio" [checked]="selectedZeppelin.id === server.id">
                         <i class="ddp-icon-radio"></i>
                       </div>
                     </td>

--- a/discovery-frontend/src/app/workspace/workspace.component.html
+++ b/discovery-frontend/src/app/workspace/workspace.component.html
@@ -619,7 +619,7 @@
 <!-- 워크스페이스 리스트 -->
 <app-workspace-list (updateComplete)="loadWorkspace($event)"></app-workspace-list>
 <!-- 노트북 생성 -->
-<app-create-notebook (createComplete)="loadWorkspace($event)" [step]="notebookStep"></app-create-notebook>
+<app-create-notebook (createComplete)="detailPage($event, 'notebook')" [step]="notebookStep"></app-create-notebook>
 <!-- 워크벤치 생성 -->
 <app-create-workbench *ngIf="workbenchStep" [workspaceId]="workspaceId" [folderId]="currentFolderId" [step]="workbenchStep"></app-create-workbench>
 <!-- 노트북 서버 설정 -->

--- a/discovery-frontend/src/app/workspace/workspace.component.ts
+++ b/discovery-frontend/src/app/workspace/workspace.component.ts
@@ -250,9 +250,9 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
       this.workbenchStep = data.name;
 
       // 워크벤치 생성 완료
-      if (data.name === 'reload-workbench') {
+      if (data.name === 'create-workbench') {
         // 재조회
-        this.getWorkspace();
+        this.detailPage( data.data, 'workbench' );
       }
     });
     this.subscriptions.push(popupSubscription);


### PR DESCRIPTION
### Description
After creating the workbench, the user expects to go directly to the detail screen and work on it. Users are inconvenienced to stay in the workspace's content list after creating the workbench.

**Related Issue** : #803 
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 워크스페이스에서 워크벤치를 생성합니다.
2. 생성한 워크벤치로 바로 이동하는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
