### PR TITLE
f#1311 Fix Metadata list when popularity is null

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/MetadataPopularityService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/MetadataPopularityService.java
@@ -28,13 +28,22 @@ public class MetadataPopularityService {
 
     MetadataPopularity popularity = popularityRepository.findByTypeAndMetadataId(MetadataPopularity.PopularityType.METADATA, metadataId);
 
-    return popularity == null ? 0.0 : popularity.getPopularity();
+    if ( popularity == null || popularity.getPopularity() == null ) {
+      return 0.0;
+    } else {
+      return popularity.getPopularity();
+    }
+
   }
 
   public Double getPopularityColumnValue(Long metaColumn) {
 
     MetadataPopularity popularity = popularityRepository.findByTypeAndMetaColumnId(MetadataPopularity.PopularityType.METACOLUMN, metaColumn);
 
-    return popularity == null ? 0.0 : popularity.getPopularity();
+    if ( popularity == null || popularity.getPopularity() == null ) {
+      return 0.0;
+    } else {
+      return popularity.getPopularity();
+    }
   }
 }

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/mdm/MetadataRestIntegrationTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/mdm/MetadataRestIntegrationTest.java
@@ -155,6 +155,26 @@ public class MetadataRestIntegrationTest extends AbstractRestIntegrationTest {
 
   @Test
   @OAuthRequest(username = "polaris", value = {"ROLE_SYSTEM_USER"})
+  @Sql({"/sql/test_mdm_popularity.sql"})
+  public void findNullMetadataList(){
+    given()
+      .auth().oauth2(oauth_token)
+      .contentType(ContentType.JSON)
+      .accept(ContentType.JSON)
+      .param("page", "0")
+      .param("size", "15")
+      .param("sort", "createdTime,desc")
+      .param("projection", "forListView")
+      .log().all()
+    .when()
+      .get("/api/metadatas")
+    .then()
+      .statusCode(HttpStatus.SC_OK)
+      .log().all();
+  }
+
+  @Test
+  @OAuthRequest(username = "polaris", value = {"ROLE_SYSTEM_USER"})
   @Sql({"/sql/test_mdm.sql"})
   public void findMetadataList() {
     // @formatter:off

--- a/discovery-server/src/test/resources/sql/test_mdm_popularity.sql
+++ b/discovery-server/src/test/resources/sql/test_mdm_popularity.sql
@@ -1,0 +1,11 @@
+INSERT INTO mdm_metadata_source(id, meta_source_type, meta_source_name, meta_source_id, meta_source_schema, meta_source_table, created_by, created_time, modified_by, modified_time, version) values
+('test_engine_source_04', 'ENGINE', 'engine_datasource_04', 'source_id_4', null, null,'admin', NOW(),'admin', NOW(), 1.0);
+
+INSERT INTO mdm_metadata(id, meta_name, meta_desc, meta_source_type, source_id, created_by, created_time, modified_by, modified_time, version) values
+('test_meta4', 'Test metadata 4', 'Metadata with null popularity', 'ENGINE', 'test_engine_source_04', 'admin', NOW(), 'admin', NOW(), 1.0);
+
+INSERT INTO mdm_metadata_column(id, meta_id, column_physical_type, column_physical_name, dictionary_id, column_type, column_name, column_format, table_id) values
+(100041, 'test_meta4', 'STRING', 'pcolumn04', null, 'STRING', 'logical name4', null, null);
+
+INSERT INTO mdm_metadata_popularity (id, popularity_column_id, popularity_metacolumn_id, popularity_metadata_id, popularity_value, popularity_score, popularity_source_id, popularity_type) values
+(100061, null, null, 'test_meta4', null, null, 'test_engine_source_04', 'METADATA');


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Fix metadata list when popularity is null.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#1311 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Go to 'Management' -> 'Metadata' Menu.
2. Metadata list is shown normally.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
