### PR TITLE
#1447 Filter edit popup error 

### DIFF
--- a/discovery-frontend/src/app/dashboard/component/update-dashboard/dashboard.layout.config.component.html
+++ b/discovery-frontend/src/app/dashboard/component/update-dashboard/dashboard.layout.config.component.html
@@ -21,7 +21,7 @@
     <!-- // Title -->
 
     <!-- Layout Config Contents -->
-    <div class="ddp-wrap-downmenu" style="padding-right:20px;">
+    <div class="ddp-wrap-downmenu" style="padding-left:20px;padding-right:20px;">
 
       <div class="ddp-box-down">
         <!-- Layout 형태 결정 메뉴 -->

--- a/discovery-frontend/src/app/dashboard/filters/inclusion-filter/inclusion-filter-panel.component.html
+++ b/discovery-frontend/src/app/dashboard/filters/inclusion-filter/inclusion-filter-panel.component.html
@@ -38,22 +38,26 @@
           <!-- 정렬 버튼 목록 -->
           <ul class="ddp-list-popup ddp-type">
             <li [class.ddp-selected]="sortBy.COUNT === filter.sort.by && sortDirection.ASC === filter.sort.direction">
-              <a href="javascript:" (click)="sortCandidateValues(filter, sortBy.COUNT, sortDirection.ASC );">
+              <a (click)="sortCandidateValues(filter, sortBy.COUNT, sortDirection.ASC );updateFilterEvent.emit(filter);"
+                 href="javascript:" >
                 {{'msg.comm.ui.soring.frequency.asc' | translate}} <em class="ddp-icon-check"></em>
               </a>
             </li>
             <li [class.ddp-selected]="sortBy.COUNT === filter.sort.by && sortDirection.DESC === filter.sort.direction">
-              <a href="javascript:" (click)="sortCandidateValues(filter, sortBy.COUNT, sortDirection.DESC);">
+              <a (click)="sortCandidateValues(filter, sortBy.COUNT, sortDirection.DESC);updateFilterEvent.emit(filter);"
+                 href="javascript:" >
                 {{'msg.comm.ui.soring.frequency.desc' | translate}} <em class="ddp-icon-check"></em>
               </a>
             </li>
             <li [class.ddp-selected]="sortBy.TEXT === filter.sort.by && sortDirection.ASC === filter.sort.direction">
-              <a href="javascript:" (click)="sortCandidateValues(filter, sortBy.TEXT, sortDirection.ASC );">
+              <a (click)="sortCandidateValues(filter, sortBy.TEXT, sortDirection.ASC );updateFilterEvent.emit(filter);"
+                 href="javascript:" >
                 {{'msg.comm.ui.soring.alphnumeric.asc' | translate}} <em class="ddp-icon-check"></em>
               </a>
             </li>
             <li [class.ddp-selected]="sortBy.TEXT === filter.sort.by && sortDirection.DESC === filter.sort.direction">
-              <a href="javascript:" (click)="sortCandidateValues(filter, sortBy.TEXT, sortDirection.DESC);">
+              <a (click)="sortCandidateValues(filter, sortBy.TEXT, sortDirection.DESC);updateFilterEvent.emit(filter);"
+                 href="javascript:" >
                 {{'msg.comm.ui.soring.alphnumeric.desc' | translate}} <em class="ddp-icon-check"></em>
               </a>
             </li>

--- a/discovery-frontend/src/app/dashboard/filters/inclusion-filter/inclusion-filter-panel.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/inclusion-filter/inclusion-filter-panel.component.ts
@@ -310,7 +310,6 @@ export class InclusionFilterPanelComponent extends AbstractFilterPanelComponent 
     this.setCandidatePage(1, true);
 
     this.safelyDetectChanges();
-    this.updateFilterEvent.emit(this.filter);
   } // function - sortCandidateValues
 
   /**

--- a/discovery-frontend/src/app/dashboard/filters/time-filter/time-list-filter.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/time-filter/time-list-filter.component.ts
@@ -117,7 +117,7 @@ export class TimeListFilterComponent extends AbstractFilterPopupComponent implem
   public ngOnChanges(changes: SimpleChanges) {
     const filterChanges: SimpleChange = changes.inputFilter;
     if (filterChanges) {
-      this.setData(filterChanges.currentValue, true );
+      this.setData(filterChanges.currentValue, !filterChanges.firstChange );
     }
   } // function - ngOnChanges
 

--- a/discovery-frontend/src/app/dashboard/filters/time-filter/time-range-filter.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/time-filter/time-range-filter.component.ts
@@ -104,7 +104,7 @@ export class TimeRangeFilterComponent extends AbstractFilterPopupComponent imple
       const prevFilter:TimeRangeFilter = filterChanges.previousValue;
       const currFilter:TimeRangeFilter = filterChanges.currentValue;
       if( !prevFilter || prevFilter.field !== currFilter.field ) {
-        this.setData(filterChanges.currentValue, true);
+        this.setData(filterChanges.currentValue, !filterChanges.firstChange);
       }
     }
   } // function - ngOnChanges

--- a/discovery-frontend/src/app/dashboard/filters/time-filter/time-relative-filter.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/time-filter/time-relative-filter.component.ts
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-import { AbstractFilterPopupComponent } from '../abstract-filter-popup.component';
+import {AbstractFilterPopupComponent} from '../abstract-filter-popup.component';
 import {
   ElementRef,
   OnDestroy,
@@ -24,14 +24,13 @@ import {
   SimpleChange,
   EventEmitter, Output, ViewChild, AfterViewInit
 } from '@angular/core';
-import { TimeUnit } from '../../../domain/workbook/configurations/field/timestamp-field';
+import {TimeUnit} from '../../../domain/workbook/configurations/field/timestamp-field';
 import {
   TimeRelativeFilter,
   TimeRelativeTense
 } from '../../../domain/workbook/configurations/filter/time-relative-filter';
-import { isNullOrUndefined } from 'util';
-import { EventBroadcaster } from '../../../common/event/event.broadcaster';
-import {TimeRangeFilter} from "../../../domain/workbook/configurations/filter/time-range-filter";
+import {isNullOrUndefined} from 'util';
+import {EventBroadcaster} from '../../../common/event/event.broadcaster';
 
 declare let moment;
 
@@ -45,7 +44,7 @@ export class TimeRelativeFilterComponent extends AbstractFilterPopupComponent im
   |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
 
   @ViewChild('filterArea')
-  private _filterArea:ElementRef;
+  private _filterArea: ElementRef;
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
   | Protected Variables
@@ -58,13 +57,13 @@ export class TimeRelativeFilterComponent extends AbstractFilterPopupComponent im
   public isShowNextComboOpts: boolean = false;    // 미래 시점 입력 콤보박스 옵션 표시 여부
   public timeUnitComboList = [
     /* { name: this.translateService.instant('msg.board.filter.ui.timeunit.seconds'), value: TimeUnit.SECOND }, */
-    { name: this.translateService.instant('msg.board.filter.ui.timeunit.minutes'), value: TimeUnit.MINUTE },
-    { name: this.translateService.instant('msg.board.filter.ui.timeunit.hours'), value: TimeUnit.HOUR },
-    { name: this.translateService.instant('msg.board.filter.ui.timeunit.days'), value: TimeUnit.DAY },
-    { name: this.translateService.instant('msg.board.filter.ui.timeunit.weeks'), value: TimeUnit.WEEK },
-    { name: this.translateService.instant('msg.board.filter.ui.timeunit.months'), value: TimeUnit.MONTH },
+    {name: this.translateService.instant('msg.board.filter.ui.timeunit.minutes'), value: TimeUnit.MINUTE},
+    {name: this.translateService.instant('msg.board.filter.ui.timeunit.hours'), value: TimeUnit.HOUR},
+    {name: this.translateService.instant('msg.board.filter.ui.timeunit.days'), value: TimeUnit.DAY},
+    {name: this.translateService.instant('msg.board.filter.ui.timeunit.weeks'), value: TimeUnit.WEEK},
+    {name: this.translateService.instant('msg.board.filter.ui.timeunit.months'), value: TimeUnit.MONTH},
     /* { name: this.translateService.instant('msg.board.filter.ui.timeunit.quarters'), value: TimeUnit.QUARTER }, */
-    { name: this.translateService.instant('msg.board.filter.ui.timeunit.years'), value: TimeUnit.YEAR }
+    {name: this.translateService.instant('msg.board.filter.ui.timeunit.years'), value: TimeUnit.YEAR}
   ];
   public selectedTimeUnitItem;
 
@@ -81,7 +80,7 @@ export class TimeRelativeFilterComponent extends AbstractFilterPopupComponent im
   @Output('change')
   public changeEvent: EventEmitter<TimeRelativeFilter> = new EventEmitter();
 
-  public isShortLabel:boolean = false;
+  public isShortLabel: boolean = false;
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
   | Constructor
@@ -89,8 +88,8 @@ export class TimeRelativeFilterComponent extends AbstractFilterPopupComponent im
 
   // 생성자
   constructor(protected broadCaster: EventBroadcaster,
-    protected elementRef: ElementRef,
-    protected injector: Injector) {
+              protected elementRef: ElementRef,
+              protected injector: Injector) {
     super(elementRef, injector);
   }
 
@@ -111,8 +110,8 @@ export class TimeRelativeFilterComponent extends AbstractFilterPopupComponent im
    */
   public ngOnChanges(changes: SimpleChanges) {
     const filterChanges: SimpleChange = changes.inputFilter;
-    if (filterChanges) {
-      this.setData(filterChanges.currentValue, true);
+    if (filterChanges && filterChanges.currentValue) {
+      this.setData(filterChanges.currentValue, !filterChanges.firstChange);
     }
   } // function - ngOnChanges
 
@@ -123,15 +122,15 @@ export class TimeRelativeFilterComponent extends AbstractFilterPopupComponent im
   public ngAfterViewInit() {
 
     // Set whether short labels
-    this.isShortLabel = ( 'PANEL' === this.mode );
+    this.isShortLabel = ('PANEL' === this.mode);
     this.safelyDetectChanges();
 
     // Widget Resize Event
-    const $filterArea = $( this._filterArea.nativeElement );
+    const $filterArea = $(this._filterArea.nativeElement);
     this.subscriptions.push(
       this.broadCaster.on<any>('RESIZE_WIDGET').subscribe(() => {
         if ('WIDGET' === this.mode) {
-          this.isShortLabel = ( 320 > $filterArea.width() );
+          this.isShortLabel = (320 > $filterArea.width());
           this.safelyDetectChanges();
         }
       })
@@ -153,7 +152,7 @@ export class TimeRelativeFilterComponent extends AbstractFilterPopupComponent im
    * @param {TimeRelativeFilter} filter
    * @param {boolean} isBroadcast
    */
-  public setData(filter: TimeRelativeFilter, isBroadcast:boolean = false ) {
+  public setData(filter: TimeRelativeFilter, isBroadcast: boolean = false) {
     let tempFilter: TimeRelativeFilter = filter;
 
     {
@@ -168,7 +167,7 @@ export class TimeRelativeFilterComponent extends AbstractFilterPopupComponent im
 
     this.targetFilter = tempFilter;
 
-    ( isBroadcast ) && ( this.changeEvent.emit(this.targetFilter) );
+    (isBroadcast) && (this.changeEvent.emit(this.targetFilter));
 
     this.safelyDetectChanges();
   } // function - setData


### PR DESCRIPTION
### Description
대시보드 편집 화면에서 필터 edit 을 클릭하면 팝업이 떴다가 사라짐

**Related Issue** : #1447 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
* Edit dashboard
* 필터위젯의 수정 버튼 클릭
* 필터 위젯의 수정 팝업이 정상적으로 표시되는지 확인

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
