### PR TITLE
#667 fix workspace comp in datasource

### DIFF
--- a/discovery-frontend/src/app/data-storage/component/set-workspace-published/set-workspace-published.component.html
+++ b/discovery-frontend/src/app/data-storage/component/set-workspace-published/set-workspace-published.component.html
@@ -76,7 +76,7 @@
                   <colgroup>
                     <col width="51px">
                     <col width="*">
-                    <col width="23%">
+                    <col width="26%">
                   </colgroup>
                   <thead>
                   <tr>
@@ -107,7 +107,7 @@
                   <colgroup>
                     <col width="51px">
                     <col width="*">
-                    <col width="23%">
+                    <col width="26%">
                   </colgroup>
                   <tbody>
                   <tr *ngIf="!personalWorkspaceList() || personalWorkspaceList().length === 0">
@@ -180,7 +180,7 @@
                     <col width="*">
                     <col width="10%">
                     <col width="10%">
-                    <col width="23%">
+                    <col width="26%">
                   </colgroup>
                   <thead>
                   <tr>
@@ -219,7 +219,7 @@
                     <col width="*">
                     <col width="10%">
                     <col width="10%">
-                    <col width="23%">
+                    <col width="26%">
                   </colgroup>
                   <tbody>
                   <tr *ngIf="!publicWorkspaceList() || publicWorkspaceList().length === 0">

--- a/discovery-frontend/src/app/data-storage/component/set-workspace-published/set-workspace-published.component.html
+++ b/discovery-frontend/src/app/data-storage/component/set-workspace-published/set-workspace-published.component.html
@@ -110,6 +110,9 @@
                     <col width="23%">
                   </colgroup>
                   <tbody>
+                  <tr *ngIf="!personalWorkspaceList() || personalWorkspaceList().length === 0">
+                    <td class="ddp-data-none " colspan="5">{{'msg.comm.ui.no.rslt' | translate}}</td>
+                  </tr>
                   <!-- 체크시 상태 tr class="ddp-tr-select" 추가 -->
                   <tr *ngFor="let workspace of personalWorkspaceList()"
                       [ngClass]="{'ddp-tr-select' : checkInWorkspaces(workspace)}"
@@ -219,6 +222,9 @@
                     <col width="23%">
                   </colgroup>
                   <tbody>
+                  <tr *ngIf="!publicWorkspaceList() || publicWorkspaceList().length === 0">
+                    <td class="ddp-data-none " colspan="5">{{'msg.comm.ui.no.rslt' | translate}}</td>
+                  </tr>
                   <tr *ngFor="let workspace of publicWorkspaceList()"
                       [ngClass]="{'ddp-tr-select' : checkInWorkspaces(workspace)}"
                       (click)="onCheckedWorkspace(workspace, 'SHARED')">

--- a/discovery-frontend/src/app/data-storage/component/set-workspace-published/set-workspace-published.component.html
+++ b/discovery-frontend/src/app/data-storage/component/set-workspace-published/set-workspace-published.component.html
@@ -115,7 +115,6 @@
                   </tr>
                   <!-- 체크시 상태 tr class="ddp-tr-select" 추가 -->
                   <tr *ngFor="let workspace of personalWorkspaceList()"
-                      [ngClass]="{'ddp-tr-select' : checkInWorkspaces(workspace)}"
                       (click)="onCheckedWorkspace(workspace, 'PRIVATE')">
                     <td class="ddp-txt-center">
                       <div class="ddp-ui-checkbox">
@@ -226,7 +225,6 @@
                     <td class="ddp-data-none " colspan="5">{{'msg.comm.ui.no.rslt' | translate}}</td>
                   </tr>
                   <tr *ngFor="let workspace of publicWorkspaceList()"
-                      [ngClass]="{'ddp-tr-select' : checkInWorkspaces(workspace)}"
                       (click)="onCheckedWorkspace(workspace, 'SHARED')">
                     <td class="ddp-txt-center">
                       <div class="ddp-ui-checkbox">

--- a/discovery-frontend/src/app/data-storage/component/set-workspace-published/set-workspace-published.component.html
+++ b/discovery-frontend/src/app/data-storage/component/set-workspace-published/set-workspace-published.component.html
@@ -12,7 +12,7 @@
   ~ limitations under the License.
   -->
 
-<div class="ddp-index ddp-layout-popuptype" *ngIf="showFl">
+<div class="ddp-layout-popuptype" *ngIf="showFl">
   <em class="ddp-bg-popup"></em>
   <div class="ddp-ui-popup">
     <!-- title -->
@@ -34,7 +34,7 @@
     </div>
     <!-- //title -->
     <div class="ddp-ui-popup-contents">
-      <div class="ddp-wrap-permission">
+      <div class="ddp-wrap-permission ddp-type">
         <!-- tab -->
         <div class="ddp-wrap-tab">
           <ul class="ddp-ui-tab ddp-clear">
@@ -76,7 +76,7 @@
                   <colgroup>
                     <col width="51px">
                     <col width="*">
-                    <col width="20%">
+                    <col width="23%">
                   </colgroup>
                   <thead>
                   <tr>
@@ -92,7 +92,7 @@
                       <em class="ddp-icon-array-des2" *ngIf="personalWorkspaces.sort === 'name,desc'"></em>
                     </th>
                     <th>
-                      {{'msg.storage.th.owner' | translate}}
+                      {{'msg.storage.th.owner' | translate}} ({{'msg.storage.ui.username' | translate}})
                     </th>
                   </tr>
                   </thead>
@@ -107,7 +107,7 @@
                   <colgroup>
                     <col width="51px">
                     <col width="*">
-                    <col width="20%">
+                    <col width="23%">
                   </colgroup>
                   <tbody>
                   <!-- 체크시 상태 tr class="ddp-tr-select" 추가 -->
@@ -127,7 +127,8 @@
                       </div>
                     </td>
                     <td>
-                      {{workspace.owner.fullName}}
+                      <span class="ddp-txt-data">{{workspace.owner.fullName}}</span>
+                      <span class="ddp-data-owner">({{workspace.owner.username}})</span>
                     </td>
                   </tr>
                   </tbody>
@@ -176,7 +177,7 @@
                     <col width="*">
                     <col width="10%">
                     <col width="10%">
-                    <col width="20%">
+                    <col width="23%">
                   </colgroup>
                   <thead>
                   <tr>
@@ -198,7 +199,7 @@
                       {{'msg.storage.th.group' | translate}}
                     </th>
                     <th>
-                      {{'msg.storage.th.owner' | translate}}
+                      {{'msg.storage.th.owner' | translate}} ({{'msg.storage.ui.username' | translate}})
                     </th>
                   </tr>
                   </thead>
@@ -215,7 +216,7 @@
                     <col width="*">
                     <col width="10%">
                     <col width="10%">
-                    <col width="20%">
+                    <col width="23%">
                   </colgroup>
                   <tbody>
                   <tr *ngFor="let workspace of publicWorkspaceList()"
@@ -240,7 +241,8 @@
                       {{workspace.countByMemberType.group}}
                     </td>
                     <td>
-                      {{workspace.owner.fullName}}
+                      <span class="ddp-txt-data">{{workspace.owner.fullName}}</span>
+                      <span class="ddp-data-owner">({{workspace.owner.username}})</span>
                     </td>
                   </tr>
                   </tbody>

--- a/discovery-frontend/src/app/data-storage/component/set-workspace-published/set-workspace-published.component.html
+++ b/discovery-frontend/src/app/data-storage/component/set-workspace-published/set-workspace-published.component.html
@@ -76,7 +76,7 @@
                   <colgroup>
                     <col width="51px">
                     <col width="*">
-                    <col width="26%">
+                    <col width="250px">
                   </colgroup>
                   <thead>
                   <tr>
@@ -107,7 +107,7 @@
                   <colgroup>
                     <col width="51px">
                     <col width="*">
-                    <col width="26%">
+                    <col width="250px">
                   </colgroup>
                   <tbody>
                   <tr *ngIf="!personalWorkspaceList() || personalWorkspaceList().length === 0">
@@ -177,9 +177,9 @@
                   <colgroup>
                     <col width="51px">
                     <col width="*">
-                    <col width="10%">
-                    <col width="10%">
-                    <col width="26%">
+                    <col width="70px">
+                    <col width="70px">
+                    <col width="250px">
                   </colgroup>
                   <thead>
                   <tr>
@@ -216,9 +216,9 @@
                   <colgroup>
                     <col width="51px">
                     <col width="*">
-                    <col width="10%">
-                    <col width="10%">
-                    <col width="26%">
+                    <col width="70px">
+                    <col width="70px">
+                    <col width="250px">
                   </colgroup>
                   <tbody>
                   <tr *ngIf="!publicWorkspaceList() || publicWorkspaceList().length === 0">

--- a/discovery-frontend/src/assets/css/metatron/component/component.table.css
+++ b/discovery-frontend/src/assets/css/metatron/component/component.table.css
@@ -95,6 +95,7 @@ table.ddp-table-form tbody tr td .ddp-link-delete:hover em.ddp-icon-delete {back
 .ddp-ui-grid .ddp-ui-empty {padding:20px; color:#b7b9c3; font-size:12px;}
 .ddp-ui-gridbody {position:absolute; top:28px; left:0; right:0; bottom:0; overflow-y:scroll;}
 .ddp-box-viewtable .ddp-ui-gridhead {height:33px;border-top:none;}
+.ddp-box-viewtable .ddp-ui-gridhead table {padding-right:18px;}
 .ddp-box-viewtable .ddp-ui-gridhead tr th {height:33px; box-sizing:border-box;}
 .ddp-box-viewtable .ddp-ui-gridbody {top:34px;}
 
@@ -202,7 +203,7 @@ table.ddp-table-select tbody tr.ddp-selected td:last-of-type {border-right:1px s
 table.ddp-table-select tbody tr td .ddp-box-tag {position:relative; top:2px;}
 table.ddp-table-type2.ddp-table-select tbody tr.ddp-selected > td {padding:12px 10px 13px 10px}
 table.ddp-table-type2.ddp-table-select tbody tr.ddp-selected > td:first-of-type {padding-left:9px;}
-table.ddp-table-type2.ddp-table-select tbody tr.ddp-selected > td:last-of-type {padding-right:29px;}
+table.ddp-table-select tbody tr td:last-of-type {padding-right:29px !important;}
 
 table.ddp-table-select tr td:last-of-type {padding-right:35px;}
 table.ddp-table-select tbody tr.ddp-selected td:first-child:before {border-left:1px solid #666eb2;}

--- a/discovery-frontend/src/assets/css/polaris.v2.page.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.page.css
@@ -7227,10 +7227,14 @@ ul.ddp-ui-tab li em.ddp-icon-user-s2,
 ul.ddp-ui-tab li em.ddp-icon-group-s2 {margin-right:8px;}
 ul.ddp-ui-tab li.ddp-selected em.ddp-icon-user-s2,
 ul.ddp-ui-tab li.ddp-selected em.ddp-icon-group-s2 {opacity:1;}
+.ddp-wrap-permission.ddp-type {padding-top:0;}
+.ddp-wrap-permission.ddp-type .ddp-wrap-viewtable {top:98px;}
 .ddp-wrap-permission {position:relative; padding-top:42px; height:100%; box-sizing:border-box;}
 .ddp-wrap-permission .ddp-type-check {display:inline-block; position:absolute; top:0;}
 .ddp-wrap-permission .ddp-wrap-viewtable{position:absolute; top:140px; left:0; right:0; bottom:68px;}
 .ddp-wrap-permission .ddp-wrap-switch .ddp-form-search {width:270px;}
+.ddp-wrap-permission table.ddp-table-type2 tbody tr > td .ddp-data-owner {float:left; color:#b7b9c2;}
+.ddp-wrap-permission table.ddp-table-type2 tbody tr > td .ddp-txt-data {float:left; padding-right:4px;}
 
 .ddp-box-popupcontents2.ddp-setting-source {width:666px;}
 .ddp-box-popupcontents2.ddp-setting-source > .ddp-wrap-edit2:first-of-type {margin-top:0;}

--- a/discovery-frontend/src/assets/i18n/en.json
+++ b/discovery-frontend/src/assets/i18n/en.json
@@ -2145,6 +2145,7 @@
   "msg.storage.ui.file.result.FV004": "Column names are allowed up to 50 characters.",
   "msg.storage.ui.file.result.FV005": "Empty column name is not allowed.",
   "msg.storage.ui.timezone": "Time zone",
+  "msg.storage.ui.username": "Username",
 
   "msg.storage.ui.timezone.country.zimbabwe": "Zimbabwe",
   "msg.storage.ui.timezone.country.zambia": "Zambia",

--- a/discovery-frontend/src/assets/i18n/en.json
+++ b/discovery-frontend/src/assets/i18n/en.json
@@ -2030,7 +2030,7 @@
   "msg.storage.ui.conn.url.ph" : "Please enter URL",
   "msg.storage.ui.conn.sid.ph" : "Please enter SID",
   "msg.storage.ui.conn.catalog.ph" : "Please enter Catalog",
-  "msg.storage.ui.spaces.search.ph" : "Search by workspace",
+  "msg.storage.ui.spaces.search.ph" : "Search by workspace or owner name",
   "msg.storage.ui.action.delete" : "Do you want to delete?",
   "msg.storage.ui.action.data.detail" : "Data detail",
   "msg.storage.ui.server" : "Server",

--- a/discovery-frontend/src/assets/i18n/ko.json
+++ b/discovery-frontend/src/assets/i18n/ko.json
@@ -2029,7 +2029,7 @@
   "msg.storage.ui.conn.url.ph" : "URL을 입력해 주세요",
   "msg.storage.ui.conn.sid.ph" : "SID를 입력해 주세요",
   "msg.storage.ui.conn.catalog.ph" : "Catalog를 입력해 주세요",
-  "msg.storage.ui.spaces.search.ph" : "워크스페이스 검색",
+  "msg.storage.ui.spaces.search.ph" : "워크스페이스 또는 소유자 검색",
   "msg.storage.ui.action.delete" : "삭제합니까?",
   "msg.storage.ui.action.data.detail" : "데이터 상세",
   "msg.storage.ui.server" : "서버",

--- a/discovery-frontend/src/assets/i18n/ko.json
+++ b/discovery-frontend/src/assets/i18n/ko.json
@@ -2143,6 +2143,7 @@
   "msg.storage.ui.file.result.FV004": "1자~50자 이내의 컬럼명으로 작성해주세요.",
   "msg.storage.ui.file.result.FV005": "빈 컬럼명은 허용되지 않습니다.",
   "msg.storage.ui.timezone": "타임존",
+  "msg.storage.ui.username": "사용자이름",
 
   "msg.storage.ui.timezone.country.zimbabwe": "짐바브웨",
   "msg.storage.ui.timezone.country.zambia": "잠비아",


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
소유자를 표시할때 username이 같이 표기되도록 수정
![2019-02-13 1 12 35](https://user-images.githubusercontent.com/42233627/52686437-0f999e80-2f91-11e9-9f70-2ef2ba9d252b.png)


**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#667 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 데이터소스 또는 커넥션 상세화면에서 워크스페이스를 지정하는 팝업 오픈
2. Owner(소유자) 에서 username이 같이 표기되는지 확인

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project. _it will be added soon_
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
