### PR TITLE
#592 Fix error scrolling user list page

### DIFF
--- a/discovery-frontend/src/app/admin/user-management/user-management.component.html
+++ b/discovery-frontend/src/app/admin/user-management/user-management.component.html
@@ -13,7 +13,7 @@
   -->
 
 <em class="ddp-bg-back"></em>
-<div class="ddp-ui-contents-in">
+<div class="ddp-ui-contents-in ddp-scroll">
   <!-- top -->
   <div class="ddp-ui-contents-top">
     <div class="ddp-ui-title">

--- a/discovery-frontend/src/app/admin/user-management/user-management.component.ts
+++ b/discovery-frontend/src/app/admin/user-management/user-management.component.ts
@@ -76,6 +76,8 @@ export class UserManagementComponent extends AbstractComponent {
 
     // Init
     super.ngOnInit();
+
+    this.removeBodyScrollHidden();
   }
 
   // Destory


### PR DESCRIPTION
### Description
관리자 > 사용자 > 멤버(탭) 화면에서 사용자 목록이 길어져도 스크롤이 활성화 되지 않습니다

**Related Issue** : #592 

### How Has This Been Tested?

- 스크롤이 생길정도의 사용자를 등록하고 스크롤이 생기는지 확인합니다

<img width="1679" alt="2019-02-20 5 34 12" src="https://user-images.githubusercontent.com/41019113/53077979-97a21a00-3536-11e9-9a89-d5c11dc0067b.png">

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context
