### PR TITLE
#1397 remove day timezone

### DIFF
--- a/discovery-frontend/src/app/common/component/data-preview/data.preview.component.html
+++ b/discovery-frontend/src/app/common/component/data-preview/data.preview.component.html
@@ -428,8 +428,7 @@
                         {{selectedField.format ? selectedField.format.format : selectedField.format}}
                       </td>
                     </tr>
-                    <!-- only show time type -->
-                    <tr *ngIf="!isUnixTypeField(selectedField)">
+                    <tr *ngIf="isEnableTimezone(selectedField)">
                       <th>
                         {{'msg.storage.ui.timezone' | translate}}
                       </th>
@@ -437,7 +436,6 @@
                         {{getTimezoneLabelInColumn(selectedField.format)}}
                       </td>
                     </tr>
-                    <!-- //only show time type -->
                   </ng-container>
                   <tr>
                     <th>

--- a/discovery-frontend/src/app/common/component/data-preview/data.preview.component.ts
+++ b/discovery-frontend/src/app/common/component/data-preview/data.preview.component.ts
@@ -544,7 +544,13 @@ export class DataPreviewComponent extends AbstractPopupComponent implements OnIn
    * @private
    */
   private _getTimezoneLabel(format: FieldFormat): string {
-    return (format && format.type === FieldFormatType.UNIX_TIME) ? 'Unix time' :this.timezoneService.getConvertedTimezoneUTCLabel(this.timezoneService.getTimezoneObject(format).utc);
+    if (format && format.type === FieldFormatType.UNIX_TIME) {
+      return 'Unix time';
+    } else if (format && format.type === FieldFormatType.DATE_TIME) {
+      return this.timezoneService.isEnableTimezoneInDateFormat(format.format) ? this.timezoneService.getConvertedTimezoneUTCLabel(this.timezoneService.getTimezoneObject(format).utc) : '';
+    } else {
+      return this.timezoneService.getConvertedTimezoneUTCLabel(this.timezoneService.getTimezoneObject(format).utc);
+    }
   }
 
   // ui init

--- a/discovery-frontend/src/app/common/component/data-preview/data.preview.component.ts
+++ b/discovery-frontend/src/app/common/component/data-preview/data.preview.component.ts
@@ -475,7 +475,7 @@ export class DataPreviewComponent extends AbstractPopupComponent implements OnIn
    * @private
    */
   private _getGridHeaderName(field: Field, headerName: string): string {
-    return field.logicalType === LogicalType.TIMESTAMP
+    return field.logicalType === LogicalType.TIMESTAMP && (this.timezoneService.isEnableTimezoneInDateFormat(field.format) || field.format && field.format.type === FieldFormatType.UNIX_TIME)
       ? `<span style="padding-left:20px;"><em class="${this.getFieldTypeIconClass(field.logicalType.toString())}"></em>${headerName}<div class="slick-column-det" title="${this._getTimezoneLabel(field.format)}">${this._getTimezoneLabel(field.format)}</div></span>`
       : `<span style="padding-left:20px;"><em class="${this.getFieldTypeIconClass(field.logicalType.toString())}"></em>${headerName}</span>`;
   }
@@ -544,10 +544,8 @@ export class DataPreviewComponent extends AbstractPopupComponent implements OnIn
    * @private
    */
   private _getTimezoneLabel(format: FieldFormat): string {
-    if (format && format.type === FieldFormatType.UNIX_TIME) {
+    if (format.type === FieldFormatType.UNIX_TIME) {
       return 'Unix time';
-    } else if (format && format.type === FieldFormatType.DATE_TIME) {
-      return this.timezoneService.isEnableTimezoneInDateFormat(format.format) ? this.timezoneService.getConvertedTimezoneUTCLabel(this.timezoneService.getTimezoneObject(format).utc) : '';
     } else {
       return this.timezoneService.getConvertedTimezoneUTCLabel(this.timezoneService.getTimezoneObject(format).utc);
     }
@@ -1048,7 +1046,11 @@ export class DataPreviewComponent extends AbstractPopupComponent implements OnIn
    * @return {string}
    */
   public getTimezoneLabelInColumn(format: FieldFormat): string {
-    return this.timezoneService.getTimezoneObject(format).label;
+    if (format.type === FieldFormatType.UNIX_TIME) {
+      return 'Unix time';
+    } else {
+      return this.timezoneService.getTimezoneObject(format).label;
+    }
   }
 
   /**
@@ -1631,16 +1633,16 @@ export class DataPreviewComponent extends AbstractPopupComponent implements OnIn
    * @return {boolean}
    */
   public isExistTimestampField(): boolean {
-    return this.joinDataSources.some(source => source.fields.some(field => field.logicalType === LogicalType.TIMESTAMP));
+    return this.joinDataSources.some(source => source.fields.some(field => field.logicalType === LogicalType.TIMESTAMP && (this.timezoneService.isEnableTimezoneInDateFormat(field.format) || field.format && field.format.type === FieldFormatType.UNIX_TIME)));
   }
 
   /**
-   * Is unix type field
+   * Is time type field
    * @param {Field} field
    * @return {boolean}
    */
-  public isUnixTypeField(field: Field): boolean {
-    return field.format && field.format.type === FieldFormatType.UNIX_TIME;
+  public isEnableTimezone(field: Field): boolean {
+    return field.format && (field.format.type === FieldFormatType.UNIX_TIME || this.timezoneService.isEnableTimezoneInDateFormat(field.format));
   }
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/discovery-frontend/src/app/dashboard/util/filter.util.ts
+++ b/discovery-frontend/src/app/dashboard/util/filter.util.ts
@@ -49,6 +49,7 @@ import {
   IntervalSelectorType
 } from '../../domain/workbook/configurations/filter/interval-filter';
 import {DIRECTION} from '../../domain/workbook/configurations/sort';
+import {TimezoneService} from "../../data-storage/service/timezone.service";
 
 declare let moment;
 
@@ -334,7 +335,11 @@ export class FilterUtil {
     } // end if - time_range
     else if (FilterUtil.isTimeRelativeFilter(filter)) {
       const timeRelativeFilter: TimeRelativeFilter = <TimeRelativeFilter>filter;
-      (timeRelativeFilter.timezone) || (timeRelativeFilter.timezone = moment.tz.guess());
+      if( timeRelativeFilter.clzField && timeRelativeFilter.clzField.format && TimezoneService.DISABLE_TIMEZONE_KEY === timeRelativeFilter.clzField.format.timeZone ) {
+        delete timeRelativeFilter.timezone;
+      } else {
+        (timeRelativeFilter.timezone) || (timeRelativeFilter.timezone = moment.tz.guess());
+      }
     } // end if - time_relative
 
     return filter;
@@ -410,7 +415,11 @@ export class FilterUtil {
     } // end if - time_range
     else if (FilterUtil.isTimeRelativeFilter(filter)) {
       const timeRelativeFilter: TimeRelativeFilter = <TimeRelativeFilter>filter;
-      (timeRelativeFilter.timezone) || (timeRelativeFilter.timezone = moment.tz.guess());
+      if( timeRelativeFilter.clzField && timeRelativeFilter.clzField.format && TimezoneService.DISABLE_TIMEZONE_KEY === timeRelativeFilter.clzField.format.timeZone ) {
+        delete timeRelativeFilter.timezone;
+      } else {
+        (timeRelativeFilter.timezone) || (timeRelativeFilter.timezone = moment.tz.guess());
+      }
     } // end if - time_relative
 
     return filter;

--- a/discovery-frontend/src/app/dashboard/util/filter.util.ts
+++ b/discovery-frontend/src/app/dashboard/util/filter.util.ts
@@ -125,12 +125,12 @@ export class FilterUtil {
    * @param {Dashboard} board
    * @param {Filter} filter
    */
-  public static getEssentialFilters(board: Dashboard, filter?:Filter): Filter[] {
+  public static getEssentialFilters(board: Dashboard, filter?: Filter): Filter[] {
     let essentialFilters: Filter[] = [];
     if (board.configuration.dataSource.temporary) {
       essentialFilters = board.configuration.filters.filter(item => {
         const filterField = DashboardUtil.getFieldByName(board, item.dataSource, item.field);
-        if( filter && filter.ui && filter.ui.filteringSeq) {
+        if (filter && filter.ui && filter.ui.filteringSeq) {
           return filter.ui.filteringSeq < filterField.filteringSeq;
         } else {
           return -1 < filterField.filteringSeq;
@@ -270,48 +270,6 @@ export class FilterUtil {
    * @return {Filter}
    */
   public static convertToServerSpec(filter: Filter): Filter {
-    // 불필요 속성 제거
-    let keyMap: string[];
-    switch (filter.type) {
-      case 'interval' :
-        keyMap = ['selector', 'startDate', 'endDate', 'intervals', 'timezone',
-          'locale', 'format', 'rrule', 'relValue', 'timeUnit'];
-        break;
-      case 'include' :
-        keyMap = ['selector', 'valueList', 'candidateValues', 'sort'];
-        break;
-      case 'timestamp' :
-        keyMap = ['selectedTimestamps', 'timeFormat'];
-        break;
-      case 'bound' :
-        keyMap = ['min', 'max'];
-        break;
-      case 'time_all' :
-        keyMap = [];
-        break;
-      case 'time_relative' :
-        keyMap = ['relTimeUnit', 'tense', 'value', 'timeUnit', 'byTimeUnit', 'discontinuous'];
-        break;
-      case 'time_range' :
-        keyMap = ['intervals', 'timeUnit', 'byTimeUnit', 'discontinuous'];
-        break;
-      case 'time_list' :
-        keyMap = ['valueList', 'candidateValues', 'timeUnit', 'byTimeUnit', 'discontinuous'];
-        break;
-      case 'wildcard' :
-        keyMap = ['contains', 'value'];
-        break;
-      case 'measure_inequality' :
-        keyMap = ['aggregation', 'inequality', 'value'];
-        break;
-      case 'measure_position' :
-        keyMap = ['aggregation', 'position', 'value'];
-        break;
-    }
-    keyMap = keyMap.concat(['type', 'field', 'ref', 'dataSource']);
-    for (let key of Object.keys(filter)) {
-      (keyMap.some(item => item === key)) || (delete filter[key]);
-    }
 
     // Time Range 필터의 타임 형식 설정
     if (FilterUtil.isTimeRangeFilter(filter)) {
@@ -335,32 +293,22 @@ export class FilterUtil {
     } // end if - time_range
     else if (FilterUtil.isTimeRelativeFilter(filter)) {
       const timeRelativeFilter: TimeRelativeFilter = <TimeRelativeFilter>filter;
-      if( timeRelativeFilter.clzField && timeRelativeFilter.clzField.format && TimezoneService.DISABLE_TIMEZONE_KEY === timeRelativeFilter.clzField.format.timeZone ) {
+      if (timeRelativeFilter.clzField && timeRelativeFilter.clzField.format && TimezoneService.DISABLE_TIMEZONE_KEY === timeRelativeFilter.clzField.format.timeZone) {
         delete timeRelativeFilter.timezone;
       } else {
         (timeRelativeFilter.timezone) || (timeRelativeFilter.timezone = moment.tz.guess());
       }
     } // end if - time_relative
 
-    return filter;
-  } // function - convertToServerSpec
-
-  /**
-   * Dashboard API 를 위해서 불필요한 속성 제거
-   * @param {Filter} filter
-   * @return {Filter}
-   */
-  public static convertToServerSpecForDashboard(filter: Filter): Filter {
     // 불필요 속성 제거
     let keyMap: string[];
     switch (filter.type) {
       case 'interval' :
         keyMap = ['selector', 'startDate', 'endDate', 'intervals', 'timezone',
-          'locale', 'format', 'rrule', 'relValue', 'timeUnitUI', 'timeUnit', 'byTimeUnit',
-          'minTime', 'maxTime', 'valueList', 'candidateValues', 'discontinuous', 'granularity'];
+          'locale', 'format', 'rrule', 'relValue', 'timeUnit'];
         break;
       case 'include' :
-        keyMap = ['selector', 'preFilters', 'valueList', 'candidateValues', 'definedValues', 'sort'];
+        keyMap = ['selector', 'valueList', 'candidateValues', 'sort'];
         break;
       case 'timestamp' :
         keyMap = ['selectedTimestamps', 'timeFormat'];
@@ -372,7 +320,7 @@ export class FilterUtil {
         keyMap = [];
         break;
       case 'time_relative' :
-        keyMap = ['relTimeUnit', 'tense', 'value', 'timeUnit', 'byTimeUnit', 'discontinuous'];
+        keyMap = ['relTimeUnit', 'tense', 'value', 'timeUnit', 'byTimeUnit', 'discontinuous', 'timezone'];
         break;
       case 'time_range' :
         keyMap = ['intervals', 'timeUnit', 'byTimeUnit', 'discontinuous'];
@@ -395,6 +343,16 @@ export class FilterUtil {
       (keyMap.some(item => item === key)) || (delete filter[key]);
     }
 
+    return filter;
+  } // function - convertToServerSpec
+
+  /**
+   * Dashboard API 를 위해서 불필요한 속성 제거
+   * @param {Filter} filter
+   * @return {Filter}
+   */
+  public static convertToServerSpecForDashboard(filter: Filter): Filter {
+
     // Time Range 필터의 타임 형식 설정
     if (FilterUtil.isTimeRangeFilter(filter)) {
       const timeRangeFilter = <TimeRangeFilter>filter;
@@ -415,12 +373,56 @@ export class FilterUtil {
     } // end if - time_range
     else if (FilterUtil.isTimeRelativeFilter(filter)) {
       const timeRelativeFilter: TimeRelativeFilter = <TimeRelativeFilter>filter;
-      if( timeRelativeFilter.clzField && timeRelativeFilter.clzField.format && TimezoneService.DISABLE_TIMEZONE_KEY === timeRelativeFilter.clzField.format.timeZone ) {
+      if (timeRelativeFilter.clzField && timeRelativeFilter.clzField.format && TimezoneService.DISABLE_TIMEZONE_KEY === timeRelativeFilter.clzField.format.timeZone) {
         delete timeRelativeFilter.timezone;
       } else {
         (timeRelativeFilter.timezone) || (timeRelativeFilter.timezone = moment.tz.guess());
       }
     } // end if - time_relative
+
+    // 불필요 속성 제거
+    let keyMap: string[];
+    switch (filter.type) {
+      case 'interval' :
+        keyMap = ['selector', 'startDate', 'endDate', 'intervals', 'timezone',
+          'locale', 'format', 'rrule', 'relValue', 'timeUnitUI', 'timeUnit', 'byTimeUnit',
+          'minTime', 'maxTime', 'valueList', 'candidateValues', 'discontinuous', 'granularity'];
+        break;
+      case 'include' :
+        keyMap = ['selector', 'preFilters', 'valueList', 'candidateValues', 'definedValues', 'sort'];
+        break;
+      case 'timestamp' :
+        keyMap = ['selectedTimestamps', 'timeFormat'];
+        break;
+      case 'bound' :
+        keyMap = ['min', 'max'];
+        break;
+      case 'time_all' :
+        keyMap = [];
+        break;
+      case 'time_relative' :
+        keyMap = ['relTimeUnit', 'tense', 'value', 'timeUnit', 'byTimeUnit', 'discontinuous', 'timezone'];
+        break;
+      case 'time_range' :
+        keyMap = ['intervals', 'timeUnit', 'byTimeUnit', 'discontinuous'];
+        break;
+      case 'time_list' :
+        keyMap = ['valueList', 'candidateValues', 'timeUnit', 'byTimeUnit', 'discontinuous'];
+        break;
+      case 'wildcard' :
+        keyMap = ['contains', 'value'];
+        break;
+      case 'measure_inequality' :
+        keyMap = ['aggregation', 'inequality', 'value'];
+        break;
+      case 'measure_position' :
+        keyMap = ['aggregation', 'position', 'value'];
+        break;
+    }
+    keyMap = keyMap.concat(['type', 'field', 'ref', 'dataSource']);
+    for (let key of Object.keys(filter)) {
+      (keyMap.some(item => item === key)) || (delete filter[key]);
+    }
 
     return filter;
   } // function - convertToServerSpecForDashboard

--- a/discovery-frontend/src/app/data-storage/component/schema-config/schema-config-detail.component.html
+++ b/discovery-frontend/src/app/data-storage/component/schema-config/schema-config-detail.component.html
@@ -267,7 +267,7 @@
             </div>
             <!-- //Time display format -->
             <!-- Timezone -->
-            <div class="ddp-wrap-edit3" *ngIf="selectedField.logicalType.toString() === 'TIMESTAMP' && isTimeTypeField(selectedField)">
+            <div class="ddp-wrap-edit3" *ngIf="isEnableTimezone(selectedField)">
               <label class="ddp-ui-label-name">
                 {{'msg.storage.ui.timezone' | translate}}
               </label>

--- a/discovery-frontend/src/app/data-storage/component/schema-config/schema-config-detail.component.ts
+++ b/discovery-frontend/src/app/data-storage/component/schema-config/schema-config-detail.component.ts
@@ -13,9 +13,9 @@
  * limitations under the License.
  */
 
-import { AbstractComponent } from '../../../common/component/abstract.component';
-import { Component, ElementRef, EventEmitter, Injector, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
-import { DatasourceService } from '../../../datasource/service/datasource.service';
+import {AbstractComponent} from '../../../common/component/abstract.component';
+import {Component, ElementRef, EventEmitter, Injector, Input, OnChanges, Output, SimpleChanges} from '@angular/core';
+import {DatasourceService} from '../../../datasource/service/datasource.service';
 import {
   Field,
   FieldFormat,
@@ -26,8 +26,8 @@ import {
   IngestionRuleType,
   LogicalType
 } from '../../../domain/datasource/datasource';
-import { StringUtil } from '../../../common/util/string.util';
-import {TimezoneService, TimeZoneObject} from "../../service/timezone.service";
+import {StringUtil} from '../../../common/util/string.util';
+import {TimeZoneObject, TimezoneService} from "../../service/timezone.service";
 
 declare let moment: any;
 
@@ -172,8 +172,6 @@ export class SchemaConfigDetailComponent extends AbstractComponent implements On
   @Output()
   public changedFieldLogicalType: EventEmitter<any> = new EventEmitter();
 
-  // TODO
-  public browserTimezone: TimeZoneObject;
   // filtered timezone list
   public filteredTimezoneList: TimeZoneObject[];
   // search keyword
@@ -463,6 +461,15 @@ export class SchemaConfigDetailComponent extends AbstractComponent implements On
   }
 
   /**
+   * Is enable timezone
+   * @param {Field} field
+   * @return {boolean}
+   */
+  public isEnableTimezone(field: Field): boolean {
+    return field.logicalType === LogicalType.TIMESTAMP && this.isTimeTypeField(field) && field.isValidTimeFormat && this._timezoneService.isEnableTimezoneInDateFormat(field.format.format);
+  }
+
+  /**
    * Logical type list show flag change event
    */
   public onChangeLogicalTypeListShowFlag(): void {
@@ -529,9 +536,6 @@ export class SchemaConfigDetailComponent extends AbstractComponent implements On
         if (LogicalType.TIMESTAMP === type.value) {
           // init format in field
           field.format = new FieldFormat();
-          // TODO set browser timezone at field
-          field.format.timeZone = this._timezoneService.browserTimezone.momentName;
-          field.format.locale = this._timezoneService.browserLocal;
           // if not exist field data
           if (this.selectedFieldDataList.length === 0) {
             // set timestamp error
@@ -548,6 +552,13 @@ export class SchemaConfigDetailComponent extends AbstractComponent implements On
                   field.format.format = result.pattern;
                   // set time format valid message
                   field.isValidTimeFormat = true;
+                  // if enable timezone, set browser timezone at field
+                  if (this._timezoneService.isEnableTimezoneInDateFormat(field.format.format)) {
+                    !field.format.timeZone && (field.format.timeZone = this._timezoneService.browserTimezone.momentName);
+                    field.format.locale = this._timezoneService.browserLocal;
+                  } else { // if not enable timezone
+                    field.format.timeZone = TimezoneService.DISABLE_TIMEZONE_KEY;
+                  }
                 }
               })
               .catch((error) => {
@@ -720,6 +731,13 @@ export class SchemaConfigDetailComponent extends AbstractComponent implements On
         if (result.valid) {
           // set time format valid TRUE
           field.isValidTimeFormat = true;
+          // if enable timezone, set browser timezone at field
+          if (this._timezoneService.isEnableTimezoneInDateFormat(field.format.format)) {
+            !field.format.timeZone && (field.format.timeZone = this._timezoneService.browserTimezone.momentName);
+            field.format.locale = this._timezoneService.browserLocal;
+          } else { // if not enable timezone
+            field.format.timeZone = TimezoneService.DISABLE_TIMEZONE_KEY;
+          }
         } else {
           // set time format valid FALSE
           field.isValidTimeFormat = false;

--- a/discovery-frontend/src/app/data-storage/component/schema-config/schema-config-detail.component.ts
+++ b/discovery-frontend/src/app/data-storage/component/schema-config/schema-config-detail.component.ts
@@ -466,7 +466,7 @@ export class SchemaConfigDetailComponent extends AbstractComponent implements On
    * @return {boolean}
    */
   public isEnableTimezone(field: Field): boolean {
-    return field.logicalType === LogicalType.TIMESTAMP && this.isTimeTypeField(field) && field.isValidTimeFormat && this._timezoneService.isEnableTimezoneInDateFormat(field.format.format);
+    return field.logicalType === LogicalType.TIMESTAMP && this.isTimeTypeField(field) && field.isValidTimeFormat && this._timezoneService.isEnableTimezoneInDateFormat(field.format);
   }
 
   /**
@@ -553,7 +553,7 @@ export class SchemaConfigDetailComponent extends AbstractComponent implements On
                   // set time format valid message
                   field.isValidTimeFormat = true;
                   // if enable timezone, set browser timezone at field
-                  if (this._timezoneService.isEnableTimezoneInDateFormat(field.format.format)) {
+                  if (this._timezoneService.isEnableTimezoneInDateFormat(field.format)) {
                     !field.format.timeZone && (field.format.timeZone = this._timezoneService.browserTimezone.momentName);
                     field.format.locale = this._timezoneService.browserLocal;
                   } else { // if not enable timezone
@@ -732,7 +732,7 @@ export class SchemaConfigDetailComponent extends AbstractComponent implements On
           // set time format valid TRUE
           field.isValidTimeFormat = true;
           // if enable timezone, set browser timezone at field
-          if (this._timezoneService.isEnableTimezoneInDateFormat(field.format.format)) {
+          if (this._timezoneService.isEnableTimezoneInDateFormat(field.format)) {
             !field.format.timeZone && (field.format.timeZone = this._timezoneService.browserTimezone.momentName);
             field.format.locale = this._timezoneService.browserLocal;
           } else { // if not enable timezone

--- a/discovery-frontend/src/app/data-storage/component/schema-config/schema-config.component.ts
+++ b/discovery-frontend/src/app/data-storage/component/schema-config/schema-config.component.ts
@@ -30,7 +30,7 @@ import * as _ from 'lodash';
 import { Alert } from '../../../common/util/alert.util';
 import { SchemaConfigActionBarComponent } from './schema-config-action-bar.component';
 import { SchemaConfigDetailComponent } from './schema-config-detail.component';
-import { TimezoneService, TimeZoneObject } from "../../service/timezone.service";
+import { TimezoneService } from "../../service/timezone.service";
 
 @Component({
   selector: 'schema-config-component',
@@ -545,9 +545,6 @@ export class SchemaConfigComponent extends AbstractComponent {
     timestampFieldList.forEach((field: Field) => {
       // init format
       field.format = new FieldFormat();
-      // TODO set browser timezone at field
-      field.format.timeZone =  this._timezoneService.browserTimezone.momentName;
-      field.format.locale = this._timezoneService.browserLocal;
       // field data
       const fieldDataList: any[] = this._getFieldDataList(field);
       // if not exist field data
@@ -749,6 +746,13 @@ export class SchemaConfigComponent extends AbstractComponent {
             field.format.format = result.pattern;
             // set time format valid TRUE
             field.isValidTimeFormat = true;
+            // if enable timezone, set browser timezone at field
+            if (this._timezoneService.isEnableTimezoneInDateFormat(field.format.format)) {
+              !field.format.timeZone && (field.format.timeZone = this._timezoneService.browserTimezone.momentName);
+              field.format.locale = this._timezoneService.browserLocal;
+            } else { // if not enable timezone
+              field.format.timeZone = TimezoneService.DISABLE_TIMEZONE_KEY;
+            }
           }
           resolve(result);
         })

--- a/discovery-frontend/src/app/data-storage/component/schema-config/schema-config.component.ts
+++ b/discovery-frontend/src/app/data-storage/component/schema-config/schema-config.component.ts
@@ -747,7 +747,7 @@ export class SchemaConfigComponent extends AbstractComponent {
             // set time format valid TRUE
             field.isValidTimeFormat = true;
             // if enable timezone, set browser timezone at field
-            if (this._timezoneService.isEnableTimezoneInDateFormat(field.format.format)) {
+            if (this._timezoneService.isEnableTimezoneInDateFormat(field.format)) {
               !field.format.timeZone && (field.format.timeZone = this._timezoneService.browserTimezone.momentName);
               field.format.locale = this._timezoneService.browserLocal;
             } else { // if not enable timezone

--- a/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/column-detail-data-source/column-detail-data-source.component.html
+++ b/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/column-detail-data-source/column-detail-data-source.component.html
@@ -258,8 +258,7 @@
                     {{selectedField.format ? selectedField.format.format : selectedField.format}}
                   </td>
                 </tr>
-                <!-- only show time type -->
-                <tr *ngIf="!isUnixTypeField(selectedField)">
+                <tr *ngIf="isEnableTimezone(selectedField)">
                   <th>
                     {{'msg.storage.ui.timezone' | translate}}
                   </th>
@@ -267,7 +266,6 @@
                     {{getTimezoneLabel(selectedField.format)}}
                   </td>
                 </tr>
-                <!-- //only show time type -->
               </ng-container>
               <tr>
                 <th>

--- a/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/column-detail-data-source/column-detail-data-source.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/column-detail-data-source/column-detail-data-source.component.ts
@@ -225,21 +225,12 @@ export class ColumnDetailDataSourceComponent extends AbstractComponent implement
   }
 
   /**
-   * Is unix type field
-   * @param {Field} field
-   * @return {boolean}
-   */
-  public isUnixTypeField(field: Field): boolean {
-    return field.format && field.format.type === FieldFormatType.UNIX_TIME;
-  }
-
-  /**
    * Is time type field
    * @param {Field} field
    * @return {boolean}
    */
-  public isTimeTypeField(field: Field): boolean {
-    return field.format && field.format.type === FieldFormatType.DATE_TIME;
+  public isEnableTimezone(field: Field): boolean {
+    return field.format && (field.format.type === FieldFormatType.UNIX_TIME || this._timezoneService.isEnableTimezoneInDateFormat(field.format));
   }
 
   /**
@@ -266,7 +257,11 @@ export class ColumnDetailDataSourceComponent extends AbstractComponent implement
    * @return {string}
    */
   public getTimezoneLabel(format: FieldFormat): string {
-    return this._timezoneService.getTimezoneObject(format).label;
+    if (format.type === FieldFormatType.UNIX_TIME) {
+      return 'Unix time';
+    } else {
+      return this._timezoneService.getTimezoneObject(format).label;
+    }
   }
 
   /**

--- a/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/data-grid-data-source/data-grid-data-source.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/data-grid-data-source/data-grid-data-source.component.ts
@@ -85,7 +85,7 @@ export class DataGridDataSourceComponent extends AbstractPopupComponent implemen
 
   // 현재 마스터 데이터소스의 연결 타입
   public connType: string;
-
+  // exist timestamp flag
   public isExistTimestamp: boolean;
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
@@ -113,7 +113,8 @@ export class DataGridDataSourceComponent extends AbstractPopupComponent implemen
     this._initView();
     // 그리드 데이터 조회
     this.fields = this.datasource.fields;
-    this.isExistTimestamp = this.datasource.fields.some(field => field.logicalType === LogicalType.TIMESTAMP);
+    // set exist timestamp flag
+    this.isExistTimestamp = this.datasource.fields.some(field => field.logicalType === LogicalType.TIMESTAMP && (this.timezoneService.isEnableTimezoneInDateFormat(field.format) || field.format && field.format.type === FieldFormatType.UNIX_TIME));
     // 마스터 소스 타입
     this.connType = this.datasource.hasOwnProperty('connType') ? this.datasource.connType.toString() : 'ENGINE';
     // linked인 경우
@@ -325,10 +326,8 @@ export class DataGridDataSourceComponent extends AbstractPopupComponent implemen
    * @private
    */
   private _getTimezoneLabel(format: FieldFormat): string {
-    if (format && format && format.type === FieldFormatType.UNIX_TIME) {
+    if (format.type === FieldFormatType.UNIX_TIME) {
       return 'Unix time';
-    } else if (format && format.type === FieldFormatType.DATE_TIME) {
-      return this.timezoneService.isEnableTimezoneInDateFormat(format.format) ? this.timezoneService.getConvertedTimezoneUTCLabel(this.timezoneService.getTimezoneObject(format).utc) : '';
     } else {
       return this.timezoneService.getConvertedTimezoneUTCLabel(this.timezoneService.getTimezoneObject(format).utc);
     }
@@ -379,7 +378,7 @@ export class DataGridDataSourceComponent extends AbstractPopupComponent implemen
    * @private
    */
   private _getGridHeaderName(field: Field, headerName: string): string {
-    return field.logicalType === LogicalType.TIMESTAMP
+    return field.logicalType === LogicalType.TIMESTAMP && (this.timezoneService.isEnableTimezoneInDateFormat(field.format) || field.format && field.format.type === FieldFormatType.UNIX_TIME)
       ? `<span style="padding-left:20px;"><em class="${this.getFieldTypeIconClass(field.logicalType.toString())}"></em>${headerName}<div class="slick-column-det" title="${this._getTimezoneLabel(field.format)}">${this._getTimezoneLabel(field.format)}</div></span>`
       : `<span style="padding-left:20px;"><em class="${this.getFieldTypeIconClass(field.logicalType.toString())}"></em>${headerName}</span>`;
   }

--- a/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/data-grid-data-source/data-grid-data-source.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/data-grid-data-source/data-grid-data-source.component.ts
@@ -325,7 +325,13 @@ export class DataGridDataSourceComponent extends AbstractPopupComponent implemen
    * @private
    */
   private _getTimezoneLabel(format: FieldFormat): string {
-    return (format && format.type === FieldFormatType.UNIX_TIME) ?  'Unix time'  : this.timezoneService.getConvertedTimezoneUTCLabel(this.timezoneService.getTimezoneObject(format).utc);
+    if (format && format && format.type === FieldFormatType.UNIX_TIME) {
+      return 'Unix time';
+    } else if (format && format.type === FieldFormatType.DATE_TIME) {
+      return this.timezoneService.isEnableTimezoneInDateFormat(format.format) ? this.timezoneService.getConvertedTimezoneUTCLabel(this.timezoneService.getTimezoneObject(format).utc) : '';
+    } else {
+      return this.timezoneService.getConvertedTimezoneUTCLabel(this.timezoneService.getTimezoneObject(format).utc);
+    }
   }
 
   /**

--- a/discovery-frontend/src/app/data-storage/service/timezone.service.ts
+++ b/discovery-frontend/src/app/data-storage/service/timezone.service.ts
@@ -75,11 +75,11 @@ export class TimezoneService {
 
   /**
    * Is enable timezone in date format
-   * @param {string} format
+   * @param {FieldFormat} format
    * @return {boolean}
    */
-  public isEnableTimezoneInDateFormat(format: string): boolean {
-    return format.toUpperCase().indexOf('H') !== -1;
+  public isEnableTimezoneInDateFormat(format: FieldFormat): boolean {
+    return format && format.format && format.format.toUpperCase().indexOf('H') !== -1;
   }
 
   /**

--- a/discovery-frontend/src/app/data-storage/service/timezone.service.ts
+++ b/discovery-frontend/src/app/data-storage/service/timezone.service.ts
@@ -28,7 +28,11 @@ export class TimezoneService {
 
   public browserTimezone: TimeZoneObject;
 
+  // TODO 추후 local => locale로 수정
   public browserLocal: string;
+
+  // if not used TIMEZONE, set this key in timeZone property
+  public static DISABLE_TIMEZONE_KEY = 'DISABLE_ZONE';
 
   constructor(protected injector: Injector) {
     this._translateService = injector.get(TranslateService);
@@ -67,6 +71,15 @@ export class TimezoneService {
       result += utc.slice(3,6);
     }
     return result;
+  }
+
+  /**
+   * Is enable timezone in date format
+   * @param {string} format
+   * @return {boolean}
+   */
+  public isEnableTimezoneInDateFormat(format: string): boolean {
+    return format.toUpperCase().indexOf('H') !== -1;
   }
 
   /**

--- a/discovery-frontend/src/app/datasource/service/datasource.service.ts
+++ b/discovery-frontend/src/app/datasource/service/datasource.service.ts
@@ -311,8 +311,14 @@ export class DatasourceService extends AbstractService {
               if ((LogicalType.TIMESTAMP.toString() === field.type.toUpperCase()
                 || LogicalType.TIMESTAMP.toString() === field.subType
                 || LogicalType.TIMESTAMP.toString() === field.subRole) && field.format) {
-                field.format['timeZone'] = this._timezoneSvc.browserTimezone.momentName;
-                field.format['locale'] = this._timezoneSvc.browserLocal;
+                const dsField:Field = dataSourceFields.find( item => item.name === field.name );
+                if( dsField && dsField.format && TimezoneService.DISABLE_TIMEZONE_KEY === dsField.format['timeZone'] ) {
+                  delete field.format['timeZone'];
+                  delete field.format['locale'];
+                } else {
+                  field.format['timeZone'] = this._timezoneSvc.browserTimezone.momentName;
+                  field.format['locale'] = this._timezoneSvc.browserLocal;
+                }
               }
             });
           });
@@ -331,8 +337,14 @@ export class DatasourceService extends AbstractService {
             if ((LogicalType.TIMESTAMP.toString() === column.type.toUpperCase()
               || LogicalType.TIMESTAMP.toString() === column.subType
               || LogicalType.TIMESTAMP.toString() === column.subRole) && column.format) {
-              column.format.timeZone = this._timezoneSvc.browserTimezone.momentName;
-              column.format.locale = this._timezoneSvc.browserLocal;
+              const dsField:Field = dataSourceFields.find( item => item.name === column.name );
+              if( dsField && dsField.format && TimezoneService.DISABLE_TIMEZONE_KEY === dsField.format['timeZone'] ) {
+                delete column.format['timeZone'];
+                delete column.format['locale'];
+              } else {
+                column.format.timeZone = this._timezoneSvc.browserTimezone.momentName;
+                column.format.locale = this._timezoneSvc.browserLocal;
+              }
             }
           });
         }
@@ -341,8 +353,14 @@ export class DatasourceService extends AbstractService {
             if ((LogicalType.TIMESTAMP.toString() === row.type.toUpperCase()
               || LogicalType.TIMESTAMP.toString() === row.subType
               || LogicalType.TIMESTAMP.toString() === row.subRole) && row.format) {
-              row.format.timeZone = this._timezoneSvc.browserTimezone.momentName;
-              row.format.locale = this._timezoneSvc.browserLocal;
+              const dsField:Field = dataSourceFields.find( item => item.name === row.name );
+              if( dsField && dsField.format && TimezoneService.DISABLE_TIMEZONE_KEY === dsField.format['timeZone'] ) {
+                delete row.format['timeZone'];
+                delete row.format['locale'];
+              } else {
+                row.format.timeZone = this._timezoneSvc.browserTimezone.momentName;
+                row.format.locale = this._timezoneSvc.browserLocal;
+              }
             }
           });
         }

--- a/discovery-frontend/src/app/page/page-pivot/page-pivot.component.ts
+++ b/discovery-frontend/src/app/page/page-pivot/page-pivot.component.ts
@@ -2008,6 +2008,9 @@ export class PagePivotComponent extends AbstractComponent implements OnInit, OnD
             shelf[idx].format.type = String(UIFormatType.TIME_CONTINUOUS);
             shelf[idx].format.discontinuous = false;
             shelf[idx].format.unit = copiedTimestampList[0].id;
+            if( field.field && field.field.format ) {
+              shelf[idx].format.timeZone = field.field.format.timeZone;
+            }
           }
           // 최초 granularity 설정
         } else {
@@ -2020,6 +2023,9 @@ export class PagePivotComponent extends AbstractComponent implements OnInit, OnD
             shelf[idx].format.type = String(UIFormatType.TIME_CONTINUOUS);
             shelf[idx].format.discontinuous = false;
             shelf[idx].format.unit = copiedTimestampList[0].id;
+            if( field.field && field.field.format ) {
+              shelf[idx].format.timeZone = field.field.format.timeZone;
+            }
           }
           else if (shelf[idx].field.role === FieldRole.DIMENSION) {
 
@@ -2028,6 +2034,9 @@ export class PagePivotComponent extends AbstractComponent implements OnInit, OnD
             shelf[idx].format.type = String(UIFormatType.TIME_CONTINUOUS);
             shelf[idx].format.discontinuous = false;
             shelf[idx].format.unit = TimeUnit.NONE;
+            if( field.field && field.field.format ) {
+              shelf[idx].format.timeZone = field.field.format.timeZone;
+            }
           }
         }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/Field.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/Field.java
@@ -457,7 +457,7 @@ public class Field implements MetatronDomain<Long> {
 
     TimeFieldFormat timeFieldFormat = (TimeFieldFormat) fieldFormat;
 
-    DateTime defaultReplaceDateTime = DateTime.now(DateTimeZone.forID(timeFieldFormat.getTimeZone()));
+    DateTime defaultReplaceDateTime = DateTime.now(DateTimeZone.forID(timeFieldFormat.selectTimezone()));
     timestampSpec.setInvalidValue(defaultReplaceDateTime);
     timestampSpec.setMissingValue(defaultReplaceDateTime);
 
@@ -474,7 +474,7 @@ public class Field implements MetatronDomain<Long> {
       timestampSpec.setFormat(timeFieldFormat.getFormat());
     }
 
-    timestampSpec.setTimeZone(timeFieldFormat.getTimeZone());
+    timestampSpec.setTimeZone(timeFieldFormat.selectTimezone());
     timestampSpec.setLocale(timeFieldFormat.getLocale());
 
     return timestampSpec;

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/geo/query/model/GeoQueryBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/geo/query/model/GeoQueryBuilder.java
@@ -261,7 +261,7 @@ public class GeoQueryBuilder extends AbstractQueryBuilder {
                                                              null,
                                                              null,
                                                              timeFormat.enableSortField() ? timeFormat.getSortFormat() : timeFormat.getFormat(),
-                                                             timeFormat.getTimeZone(),
+                                                             timeFormat.selectTimezone(),
                                                              timeFormat.getLocale());
 
           ExprVirtualColumn exprVirtualColumn = new ExprVirtualColumn(timeFormatFunc.toExpression(), innerFieldName);
@@ -311,7 +311,7 @@ public class GeoQueryBuilder extends AbstractQueryBuilder {
 
         TimeFormatFunc timeFormatFunc = new TimeFormatFunc(predefinedFieldName,
                                                            timeFormat.enableSortField() ? timeFormat.getSortFormat() : timeFormat.getFormat(),
-                                                           timeFormat.getTimeZone(),
+                                                           timeFormat.selectTimezone(),
                                                            timeFormat.getLocale());
 
         ExprVirtualColumn exprVirtualColumn = new ExprVirtualColumn(timeFormatFunc.toExpression(), innerFieldName);

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/filter/TimeListFilter.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/filter/TimeListFilter.java
@@ -107,7 +107,7 @@ public class TimeListFilter extends TimeFilter {
 
       DateTimeMillisFunc millisFunc = new DateTimeMillisFunc(columnName,
                                                              fieldFormat.getFormat(),
-                                                             fieldFormat.getTimeZone(),
+                                                             fieldFormat.selectTimezone(),
                                                              fieldFormat.getLocale());
       field = millisFunc.toExpression();
     }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/filter/TimeRangeFilter.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/filter/TimeRangeFilter.java
@@ -140,7 +140,7 @@ public class TimeRangeFilter extends TimeFilter {
 
         DateTimeMillisFunc millisFunc = new DateTimeMillisFunc(columnName,
                                                                fieldFormat.getFormat(),
-                                                               fieldFormat.getTimeZone(),
+                                                               fieldFormat.selectTimezone(),
                                                                fieldFormat.getLocale());
         field = millisFunc.toExpression();
       }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/filter/TimeRelativeFilter.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/filter/TimeRelativeFilter.java
@@ -113,7 +113,7 @@ public class TimeRelativeFilter extends TimeFilter {
 
       DateTimeMillisFunc millisFunc = new DateTimeMillisFunc(columnName,
                                                              fieldFormat.getFormat(),
-                                                             fieldFormat.getTimeZone(),
+                                                             fieldFormat.selectTimezone(),
                                                              fieldFormat.getLocale());
       field = millisFunc.toExpression();
     }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/format/ContinuousTimeFormat.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/format/ContinuousTimeFormat.java
@@ -98,7 +98,7 @@ public class ContinuousTimeFormat extends TimeFieldFormat implements FieldFormat
     if (enableSortField()) {
       return String.format(PivotColumn.SortComparator.DATETIME,
                            "'" + this.getFormat() + "'",
-                           this.getTimeZone(),
+                           this.selectTimezone(),
                            this.getLocale());
     } else {
       if (unit == TimeUnit.MONTH && byUnit != ByTimeUnit.QUARTER) {

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/format/TimeFieldFormat.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/format/TimeFieldFormat.java
@@ -31,6 +31,8 @@ public abstract class TimeFieldFormat {
 
   public static final String DEFAULT_DATETIME_FORMAT = "yyyy-MM-dd HH:mm:ss";
 
+  public static final String DISABLE_TIMEZONE = "DISABLE_ZONE";
+
   String timeZone;
 
   String locale;
@@ -44,10 +46,15 @@ public abstract class TimeFieldFormat {
   }
 
   public TimeFieldFormat(String timeZone, String locale, String filteringType) {
-    try {
-      this.timeZone = timeZone == null ? EngineQueryProperties.getDefaultTimezone() : DateTimeZone.forID(timeZone).toString();
-    } catch (Exception e) {
-      throw new BadRequestException("Invalid timezone ID : " + e.getMessage());
+
+    if (DISABLE_TIMEZONE.equalsIgnoreCase(timeZone)) {
+      this.timeZone = timeZone;
+    } else {
+      try {
+        this.timeZone = timeZone == null ? EngineQueryProperties.getDefaultTimezone() : DateTimeZone.forID(timeZone).toString();
+      } catch (Exception e) {
+        throw new BadRequestException("Invalid timezone ID : " + e.getMessage());
+      }
     }
 
     try {
@@ -57,6 +64,14 @@ public abstract class TimeFieldFormat {
     }
 
     this.filteringType = EnumUtils.getUpperCaseEnum(FilteringType.class, filteringType);
+  }
+
+  public String selectTimezone() {
+    if (DISABLE_TIMEZONE.equalsIgnoreCase(timeZone)) {
+      return "UTC";
+    } else {
+      return timeZone;
+    }
   }
 
   public String getTimeZone() {

--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/AbstractQueryBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/AbstractQueryBuilder.java
@@ -574,7 +574,7 @@ public abstract class AbstractQueryBuilder {
         TimeFieldFormat timeFormat = (TimeFieldFormat) timestampFilter.getTimeFormat();
         TimeFormatFunc timeFormatFunc = new TimeFormatFunc(field,
                                                            timeFormat.getFormat(),
-                                                           timeFormat.getTimeZone(),
+                                                           timeFormat.selectTimezone(),
                                                            timeFormat.getLocale());
 
         InFunc inFunc = new InFunc(timeFormatFunc.toExpression(), timestampFilter.getSelectedTimestamps());

--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/AbstractQueryBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/AbstractQueryBuilder.java
@@ -362,16 +362,16 @@ public abstract class AbstractQueryBuilder {
 
       timeFormatFunc = new TimeFormatFunc(expr,
                                           timeFormat.enableSortField() ? timeFormat.getSortFormat() : timeFormat.getFormat(),
-                                          timeFormat.getTimeZone(),
+                                          timeFormat.selectTimezone(),
                                           timeFormat.getLocale());
 
     } else {
       timeFormatFunc = new TimeFormatFunc("\"" + fieldName + "\"",
                                           originalTimeFormat.getFormat(),
-                                          originalTimeFormat.getTimeZone(),
+                                          originalTimeFormat.selectTimezone(),
                                           originalTimeFormat.getLocale(),
                                           timeFormat.enableSortField() ? timeFormat.getSortFormat() : timeFormat.getFormat(),
-                                          timeFormat.getTimeZone(),
+                                          timeFormat.selectTimezone(),
                                           timeFormat.getLocale());
 
     }

--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/limits/PivotColumn.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/limits/PivotColumn.java
@@ -53,10 +53,10 @@ public class PivotColumn {
       TimeFieldFormat format = (TimeFieldFormat) field.getFormat();
       TimeFormatFunc timeFormatFunc = new TimeFormatFunc("\"" + field.getAlias() + "\"",
                                                          format.enableSortField() ? format.getSortFormat() : format.getFormat(),
-                                                         format.getTimeZone(),
+                                                         format.selectTimezone(),
                                                          format.getLocale(),
                                                          format.getFormat(),
-                                                         format.getTimeZone(),
+                                                         format.selectTimezone(),
                                                          format.getLocale());
       this.expression = timeFormatFunc.toExpression();
       this.dimensionOrder = format.getSortComparator();

--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/model/HoltWintersPostProcessor.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/model/HoltWintersPostProcessor.java
@@ -155,7 +155,7 @@ public class HoltWintersPostProcessor implements PostProcessor {
     // 클라이언트가 지정한 Format 으로 변환
     TimeFormatFunc postFormatFunc = new TimeFormatFunc("__time",
                                                        timeFormat.getFormat(),
-                                                       timeFormat.getTimeZone(),
+                                                       timeFormat.selectTimezone(),
                                                        timeFormat.getLocale());
 
     MathPostAggregator mathPostAggregator = new MathPostAggregator(timeField.getAlias(), postFormatFunc.toExpression(), null);

--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/queries/SelectQueryBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/queries/SelectQueryBuilder.java
@@ -229,8 +229,8 @@ public class SelectQueryBuilder extends AbstractQueryBuilder {
         }
 
         TimeFormatFunc timeFormatFunc = new TimeFormatFunc(timestampField.getPredefinedColumn(dataSource instanceof MappingDataSource),
+                                                           timeFormat.getFormat(),
                                                            timeFormat.selectTimezone(),
-                                                           timeFormat.getTimeZone(),
                                                            timeFormat.getLocale());
 
         dimensions.add(new ExpressionDimension(aliasName, timeFormatFunc.toExpression()));

--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/queries/SelectQueryBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/queries/SelectQueryBuilder.java
@@ -229,7 +229,7 @@ public class SelectQueryBuilder extends AbstractQueryBuilder {
         }
 
         TimeFormatFunc timeFormatFunc = new TimeFormatFunc(timestampField.getPredefinedColumn(dataSource instanceof MappingDataSource),
-                                                           timeFormat.getFormat(),
+                                                           timeFormat.selectTimezone(),
                                                            timeFormat.getTimeZone(),
                                                            timeFormat.getLocale());
 

--- a/discovery-server/src/main/resources/scripts/default.sql
+++ b/discovery-server/src/main/resources/scripts/default.sql
@@ -138,7 +138,7 @@ INSERT INTO field(id, ds_id, seq, field_name, field_type, field_logical_type, fi
 (10047011, 'ds-gis-37', 11, 'Region', 'STRING', null, 'DIMENSION', null),
 (10047012, 'ds-gis-37', 12, 'Sales', 'DOUBLE', null, 'MEASURE', null),
 (10047013, 'ds-gis-37', 13, 'Segment', 'STRING', null, 'DIMENSION', null),
-(10047014, 'ds-gis-37', 14, 'ShipDate', 'STRING', 'TIMESTAMP', 'DIMENSION', '{"type":"time_format","format":"yyyy. MM. dd."}'),
+(10047014, 'ds-gis-37', 14, 'ShipDate', 'STRING', 'TIMESTAMP', 'DIMENSION', '{"type":"time_format","format":"yyyy. MM. dd.","timeZone":"DISABLE_ZONE"}'),
 (10047015, 'ds-gis-37', 15, 'ShipMode', 'STRING', null, 'DIMENSION', null),
 (10047016, 'ds-gis-37', 16, 'State', 'STRING', null, 'DIMENSION', null),
 (10047017, 'ds-gis-37', 17, 'Sub-Category', 'STRING', null, 'DIMENSION', null),

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/datasource/data/DataQueryRestIntegrationTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/datasource/data/DataQueryRestIntegrationTest.java
@@ -830,7 +830,7 @@ public class DataQueryRestIntegrationTest extends AbstractRestIntegrationTest {
   @OAuthRequest(username = "polaris", value = {"ROLE_SYSTEM_USER", "PERM_SYSTEM_WRITE_DATASOURCE"})
   public void searchQueryForSalesWithTimestamp() throws JsonProcessingException {
 
-    DataSource dataSource1 = new DefaultDataSource("sales");
+    DataSource dataSource1 = new DefaultDataSource("sales_geo");
 
     // Limit
     Limit limit = new Limit();
@@ -890,7 +890,7 @@ public class DataQueryRestIntegrationTest extends AbstractRestIntegrationTest {
         new MeasureField("Sales", MeasureField.AggregationType.AVG)
     ));
 
-    SearchQueryRequest request = new SearchQueryRequest(dataSource1, filters, pivot1, limit);
+    SearchQueryRequest request = new SearchQueryRequest(dataSource1, filters, pivot2, limit);
 
     // @formatter:off
     given()


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
데이터소스 생성화면에서 시간, 분, 초 의 datetime format 인 경우에만 timezone 셀렉트박스가 나오도록 수정
일 이상의 포맷은 데이터소스 상세화면과 데이터소스 생성화면에서 timezone 표시가 되지 않도록 수정

- 생성화면에서 타임존이 선택이 가능한 포맷 형태
![2019-02-12 11 24 24](https://user-images.githubusercontent.com/42233627/52607406-751a5c00-2eb9-11e9-9d61-e6da9db35bdb.png)

- 생성화면에서 타임존이 선택 불가능한 포맷인 경우와, format validation 을 통과하지 못한경우
![2019-02-12 11 24 28](https://user-images.githubusercontent.com/42233627/52607438-8cf1e000-2eb9-11e9-90d6-793a0d1234d3.png)
![2019-02-12 11 24 39](https://user-images.githubusercontent.com/42233627/52607443-911dfd80-2eb9-11e9-8c5f-22366c95ca1a.png)

- 타임존 선택이 불가능한 포맷으로 데이터소스 생성시, 상세화면에서 표시되는 형태
![2019-02-12 11 24 48](https://user-images.githubusercontent.com/42233627/52607484-a5fa9100-2eb9-11e9-869b-a65508d6db46.png)
![2019-02-12 11 24 54](https://user-images.githubusercontent.com/42233627/52607496-ad219f00-2eb9-11e9-9db1-5f736a340930.png)

- 타임존 선택이 불가능한 포맷과, 가능한 포맷으로 데이터소스 생성시, 상세화면에서 표시되는 형태
![2019-02-12 11 25 00](https://user-images.githubusercontent.com/42233627/52607506-bad72480-2eb9-11e9-87a4-7c1bed1c753f.png)



**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#1397 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 데이터소스 > 데이터소스 생성 > datetime으로 필드를 변경 
2. 해당 컬럼이 yyyy-MM-dd 이상의 포맷인 경우 타임존 선택박스가 나오지 않는것 확인
3. 2와 같은 포맷으로 데이터소스를 생성 후 상세화면에서 timezone 에 대한 정보가 나오지 않는것 확인

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project. _it will be added soon_
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
