### PR TITLE
#1300 Fix tooltip z-index

### DIFF
--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-aggregate.component.html
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-aggregate.component.html
@@ -42,7 +42,7 @@
     <!-- //select box -->
     <!--<span class="ddp-txt-error ddp-size"><em class="ddp-icon-error-s"></em>{{'msg.dp.ui.aggregate.warning' | translate }}</span>-->
 
-    <div class="ddp-wrap-warning ddp-size">
+    <div class="ddp-wrap-warning ddp-size" style="position: relative; z-index: 10;">
       <div class="ddp-box-warning">
         <em class="ddp-icon-warning"></em>
         <div class="ddp-txt-warning">


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Change zindex of aggregation tool tip

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#1300 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1 . Go to dataflow main grid 
2 . select `aggregate` command 
3 . click expression input (drop down list will come down)
4 . hover yellow icon next to group by (when expression drop down is opened) 
5 . check if tool tip is not hiding under drop down

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
