### PR TITLE
Set granularities properly when import datasource from Druid.

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/engine/model/SegmentMetaDataResponse.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/engine/model/SegmentMetaDataResponse.java
@@ -244,6 +244,14 @@ public class SegmentMetaDataResponse implements Serializable {
     this.queryGranularity = queryGranularity;
   }
 
+  public Granularity getSegmentGranularity() {
+    return segmentGranularity;
+  }
+
+  public void setSegmentGranularity(Granularity segmentGranularity) {
+    this.segmentGranularity = segmentGranularity;
+  }
+
   public String getErrorMessage() { return errorMessage; }
 
   public void setErrorMessage(String errorMessage) { this.errorMessage = errorMessage; }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Set granularities properly when import datasource from Druid.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#118

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Metatron Discovery를 거치지 않고, Druid API를 통해 데이터소스를 적재 합니다.
  1-1. Granularity Spec을 Simple로 설정 합니다.
```json
 "granularitySpec": {
        "type": "uniform",
        "segmentGranularity": "MINUTE",
        "queryGranularity": {"type": "MONTH"},
        "intervals": [
          "1970-01-01/2050-01-01"
        ],
        "rollup": true
      }
```
  1-2. Granularity Spec을 Duration으로 설정합니다.
```json
 "granularitySpec": {
        "type": "uniform",
        "segmentGranularity": {"type": "duration", "duration": "3600000"},
        "queryGranularity": {"type": "duration", "duration": "3600000"},
        "intervals": [
          "1970-01-01/2050-01-01"
        ],
        "rollup": true
      }
```

  1-3. Granularity Spec을 Period로 설정합니다.
```json
 "granularitySpec": {
        "type": "uniform",
        "segmentGranularity": {"type": "period", "period": "PT1H"},
        "queryGranularity": {"type": "period", "period": "P1D"},
        "intervals": [
          "1970-01-01/2050-01-01"
        ],
        "rollup": true
      }
```

2. Discovery에서 데이터소스 > Metatorn engine으로 1항에서 만든 데이터소스를 import 합니다.

3. 세가지 방법 모두 정상적으로 granularity가 등록되었는지 확인 합니다.
![image](https://user-images.githubusercontent.com/42234141/51154704-490abb80-18b8-11e9-85eb-9082d022088e.png)



### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Additional Context<!-- if not appropriate, remove this topic. -->
Mapping information default and period.

| Tables   |      Simple      |  Period |
|----------|:-------------:|------:|
| 1 sec |  SECOND | PT1S |
| 1 min |  MINUTE | PT1M |
| 5 min |  FIVE_MINUTE | PT5M |
| 10 min |  TEN_MINUTE | PT10M |
| 15 min |  FIFTEEN_MINUTE | PT15M |
| 30 min |  THIRTY_MINUTE | PT30M |
| 1 hour |  HOUR | PT1H |
| 6 hours |  SIX_HOUR | PT6H |
| 1 day |  DAY | P1D |
| 1 week |  WEEK | P1W |
| 1 month |  MONTH | P1M |
| 1 quarter |  QUARTER | P3M |
| 1 year |  YEAR | P1Y |