### PR TITLE
#1276 Remove unusing fields into SelectMeta Query.

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/queries/SelectMetaQueryBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/queries/SelectMetaQueryBuilder.java
@@ -90,6 +90,10 @@ public class SelectMetaQueryBuilder extends AbstractQueryBuilder {
 
       String aliasName = reqField.getAlias();
 
+      if (UserDefinedField.REF_NAME.equals(reqField.getRef())) {
+        unUsedVirtualColumnName.remove(fieldName);
+      }
+
       if (reqField instanceof DimensionField || reqField instanceof TimestampField) {
           dimensions.add(new DefaultDimension(fieldName, aliasName));
       } else if (reqField instanceof MeasureField) {
@@ -161,6 +165,9 @@ public class SelectMetaQueryBuilder extends AbstractQueryBuilder {
     }
 
     if (virtualColumns != null) {
+      for (String removeColumnName : unUsedVirtualColumnName) {
+        virtualColumns.remove(removeColumnName);
+      }
       selectMetaQuery.setVirtualColumns(Lists.newArrayList(virtualColumns.values()));
     }
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
위젯 다운로드 화면에서 대상 파일의 사이즈 및 row 수를 계산하기 위한 selectMeta 쿼리 수행시 
불필요한 필드를 포함하여 druid에 보내는 케이스가 있습니다.

![image](https://user-images.githubusercontent.com/42234141/51591045-4438ae00-1f2f-11e9-9ea3-b5053b7a950c.png)

이로 인해 druid parser 에러가 발생하게 되기 때문에 
user defiend field를 실제 사용하는 경우에만 쿼리에 포함되도록 수정하였습니다.



**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#1276 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 측정값에 사용자 컬럼을 추가합니다.
   - 수식 : COUNTD( [City] ) 등

2. 1항에서 생성한 사용자 컬럼을 **포함하지 않고** grid 차트를 만듭니다.

3. grid차트 설정 창에서 '공통 설정' > '차트 유형' 을 "원본 데이터"로 설정 합니다.

![image](https://user-images.githubusercontent.com/42234141/51508575-37d22980-1e39-11e9-830f-4f13979de542.png)

4. 차트와 대시보드를 저장한 뒤, 위에서 생성한 위젯 우측 상단의 다운로드 기능이 정상적으로 동작하는지 확인합니다.

5. 확인 가능하다면, 드루이드 쿼리 스펙에 아래와 같이 vitual column에 사용하지 않는 필드가 빠져있음을 확인합니다.

``` json
  "virtualColumns": [
    **{
      "type": "expr",
      "outputName": "user_defined.countd",
      "expression": "COUNTD(\"City\")"
    },**
    {
      "type": "expr",
      "outputName": "user_defined.count",
      "expression": "count"
    }
  ],
```



### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Additional Context<!-- if not appropriate, remove this topic. -->
