### PR TITLE
#1260 histogram never fails no matter how wide the timestamp range is

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/Histogram.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/Histogram.java
@@ -1059,8 +1059,8 @@ public class Histogram implements Serializable {
     List<Granule> granules  = new ArrayList<>();
     List<Integer> unitSizes = new ArrayList<>();
 
-    granules.addAll( Arrays.asList(new Granule[]{YEAR, YEAR, YEAR, YEAR}));
-    unitSizes.addAll(Arrays.asList(new Integer[]{  10,    5,    2,    1}));
+    granules.addAll( Arrays.asList(new Granule[]{YEAR, YEAR, YEAR, YEAR, YEAR, YEAR, YEAR, YEAR, YEAR}));
+    unitSizes.addAll(Arrays.asList(new Integer[]{5000, 1000,  500,  100,   50,   10,    5,    2,    1}));
 
     granules.addAll( Arrays.asList(new Granule[]{MONTH, MONTH, MONTH, MONTH}));
     unitSizes.addAll(Arrays.asList(new Integer[]{    6,    3,      2,     1}));


### PR DESCRIPTION
### Description
Histogram never fails no matter how wide the timestamp range is like centuries.

**Related Issue** : https://github.com/metatron-app/metatron-discovery/issues/1260


### How Has This Been Tested?
Run locally.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.