### PR TITLE
#475 Filters set in presentation mode will continue to apply in the future, but not visible

### DIFF
--- a/discovery-frontend/src/app/dashboard/util/dashboard.util.ts
+++ b/discovery-frontend/src/app/dashboard/util/dashboard.util.ts
@@ -673,6 +673,12 @@ export class DashboardUtil {
         board.configuration.filters[idx] = _.merge(board.configuration.filters[idx], filter);
       }
     }
+
+    // for presentation mode
+    const targetWidget:FilterWidget
+      = <FilterWidget>board.widgets.find( item => this.isSameFilterAndWidget( board, filter, item ) );
+    ( targetWidget ) && ( targetWidget.configuration.filter = filter );
+
     return board;
   } // function - updateBoardFilter
 


### PR DESCRIPTION
### Description
When I select a filter in Presentation mode, the selected filter is applied well.
This is true even if I continue to be in playing presentation, but the problem is that the filter does not appear on the screen (but applied).

**Related Issue** : #475 <!--- Please link to the issue here. -->

### How Has This Been Tested?
1. 대시보드에 차트와 필터 위젯을 만들어 배치합니다. 
2. 프레젠테이션 뷰로 이동합니다.
3. 필터 위젯의 값을 선택합니다. 
4. 'Play' 버튼을 누릅니다.
5. 대시보드가 변경되면서 이전에 선택된 필터값이 유지되는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
