### PR TITLE
#1274 Checkbox global filter widget does not work properly

### DIFF
--- a/discovery-frontend/src/app/dashboard/filters/component/filter-multi-select/filter-multi-select.component.html
+++ b/discovery-frontend/src/app/dashboard/filters/component/filter-multi-select/filter-multi-select.component.html
@@ -36,7 +36,7 @@
             <label class="ddp-label-checkbox">
               <input type="checkbox"
                      [disabled]="isMockup" (change)="checkAll($event)"
-                     [checked]="selectedArray && selectedArray.length > 0 && selectedArray.length === array.length">
+                     [checked]="isSelectedAll">
               <i class="ddp-icon-checkbox ddp-dark"></i>
               <span class="ddp-txt-checkbox">{{'msg.comm.ui.list.all'|translate}}</span>
             </label>

--- a/discovery-frontend/src/app/dashboard/filters/component/filter-multi-select/filter-multi-select.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/component/filter-multi-select/filter-multi-select.component.ts
@@ -141,6 +141,13 @@ export class FilterMultiSelectComponent extends AbstractComponent implements OnI
   } // function - isSelectedItem
 
   /**
+   * Returns whether all item selected
+   */
+  public get isSelectedAll() {
+    return this.selectedArray && this.selectedArray.length > 0 && this.selectedArray.length === this.array.length;
+  } // function - isSelectedAll
+
+  /**
    * 아이템 선택
    * @param item
    * @param $event
@@ -153,12 +160,11 @@ export class FilterMultiSelectComponent extends AbstractComponent implements OnI
       return;
     }
 
-    if ($event.currentTarget.checked) {
-      this.selectedArray.push(item);
-    } else {
+    if (this.isSelectedItem( item )) {
       const idx = this.selectedArray.indexOf(item);
       this.selectedArray.splice(idx, 1);
-
+    } else {
+      this.selectedArray.push(item);
     }
 
     this.updateView(this.selectedArray);
@@ -176,16 +182,15 @@ export class FilterMultiSelectComponent extends AbstractComponent implements OnI
       return;
     }
 
-    const checked = $event.target ? $event.target.checked : $event.currentTarget.checked;
-    if (checked) {
+    if (this.isSelectedAll) {
       this.selectedArray = [];
-      this.array.forEach(item => this.selectedArray.push(item));
     } else {
       this.selectedArray = [];
+      this.array.forEach(item => this.selectedArray.push(item));
     }
 
     this.updateView(this.selectedArray);
-  }
+  } // function - checkAll
 
   /**
    * 외부영역 클릭

--- a/discovery-frontend/src/app/dashboard/widgets/filter-widget/filter-widget.component.html
+++ b/discovery-frontend/src/app/dashboard/widgets/filter-widget/filter-widget.component.html
@@ -79,7 +79,7 @@
         </li>
         <li *ngFor="let item of candidateList">
           <label class="ddp-label-checkbox">
-            <input type="checkbox" (click)="onSelectInclude(item, $event)"
+            <input type="checkbox" (click)="onSelectInclude(item)"
                    [disabled]="isEditMode"
                    [checked]="convertToIncludeFilter(filter).valueList.indexOf(item.name) > -1">
             <i class="ddp-icon-checkbox ddp-dark"></i>
@@ -102,7 +102,7 @@
         </li>
         <li *ngFor="let item of candidateList">
           <label class="ddp-label-radio">
-            <input type="radio" name="{{filter.field + widget.id}}" (click)="onSelectInclude(item, $event)"
+            <input type="radio" name="{{filter.field + widget.id}}" (click)="onSelectInclude(item)"
                    [disabled]="isEditMode"
                    [checked]="convertToIncludeFilter(filter).valueList.indexOf(item.name) > -1">
             <i class="ddp-icon-radio"></i>

--- a/discovery-frontend/src/app/dashboard/widgets/filter-widget/filter-widget.component.ts
+++ b/discovery-frontend/src/app/dashboard/widgets/filter-widget/filter-widget.component.ts
@@ -342,9 +342,8 @@ export class FilterWidgetComponent extends AbstractWidgetComponent implements On
   /**
    * Include Filter 값 선택
    * @param item
-   * @param $event
    */
-  public onSelectInclude(item: any, $event?: any) {
+  public onSelectInclude(item: any) {
 
     const filter = <InclusionFilter>this.filter;
 
@@ -362,8 +361,7 @@ export class FilterWidgetComponent extends AbstractWidgetComponent implements On
       filter.valueList.push(item.name);
     } else if (filter.selector === InclusionSelectorType.MULTI_LIST) {
       // 멀티 리스트
-      const checked = $event.target ? $event.target.checked : $event.currentTarget.checked;
-      if (checked) {
+      if (-1 === filter.valueList.indexOf( item.name ) ) {
         filter.valueList.push(item.name);
       } else {
         const idx = filter.valueList.indexOf(item.name);


### PR DESCRIPTION
### Description
글로벌차트 위젯으로 구성한 대시보드의 경우 체크박스 선택이 의도와 달리 작동함
예를 들어 체크리스트 중 2를 선택했으나 1,2가 동시 선택되거나 전체를 선택했으나 2가 빠짐

**Related Issue** : #1274 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
1. 필터 위젯이 포함된 대시보드를 생성합니다.
2. 필터 값의 체크 및 체크 해제가 정상적으로 동작하는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
