### PR TITLE
#1438 Filters do not apply to line charts.

### DIFF
--- a/discovery-frontend/src/app/common/component/chart/base-chart.ts
+++ b/discovery-frontend/src/app/common/component/chart/base-chart.ts
@@ -50,25 +50,25 @@ import {
 import {Field as AbstractField, Field} from '../../../domain/workbook/configurations/field/field';
 
 import * as _ from 'lodash';
-import { OptionGenerator } from './option/util/option-generator';
-import { Series } from './option/define/series';
-import { DataZoomType } from './option/define/datazoom';
-import { ColorOptionConverter } from './option/converter/color-option-converter';
-import { AxisOptionConverter } from './option/converter/axis-option-converter';
-import { LabelOptionConverter } from './option/converter/label-option-converter';
-import { FormatOptionConverter } from './option/converter/format-option-converter';
-import { CommonOptionConverter } from './option/converter/common-option-converter';
-import { ToolOptionConverter } from './option/converter/tool-option-converter';
-import { LegendOptionConverter } from './option/converter/legend-option-converter';
-import { analysis } from '../../../page/component/value/analysis';
-import { ColorRange, UIChartColorGradationByValue } from './option/ui-option/ui-color';
-import { UIScatterChart } from './option/ui-option/ui-scatter-chart';
+import {OptionGenerator} from './option/util/option-generator';
+import {Series} from './option/define/series';
+import {DataZoomType} from './option/define/datazoom';
+import {ColorOptionConverter} from './option/converter/color-option-converter';
+import {AxisOptionConverter} from './option/converter/axis-option-converter';
+import {LabelOptionConverter} from './option/converter/label-option-converter';
+import {FormatOptionConverter} from './option/converter/format-option-converter';
+import {CommonOptionConverter} from './option/converter/common-option-converter';
+import {ToolOptionConverter} from './option/converter/tool-option-converter';
+import {LegendOptionConverter} from './option/converter/legend-option-converter';
+import {analysis} from '../../../page/component/value/analysis';
+import {ColorRange, UIChartColorGradationByValue} from './option/ui-option/ui-color';
+import {UIScatterChart} from './option/ui-option/ui-scatter-chart';
 import UI = OptionGenerator.UI;
 import {UIChartAxisGrid} from "./option/ui-option/ui-axis";
-import { TooltipOptionConverter } from './option/converter/tooltip-option-converter';
-import { Shelf } from '../../../domain/workbook/configurations/shelf/shelf';
-import { fromEvent } from 'rxjs';
-import { map, debounceTime } from 'rxjs/operators';
+import {TooltipOptionConverter} from './option/converter/tooltip-option-converter';
+import {Shelf} from '../../../domain/workbook/configurations/shelf/shelf';
+import {fromEvent} from 'rxjs';
+import {map, debounceTime} from 'rxjs/operators';
 
 declare let echarts: any;
 
@@ -608,37 +608,37 @@ export abstract class BaseChart extends AbstractComponent implements OnInit, OnD
 
       return list;
     });
-/*
-    _.each(this.data.columns, (data, index) => {
-      data.categoryName = _.cloneDeep(this.data.rows); // 해당 dataIndex걸로 넣어주면됨
+    /*
+        _.each(this.data.columns, (data, index) => {
+          data.categoryName = _.cloneDeep(this.data.rows); // 해당 dataIndex걸로 넣어주면됨
 
-      data.categoryValue = [];
-      data.categoryPercent = [];
+          data.categoryValue = [];
+          data.categoryPercent = [];
 
-      // 해당 dataIndex걸로 넣어주면됨
-      // 단일 series인 경우
-      if (!this.data.categories || (this.data.categories && this.data.categories.length == 0)) {
+          // 해당 dataIndex걸로 넣어주면됨
+          // 단일 series인 경우
+          if (!this.data.categories || (this.data.categories && this.data.categories.length == 0)) {
 
-        data.categoryValue = addAllValues(_.cloneDeep(this.originalData.columns), 'value');
-        data.categoryPercent = addAllValues(_.cloneDeep(this.data.columns), 'percentage');
-        data.seriesName = _.cloneDeep(this.data.rows);
-        // 멀티 series인 경우
-      } else {
-        if (this.data.categories) {
-          for (const category of this.data.categories) {
-            data.categoryValue = _.cloneDeep(category.value);
-            data.categoryPercent = _.cloneDeep(category.percentage);
+            data.categoryValue = addAllValues(_.cloneDeep(this.originalData.columns), 'value');
+            data.categoryPercent = addAllValues(_.cloneDeep(this.data.columns), 'percentage');
+            data.seriesName = _.cloneDeep(this.data.rows);
+            // 멀티 series인 경우
+          } else {
+            if (this.data.categories) {
+              for (const category of this.data.categories) {
+                data.categoryValue = _.cloneDeep(category.value);
+                data.categoryPercent = _.cloneDeep(category.percentage);
+              }
+            }
+
+            data.seriesName = _.split(data.name, CHART_STRING_DELIMITER)[0];
           }
-        }
 
-        data.seriesName = _.split(data.name, CHART_STRING_DELIMITER)[0];
-      }
-
-      // 해당 dataIndex로 설정
-      data.seriesValue = _.cloneDeep(this.originalData.columns[index].value);
-      data.seriesPercent = _.cloneDeep(data.percentage);
-    });
-*/
+          // 해당 dataIndex로 설정
+          data.seriesValue = _.cloneDeep(this.originalData.columns[index].value);
+          data.seriesPercent = _.cloneDeep(data.percentage);
+        });
+    */
 
     // rows 축의 개수만큼 넣어줌
     const copyOfData = JSON.parse(JSON.stringify(this.data));
@@ -702,7 +702,7 @@ export abstract class BaseChart extends AbstractComponent implements OnInit, OnD
     // Resize
     const resizeEvent$ = fromEvent(window, 'resize')
       .pipe(
-        map( () => document.documentElement.clientWidth + 'x' + document.documentElement.clientHeight ),
+        map(() => document.documentElement.clientWidth + 'x' + document.documentElement.clientHeight),
         debounceTime(500)
       );
 
@@ -711,7 +711,8 @@ export abstract class BaseChart extends AbstractComponent implements OnInit, OnD
         if (this.chart && this.chart.resize) {
           this.chart.resize();
         }
-      } catch (error) {}
+      } catch (error) {
+      }
     });
 
     this.subscriptions.push(windowResizeSubscribe);
@@ -745,6 +746,12 @@ export abstract class BaseChart extends AbstractComponent implements OnInit, OnD
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Public Method
    |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
+  /**
+   * 차트 클리어
+   */
+  public clear(): void {
+    ('function' === typeof this.chart.clear) && (this.chart.clear());
+  } // function - clear
 
   /**
    * 차트에 설정된 옵션으로 차트를 그린다.
@@ -2515,7 +2522,9 @@ export abstract class BaseChart extends AbstractComponent implements OnInit, OnD
             const shelveData = !_.isEmpty(data) ? data[idx] : dataAlter[idx];
 
             // selectDataList에 해당 name의 값이 없을때
-            if (-1 === _.findIndex(returnList, (obj) => { return obj.name === shelveData.name})) {
+            if (-1 === _.findIndex(returnList, (obj) => {
+              return obj.name === shelveData.name
+            })) {
 
               // selectDataList에 추가
               returnList.push(shelveData);

--- a/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
+++ b/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
@@ -25,7 +25,7 @@ import {
   ViewChild
 } from '@angular/core';
 import * as _ from 'lodash';
-import { ClipboardService } from 'ngx-clipboard';
+import {ClipboardService} from 'ngx-clipboard';
 import {
   BrushType,
   ChartMouseMode,
@@ -79,7 +79,7 @@ declare let $;
   selector: 'page-widget',
   templateUrl: 'page-widget.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  styles:[ '.ddp-pop-preview { position: fixed; width: 700px; height: 500px; top: 50%; left: 50%; margin-left: -350px; margin-top: -250px;}' ]
+  styles: ['.ddp-pop-preview { position: fixed; width: 700px; height: 500px; top: 50%; left: 50%; margin-left: -350px; margin-top: -250px;}']
 })
 export class PageWidgetComponent extends AbstractWidgetComponent implements OnInit, OnDestroy {
 
@@ -111,8 +111,10 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
   // 현재 위젯에서 발생시킨 필터정보
   private _selectFilterList: any[] = [];
 
-  // Current Selection Filters
+  // Current Filters
   private _currentSelectionFilters: Filter[] = [];
+  private _currentSelectionFilterString: string = '';
+  private _currentGlobalFilterString: string = '';
 
   // child widget id list
   private _childWidgetIds: string[] = [];
@@ -140,7 +142,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
   public isMaximize = false;                // 최대 여부
   public mouseMode: string = 'SINGLE';     // 차트 마우스 모드
 
-  public isSetChartData:boolean = false;          // 차트 데이터 설정 여부
+  public isSetChartData: boolean = false;          // 차트 데이터 설정 여부
   public isUpdateRedraw: boolean = true;          // 다시그리는 새로고침
   public isShowHierarchyView: boolean = false;    // 차트 계층 표시 여부
   public isInvalidPivot: boolean = false;          // 선반정보를 확인해야 하는 경우
@@ -150,7 +152,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
   public duringImageDown: boolean = false;        // 이미지 다운로드 진행 여부
 
   // Limit 정보
-  public limitInfo: ChartLimitInfo = { id: '', isShow: false, currentCnt: 0, maxCnt: 0 };
+  public limitInfo: ChartLimitInfo = {id: '', isShow: false, currentCnt: 0, maxCnt: 0};
 
   // Pivot 내 사용자 정의 컬럼 사용 여부
   public useCustomField: boolean = false;
@@ -175,8 +177,8 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
 
   // is Origin data down
   public isOriginDown: boolean = false;
-  public srchText:string = '';
-  public isCanNotDownAggr:boolean = false;
+  public srchText: string = '';
+  public isCanNotDownAggr: boolean = false;
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Public Variables - Input & Output
@@ -431,14 +433,13 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
           } else if (this.chart.uiOption.type === ChartType.LABEL) {
 
           } else if (this.chart.uiOption.type === ChartType.NETWORK) {
-            ( this.isSetChartData ) && ( (<NetworkChartComponent>this.chart).draw() );
+            (this.isSetChartData) && ((<NetworkChartComponent>this.chart).draw());
           } else if (this.chart.uiOption.type === ChartType.MAP) {
             (<MapChartComponent>this.chart).resize();
           } else {
             try {
               if (this.chart && this.chart.chart) this.chart.chart.resize();
-            }
-            catch (error) {
+            } catch (error) {
             }
           }
           // 변경 적용
@@ -496,8 +497,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
       }
       if (selectData.length == 0 && !_.eq(data.mode, ChartSelectMode.CLEAR)) {
         return;
-      }
-      else {
+      } else {
         data.data = selectData;
       }
 
@@ -755,7 +755,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
    */
   public copyWidgetIdToClipboard() {
     if (this.widget) {
-      this._clipboardService.copyFromContent( this.widget.id );
+      this._clipboardService.copyFromContent(this.widget.id);
     }
   } // function - copyWidgetIdToClipboard
 
@@ -982,7 +982,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
     (clonePivot.columns) && (fields = fields.concat(clonePivot.columns));
     (clonePivot.aggregations) && (fields = fields.concat(clonePivot.aggregations));
 
-    if( isOriginal && fields.some((field: Field) => ( field['field'] && field['field'].aggregated ) ) ) {
+    if (isOriginal && fields.some((field: Field) => (field['field'] && field['field'].aggregated))) {
       this.isCanNotDownAggr = true;
       this.safelyDetectChanges();
       return false;
@@ -996,13 +996,13 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
       // 헤더정보 생성
       const headers: header[]
         = fields.map((field: Field) => {
-        const logicalType:string = ( field['field'] && field['field'].logicalType ) ? field['field'].logicalType.toString() : '';
+        const logicalType: string = (field['field'] && field['field'].logicalType) ? field['field'].logicalType.toString() : '';
         let headerName: string = field.name;
-        if( field['aggregationType'] ) {
-          if( !isOriginal ) {
+        if (field['aggregationType']) {
+          if (!isOriginal) {
             headerName = field.alias ? field.alias : field['aggregationType'] + '(' + field.name + ')';
           }
-        } else if( field.alias ) {
+        } else if (field.alias) {
           headerName = field.alias;
         }
 
@@ -1052,7 +1052,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
         this.loadingHide();
       }
     }).catch((err) => {
-      console.error( err );
+      console.error(err);
       this.loadingHide();
       // 변경 적용
       this.safelyDetectChanges();
@@ -1064,7 +1064,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
    * 검색어 설정 및 그리드 검색
    * @param {string} srchText
    */
-  public setSearchText(srchText:string) {
+  public setSearchText(srchText: string) {
     this.srchText = srchText;
     this._dataGridComp.search(this.srchText);
   } // function - setSearchText
@@ -1329,8 +1329,15 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
       this.chart['setQuery'] = this.query;
     }
 
-    // 유효한 선택 필터 정보 저장
+    // 차트 클리어 여부 판단
+    const isClear: boolean = (this.chart && 'function' === typeof this.chart.clear
+      && (this._currentSelectionFilterString !== JSON.stringify(currentSelectionFilters)
+        || this._currentGlobalFilterString !== JSON.stringify(globalFilters)));
+
+    // 필터 정보 저장
     this._currentSelectionFilters = currentSelectionFilters;
+    this._currentSelectionFilterString = JSON.stringify(currentSelectionFilters);
+    this._currentGlobalFilterString = JSON.stringify(globalFilters);
 
     this.datasourceService.searchQuery(cloneQuery).then((data) => {
 
@@ -1359,6 +1366,10 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
       }
 
       setTimeout(() => {
+
+        // 차트 클리어
+        (isClear) && (this.chart.clear());
+
         // line차트이면서 columns 데이터가 있는경우
         if (this.chartType === 'line' && this.resultData.data.columns && this.resultData.data.columns.length > 0) {
           // 고급분석 예측선 API 호출
@@ -1369,8 +1380,8 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
         }
 
         // Set Limit Info
-        this.limitInfo = DashboardUtil.getChartLimitInfo( this.widget.id, ChartType[this.chartType.toUpperCase()], data );
-        if (this.layoutMode === LayoutMode.EDIT ) {
+        this.limitInfo = DashboardUtil.getChartLimitInfo(this.widget.id, ChartType[this.chartType.toUpperCase()], data);
+        if (this.layoutMode === LayoutMode.EDIT) {
           this.broadCaster.broadcast('WIDGET_LIMIT_INFO', this.limitInfo);
         }
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
대시보드 상에서 글로벌필터 적용 시, 라인차트에는 반영 안됨

**Related Issue** : #1438 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
* 표차트, 막대차트, 라인차트 생성합니다.
* 특정 차원값으로 글로벌 필터 생성 후, 필터 위젯으로 추가합니다.
* 대시보드 저장 후 열람화면에서 필터 위젯의 값을 선택합니다.
* 라인차트에 정상적으로 필터가 적용되는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
