### PR TITLE
if an excel has null value, the value is presented by empty value

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetFileService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetFileService.java
@@ -556,8 +556,11 @@ public class PrepDatasetFileService {
                                     if(c==null) {
                                         result.put(f.getName(), null);
                                     } else {
+                                        String strCellValue = null;
                                         Object cellValue = ExcelProcessor.getCellValue(c);
-                                        String strCellValue = String.valueOf(cellValue);
+                                        if(cellValue!=null) {
+                                            strCellValue = String.valueOf(cellValue);
+                                        }
                                         result.put(f.getName(), strCellValue);
                                     }
                                 }
@@ -1342,14 +1345,16 @@ public class PrepDatasetFileService {
                     }
 
                     Object cellValue = ExcelProcessor.getCellValue(c);
-                    String value = String.valueOf(cellValue);
-                    if (value.contains("\"")) {
-                        value = value.replace("\"", "\"\"");
+                    if(cellValue!=null) {
+                        String value = String.valueOf(cellValue);
+                        if (value.contains("\"")) {
+                            value = value.replace("\"", "\"\"");
+                        }
+                        if (value.contains(",")) {
+                            value = "\"" + value + "\"";
+                        }
+                        sb.append(value);
                     }
-                    if (value.contains(",")) {
-                        value = "\"" + value + "\"";
-                    }
-                    sb.append(value);
                 }
                 sb.append("\n");
                 writer.append(sb.toString());


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
If a file dataset has null value.
we have to show an empty string not the string of "null" 

**Related Issue** : 
[#1242](https://github.com/metatron-app/metatron-discovery/issues/1242)


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. create a file dataset has null values
2. check the grid of preview
3. if the value is presented by empty value, that is ok. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
