### PR TITLE
Support Chinese currency on the chart.

### DIFF
--- a/discovery-frontend/src/app/common/component/chart/option/converter/format-option-converter.ts
+++ b/discovery-frontend/src/app/common/component/chart/option/converter/format-option-converter.ts
@@ -257,6 +257,7 @@ export class FormatOptionConverter {
           value = '£ ' + value;
           break;
         case String(UIFormatCurrencyType.JPY) :
+        case String(UIFormatCurrencyType.CNY) :
           value = '¥ ' + value;
           break;
         case String(UIFormatCurrencyType.EUR) :

--- a/discovery-frontend/src/app/common/component/chart/option/define/common.ts
+++ b/discovery-frontend/src/app/common/component/chart/option/define/common.ts
@@ -844,7 +844,8 @@ export enum UIFormatCurrencyType {
   USCENT = <any>'USCENT',
   GBP = <any>'GBP',
   JPY = <any>'JPY',
-  EUR = <any>'EUR'
+  EUR = <any>'EUR',
+  CNY = <any>'CNY'
 }
 
 /**

--- a/discovery-frontend/src/app/page/chart-style/format/format-item.component.ts
+++ b/discovery-frontend/src/app/page/chart-style/format/format-item.component.ts
@@ -80,7 +80,8 @@ export class FormatItemComponent extends AbstractComponent implements OnInit, On
     {name: '$ (USD)', value: 'USD'},
     {name: '£ (GBP)', value: 'GBP'},
     {name: '¥ (JPY)', value: 'JPY'},
-    {name: '€ (EUR)', value: 'EUR'}
+    {name: '€ (EUR)', value: 'EUR'},
+    {name: '¥ (CNY)', value: 'CNY'}
   ];
 
   // 선택된 기호


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Add Chinese currency on chart's number format option.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#1291 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Create any chart and go to the edit mode.
2. Click 'Number format' option.
3. Set format option to 'Currency'
4. There is a new currency option named '¥ (CNY)'
5. Select '¥ (CNY)' then check the number format is adapted.

![image](https://user-images.githubusercontent.com/42234141/51657497-7a863400-1fe8-11e9-881a-a53404b71879.png)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
