### PR TITLE
#1159 Support for querying data in a table with a very large number of columns

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/QueryEditorResult.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/QueryEditorResult.java
@@ -23,7 +23,8 @@ public class QueryEditorResult {
   @Column(name = "file_path")
   private String filePath;
 
-  @Column(name = "fields", length = 65535, columnDefinition = "TEXT")
+  @Lob
+  @Column(name = "fields")
   @JsonRawValue
   @JsonDeserialize(using = KeepAsJsonDeserialzier.class)
   private String fields;


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
* 워크 벤치에서 컬럼 갯수가 매우 많은 테이블(예. 500개 이상)을 select 시에 오류나는 것을 수정했습니다.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#1159 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
* 메타트론 데이터베이스를 MySQL로 사용하고 MySQL 다른 데이터베이스 1000개 컬럼을 가진 테스트 테이블을 만들었습니다.
* 메타트론 워크벤치에서 오류나지 않고 SELECT 되는 것을 확인했습니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

### Additional Context<!-- if not appropriate, remove this topic. -->
