### PR TITLE
F#932 add create dataset in swap popup

### DIFF
--- a/discovery-frontend/src/app/data-preparation/component/long-update-popup.component.html
+++ b/discovery-frontend/src/app/data-preparation/component/long-update-popup.component.html
@@ -6,9 +6,14 @@
       <span class="ddp-txt-title-name">
         {{title}}
       </span>
-      <div class="ddp-ui-pop-buttons">
+      <div class="ddp-ui-pop-buttons" *ngIf="layoutType == 'ADD'">
         <a href="javascript:" class="ddp-btn-pop" (click)="close()">{{'msg.comm.btn.cancl' | translate}}</a>
-        <a href="javascript:" class="ddp-btn-pop ddp-bg-black" (click)="done()">{{'msg.comm.btn.done2' | translate}}</a>
+        <a href="javascript:" class="ddp-btn-pop ddp-bg-black" [class.ddp-disabled]="selectedDatasets === undefined || selectedDatasets === null || selectedDatasets.length === 0" (click)="done()">{{'msg.comm.btn.done2' | translate}}</a>
+      </div>
+
+      <div class="ddp-ui-pop-buttons" *ngIf="layoutType == 'SWAP'">
+        <a href="javascript:" class="ddp-btn-pop" (click)="close()">{{'msg.comm.btn.cancl' | translate}}</a>
+        <a href="javascript:" class="ddp-btn-pop ddp-bg-black" [class.ddp-disabled]="swappingDatasetId === undefined || swappingDatasetId === null || swappingDatasetId === ''" (click)="done()">{{'msg.comm.btn.done2' | translate}}</a>
       </div>
       <!-- det -->
     </div>
@@ -33,37 +38,245 @@
         <!-- //옵션 -->
         <div class="ddp-wrap-variable">
           <!-- 그리드 영역 -->
-          <!-- 설명 나올때 ddp-selected 추가 -->
+          <!--ADD : heckbox-select-dataset-->
+          <div class="ddp-wrap-grid" *ngIf="layoutType == 'ADD'" [class.ddp-selected]="selectedDatasetId != ''">
+            <!-- 테이블 -->
+            <div class="ddp-wrap-viewtable ddp-add">
+              <div class="ddp-box-viewtable">
+                <!-- gridhead -->
+                <div class="ddp-ui-gridhead">
+                  <table class="ddp-table-form ddp-table-type2">
+                    <colgroup>
+                      <col width="51px">
+                      <col width="*">
+                      <col width="120px">
+                      <col width="180px">
+                    </colgroup>
+                    <thead>
+                    <tr>
+                      <th class="ddp-txt-center" (click)="checkAll();">
+                        <div class="ddp-ui-checkbox">
+                          <!--<div class="ddp-ui-checkbox" [ngClass]="{'ddp-checkboxtype' : partialChecked()}" >-->
+                          <input type="checkbox" class="ddp-checkbox-form" [checked]="isCheckAll && !isCheckAllDisabled" [disabled]="isCheckAllDisabled">
+                          <i class="ddp-icon-checkbox"></i>
+                        </div>
+                      </th>
+                      <th class="ddp-cursor" (click)="changeOrder('dsName');">
+                        {{'msg.comm.menu.manage.prep.set' | translate}}
+                        <em class="ddp-icon-array-default2" *ngIf="selectedContentSort.key !== 'dsName' || selectedContentSort.sort === 'default'"></em>
+                        <em class="ddp-icon-array-asc2" *ngIf="selectedContentSort.key === 'dsName' && selectedContentSort.sort === 'asc'"></em>
+                        <em class="ddp-icon-array-des2" *ngIf="selectedContentSort.key === 'dsName' && selectedContentSort.sort === 'desc'"></em>
+                      </th>
+                      <th>
+                        {{'msg.comm.th.type' | translate}}
+                      </th>
+                      <th (click)="changeOrder('modifiedTime');">
+                        {{'msg.comm.ui.list.last' | translate}}
+                        <em class="ddp-icon-array-default2" *ngIf="selectedContentSort.key !== 'modifiedTime' || selectedContentSort.sort === 'default'"></em>
+                        <em class="ddp-icon-array-asc2" *ngIf="selectedContentSort.key === 'modifiedTime' && selectedContentSort.sort === 'asc'"></em>
+                        <em class="ddp-icon-array-des2" *ngIf="selectedContentSort.key === 'modifiedTime' && selectedContentSort.sort === 'desc'"></em>
+                      </th>
+                    </tr>
+                    </thead>
 
-          <checkbox-select-dataset *ngIf="!isRadio">
+                  </table>
+                </div>
+                <!--// gridhead -->
 
-          </checkbox-select-dataset>
+                <!-- gridbody -->
+                <div class="ddp-ui-gridbody">
+                  <table class="ddp-table-form ddp-table-type2 ddp-table-select">
+                    <colgroup>
+                      <col width="51px">
+                      <col width="*">
+                      <col width="120px">
+                      <col width="180px">
+                    </colgroup>
 
+                    <tbody>
+                    <tr *ngFor="let item of datasets"
+                        (click)="selectDataset(item);"
+                        [ngClass]="{'ddp-selected': selectedDatasetId == item.dsId}">
+                      <td class="ddp-txt-center"  (click)="check($event, item);">
+                        <div class="ddp-ui-checkbox">
+                          <input type="checkbox" class="ddp-checkbox-form" [disabled]="item.origin" [checked]="item.selected && !item.origin" >
+                          <i class="ddp-icon-checkbox"></i>
+                        </div>
+                      </td>
+                      <td>
+                        <div class="ddp-txt-long">
+                          {{item.dsName}}
+                          <span class="ddp-txt-colortype" *ngIf="item.dsDesc">- {{item.dsDesc}}</span>
+                        </div>
+                      </td>
 
-          <radio-select-dataset *ngIf="isRadio"
-                                [selectedDatasetId]="selectedDatasetId"
-                                [importedDatasets]="datasets"
-                                [page]="page"
-                                [pageResult]="pageResult"
-                                (sortEvent)="sortEvent($event)"
-                                (getMoreDatasetEvent)="getDatasets()"
-                                (datasetSelectEvent)="selectedDatasetId = $event">
-          </radio-select-dataset>
+                      <!--<td>-->
+                      <!--<span *ngIf="item.dsType.toString() === 'WRANGLED'">{{'msg.dp.ui.wrangled.ds' | translate}}</span>-->
+                      <!--<span *ngIf="item.dsType.toString() === 'IMPORTED'">Imported ({{prepCommonUtil.getImportType(item.importType)}})</span>-->
+                      <!--</td>-->
+                      <td *ngIf="item.dsType.toString() === 'WRANGLED'">
+                        <span>{{'msg.dp.ui.wrangled.ds' | translate}}</span>
+                      </td>
+
+                      <td *ngIf="item.dsType !== null && item.dsType.toString() === 'IMPORTED'">
+                        <!--<span *ngIf="item.importType.toString() === 'IMPORTED'">Imported ({{prepCommonUtil.getImportType(item.importType)}})</span>-->
+                        <span calss="ddp-data-source" *ngIf="item.importType !== null && item.importType.toString() === 'UPLOAD'">
+                          <em class="ddp-icon-file"></em>
+                          File
+                        </span>
+                        <span calss="ddp-data-source" *ngIf="item.importType !== null && item.importType.toString() === 'DATABASE'">
+                          <em class="ddp-icon-db-s"></em>
+                          Database
+                        </span>
+                        <span calss="ddp-data-source" *ngIf="item.importType !== null && item.importType.toString() === 'STAGING_DB'">
+                          <em class="ddp-icon-staging"></em>
+                          Staging DB
+                        </span>
+                      </td>
+
+                      <td>
+                        {{item.modifiedTime | mdate:'YYYY-MM-DD HH:mm'}}
+                      </td>
+                    </tr>
+                    </tbody>
+                  </table>
+                </div>
+                <!--// gridbody -->
+              </div>
+              <div class="ddp-box-add-link3" [ngClass]="{'ddp-disabled' : !(page.page < pageResult.totalPages)}" (click)="getMoreList()">
+                <span class="ddp-link-type">{{'msg.comm.ui.more' | translate}} <em class="ddp-icon-view"></em></span>
+              </div>
+            </div>
+            <!-- //테이블 -->
+          </div>
           <!-- //그리드 영역 -->
+
+
+          <!--SWAP : radio-select-dataset-->
+          <div class="ddp-wrap-grid" *ngIf="layoutType == 'SWAP'" [ngClass]="{'ddp-selected': selectedDatasetId !== ''}">
+            <!-- 테이블 -->
+            <div class="ddp-wrap-viewtable ddp-add">
+              <div class="ddp-box-viewtable">
+                <!-- gridhead -->
+                <div class="ddp-ui-gridhead">
+                  <table class="ddp-table-form ddp-table-type2">
+                    <colgroup>
+                      <col width="51px">
+                      <col width="*">
+                      <col width="120px">
+                      <col width="180px">
+                    </colgroup>
+                    <thead>
+                    <tr>
+                      <th class="ddp-txt-center">
+                        <!--<div class="ddp-ui-checkbox" [ngClass]="{'ddp-checkboxtype' : partialChecked()}" >-->
+                        <!--<input type="checkbox" class="ddp-checkbox-form" [checked]="isCheckAll && !isCheckAllDisabled" [disabled]="isCheckAllDisabled">-->
+                        <!--<i class="ddp-icon-checkbox"></i>-->
+                        <!--</div>-->
+                      </th>
+                      <th class="ddp-cursor" (click)="changeOrder('dsName');">
+                        {{'msg.comm.menu.manage.prep.set' | translate}}
+                        <em class="ddp-icon-array-default2" *ngIf="selectedContentSort.key !== 'dsName' || selectedContentSort.sort === 'default'"></em>
+                        <em class="ddp-icon-array-asc2" *ngIf="selectedContentSort.key === 'dsName' && selectedContentSort.sort === 'asc'"></em>
+                        <em class="ddp-icon-array-des2" *ngIf="selectedContentSort.key === 'dsName' && selectedContentSort.sort === 'desc'"></em>
+                      </th>
+                      <th>
+                        {{'msg.comm.th.type' | translate}}
+                      </th>
+                      <th (click)="changeOrder('modifiedTime');">
+                        {{'msg.comm.ui.list.last' | translate}}
+                        <em class="ddp-icon-array-default2" *ngIf="selectedContentSort.key !== 'modifiedTime' || selectedContentSort.sort === 'default'"></em>
+                        <em class="ddp-icon-array-asc2" *ngIf="selectedContentSort.key === 'modifiedTime' && selectedContentSort.sort === 'asc'"></em>
+                        <em class="ddp-icon-array-des2" *ngIf="selectedContentSort.key === 'modifiedTime' && selectedContentSort.sort === 'desc'"></em>
+                      </th>
+                    </tr>
+                    </thead>
+
+                  </table>
+                </div>
+                <!--// gridhead -->
+
+                <!-- gridbody -->
+                <div class="ddp-ui-gridbody">
+                  <table class="ddp-table-form ddp-table-type2 ddp-table-select">
+                    <colgroup>
+                      <col width="51px">
+                      <col width="*">
+                      <col width="120px">
+                      <col width="180px">
+                    </colgroup>
+
+                    <tbody>
+                    <tr *ngFor="let item of datasets"
+                        (click)="selectDataset(item);"
+                        [ngClass]="{'ddp-selected': selectedDatasetId == item.dsId}">
+                      <td class="ddp-txt-center"  (click)="radioCheck($event, item);">
+                        <div class="ddp-ui-radio">
+                          <input type="radio" class="ddp-checkbox-form" [checked]="swappingDatasetId === item.dsId" name="datasetRadio">
+                          <i class="ddp-icon-radio"></i>
+                        </div>
+                      </td>
+                      <td>
+                        <div class="ddp-txt-long">
+                          {{item.dsName}}
+                          <span class="ddp-txt-colortype" *ngIf="item.dsDesc">- {{item.dsDesc}}</span>
+                        </div>
+                      </td>
+
+                      <td *ngIf="item.dsType !== null && item.dsType.toString() === 'WRANGLED'">
+                        <span>{{'msg.dp.ui.wrangled.ds' | translate}}</span>
+                      </td>
+
+                      <td *ngIf="item.dsType !== null && item.dsType.toString() === 'IMPORTED'">
+                        <!--<span *ngIf="item.importType.toString() === 'IMPORTED'">Imported ({{prepCommonUtil.getImportType(item.importType)}})</span>-->
+                        <span calss="ddp-data-source" *ngIf="item.importType !== null && item.importType.toString() === 'UPLOAD'">
+                          <em class="ddp-icon-file"></em>
+                          File
+                        </span>
+                        <span calss="ddp-data-source" *ngIf="item.importType !== null && item.importType.toString() === 'DATABASE'">
+                          <em class="ddp-icon-db-s"></em>
+                          Database
+                        </span>
+                        <span calss="ddp-data-source" *ngIf="item.importType !== null && item.importType.toString() === 'STAGING_DB'">
+                          <em class="ddp-icon-staging"></em>
+                          Staging DB
+                        </span>
+                      </td>
+
+                      <td>
+                        {{item.modifiedTime | mdate:'YYYY-MM-DD HH:mm'}}
+                      </td>
+                    </tr>
+                    </tbody>
+                  </table>
+                </div>
+                <!--// gridbody -->
+              </div>
+              <div class="ddp-box-add-link3" [ngClass]="{'ddp-disabled' : !(page.page < pageResult.totalPages)}" (click)="getMoreList()">
+                <span class="ddp-link-type">{{'msg.comm.ui.more' | translate}} <em class="ddp-icon-view"></em></span>
+              </div>
+            </div>
+            <!-- //테이블 -->
+
+          </div>
+          <!--SWAP : radio-select-dataset-->
+
+
+
         </div>
         <!-- 설명 -->
-        <app-dataset-summary *ngIf="selectedDatasetId !== ''" (close)="onCloseSummary()" [datasetId]="selectedDatasetId"></app-dataset-summary>
+        <app-dataset-summary *ngIf="selectedDatasetId != null && selectedDatasetId !=''" (close)="onCloseSummary()" [datasetId]="selectedDatasetId"></app-dataset-summary>
         <!-- //설명 -->
         <!-- bottom option -->
-        <!--<div class="ddp-ui-bottomoption ddp-clear" *ngIf="!isRadio">-->
-          <!--<span class="ddp-data-type ddp-fleft">{{'msg.dp.ui.sel.count' | translate: { value : countSelected } }}</span>-->
+        <div class="ddp-ui-bottomoption ddp-clear">
+          <span class="ddp-data-type ddp-fleft" *ngIf="layoutType == 'ADD'">{{'msg.dp.ui.sel.count' | translate: { value : countSelected } }}</span>
 
-          <!--<a href="javascript:"-->
-             <!--class="ddp-type-link3 ddp-fright"-->
-             <!--(click)="createDataset()">-->
-            <!--<em class="ddp-icon-linkplus"></em> {{'msg.dp.btn.create-ds' | translate }}-->
-          <!--</a>-->
-        <!--</div>-->
+          <a href="javascript:"
+             class="ddp-type-link3 ddp-fright"
+             (click)="createDataset()">
+            <em class="ddp-icon-linkplus"></em> {{'msg.dp.btn.create-ds' | translate }}
+          </a>
+        </div>
         <!-- //bottom option -->
       </div>
 
@@ -73,3 +286,5 @@
   </div>
 
 </div>
+
+<app-create-dataset [step]="step"></app-create-dataset>

--- a/discovery-frontend/src/app/data-preparation/component/long-update-popup.component.ts
+++ b/discovery-frontend/src/app/data-preparation/component/long-update-popup.component.ts
@@ -136,7 +136,13 @@ export class LongUpdatePopupComponent extends AbstractComponent implements OnIni
     this.popupSubscription = this.popupService.view$.subscribe((data: SubscribeArg) => {
       this.step = data.name;
       if (this.step === 'complete-dataset-create') {
-        this.selectedDatasetId = '';
+
+        if(data.hasOwnProperty('data') && data.data !== null) {
+          this.selectedDatasetId = data.data;
+          if(this.layoutType == 'SWAP') {
+            this.swappingDatasetId = data.data;
+          }
+        }
         $('.ddp-ui-gridbody').scrollTop(0);
         this._initViewPage()
       }
@@ -149,7 +155,6 @@ export class LongUpdatePopupComponent extends AbstractComponent implements OnIni
     }else {
       // 새로운 데이터셋 추가 ADD
       this.layoutType = 'ADD';
-      this.selectedDatasets = [];
     }
     this.selectedDatasetId = '';
 
@@ -248,7 +253,7 @@ export class LongUpdatePopupComponent extends AbstractComponent implements OnIni
 
     // 선택된 radio 항목 초기화
     this.swappingDatasetId = '';
-    this.firstLoadCompleted = false;
+    // this.firstLoadCompleted = false;
 
     // 데이터소스 리스트 조회
     this.getDatasets();
@@ -430,6 +435,12 @@ export class LongUpdatePopupComponent extends AbstractComponent implements OnIni
   private _initViewPage() {
     // 검색어 초기화
     this.searchText  = '';
+
+    // 선택된 checkbox  항목 초기화
+    this.selectedDatasets = [];
+
+    // radio all check false
+    this.isCheckAll = false;
 
     // 정렬
     this.selectedContentSort = new Order();

--- a/discovery-frontend/src/app/data-preparation/component/long-update-popup.component.ts
+++ b/discovery-frontend/src/app/data-preparation/component/long-update-popup.component.ts
@@ -142,34 +142,27 @@ export class LongUpdatePopupComponent extends AbstractComponent implements OnIni
     });
 
     if(this.isRadio) {
-      this.layoutType = 'SWAP';
-    }else {
-      this.layoutType = 'ADD';
-    }
-
-    if(this.popType == 'add') {
-
-      this.title = 'Add datasets';
-
-    } else if(this.popType == 'imported') {
-
-      this.title = 'Replace dataset';
-
-    } else if(this.popType == 'wrangled') {
-
-      this.title = 'Change input dataset';
-    }
-
-    if(this.layoutType == 'ADD') {
-      // 새로운 데이터셋 추가 ADD
-      this.selectedDatasets = [];
-    }else if(this.layoutType == 'SWAP'){
       // 기존 데이터셋 치환 SWAP
+      this.layoutType = 'SWAP';
       this.originalDatasetId = this.selectedDatasetId;
+    }else {
+      // 새로운 데이터셋 추가 ADD
+      this.layoutType = 'ADD';
+      this.selectedDatasets = [];
     }
     this.selectedDatasetId = '';
-    this.init();
 
+    if(this.popType == 'add') {
+      // this.title = 'Add datasets';
+      this.title = this.translateService.instant('msg.dp.btn.add.ds');
+    } else if(this.popType == 'imported') {
+      // this.title = 'Replace dataset';
+      this.title = this.translateService.instant('msg.dp.ui.swap.dataset');
+    } else if(this.popType == 'wrangled') {
+      // this.title = 'Change input dataset';
+      this.title = this.translateService.instant('msg.dp.ui.change.input.dataset');
+    }
+    this.init();
   }
 
   // Destroy
@@ -339,17 +332,17 @@ export class LongUpdatePopupComponent extends AbstractComponent implements OnIni
             this.datasets.length === allTicked ? this.isCheckAll = true : this.isCheckAll = false;
           }
 
-          if (sessionStorage.getItem('DATASET_ID')) {
-            this.selectedDatasetId = sessionStorage.getItem('DATASET_ID');
-            this.datasets.filter((item) => {
-              if (item.dsId === this.selectedDatasetId) {
-                item.selected = true;
-                this.selectedDatasets.push(item);
-              }
-            });
-            sessionStorage.removeItem('DATASET_ID');
-            this.datasetService.dataflowId = undefined;
-          }
+          // if (sessionStorage.getItem('DATASET_ID')) {
+          //   this.selectedDatasetId = sessionStorage.getItem('DATASET_ID');
+          //   this.datasets.filter((item) => {
+          //     if (item.dsId === this.selectedDatasetId) {
+          //       item.selected = true;
+          //       this.selectedDatasets.push(item);
+          //     }
+          //   });
+          //   sessionStorage.removeItem('DATASET_ID');
+          //   this.datasetService.dataflowId = undefined;
+          // }
 
           // 총페이지 수
           this.page.page += 1;

--- a/discovery-frontend/src/app/data-preparation/component/long-update-popup.component.ts
+++ b/discovery-frontend/src/app/data-preparation/component/long-update-popup.component.ts
@@ -137,6 +137,7 @@ export class LongUpdatePopupComponent extends AbstractComponent implements OnIni
       this.step = data.name;
       if (this.step === 'complete-dataset-create') {
         this.selectedDatasetId = '';
+        $('.ddp-ui-gridbody').scrollTop(0);
         this._initViewPage()
       }
     });

--- a/discovery-frontend/src/app/data-preparation/component/long-update-popup.component.ts
+++ b/discovery-frontend/src/app/data-preparation/component/long-update-popup.component.ts
@@ -23,7 +23,10 @@ import {DatasetService} from "../dataset/service/dataset.service";
 import {DataflowModelService} from "../dataflow/service/dataflow.model.service";
 import {PreparationAlert} from "../util/preparation-alert.util";
 import {RadioSelectDatasetComponent} from "./radio-select-dataset.component";
-
+import {PreparationCommonUtil} from "../util/preparation-common.util";
+import { PopupService } from '../../common/service/popup.service';
+import { SubscribeArg } from '../../common/domain/subscribe-arg';
+import { Subscription } from 'rxjs/Subscription';
 
 @Component({
   selector: 'long-update-popup',
@@ -37,11 +40,21 @@ export class LongUpdatePopupComponent extends AbstractComponent implements OnIni
   @ViewChild('inputSearch')
   private _inputSearch: ElementRef;
 
+  private swappingDatasetId : string;
+
+  private popupSubscription: Subscription;
+
+  private firstLoadCompleted: boolean = false;
+
   @Output()
   public closeEvent = new EventEmitter();
 
   @Output()
   public doneEvent = new EventEmitter();
+
+  @Output()
+  public addEvent = new EventEmitter();
+
 
   @Input()
   public dataflowId : string; // 현재 데이터플로우 아이디
@@ -50,7 +63,10 @@ export class LongUpdatePopupComponent extends AbstractComponent implements OnIni
   public isRadio : boolean = false;
 
   @Input()
+  public popType : string = '';
+
   public title : string;
+  public layoutType: string ='ADD'; // 새로운 데이터셋 추가 ADD, 기존 데이터셋 치환 SWAP
 
   @Input()
   //public originalDatasetList: Dataset[] = []; // 현재 데이터플로우에 추가되어 있는 모든 데이터셋 정보
@@ -59,12 +75,14 @@ export class LongUpdatePopupComponent extends AbstractComponent implements OnIni
 
   @Input()
   public selectedDatasetId : string; // 미리보기를 위해 화면에 선택된 데이터셋
-
   public originalDatasetId : string;
-
-
-  //public datasets: Dataset[] = []; // 화면에 보여지는 데이터셋 리스트 imported 만 빼서 저장하자
   public datasets: PrDataset[] = []; // 화면에 보여지는 데이터셋 리스트 imported 만 빼서 저장하자
+
+
+  // public clonedOriginalDatasetList : any [] = []; // 현재 데이터플로우에 추가되어있는 imported datasets
+  public isCheckAllDisabled : boolean = false;
+  public selectedDatasets : PrDataset[]; // 선택된 데이터셋 리스트
+
 
   @ViewChild(RadioSelectDatasetComponent)
   public radioSelectDatasetComponent : RadioSelectDatasetComponent;
@@ -74,14 +92,13 @@ export class LongUpdatePopupComponent extends AbstractComponent implements OnIni
   |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
   // 정렬
   public selectedContentSort: Order = new Order();
-
   public isCheckAll: boolean = false;
-
   public searchText: string = '';
   public searchType: string = 'IMPORTED';
-
   public isShow : boolean = false;
 
+  // popup status
+  public step: string;
 
   get countSelected() {
 
@@ -103,6 +120,7 @@ export class LongUpdatePopupComponent extends AbstractComponent implements OnIni
               protected injector: Injector,
               private dataflowService: DataflowService,
               private datasetService : DatasetService,
+              private popupService: PopupService,
               private dataflowModelService : DataflowModelService) {
     super(elementRef, injector);
   }
@@ -114,7 +132,42 @@ export class LongUpdatePopupComponent extends AbstractComponent implements OnIni
   // Init
   public ngOnInit() {
     super.ngOnInit();
-    this.originalDatasetId = this.selectedDatasetId;
+
+    this.popupSubscription = this.popupService.view$.subscribe((data: SubscribeArg) => {
+      this.step = data.name;
+      if (this.step === 'complete-dataset-create') {
+        this.selectedDatasetId = '';
+        this._initViewPage()
+      }
+    });
+
+    if(this.isRadio) {
+      this.layoutType = 'SWAP';
+    }else {
+      this.layoutType = 'ADD';
+    }
+
+    if(this.popType == 'add') {
+
+      this.title = 'Add datasets';
+
+    } else if(this.popType == 'imported') {
+
+      this.title = 'Replace dataset';
+
+    } else if(this.popType == 'wrangled') {
+
+      this.title = 'Change input dataset';
+    }
+
+    if(this.layoutType == 'ADD') {
+      // 새로운 데이터셋 추가 ADD
+      this.selectedDatasets = [];
+    }else if(this.layoutType == 'SWAP'){
+      // 기존 데이터셋 치환 SWAP
+      this.originalDatasetId = this.selectedDatasetId;
+    }
+    this.selectedDatasetId = '';
     this.init();
 
   }
@@ -143,23 +196,6 @@ export class LongUpdatePopupComponent extends AbstractComponent implements OnIni
    * 화면 초기화
    */
   public init() {
-
-    // if (this.dataflowModelService.getDatasetsFromDataflow().length !== 0 ) {
-    //   this.originalDatasetList = this.dataflowModelService.getDatasetsFromDataflow();
-    //   this.dataflowModelService.setDatasetsFromDataflow([]);
-    // }
-    //
-    // // 데이터플로우에 이미 추가된 데이터셋이 있다면 imported 만 clonedOriginalDatasetList에 넣는다.
-    // if (this.originalDatasetList.length > 0 ) {
-    //   this.originalDatasetList.forEach((item) => {
-    //     if (item.dsType === DsType.IMPORTED ) {
-    //       this.clonedOriginalDatasetList.push(item.dsId)
-    //     }
-    //   });
-    // }
-    //
-    // this.selectedDatasets = [];
-    //
     this._initViewPage();
   } // function - init
 
@@ -167,14 +203,22 @@ export class LongUpdatePopupComponent extends AbstractComponent implements OnIni
    * 다음 단계로 이동
    */
   public done() {
-
-    let param = {oldDsId:this.originalDatasetId, newDsId : this.radioSelectDatasetComponent.getSelectedDataset()};
-    if (this.title === 'Replace dataset') {
-      param['type'] = 'imported';
-    } else if (this.title === 'Change input dataset') {
-      param['type'] = 'wrangled';
+    if(this.layoutType == 'ADD') {
+      // 선택된 데이터셋이 없으면 X
+      if (this.selectedDatasets == undefined || this.selectedDatasets == null || this.selectedDatasets.length === 0 ) {
+        return
+      }
+      let datasetLists: string[] =  [];
+      this.selectedDatasets.forEach((ds) => {
+        datasetLists.push(ds.dsId);
+      });
+      this.addEvent.emit(datasetLists);
+    }else if(this.layoutType == 'SWAP') {
+      let param = {oldDsId:this.originalDatasetId, newDsId : this.swappingDatasetId};
+      param['type'] = this.popType;
+      this.doneEvent.emit(param);
     }
-    this.doneEvent.emit(param);
+
   } // function - next
 
   public sortEvent(data) {
@@ -201,6 +245,17 @@ export class LongUpdatePopupComponent extends AbstractComponent implements OnIni
     this.searchText = this._inputSearch.nativeElement.value;
     // 페이지 초기화
     this.page.page = 0;
+
+    // 상세정보 화면 초기화
+    this.selectedDatasetId = '';
+
+    // 선택된 checkbox  항목 초기화
+    this.selectedDatasets = [];
+
+    // 선택된 radio 항목 초기화
+    this.swappingDatasetId = '';
+    this.firstLoadCompleted = false;
+
     // 데이터소스 리스트 조회
     this.getDatasets();
   } // function - searchEvent
@@ -234,71 +289,138 @@ export class LongUpdatePopupComponent extends AbstractComponent implements OnIni
    */
   public createDataset() {
 
-    // 데이터셋 생성 페이지로 이동
-    this.router.navigate(['/management/datapreparation/dataset']);
-    sessionStorage.setItem('DATAFLOW_ID',this.dataflowId);
-    this.dataflowModelService.setDatasetsFromDataflow(this.originalDatasetList)
-
+    // 데이터셋 생성 팝업 생성
+    this.step = 'select-datatype';
 
   } // function - createDataset
 
   /**
    * 데이터셋 목록 불러오기
    */
-  public getDatasets() {
+  private getDatasets() {
+
     this.loadingShow();
-
     // const dslist = this.selectedDatasets.map((ds) => {return ds.dsId;});
+    if(this.layoutType == 'ADD') {
+      // 새로운 데이터셋 추가 ADD
+      const dslist = this.originalDatasetList.map((ds) => {return ds.dsId;});
 
-    this.dataflowService.getDatasets(this.searchText, this.page, 'listing', this.searchType, '')
-      .then((data) => {
-        this.loadingHide();
-        this.pageResult = data['page'];
-        const sorting = this.page.sort.split(',');
-        this.selectedContentSort.key = sorting[0];
-        this.selectedContentSort.sort = sorting[1];
+      this.dataflowService.getDatasets(this.searchText, this.page, 'listing', this.searchType, '')
+        .then((data) => {
+          this.loadingHide();
+          this.pageResult = data['page'];
+          const sorting = this.page.sort.split(',');
+          this.selectedContentSort.key = sorting[0];
+          this.selectedContentSort.sort = sorting[1];
 
-        if (this.page.page === 0) {
-          // 첫번째 페이지이면 초기화
-          this.datasets = [];
-        }
-
-        this.datasets = this.datasets.concat(data['_embedded'].preparationdatasets);
-
-        // 데이터플로우에 이미 추가된 데이터셋이라면 selected, origin 을 true 로 준다.
-        this.datasets.forEach((item) => {
-
-          if (item.dsId === this.selectedDatasetId ) {
-            // 데이터플로우에서 선택된 데이터셋이면 origin = true, selected = true;
-            item.selected = true;
-            item.origin = true;
-          } else{
-            item.selected = false;
-            item.origin = false;
+          if (this.page.page === 0) {
+            // 첫번째 페이지이면 초기화
+            this.datasets = [];
           }
 
-        });
+          this.datasets = this.datasets.concat(data['_embedded'].preparationdatasets);
 
-
-        if (sessionStorage.getItem('DATASET_ID')) {
-          this.selectedDatasetId = sessionStorage.getItem('DATASET_ID');
-          this.datasets.filter((item) => {
-            if (item.dsId === this.selectedDatasetId) {
-              item.selected = true;
+          // 데이터플로우에 이미 추가된 데이터셋이라면 selected, origin 을 true 로 준다.
+          this.datasets.forEach((item) => {
+            if (dslist.indexOf(item.dsId) > -1) {
+              // item.selected = true;
+              item.origin = true;
             }
           });
-          sessionStorage.removeItem('DATASET_ID');
-          this.datasetService.dataflowId = undefined;
-        }
 
-        // 총페이지 수
-        this.page.page += 1;
-      })
-      .catch((error) => {
-        this.loadingHide();
-        let prep_error = this.dataprepExceptionHandler(error);
-        PreparationAlert.output(prep_error, this.translateService.instant(prep_error.message));
-      });
+          this.isCheckAllDisabled = this.datasets.every((item) => {
+            return item.origin
+          });
+
+          if (0 !== this.datasets.length) {  // 데이터셋이 하나라도 있을때
+            const allTicked = this.datasets.filter((data) => {
+              return data.selected;
+            }).length;
+            this.datasets.length === allTicked ? this.isCheckAll = true : this.isCheckAll = false;
+          }
+
+          if (sessionStorage.getItem('DATASET_ID')) {
+            this.selectedDatasetId = sessionStorage.getItem('DATASET_ID');
+            this.datasets.filter((item) => {
+              if (item.dsId === this.selectedDatasetId) {
+                item.selected = true;
+                this.selectedDatasets.push(item);
+              }
+            });
+            sessionStorage.removeItem('DATASET_ID');
+            this.datasetService.dataflowId = undefined;
+          }
+
+          // 총페이지 수
+          this.page.page += 1;
+        })
+        .catch((error) => {
+          this.loadingHide();
+          let prep_error = this.dataprepExceptionHandler(error);
+          PreparationAlert.output(prep_error, this.translateService.instant(prep_error.message));
+        });
+
+    }else if(this.layoutType == 'SWAP'){
+      // 기존 데이터셋 치환 SWAP
+
+      this.dataflowService.getDatasets(this.searchText, this.page, 'listing', this.searchType, '')
+        .then((data) => {
+          this.loadingHide();
+          this.pageResult = data['page'];
+          const sorting = this.page.sort.split(',');
+          this.selectedContentSort.key = sorting[0];
+          this.selectedContentSort.sort = sorting[1];
+
+          if (this.page.page === 0) {
+            // 첫번째 페이지이면 초기화
+            this.datasets = [];
+          }
+
+          this.datasets = this.datasets.concat(data['_embedded'].preparationdatasets);
+
+          // 데이터 플로우에 이미 추가된 데이터셋이라면 selected, origin 을 true 로 준다.
+          this.datasets.forEach((item) => {
+            if (item.dsId === this.selectedDatasetId ) {
+              // 데이터플로우에서 선택된 데이터셋이면 origin = true, selected = true;
+              item.selected = true;
+              item.origin = true;
+            } else{
+              item.selected = false;
+              item.origin = false;
+            }
+          });
+
+          // SWAP (radio button) mode : radio button 이 check 되지 않은 상태에서 부모화면에서 선택한 데이터셋이 load 된 경우, 이 항목의 radio button 을 check 한다
+          if(this.firstLoadCompleted == false && (this.swappingDatasetId == undefined || this.swappingDatasetId == '')) {
+            for(let i: number =0; i < this.datasets.length; i = i +1) {
+              if(this.originalDatasetId == this.datasets[i].dsId) {
+                this.swappingDatasetId = this.datasets[i].dsId;
+                this.firstLoadCompleted = true;
+                break;
+              }
+            }
+          }
+
+          // if (sessionStorage.getItem('DATASET_ID')) {
+          //   this.selectedDatasetId = sessionStorage.getItem('DATASET_ID');
+          //   this.datasets.filter((item) => {
+          //     if (item.dsId === this.selectedDatasetId) {
+          //       item.selected = true;
+          //     }
+          //   });
+          //   sessionStorage.removeItem('DATASET_ID');
+          //   this.datasetService.dataflowId = undefined;
+          // }
+
+          // 총페이지 수
+          this.page.page += 1;
+        })
+        .catch((error) => {
+          this.loadingHide();
+          let prep_error = this.dataprepExceptionHandler(error);
+          PreparationAlert.output(prep_error, this.translateService.instant(prep_error.message));
+        });
+    }
   } // function - getDatasets
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
   | Protected Method
@@ -312,6 +434,8 @@ export class LongUpdatePopupComponent extends AbstractComponent implements OnIni
    * @private
    */
   private _initViewPage() {
+    // 검색어 초기화
+    this.searchText  = '';
 
     // 정렬
     this.selectedContentSort = new Order();
@@ -321,9 +445,151 @@ export class LongUpdatePopupComponent extends AbstractComponent implements OnIni
     // page 설정
     this.page.page = 0;
     this.page.size = 15;
+    this.page.sort = this.selectedContentSort.key + ',' + this.selectedContentSort.sort;
 
     this.getDatasets();
   } // function - initViewPage
+
+
+
+  /**
+   * 정렬 정보 변경
+   * @param {string} column
+   */
+  public changeOrder(column: string) {
+
+    // 선택된 radio 항목 초기화
+    this.swappingDatasetId = '';
+    // this.firstLoadCompleted = false;
+
+    // 상세화면 초기화(close)
+    this.selectedDatasetId = '';
+    // checkbox 선택 항목 초기화
+    this.selectedDatasets = [];
+
+
+    // page sort 초기화
+    this.selectedContentSort.sort = this.selectedContentSort.key !== column ? 'default' : this.selectedContentSort.sort;
+    // 정렬 정보 저장
+    this.selectedContentSort.key = column;
+
+    if (this.selectedContentSort.key === column) {
+      // asc, desc, default
+      switch (this.selectedContentSort.sort) {
+        case 'asc':
+          this.selectedContentSort.sort = 'desc';
+          break;
+        case 'desc':
+          this.selectedContentSort.sort = 'asc';
+          break;
+        case 'default':
+          this.selectedContentSort.sort = 'desc';
+          break;
+      }
+    }
+
+    // 페이지 초기화
+    this.page.page = 0;
+
+    this.page.sort = column + ',' + this.selectedContentSort.sort;
+
+    this.getDatasets();
+
+    // this.sortEvent.emit(this.page);
+  } // function - changeOrder
+
+  /**
+   * 데이터 셋 선택
+   * @param dataset
+   */
+  public selectDataset(dataset : any) {
+
+    // 지금 보고있는 데이터면 show 해제
+    if (dataset.dsId === this.selectedDatasetId) {
+      this.selectedDatasetId = '';
+    } else {
+      // 데이터 아이디 저장
+      this.selectedDatasetId = dataset.dsId;
+    }
+  } // function - selectDataset
+
+  /**
+   *  라디오 버튼 선택
+   */
+  public radioCheck(event,item) {
+    event.stopPropagation();
+    this.swappingDatasetId = item.dsId;
+  } // function - check
+
+  /**
+   * 체크박스 전체 선택
+   */
+  public checkAll() {
+
+    const currentCheck: boolean = this.isCheckAll;
+    this.isCheckAll = !currentCheck;
+
+    this.datasets = this.datasets.map((obj) => {
+      if(obj.origin == true) {
+        obj.selected = false; //  obj.selected = true or false
+      }else{
+        obj.selected = this.isCheckAll; //  obj.selected = true or false
+      }
+      return obj;
+    });
+
+    this.selectedDatasets = [];
+    if(this.datasets !== null && this.datasets !== undefined) {
+      for(let i: number =0; i < this.datasets.length; i = i + 1) {
+        if(this.datasets[i].hasOwnProperty('selected') && this.datasets[i]['selected'] == true) {
+          this.selectedDatasets.push(this.datasets[i]);
+        }
+      }
+    }
+  } // function - checkAll
+
+  /**
+   * 체크박스 선택
+   */
+  public check(event,item) {
+    event.stopImmediatePropagation();
+
+    if (item.origin) {
+      return;
+    }
+
+    item.selected = !item.selected;
+    this.selectedDatasets = [];
+    let originDatasetsCount: number = 0;
+
+    if(this.datasets !== null && this.datasets !== undefined) {
+      for(let i: number =0; i < this.datasets.length; i = i + 1) {
+        if(this.datasets[i].hasOwnProperty('origin') && this.datasets[i]['origin'] == true) {
+          originDatasetsCount ++;
+        }else if(this.datasets[i].hasOwnProperty('selected') && this.datasets[i]['selected'] == true) {
+          this.selectedDatasets.push(this.datasets[i]);
+        }
+      }
+    }
+
+    const num = this.datasets.filter((data) => {
+      return data.selected;
+    }).length;
+
+    this.datasets.length === (num + originDatasetsCount) ? this.isCheckAll = true : this.isCheckAll = false;
+
+  } // function - check
+
+  /**
+   * 더보기 버튼 클릭
+   */
+  public getMoreList() {
+    // 더 보여줄 데이터가 있다면
+    if (this.page.page < this.pageResult.totalPages) {
+      // 데이터셋 조회
+      this.getDatasets();
+    }
+  } // function - getMoreList
 
 
 }

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/dataflow-detail.component.html
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/dataflow-detail.component.html
@@ -152,12 +152,12 @@
 </app-edit-dataflow-rule-2>
 <!-- //룰 편집 화면 -->
 
-<app-add-dataset *ngIf="isDatasetAddPopupOpen"
-                 (closeEvent)="closeAddDatasetPopup()"
-                 (doneEvent)="datasetComplete($event);"
-                 [dataflowId]="dataflow.dfId"
-                 [originalDatasetList]="dataSetList">
-</app-add-dataset>
+<!--<app-add-dataset *ngIf="isDatasetAddPopupOpen"-->
+                 <!--(closeEvent)="closeAddDatasetPopup()"-->
+                 <!--(doneEvent)="datasetComplete($event);"-->
+                 <!--[dataflowId]="dataflow.dfId"-->
+                 <!--[originalDatasetList]="dataSetList">-->
+<!--</app-add-dataset>-->
 
 <long-update-popup
   *ngIf="isSelectDatasetPopupOpen"

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/dataflow-detail.component.html
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/dataflow-detail.component.html
@@ -161,10 +161,12 @@
 
 <long-update-popup
   *ngIf="isSelectDatasetPopupOpen"
-  [title]="datasetPopupTitle"
+  [popType]="longUpdatePopupType"
   [selectedDatasetId]="swapDatasetId"
+  [originalDatasetList]="dataSetList"
   (closeEvent)="isSelectDatasetPopupOpen = false"
   (doneEvent)="datasetPopupFinishEvent($event)"
+  (addEvent)="datasetPopupAddEvent($event)"
   [isRadio]="isRadio">
 </long-update-popup>
 

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/dataflow-detail.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/dataflow-detail.component.ts
@@ -162,8 +162,9 @@ export class DataflowDetailComponent extends AbstractPopupComponent implements O
   public isDatasetAddPopupOpen: boolean = false;
 
   public step: string;
+  public longUpdatePopupType: string = '';
 
-  public datasetPopupTitle : string = 'Add datasets';   // Swap dataset popup title
+  // public datasetPopupTitle : string = 'Add datasets';   // Swap dataset popup title
   public isSelectDatasetPopupOpen : boolean = false;    // Swap dataset popup open/close
   public isRadio : boolean = false;                     // If swapping -> true / if Adding -> false
   public swapDatasetId : string;                        // Swapping 대상 imported 면 dataset id wrangled 면 upstreamId
@@ -261,10 +262,11 @@ export class DataflowDetailComponent extends AbstractPopupComponent implements O
   }
 
   public addDatasets() {
-    this.isDatasetAddPopupOpen = true;
-    if (this.datasetInfoPopup) {
-      this.datasetInfoPopup.clearExistingInterval();
-    }
+    // this.isDatasetAddPopupOpen = true;
+    // if (this.datasetInfoPopup) {
+    //   this.datasetInfoPopup.clearExistingInterval();
+    // }
+    this.openAddDatasetPopup(null);
   }
 
   public closeAddDatasetPopup() {
@@ -1081,6 +1083,35 @@ export class DataflowDetailComponent extends AbstractPopupComponent implements O
   }
 
 
+
+  /**
+   * Add datasets (event listener)
+   * @param data
+   */
+  public datasetPopupAddEvent(data): void {
+
+    if (data == undefined || data == null || data.length === 0 ) {
+      return
+    }
+    this.loadingShow();
+    this.dataSetList.forEach((ds) => {
+      data.push(ds.dsId);
+    });
+
+    this.dataflowService.updateDataSets(this.dataflow.dfId, { dsIds : data }).then((result) => {
+      this.loadingHide();
+      this.selectedDataSet.dsId = '';
+      this.isSelectDatasetPopupOpen = false;
+      Alert.success(this.translateService.instant('msg.dp.alert.add.ds.success'));
+      this.getDataflow();
+    }).catch((error) => {
+      this.loadingHide();
+      Alert.error(this.translateService.instant(error.message));
+      console.info('error -> ', error);
+    });
+  }
+
+
   private _addDatasetToDataflow(dfId, datasetLists) {
     return new Promise(((resolve, reject) => {
       this.dataflowService.updateDataSets(dfId, { dsIds : datasetLists, forSwap: true })
@@ -1125,15 +1156,23 @@ export class DataflowDetailComponent extends AbstractPopupComponent implements O
    */
   public openAddDatasetPopup(data :any) {
 
-    this.swapDatasetId = data.dsId;
-    if (data.type === 'imported') {
-      this.datasetPopupTitle = 'Replace dataset';
-      this.isRadio = true;
-    } else if (data.type === 'wrangled') {
-      this.datasetPopupTitle = 'Change input dataset';
-      this.isRadio = true;
-    } else {
-      this.datasetPopupTitle = 'Add datasets';
+    // console.info('openAddDatasetPopup', data);
+    if(data === null) {
+      this.swapDatasetId = null;
+      this.longUpdatePopupType = 'add';
+      // this.datasetPopupTitle = 'Add datasets';
+      this.isRadio = false;
+    }else{
+      this.swapDatasetId = data.dsId;
+      if (data.type === 'imported') {
+        // this.datasetPopupTitle = 'Replace dataset';
+        this.isRadio = true;
+        this.longUpdatePopupType = 'imported';
+      } else if (data.type === 'wrangled') {
+        // this.datasetPopupTitle = 'Change input dataset';
+        this.isRadio = true;
+        this.longUpdatePopupType = 'wrangled';
+      }
     }
     this.isSelectDatasetPopupOpen = true;
   }

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/dataflow-detail.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/dataflow-detail.component.ts
@@ -159,7 +159,7 @@ export class DataflowDetailComponent extends AbstractPopupComponent implements O
 
   public cloneFlag: boolean = false;
 
-  public isDatasetAddPopupOpen: boolean = false;
+  // public isDatasetAddPopupOpen: boolean = false;
 
   public step: string;
   public longUpdatePopupType: string = '';
@@ -270,7 +270,7 @@ export class DataflowDetailComponent extends AbstractPopupComponent implements O
   }
 
   public closeAddDatasetPopup() {
-    this.isDatasetAddPopupOpen = false;
+    // this.isDatasetAddPopupOpen = false;
   }
 
   /**
@@ -550,24 +550,24 @@ export class DataflowDetailComponent extends AbstractPopupComponent implements O
   }
 
   // 데이터셋 추가하기 show/hide 처리
-  public datasetComplete(data) {
-
-    this.isDatasetModalShow = false;
-    this.isDatasetAddPopupOpen = false;
-    if (!data.isCancel) { // dataflow를 새로 불러와야 하는 경우만 차트를 다시 그린다
-      this.getDataflow();
-
-      //선택된 데이터셋 초기화
-      this.initSelectedDataSet()
-
-    }
-  }
+  // public datasetComplete(data) {
+  //
+  //   this.isDatasetModalShow = false;
+  //   // this.isDatasetAddPopupOpen = false;
+  //   if (!data.isCancel) { // dataflow를 새로 불러와야 하는 경우만 차트를 다시 그린다
+  //     this.getDataflow();
+  //
+  //     //선택된 데이터셋 초기화
+  //     this.initSelectedDataSet()
+  //
+  //   }
+  // }
 
   // 데이터셋 교체 show/hide 처리
-  public datasetExchangeComplete() {
-    this.isDatasetExchangeModalShow = false;
-    this.getDataflow();
-  }
+  // public datasetExchangeComplete() {`
+  //   this.isDatasetExchangeModalShow = false;
+  //   this.getDataflow();
+  // }
 
   /**
    * 데이터셋 타입 아이콘
@@ -1134,7 +1134,7 @@ export class DataflowDetailComponent extends AbstractPopupComponent implements O
     this.loadingShow();
 
     this.dataflowService.swapDataset(param).then((result) => {
-      console.info('swapping >>>>>>>>>>>>', result);
+      // console.info('swapping >>>>>>>>>>>>', result);
       Alert.success('Swap successful');
 
       this.isSelectDatasetPopupOpen = false;

--- a/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-name.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-name.component.ts
@@ -264,7 +264,7 @@ export class CreateDatasetNameComponent extends AbstractPopupComponent implement
     this.close();
     this.popupService.notiPopup({
       name: 'complete-dataset-create',
-      data: null
+      data: result.dsId
     });
 
   }

--- a/discovery-frontend/src/assets/i18n/en.json
+++ b/discovery-frontend/src/assets/i18n/en.json
@@ -1286,7 +1286,7 @@
   "msg.dp.btn.switch.builder" : "Switch to builder",
   "msg.dp.btn.create.dataflow.dataset" : "Create dataflow with this dataset",
   "msg.dp.ui.swap.dataset" : "Swap dataset",
-  "msg.dp.ui.change.input.dataset" : "Change input dataset",
+  "msg.dp.ui.change.input.dataset" : "Swap input dataset",
   "msg.dp.ui.search-by.dataset" :"Search by dataset name",
   "msg.dp.ui.one.col.required" : "At least one column is required",
   "msg.dp.alert.enter.group.every" : "Please enter group every",

--- a/discovery-frontend/src/assets/i18n/ko.json
+++ b/discovery-frontend/src/assets/i18n/ko.json
@@ -1284,7 +1284,7 @@
   "msg.dp.btn.switch.builder" : "빌더로 전환",
   "msg.dp.btn.create.dataflow.dataset" : "이 데이터셋으로 새로운 데이터플로우 생성",
   "msg.dp.ui.swap.dataset" : "데이터셋 치환",
-  "msg.dp.ui.change.input.dataset" : "입력 데이터셋 변경",
+  "msg.dp.ui.change.input.dataset" : "입력 데이터셋 치환",
   "msg.dp.ui.search-by.dataset" :"데이터셋 이름으로 검색하세요",
   "msg.dp.ui.one.col.required" : "하나 이상의 컬럼이 필요합니다",
   "msg.dp.alert.enter.group.every" : "그룹 수를 입력하세요",

--- a/discovery-frontend/src/assets/i18n/zh.json
+++ b/discovery-frontend/src/assets/i18n/zh.json
@@ -1218,8 +1218,8 @@
   "msg.dp.btn.switch.editor": "转换为编辑",
   "msg.dp.btn.switch.builder": "转换为builder",
   "msg.dp.btn.create.dataflow.dataset": "用该数据组生成新的数据流",
-  "msg.dp.ui.swap.dataset": "数据组置换",
-  "msg.dp.ui.change.input.dataset": "变更输入数据组",
+  "msg.dp.ui.swap.dataset": "数据组置換",
+  "msg.dp.ui.change.input.dataset": "置換输入数据组",
   "msg.dp.ui.search-by.dataset": "请用数据组名进行搜索",
   "msg.dp.ui.one.col.required": "需要一个以上的列",
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
* add create dataset in swap popup
The add dataset screen, which runs on the Dataflow detail screen, has been changed.
"Create dataset" button has been added at the bottom of the add dataset, swap dataset pop-up screen.
The pop-up screen title has been changed.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#932 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. menu MANAGEMENT > DataPreparation > Dataflow
2. click dataflow item
3. click '+Add dataset' button
4. click '+Create Dataset' at the bottom of screen
5. dataset creation progress
6. confirms that the data set is normally added/selected after it has been created

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
