### PR TITLE
#743 add sql beautifier and save

### DIFF
--- a/discovery-frontend/src/app/workbench/workbench.component.ts
+++ b/discovery-frontend/src/app/workbench/workbench.component.ts
@@ -2606,6 +2606,11 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
 
     // textAll = this.replaceAll(textAll, textSelected, text);
     // this.editor.setText(textAll);
+
+    // 쿼리 저장
+    this.textList[this.selectedTabNum]['query'] = this.getSelectedTabText();
+    // 로컬 스토리지에 쿼리에 저장
+    this.saveLocalStorage(this.getSelectedTabText(), this.textList[this.selectedTabNum]['editorId']);
   }
 
   public replaceAll(str, find, replace) {


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
sql beautifier 기능을 수행하고 다른 작성 탭으로 이동 후, 다시 원래 작성하던 탭으로 이동 시 쿼리의 내용이 저장되도록 수정 

**Related Issue** : #743  <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 워크벤치 화면으로 이동합니다. 
2. 쿼리를 입력하고, sql beautifier 버튼을 클릭하여 쿼리에 적용합니다. 
3. 다른 입력 탭으로 이동 후, 이전 작성하던 탭으로 이동 후 쿼리 내용이 정상적으로 남아있는지 확인합니다. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
