### PR TITLE
#971 fix escaping separator when processing pivot column

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/data/result/PivotResultFormat.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/data/result/PivotResultFormat.java
@@ -14,6 +14,31 @@
 
 package app.metatron.discovery.domain.datasource.data.result;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.net.URI;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 import app.metatron.discovery.common.GlobalObjectMapper;
 import app.metatron.discovery.common.MatrixResponse;
 import app.metatron.discovery.domain.datasource.data.QueryTimeExcetpion;
@@ -34,28 +59,6 @@ import app.metatron.discovery.query.druid.limits.PivotSpec;
 import app.metatron.discovery.query.druid.limits.PivotWindowingSpec;
 import app.metatron.discovery.query.druid.queries.GroupingSet;
 import app.metatron.discovery.util.EnumUtils;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.File;
-import java.net.URI;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Created by kyungtaak on 2016. 8. 21..
@@ -265,8 +268,8 @@ public class PivotResultFormat extends SearchResultFormat {
       while (fields.hasNext()) {
         Map.Entry<String, JsonNode> nodeMap = fields.next();
         String nodeKey = nodeMap.getKey();
-        // Escape separator if nodeKey start with separator. ex. -SUM(m1)
-        nodeKey = nodeKey.startsWith(separator) ? nodeKey.substring(1) : nodeKey;
+        // Escape separator if nodeKey start with separator. ex. -SUM(m1) --SUM(m1)
+        nodeKey = nodeKey.startsWith(separator) ? nodeKey.substring(pivots.size()) : nodeKey;
         JsonNode nodeValue = nodeMap.getValue();
 
         // Percentage Case

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/datasource/data/DataQueryRestIntegrationTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/datasource/data/DataQueryRestIntegrationTest.java
@@ -42,7 +42,6 @@
 
 package app.metatron.discovery.domain.datasource.data;
 
-import app.metatron.discovery.fixture.SalesGeoDataSourceTestFixture;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
@@ -114,7 +113,7 @@ public class DataQueryRestIntegrationTest extends AbstractRestIntegrationTest {
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-    SalesGeoDataSourceTestFixture.setUp(datasourceEngineName);
+    //SalesGeoDataSourceTestFixture.setUp(datasourceEngineName);
   }
 
   @Before
@@ -1387,10 +1386,21 @@ public class DataQueryRestIntegrationTest extends AbstractRestIntegrationTest {
         new MeasureField("Discount", MeasureField.AggregationType.SUM)
     ));
 
-    SearchQueryRequest request = new SearchQueryRequest(dataSource1, filters, pivot2, limit);
+    // Case 2.
+    Pivot pivot3 = new Pivot();
+    pivot3.setColumns(Lists.newArrayList(new TimestampField("OrderDate", null,
+                                                            new ContinuousTimeFormat(false, TimeFieldFormat.TimeUnit.YEAR.name(), null))));
+    pivot3.setRows(null);
+    pivot3.setAggregations(Lists.newArrayList(
+        new DimensionField("Category"),
+        new DimensionField("Sub-Category"),
+        new MeasureField("Discount", MeasureField.AggregationType.SUM)
+    ));
+
+    SearchQueryRequest request = new SearchQueryRequest(dataSource1, filters, pivot3, limit);
     ChartResultFormat format = new ChartResultFormat("line");
-    //    format.addOptions("showPercentage", true);
-    //    format.addOptions("showCategory", true);
+    format.addOptions("showPercentage", true);
+    format.addOptions("showCategory", true);
     format.addOptions("isCumulative", true);
     format.addOptions("addMinMax", true);
     request.setResultFormat(format);


### PR DESCRIPTION
### Description
Pivot 대상의 컬럼이 2개 이상일경우, 엔진에서 전달받은 구분자가 포함된 컬럼 키를 제대로 파싱하지 못해 발생한 오류 입니다. Pivot 항목 수에 따라 구분자를 제거하도록 수정했습니다.

**Related Issue** : #971 

### How Has This Been Tested?
Pivot 대상의 컬럼이 2개 이상일 경우를 확인합니다.

0. 워크스페이스 > 워크북 생성 > 대시보드 내 차트위젯을 생성합니다.
1. Line Chart : 선반내 열 항목에 dimension 을 2개 이상 배치합니다.
  ex. 
![image](https://user-images.githubusercontent.com/822255/51801203-02d13700-227e-11e9-84d3-ac9b107403b0.png)


2. Bar Chart : 선반내 교차 항목에 dimension 을 2개 이상 배치합니다.
  ex. 
![image](https://user-images.githubusercontent.com/822255/51801217-1c727e80-227e-11e9-9582-7d9559ca32ed.png)



### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project. _it will be added soon_
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
