### PR TITLE
Change row parser to string on hadoop ingestion

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/AbstractSpecBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/AbstractSpecBuilder.java
@@ -28,6 +28,7 @@ import app.metatron.discovery.common.datasource.DataType;
 import app.metatron.discovery.domain.datasource.DataSource;
 import app.metatron.discovery.domain.datasource.DataSourceIngestionException;
 import app.metatron.discovery.domain.datasource.Field;
+import app.metatron.discovery.domain.datasource.ingestion.HdfsIngestionInfo;
 import app.metatron.discovery.domain.datasource.ingestion.HiveIngestionInfo;
 import app.metatron.discovery.domain.datasource.ingestion.IngestionInfo;
 import app.metatron.discovery.domain.datasource.ingestion.LocalFileIngestionInfo;
@@ -50,15 +51,7 @@ import app.metatron.discovery.spec.druid.ingestion.granularity.UniformGranularit
 import app.metatron.discovery.spec.druid.ingestion.index.LuceneIndexStrategy;
 import app.metatron.discovery.spec.druid.ingestion.index.LuceneIndexing;
 import app.metatron.discovery.spec.druid.ingestion.index.SecondaryIndexing;
-import app.metatron.discovery.spec.druid.ingestion.parser.CsvStreamParser;
-import app.metatron.discovery.spec.druid.ingestion.parser.DimensionsSpec;
-import app.metatron.discovery.spec.druid.ingestion.parser.JsonParseSpec;
-import app.metatron.discovery.spec.druid.ingestion.parser.OrcParser;
-import app.metatron.discovery.spec.druid.ingestion.parser.ParquetParser;
-import app.metatron.discovery.spec.druid.ingestion.parser.Parser;
-import app.metatron.discovery.spec.druid.ingestion.parser.StringParser;
-import app.metatron.discovery.spec.druid.ingestion.parser.TimeAndDimsParseSpec;
-import app.metatron.discovery.spec.druid.ingestion.parser.TimestampSpec;
+import app.metatron.discovery.spec.druid.ingestion.parser.*;
 
 public class AbstractSpecBuilder {
 
@@ -212,6 +205,8 @@ public class AbstractSpecBuilder {
       throw new IllegalArgumentException("Required file format.");
     }
 
+    boolean hadoopIngestion = (ingestionInfo instanceof HdfsIngestionInfo) || (ingestionInfo instanceof HiveIngestionInfo);
+
     Parser parser;
 
     if (fileFormat instanceof CsvFileFormat || fileFormat instanceof ExcelFileFormat) {
@@ -222,44 +217,68 @@ public class AbstractSpecBuilder {
                                        .map((field) -> field.getName())
                                        .collect(Collectors.toList());
 
-      CsvStreamParser csvStreamParser = new CsvStreamParser();
-
-      if (ingestionInfo instanceof LocalFileIngestionInfo) {
-        boolean skipHeaderRow = ((LocalFileIngestionInfo) ingestionInfo).getRemoveFirstRow();
-
-        // In case of Excel file, it is set to false because it is converted to headerless csv.
-        if(fileFormat instanceof ExcelFileFormat) {
-          skipHeaderRow = false;
-        }
-
-        csvStreamParser.setSkipHeaderRecord(skipHeaderRow);
-      }
-
-      if (fileFormat instanceof CsvFileFormat) {
-
+      if (hadoopIngestion) {
         CsvFileFormat csvFormat = (CsvFileFormat) fileFormat;
 
-        if (!csvFormat.isDefaultCsvMode()) {
-          csvStreamParser.setTimestampSpec(timestampSpec);
-          csvStreamParser.setDimensionsSpec(dimensionsSpec);
-          csvStreamParser.setColumns(columns);
-          csvStreamParser.setDelimiter(csvFormat.getDelimeter());
+        if (csvFormat.isDefaultCsvMode()) {
+          CsvParseSpec parseSpec = new CsvParseSpec();
+          parseSpec.setTimestampSpec(timestampSpec);
+          parseSpec.setDimensionsSpec(dimensionsSpec);
+          parseSpec.setColumns(columns);
 
-          parser = csvStreamParser;
+          parser = new StringParser(parseSpec);
+        } else {
+          TsvParseSpec parseSpec = new TsvParseSpec();
+          parseSpec.setTimestampSpec(timestampSpec);
+          parseSpec.setDimensionsSpec(dimensionsSpec);
+          parseSpec.setColumns(columns);
+
+          parseSpec.setDelimiter(csvFormat.getDelimeter());
+          parseSpec.setListDelimiter(csvFormat.getLineSeparator());
+
+          parser = new StringParser(parseSpec);
+        }
+      } else {
+
+        CsvStreamParser csvStreamParser = new CsvStreamParser();
+
+        if (ingestionInfo instanceof LocalFileIngestionInfo) {
+          boolean skipHeaderRow = ((LocalFileIngestionInfo) ingestionInfo).getRemoveFirstRow();
+
+          // In case of Excel file, it is set to false because it is converted to headerless csv.
+          if (fileFormat instanceof ExcelFileFormat) {
+            skipHeaderRow = false;
+          }
+
+          csvStreamParser.setSkipHeaderRecord(skipHeaderRow);
+        }
+
+        if (fileFormat instanceof CsvFileFormat) {
+
+          CsvFileFormat csvFormat = (CsvFileFormat) fileFormat;
+
+          if (!csvFormat.isDefaultCsvMode()) {
+            csvStreamParser.setTimestampSpec(timestampSpec);
+            csvStreamParser.setDimensionsSpec(dimensionsSpec);
+            csvStreamParser.setColumns(columns);
+            csvStreamParser.setDelimiter(csvFormat.getDelimeter());
+
+            parser = csvStreamParser;
+          } else {
+            csvStreamParser.setTimestampSpec(timestampSpec);
+            csvStreamParser.setDimensionsSpec(dimensionsSpec);
+            csvStreamParser.setColumns(columns);
+            csvStreamParser.setDelimiter(csvFormat.getDelimeter());
+
+            parser = csvStreamParser;
+          }
         } else {
           csvStreamParser.setTimestampSpec(timestampSpec);
           csvStreamParser.setDimensionsSpec(dimensionsSpec);
           csvStreamParser.setColumns(columns);
-          csvStreamParser.setDelimiter(csvFormat.getDelimeter());
 
           parser = csvStreamParser;
         }
-      } else {
-        csvStreamParser.setTimestampSpec(timestampSpec);
-        csvStreamParser.setDimensionsSpec(dimensionsSpec);
-        csvStreamParser.setColumns(columns);
-
-        parser = csvStreamParser;
       }
 
     } else if (fileFormat instanceof JsonFileFormat) {


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Hadoop을 통해 druid에 적재하는 경우, csv.stream이 아닌 string row parser를 이용합니다.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#1341 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Management > Datasource 메뉴에서 Staging DB로 데이터소스를 생성합니다.
2. default.nbis_tmp 테이블로 적재를 합니다.
3. 적재 스펙이 csv.stream이 아닌 string으로 변경되었는지 확인합니다.

As-Is)
```json
"parser" : {
        "type" : "csv.stream",
        "timestampSpec" : {
          "type" : "hadoop",
          "column" : "current_datetime",
          "missingValue" : "2019-01-30T11:11:58.528Z",
          "invalidValue" : "2019-01-30T11:11:58.528Z",
          "replaceWrongColumn" : true
        },
        "dimensionsSpec" : {
          "dimensions" : [ "~~~~" ],
          "dimensionExclusions" : [ ],
          "spatialDimensions" : [ ]
        },
        "columns" : [ "~~~~~" ],
        "delimiter" : "\t"
      },
      "metricsSpec" : [ {
        "type" : "count",
        "name" : "count"
      } ],
      "enforceType" : true,
      "granularitySpec" : {
        "type" : "uniform",
        "segmentGranularity" : "MONTH",
        "queryGranularity" : "MONTH",
        "rollup" : true,
        "append" : false,
        "intervals" : [ "1970-01-01T00:00:00.000Z/2050-01-01T00:00:00.000Z" ]
      },
      "evaluations" : [ ],
      "validations" : [ ]
    },
```

To-Be)
```json
"parser" : {
        "type" : "string",
        "parseSpec" : {
          "format" : "csv",
          "dimensionsSpec" : {
            "dimensions" : [ "date1", "col2" ],
            "dimensionExclusions" : [ ],
            "spatialDimensions" : [ ]
          },
          "timestampSpec" : {
            "type" : "hadoop",
            "column" : "date2",
            "format" : "yyyyMMddHH",
            "missingValue" : "2019-01-30T10:55:18.995Z",
            "invalidValue" : "2019-01-30T10:55:18.995Z",
            "replaceWrongColumn" : true
          },
          "columns" : [ "date1", "date2", "col1", "col2" ]
        }
      },
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
