### PR TITLE
#1401 Down arrow event in korean input mode.

### DIFF
--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-rename.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-rename.component.ts
@@ -117,7 +117,7 @@ export class EditRuleRenameComponent extends EditRuleComponent implements OnInit
       command: 'rename',
       to: this.newFieldName,
       col: selectedFieldName,
-      ruleString: 'rename col: `' + selectedFieldName + '`' + `to: '${this.newFieldName}'`
+      ruleString: 'rename col: `' + selectedFieldName + '`' + ` to: '${this.newFieldName}'`
     };
 
   } // function - getRuleData

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/rule-suggest-input.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/rule-suggest-input.component.ts
@@ -506,8 +506,7 @@ export class RuleSuggestInputComponent extends AbstractComponent implements OnIn
   protected prcessEvent($event) {
     const keyCode = $event.keyCode;
 
-    if( $event.metaKey === true || $event.ctrlKey === true || 
-        $event.altKey === true ){
+    if( $event.metaKey === true || $event.ctrlKey === true || $event.altKey === true ){
       return true;
     } else if ( 16 === keyCode && this.isSuggestOpen ) {
       // 대소문자 입력후 아무일도 하지 않는다.
@@ -517,7 +516,7 @@ export class RuleSuggestInputComponent extends AbstractComponent implements OnIn
     if( keyCode === 38 || keyCode == 40) {
 
       if( this.isArrowDown) {
-        // 이전에 화살표 Down Event가 아니면 
+        // 이전에 화살표 Down Event가 아니면
         // 화살표 위 아래 처리
         this.isArrowDown = false;
         return this.processUpDown(keyCode, $event);

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/rule-suggest-input.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/rule-suggest-input.component.ts
@@ -94,6 +94,9 @@ export class RuleSuggestInputComponent extends AbstractComponent implements OnIn
   @Input()
   public isBackTick = true; 
 
+  /** 화살표 버튼이 눌러졌는지 여부 (한글 완전히 입력하지 않았을 경우 down arrow 검사용) */
+  public isArrowDown = false;
+
   /** 아이템 높이 (화살표시 이동할 스크롤 바 ) */
   public itemHeight = 25;
 
@@ -257,6 +260,8 @@ export class RuleSuggestInputComponent extends AbstractComponent implements OnIn
       const keyCode = $event.keyCode;
 
       if( keyCode === 38 || keyCode == 40) {
+        this.isArrowDown = true; /* 한글 입력이 완료되지 않고 아래 화살표를 누르면 화살표 업 이벤트가 실행 된다. */
+
         // suggetion 이 있을 경우 하살표 위 아래의 동작이 맨앞으로 가거나 맨 뒤로 가지 않도록한다.
         if( this.isSuggestOpen && this.suggestItems && this.suggestItems.length > 0 ) {
           if( keyCode === 38 ) {
@@ -510,8 +515,16 @@ export class RuleSuggestInputComponent extends AbstractComponent implements OnIn
     }
 
     if( keyCode === 38 || keyCode == 40) {
-      // 화살표 위 아래 처리
-      return this.processUpDown(keyCode, $event);
+
+      if( this.isArrowDown) {
+        // 이전에 화살표 Down Event가 아니면 
+        // 화살표 위 아래 처리
+        this.isArrowDown = false;
+        return this.processUpDown(keyCode, $event);
+      } else {
+        this.isArrowDown = false;
+        return true;
+      }
     } else if (keyCode === 13 || keyCode === 108) {   
       // Enter
       return this.processEnter($event);


### PR DESCRIPTION
### Description
When selecting korean column name in the suggestion layer , Down Arrow goes to the first column.
한글 컬럼 이름 suggetion을 선택할때, 아래 화살표를 입력하면 첫번째 컬럼으로 간도록 수정

**Related Issue** : <!--- Please link to the issue here. -->
#1401 


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. menu > MANAGEMENT > DataPreparation.
2. click Dataflow > click Wrangled Data > Edit rules.
3. select rule  aggregate, pivot and window.
4. add function and then add korean column name.
5. select column name in suggestion layer.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Additional Context