### PR TITLE
#199 fix error input component

### DIFF
--- a/discovery-frontend/src/app/common/component/input/input.component.ts
+++ b/discovery-frontend/src/app/common/component/input/input.component.ts
@@ -66,6 +66,8 @@ export class InputComponent implements OnInit, OnDestroy {
 
   @Input() public inputClass: string = ''; // Input Element 클래스
 
+  @Input() public autoFocus: boolean = true;  // 자동으로 focus 여부
+
   @Input() public optionalClass: string = '';   // 추가적인 스타일 적용을 위한 클래스
 
   @Input() public optionalStyle: string = '';   // 추가적인 스타일 적용을 위한 스타일
@@ -145,7 +147,7 @@ export class InputComponent implements OnInit, OnDestroy {
 
     this._safelyDetectChanges();
 
-    setTimeout( () => {
+    this.autoFocus && setTimeout( () => {
       inputNativeElm.focus();
     }, 400 );
   } // function - ngAfterViewInit

--- a/discovery-frontend/src/app/dashboard/component/create-dashboard/create-board-complete.component.html
+++ b/discovery-frontend/src/app/dashboard/component/create-dashboard/create-board-complete.component.html
@@ -55,13 +55,8 @@
       <!-- edit -->
       <div class="ddp-wrap-edit2" [class.ddp-error]="isInvalidName">
         <label class="ddp-label-type">{{'msg.comm.ui.name' | translate}}</label>
-        <component-input
-          [value]="dashboard.name"
-          [inputClass]="'ddp-input-type'"
-          [maxLen]="50"
-          [placeHolder]="'msg.comm.ui.create.name' | translate"
-          (inputFocus)="isInvalidName=false"
-          (changeValue)="dashboard.name = $event"></component-input>
+        <input type="text" class="ddp-input-type" placeholder="{{'msg.comm.ui.create.name' | translate}}"
+               [(ngModel)]="dashboard.name" (focus)="isInvalidName=false" maxlength="50" />
         <!-- error -->
         <span class="ddp-ui-error">{{errMsgName}}</span>
         <!-- error -->
@@ -71,13 +66,8 @@
       <!-- edit -->
       <div class="ddp-wrap-edit2" [class.ddp-error]="isInvalidDesc">
         <label class="ddp-label-type">{{'msg.comm.ui.description' | translate}}</label>
-        <component-input
-          [value]="dashboard.description"
-          [inputClass]="'ddp-input-type'"
-          [maxLen]="150"
-          [placeHolder]="'msg.comm.ui.create.desc' | translate"
-          (inputFocus)="isInvalidDesc=false"
-          (changeValue)="dashboard.description = $event"></component-input>
+        <input type="text" class="ddp-input-type" placeholder="{{'msg.comm.ui.create.desc' | translate}}"
+               [(ngModel)]="dashboard.description" (focus)="isInvalidDesc=false" maxlength="150" />
         <!-- error -->
         <span class="ddp-ui-error">{{errMsgDesc}}</span>
         <!-- error -->

--- a/discovery-frontend/src/app/data-storage/data-connection/data-connection.component.html
+++ b/discovery-frontend/src/app/data-storage/data-connection/data-connection.component.html
@@ -36,6 +36,7 @@
       <div class="ddp-filter-search ddp-fright">
         <div class="ddp-form-filter-search">
           <component-input
+            [autoFocus]="false"
             [value]="searchKeyword"
             [placeHolder]="'msg.storage.ph.connection.search' | translate"
             (changeValue)="onChangedSearchKeyword($event)">

--- a/discovery-frontend/src/app/data-storage/data-source-list/data-source-list.component.html
+++ b/discovery-frontend/src/app/data-storage/data-source-list/data-source-list.component.html
@@ -37,6 +37,7 @@
       <div class="ddp-filter-search ddp-fright">
         <div class="ddp-form-filter-search">
           <component-input
+            [autoFocus]="false"
             [value]="searchKeyword"
             [placeHolder]="'msg.storage.ph.source.search' | translate"
             (changeValue)="onChangedSearchKeyword($event)">

--- a/discovery-frontend/src/app/layout/layout/component/gnb/gnb.component.ts
+++ b/discovery-frontend/src/app/layout/layout/component/gnb/gnb.component.ts
@@ -80,9 +80,7 @@ export class GnbComponent extends AbstractComponent implements OnInit, OnDestroy
     }).catch((err) => this.commonExceptionHandler(err));
     // check stageDB enable
     this.storageService.checkEnableStageDB().then((result) => {
-      console.log(result);
     }).catch((err) => this.commonExceptionHandler(err));
-
   }
 
   // Destroy

--- a/discovery-frontend/src/app/meta-data-management/catalog/catalog.component.html
+++ b/discovery-frontend/src/app/meta-data-management/catalog/catalog.component.html
@@ -20,6 +20,7 @@
       <div class="ddp-form-search ddp-fleft">
         <em class="ddp-icon-search"></em>
         <component-input
+          [autoFocus]="false"
           [compType]="'search'"
           [value]="searchText"
           [placeHolder]="'msg.metadata.cat.ui.ph.search' | translate"

--- a/discovery-frontend/src/app/meta-data-management/code-table/code-table.component.html
+++ b/discovery-frontend/src/app/meta-data-management/code-table/code-table.component.html
@@ -35,6 +35,7 @@
       <div class="ddp-form-search ddp-fleft">
         <em class="ddp-icon-search"></em>
         <component-input
+          [autoFocus]="false"
           [compType]="'search'"
           [value]="searchText"
           [placeHolder]="'msg.metadata.ui.codetable.search.ph' | translate"

--- a/discovery-frontend/src/app/meta-data-management/column-dictionary/column-dictionary.component.html
+++ b/discovery-frontend/src/app/meta-data-management/column-dictionary/column-dictionary.component.html
@@ -35,6 +35,7 @@
       <div class="ddp-form-search ddp-fleft">
         <em class="ddp-icon-search"></em>
         <component-input
+          [autoFocus]="false"
           [compType]="'search'"
           [value]="searchText"
           [placeHolder]="'msg.metadata.ui.dictionary.search.ph' | translate"

--- a/discovery-frontend/src/app/meta-data-management/metadata/metadata.component.html
+++ b/discovery-frontend/src/app/meta-data-management/metadata/metadata.component.html
@@ -118,6 +118,7 @@
       <div class="ddp-form-search ddp-fleft">
         <em class="ddp-icon-search"></em>
         <component-input
+          [autoFocus]="false"
           [compType]="'search'"
           [value]="listSearchText"
           [placeHolder]="'msg.metadata.md.ui.search.ph' | translate"


### PR DESCRIPTION
### Description
1. 대시보드 생성 시, 이름 입력과 동시에 Done 버튼이 활성화되지 않습니다.
2. 데이터소스/데이터커넥션의 필터 메뉴가 마우스를 두번 클릭했을 때 동작합니다.

**Related Issue** : #199 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 대시보드 생성 시, 이름  입력과 동시에 Done 버튼이 활성화 되어야 합니다.
2. 데이터소스/데이터커넥션 필터 메뉴를 클릭했을 때 바로 동작해야 합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
