### PR TITLE
#1215 roll up false for chart preview

### DIFF
--- a/discovery-frontend/src/app/workbench/workbench.component.ts
+++ b/discovery-frontend/src/app/workbench/workbench.component.ts
@@ -2792,7 +2792,7 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
       },
       removeFirstRow: true,
       path: currentResultTab.result.csvFilePath,
-      rollup: true
+      rollup: false
     };
 
     this.loadingShow();


### PR DESCRIPTION
### Description
Changed the rollup parameter to false when creating Chart Preview DataSource

**Related Issue** : #1215 


### How Has This Been Tested?
1. goto workbench
2. input simple query and execute query.
```
select 'aa' as col1
union all 
select 'aa' as col1;
```
3. click 'chart preview' button

4. click 'datasource info' button
<img width="535" alt="metatron_discovery" src="https://user-images.githubusercontent.com/3770446/51221194-d6631400-197b-11e9-9e24-301e1e75b3a4.png">

5. grid must have two rows.
<img width="324" alt="metatron_discovery" src="https://user-images.githubusercontent.com/3770446/51221250-0e6a5700-197c-11e9-9829-0cb853692210.png">




### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
