### PR TITLE
#1367 The icon in the results pane disappears when you query the workbench.

### DIFF
--- a/discovery-frontend/src/app/workbench/workbench.component.ts
+++ b/discovery-frontend/src/app/workbench/workbench.component.ts
@@ -1351,8 +1351,6 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
     this.isCanceled = false;
     this.executeTabIds = [];
     this.executeEditorId = item.editorId;
-    item.startDate = '';
-    item.finishDate = '';
 
     this.workbenchService.checkConnectionStatus(item.editorId, this.websocketId)
       .then((result) => {
@@ -3246,6 +3244,9 @@ class ResultTab {
     this.resultStatus = 'NONE';
     this.result = undefined;
     this.name = 'Loading..';
+    this.startDate = undefined;
+    this.finishDate = undefined;
+    this.message = undefined;
     this.appendLog(this.sql);
     this.setExecuteStatus('GET_CONNECTION');
   } // function - initialize


### PR DESCRIPTION
### Description
The icon in the results pane disappears when you query the workbench.
This happens when the query is canceled and then re-executed.

**Related Issue** : #1367 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Go to workbench
2. execute query
3. cancel query
4. retry the query

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
