### PR TITLE
#1464 add double quote to druid table name for workbench data preview

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/DruidConnection.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/DruidConnection.java
@@ -1,6 +1,7 @@
 package app.metatron.discovery.domain.datasource.connection.jdbc;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
+
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.domain.Pageable;
 
@@ -183,9 +184,9 @@ public class DruidConnection extends JdbcDataConnection {
   @Override
   public String getTableName(String schema, String table) {
     if(StringUtils.isEmpty(schema) || schema.equals(database)) {
-      return "`" + table + "`";
+      return "\"" + table + "\"";
     }
-    return schema + ".`" + table + "`";
+    return schema + ".\"" + table + "\"";
   }
 
   @Override

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcConnectionService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcConnectionService.java
@@ -974,10 +974,9 @@ public class JdbcConnectionService {
 
     if (type == JdbcIngestionInfo.DataType.TABLE) {
       NativeCriteria nativeCriteria = new NativeCriteria(DataConnection.Implementor.getImplementor(connection));
-      String database = schema;
-      String table = query;
-      String tableName = (!table.contains(".") && database != null) ? database + "." + table : table;
-      nativeCriteria.addTable(tableName, table);
+      String tableName = connection.getTableName(schema, query);
+      String tableAlias = connection.getTableName("", query);
+      nativeCriteria.addTable(tableName, tableAlias);
 
       //add projection for partition
       if (partitionList != null && !partitionList.isEmpty()) {


### PR DESCRIPTION
### Description
An error occurs if the druid table starts with a number in the Data tab view of the schema browser
Modify source to wrap table names in double quote

**Related Issue** : #1464 #1099 


### How Has This Been Tested?
1. goto druid workbench
2. popup schema browser
3. select table starts with a number
4. click data tab

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
