### PR TITLE
#1406 Fix dataprep main grid css

### DIFF
--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/edit-rule-grid.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/edit-rule-grid.component.ts
@@ -733,7 +733,10 @@ export class EditRuleGridComponent extends AbstractComponent implements OnInit, 
           'line-height': '29px',
           'white-space': 'nowrap',
           'text-overflow': 'ellipsis',
-          'overflow': 'hidden'
+          'overflow': 'hidden',
+          'paddingLeft' : '9px',
+          'paddingRight' : '9px',
+          'box-sizing' :'border-box'
         })
         .appendTo(args.node);
 

--- a/discovery-frontend/src/assets/css/metatron/page/metatron.page.99Preperation_dataflow_rule.css
+++ b/discovery-frontend/src/assets/css/metatron/page/metatron.page.99Preperation_dataflow_rule.css
@@ -53,4 +53,7 @@
 .page-prep-dataflow .ddp-box-warning .ddp-txt-warning {display:none; position:absolute; top:100%; right:0; padding:7px 10px; margin-top:2px; background-color:#e9b017; color:#fff; font-size:12px; white-space:nowrap; border-radius:2px;}
 .page-prep-dataflow .ddp-box-warning:hover .ddp-txt-warning {display:block;}
 
+.page-prep-dataflow .slick-headerrow-column.ui-state-default {border-right:1px solid #ebebed;}
+.page-prep-dataflow .slick-headerrow.ui-state-default {border-top:1px solid #ebebed;}
+
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Fix main grid css

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#1406 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
![image](https://user-images.githubusercontent.com/42233517/52690357-b8032f00-2fa0-11e9-8be3-8b9f5b86bd9e.png)
In dataprep main grid, check histogram box has a border, and histogram description has a padding

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
