### PR TITLE
Fix date range format (Add T for time)

### DIFF
--- a/discovery-frontend/src/app/common/directive/input-mask.directive.ts
+++ b/discovery-frontend/src/app/common/directive/input-mask.directive.ts
@@ -27,7 +27,7 @@ export class InputMaskDirective {
     number: '^[0-9]*$',
     float: '^[+-]?([0-9]*[.])?[0-9]+$',
     words: '([A-z]*\\s)*',
-    calendar: '^[0-9:\-\\s]*$'
+    calendar: '^[0-9:T\-\\s]*$'
   };
 
   @Input('input-mask')

--- a/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/information-dats-source/information-data-source.component.html
+++ b/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/information-dats-source/information-data-source.component.html
@@ -211,7 +211,7 @@
             </label>
             <!-- edit option -->
             <div class="ddp-ui-edit-option">
-              {{getIngestionInterval()}}
+              {{getDataRangeLabel()}}
             </div>
             <!-- //edit option -->
           </div>

--- a/discovery-frontend/src/app/data-storage/service/granularity.service.ts
+++ b/discovery-frontend/src/app/data-storage/service/granularity.service.ts
@@ -216,11 +216,11 @@ export class GranularityService {
   private _getDateTimeFormat(granularity: GranularityObject): string {
     switch (granularity.value) {
       case Granularity.SECOND:
-        return 'YYYY-MM-DD HH:mm:ss';
+        return 'YYYY-MM-DDTHH:mm:ss';
       case Granularity.MINUTE:
-        return 'YYYY-MM-DD HH:mm';
+        return 'YYYY-MM-DDTHH:mm';
       case Granularity.HOUR:
-        return 'YYYY-MM-DD HH';
+        return 'YYYY-MM-DDTHH';
       case Granularity.DAY:
         return 'YYYY-MM-DD';
       case Granularity.MONTH:
@@ -228,7 +228,7 @@ export class GranularityService {
       case Granularity.YEAR:
         return 'YYYY';
       default:
-        return 'YYYY-MM-DD HH:mm:ss';
+        return 'YYYY-MM-DDTHH:mm:ss';
     }
   }
 
@@ -296,11 +296,11 @@ export class GranularityService {
   private _getDateTimeRegexp(granularity: GranularityObject): RegExp {
     switch (granularity.value) {
       case Granularity.SECOND:  // YYYY-MM-DD HH:mm:ss
-        return /^(\d{4}|\d{2})-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])\s(2[0-3]|[01][0-9]):[0-5][0-9]:[0-5][0-9]$/;
+        return /^(\d{4}|\d{2})-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T(2[0-3]|[01][0-9]):[0-5][0-9]:[0-5][0-9]$/;
       case Granularity.MINUTE:  // YYYY-MM-DD HH:mm
-        return /^(\d{4}|\d{2})-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])\s(2[0-3]|[01][0-9]):[0-5][0-9]$/;
+        return /^(\d{4}|\d{2})-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T(2[0-3]|[01][0-9]):[0-5][0-9]$/;
       case Granularity.HOUR:  // YYYY-MM-DD HH
-        return /^(\d{4}|\d{2})-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])\s(2[0-3]|[01][0-9])$/;
+        return /^(\d{4}|\d{2})-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T(2[0-3]|[01][0-9])$/;
       case Granularity.DAY:  // YYYY-MM-DD
         return /^(\d{4}|\d{2})-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$/;
       case Granularity.MONTH:  // YYYY-MM


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
interval을 포함한 적재 수행시에, 타임 포맷에 공백이 있는 경우 
druid에서 invalid format 에러가 발생합니다.

서버단에서 적재 케이스마다 치환하는 로직을 넣기보다는
화면단 로직에서 포맷정의시 "T"를 포함하여 interval을 설정하게 하였습니다.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#1092

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. StagingDB 방식으로 데이터소스를 적재합니다.
2. 임의의 테이블을 선택한 뒤 수집 설정 화면에서 
"세그먼트 단위"를 "시간"으로 선택합니다.

3. 데이터 범위에서 날짜와 시간 사이에 공백이 아닌 "T"가 나타나는것으로 확인합니다.
4. "다음" 버튼 클릭 및 적재 수행시 포맷 에러 없이 정상 적재됨을 확인합니다.


### Additional Context<!-- if not appropriate, remove this topic. -->
input-mask 제어로직 중, calendar 타입일 경우 숫자 이외에도 T를 허용하게 변경했습니다.

(숫자, 공백, : , T 가 허용됩니다)