### PR TITLE
#1376 updated json parsing rules

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetFileService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetFileService.java
@@ -22,7 +22,6 @@ import app.metatron.discovery.domain.dataprep.exceptions.PrepErrorCodes;
 import app.metatron.discovery.domain.dataprep.exceptions.PrepException;
 import app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey;
 import app.metatron.discovery.domain.dataprep.json.PrepJsonUtil;
-import app.metatron.discovery.domain.dataprep.repository.PrDatasetRepository;
 import app.metatron.discovery.domain.dataprep.teddy.ColumnType;
 import app.metatron.discovery.domain.dataprep.teddy.DataFrame;
 import app.metatron.discovery.domain.dataprep.teddy.DataFrameService;
@@ -37,16 +36,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.monitorjbl.xlsx.StreamingReader;
-import org.apache.commons.codec.binary.StringUtils;
-import org.apache.commons.io.ByteOrderMark;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.io.input.BOMInputStream;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.ContentSummary;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
-import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
@@ -62,8 +61,10 @@ import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
-import java.nio.charset.Charset;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.Future;
 
 @Service
@@ -361,6 +362,62 @@ public class PrepDatasetFileService {
     }
 
     public DataFrame getPreviewLinesFromFileForDataFrame(PrDataset dataset, String sheetindex, String size) throws IOException, TeddyException {
+        DataFrame dataFrame = null;
+
+        if (dataset == null) {
+            throw PrepException.create(PrepErrorCodes.PREP_DATAFLOW_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_NO_DATASET);
+        }
+
+        assert dataset.getImportType() == PrDataset.IMPORT_TYPE.UPLOAD || dataset.getImportType() == PrDataset.IMPORT_TYPE.URI;
+
+        String storedUri = dataset.getStoredUri();
+
+        try {
+            String extensionType = FilenameUtils.getExtension(storedUri);
+            int limitRows = Integer.parseInt(size);
+            boolean autoTyping = true;
+
+            if(dataset.getDsType() == PrDataset.DS_TYPE.WRANGLED) {
+                autoTyping = false;
+            }
+
+            File theFile = new File(new URI(storedUri));
+            if(theFile.exists()==false) {
+                throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_FILE_NOT_FOUND, "No file : " + storedUri);
+            }
+
+            Map<String, Object> responseMap = null;
+            switch (extensionType) {
+                case "xlsx":
+                case "xls":
+                    // Excel files are treated as CSV
+                    break;
+                case "json":
+                    responseMap = getResponseMapFromJson(storedUri, limitRows, autoTyping);
+                    break;
+                default:
+                    String delimiterCol = dataset.getDelimiter();
+                    responseMap = getResponseMapFromCsv(storedUri, limitRows, delimiterCol, autoTyping);
+            }
+
+            if(responseMap != null) {
+                List<DataFrame> gridResponses = (List<DataFrame>)responseMap.get("gridResponses");
+                if( gridResponses.isEmpty()==false ) {
+                    dataFrame = (DataFrame)gridResponses.get(0);
+                }
+            }
+        } catch (URISyntaxException e1) {
+            e1.printStackTrace();
+            throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_MALFORMED_URI_SYNTAX, storedUri);
+        } catch (Exception e) {
+            LOGGER.error("Failed to read file : {}", e.getMessage());
+            throw e;
+        }
+
+        return dataFrame;
+    }
+
+    public DataFrame getPreviewLinesFromFileForDataFrame_bak(PrDataset dataset, String sheetindex, String size) throws IOException, TeddyException {
         DataFrame dataFrame = new DataFrame();
         String strUri = null;
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/csv/PrepCsvUtil.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/csv/PrepCsvUtil.java
@@ -167,7 +167,7 @@ public class PrepCsvUtil {
         int colCnt = csvRow.size();
         result.maxColCnt = Math.max(result.maxColCnt, colCnt);
 
-        String[] row = new String[colCnt];
+        String[] row = new String[result.maxColCnt];
         for (int i = 0; i < colCnt; i++) {
           row[i] = csvRow.get(i);
         }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/service/PrDatasetService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/service/PrDatasetService.java
@@ -135,8 +135,8 @@ public class PrDatasetService {
         String csvStrUri = null;
         if(dataset.getFileFormat() == PrDataset.FILE_FORMAT.EXCEL) {
             csvStrUri = this.datasetFilePreviewService.moveExcelToCsv(storedUri, sheetName, delimiter);
-        } else if(dataset.getFileFormat() == PrDataset.FILE_FORMAT.JSON) {
-            csvStrUri = this.datasetFilePreviewService.moveJsonToCsv(storedUri, null, delimiter);
+        //} else if(dataset.getFileFormat() == PrDataset.FILE_FORMAT.JSON) {
+        //    csvStrUri = this.datasetFilePreviewService.moveJsonToCsv(storedUri, null, delimiter);
         }
         if(csvStrUri!=null) {
             dataset.setStoredUri(csvStrUri);


### PR DESCRIPTION
### Description
We consider all input data to be input initially as a string
However, JSON can have JSON object as a child
So we will assume that the input data is all strings
The data in the imported dataset will be represented as a String even if it is JSON

**Related Issue** : 
[#1376](https://github.com/metatron-app/metatron-discovery/issues/1376)

### How Has This Been Tested?
Attached two test files.
Import them for test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
