### PR TITLE
#1487 Apply caching static resource

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/config/ApiResourceConfig.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/config/ApiResourceConfig.java
@@ -123,9 +123,15 @@ public class ApiResourceConfig extends WebMvcConfigurerAdapter {
     private static Logger LOGGER = LoggerFactory.getLogger(ApiResourceConfig.class);
 
     private static final String RESOURCE_PATH = "/resource/";
-    private static final String CHUNK_JS = RESOURCE_PATH + "*.*.chunk.js";
-    private static final String BUNDLE_JS = RESOURCE_PATH + "*.*.bundle.js";
-    private static final String BUNDLE_CSS = RESOURCE_PATH + "*.*.bundle.css";
+    private static final String COMMON_JS = RESOURCE_PATH + "common.*.js";
+    private static final String RUNTIME_JS = RESOURCE_PATH + "runtime.*.js";
+    private static final String MAIN_JS = RESOURCE_PATH + "main.*.js";
+    private static final String POLYFILLS_JS = RESOURCE_PATH + "polyfills.*.js";
+    private static final String SCRIPTS_JS = RESOURCE_PATH + "scripts.*.js";
+    private static final String OTHER_JS = RESOURCE_PATH + "*.*.js";
+
+    private static final String STYLES_CSS = RESOURCE_PATH + "styles.*.css";
+
     private static final String PNG = RESOURCE_PATH + "*.*.png";
     private static final String JPG = RESOURCE_PATH + "*.*.jpg";
     private static final String WOFF = RESOURCE_PATH + "*.*.woff";
@@ -180,7 +186,7 @@ public class ApiResourceConfig extends WebMvcConfigurerAdapter {
 
         ofNullable(cacheControlMaxAge).ifPresent(value -> {
             try {
-                registry.addResourceHandler(CHUNK_JS, BUNDLE_JS, BUNDLE_CSS, PNG, JPG, WOFF, EOF, TTF)
+                registry.addResourceHandler(COMMON_JS, RUNTIME_JS, MAIN_JS, POLYFILLS_JS, SCRIPTS_JS, OTHER_JS, STYLES_CSS, PNG, JPG, WOFF, EOF, TTF)
                     .addResourceLocations("classpath:resource/")
                     .setCacheControl(CacheControl.maxAge(value, TimeUnit.SECONDS).cachePublic());
             } catch (Exception e) {


### PR DESCRIPTION
### Description
프론트엔드 라이브러리 버전업 이후에 정적 리소스가 캐싱되지 않고 있습니다

**Related Issue** : #1487 
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
1.  페이지 로딩 합니다
2. 브라우저의 디버그 모드 HTTP 응답에서 캐싱 항목을 확인합니다

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

### Additional Context<!-- if not appropriate, remove this topic. -->

<img width="1680" alt="2019-02-21 10 19 50" src="https://user-images.githubusercontent.com/41019113/53136483-86065400-35c2-11e9-97cc-326c4b1b501f.png">