### PR TITLE
#1472 remove adding unnecessary advanced filter specification even if doing nothing

### DIFF
--- a/discovery-frontend/src/app/common/component/chart/type/map-chart/map-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/map-chart/map-chart.component.ts
@@ -373,7 +373,7 @@ export class MapChartComponent extends BaseChart implements AfterViewInit {
     ////////////////////////////////////////////////////////
 
     // 엘리먼트 반영
-    this.changeDetect.detectChanges();
+    this.safelyDetectChanges();
 
     // Show data
     this.data.show = true;
@@ -2100,7 +2100,7 @@ export class MapChartComponent extends BaseChart implements AfterViewInit {
     } else this.tooltipInfo.enable = true;
 
     // Element apply
-    this.changeDetect.detectChanges();
+    this.safelyDetectChanges();
 
     if (_.eq(this.tooltipInfo.geometryType, String(MapGeometryType.LINE))) {
       let extent = feature.getGeometry().getExtent();

--- a/discovery-frontend/src/app/dashboard/component/dashboard-layout/dashboard.layout.component.ts
+++ b/discovery-frontend/src/app/dashboard/component/dashboard-layout/dashboard.layout.component.ts
@@ -1286,10 +1286,10 @@ export abstract class DashboardLayoutComponent extends AbstractComponent impleme
         if (boardInfo.configuration.filters) {
           // remove current_time timestamp filter - S
           boardInfo.configuration.filters
-            = boardInfo.configuration.filters.filter( (filter:Filter) => {
-            if( FilterUtil.isTimeFilter(filter) && (<TimeFilter>filter).clzField ) {
-              const filterField:Field = (<TimeFilter>filter).clzField;
-              if( FieldRole.TIMESTAMP === filterField.role && CommonConstant.COL_NAME_CURRENT_DATETIME === filterField.name ) {
+            = boardInfo.configuration.filters.filter((filter: Filter) => {
+            if (FilterUtil.isTimeFilter(filter) && (<TimeFilter>filter).clzField) {
+              const filterField: Field = (<TimeFilter>filter).clzField;
+              if (FieldRole.TIMESTAMP === filterField.role && CommonConstant.COL_NAME_CURRENT_DATETIME === filterField.name) {
                 const filterId: string = filter.dataSource + '_' + filter.field;
                 const filterWidgets: Widget[] = boardInfo.widgets.filter(widget => {
                   if ('filter' === widget.type) {
@@ -1302,7 +1302,7 @@ export abstract class DashboardLayoutComponent extends AbstractComponent impleme
                   promises.push(new Promise((res) => {
                     this.widgetService.deleteWidget(item.id)
                       .then(() => {
-                        console.info( '+=+=+=+=+=+=+=+=+=+=+=+=+=+=+= remove current_time filter' );
+                        console.info('+=+=+=+=+=+=+=+=+=+=+=+=+=+=+= remove current_time filter');
                         boardInfo.widgets = boardInfo.widgets.filter(widgetItem => widgetItem.id !== item.id);
                         res();
                       });

--- a/discovery-frontend/src/app/dashboard/update-dashboard.component.ts
+++ b/discovery-frontend/src/app/dashboard/update-dashboard.component.ts
@@ -431,10 +431,6 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
       if ('page' === item.type) {
         // 스펙 변경
         item.configuration = DashboardUtil.convertPageWidgetSpecToServer(item.configuration);
-        // 필터 설정
-        for (let filter of item.configuration['filters']) {
-          filter = FilterUtil.convertToServerSpecForDashboard(filter);
-        }
       } else if ('filter' === item.type) {
         item.configuration['filter'] = FilterUtil.convertToServerSpecForDashboard(item.configuration['filter']);
       }
@@ -696,12 +692,6 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
           } else {
             // 스펙 변경
             param.configuration = DashboardUtil.convertPageWidgetSpecToServer(param.configuration);
-
-            // 필터 설정
-            for (let filter of param.configuration['filters']) {
-              filter = FilterUtil.convertToServerSpecForDashboard(filter);
-            }
-
             promises.push(() => this.widgetService.updateWidget(result.id, param));   // update widget
           }
         } else if ('filter' === result.type) {

--- a/discovery-frontend/src/app/dashboard/util/dashboard.util.ts
+++ b/discovery-frontend/src/app/dashboard/util/dashboard.util.ts
@@ -35,6 +35,7 @@ import {CommonUtil} from '../../common/util/common.util';
 import {ChartType} from '../../common/component/chart/option/define/common';
 import {CommonConstant} from "../../common/constant/common.constant";
 import {ChartUtil} from "../../common/component/chart/option/util/chart-util";
+import {FilterUtil} from "./filter.util";
 
 export class DashboardUtil {
 
@@ -194,7 +195,7 @@ export class DashboardUtil {
 
   /**
    * 페이지위젯 스펙을 서버 스펙으로 변경함
-   * @param configuration
+   * @param {any} configuration
    * @return {any}
    */
   public static convertPageWidgetSpecToServer(configuration: any): any {
@@ -217,6 +218,13 @@ export class DashboardUtil {
     if (configuration.customFields) {
       configuration['fields'] = _.cloneDeep(configuration.customFields);
       delete configuration.customFields;
+    }
+
+    // 필터 설정
+    if( configuration.filters ) {
+      for (let filter of configuration.filters) {
+        filter = FilterUtil.convertToServerSpecForDashboard(filter);
+      }
     }
 
     return configuration;

--- a/discovery-frontend/src/app/dashboard/util/filter.util.ts
+++ b/discovery-frontend/src/app/dashboard/util/filter.util.ts
@@ -410,7 +410,7 @@ export class FilterUtil {
           'minTime', 'maxTime', 'valueList', 'candidateValues', 'discontinuous', 'granularity'];
         break;
       case 'include' :
-        keyMap = ['selector', 'preFilters', 'valueList', 'candidateValues', 'definedValues', 'sort'];
+        keyMap = ['selector', 'valueList', 'candidateValues', 'definedValues', 'sort'];
         break;
       case 'timestamp' :
         keyMap = ['selectedTimestamps', 'timeFormat'];

--- a/discovery-frontend/src/app/datasource/service/datasource.service.ts
+++ b/discovery-frontend/src/app/datasource/service/datasource.service.ts
@@ -161,7 +161,7 @@ export class DatasourceService extends AbstractService {
    * @returns {Promise<any>}
    */
   public getCandidateForFilter(filter: Filter, board: Dashboard,
-                               filters?: Filter[], field?: (Field | CustomField), sortBy?: string, searchWord?:string ): Promise<any> {
+                               filters?: Filter[], field?: (Field | CustomField), sortBy?: string, searchWord?: string): Promise<any> {
 
     const param: any = {};
     param.dataSource = DashboardUtil.getDataSourceForApi(
@@ -225,31 +225,33 @@ export class DatasourceService extends AbstractService {
       if ('include' === filter.type) {
         // Dimension Filter
         const tempFilters: Filter[] = [];
-        (<InclusionFilter>filter).preFilters.filter((preFilter: AdvancedFilter) => {
-          if (preFilter.type === 'measure_inequality') {
-            const condition: MeasureInequalityFilter = <MeasureInequalityFilter>preFilter;
-            if (condition.inequality && condition.aggregation && condition.field && 0 < condition.value) {
-              tempFilters.push(FilterUtil.convertToServerSpec(condition));
+        if (((<InclusionFilter>filter).preFilters)) {
+          (<InclusionFilter>filter).preFilters.filter((preFilter: AdvancedFilter) => {
+            if (preFilter.type === 'measure_inequality') {
+              const condition: MeasureInequalityFilter = <MeasureInequalityFilter>preFilter;
+              if (condition.inequality && condition.aggregation && condition.field && 0 < condition.value) {
+                tempFilters.push(FilterUtil.convertToServerSpec(condition));
+              }
+            } else if (preFilter.type === 'measure_position') {
+              const limitation: MeasurePositionFilter = <MeasurePositionFilter>preFilter;
+              if (limitation.position && limitation.aggregation && limitation.field && 0 < limitation.value) {
+                tempFilters.push(FilterUtil.convertToServerSpec(limitation));
+              }
+            } else if (preFilter.type === 'wildcard') {
+              const wildcard: WildCardFilter = <WildCardFilter>preFilter;
+              if (wildcard.contains && wildcard.value && wildcard.value.length > 0) {
+                tempFilters.push(FilterUtil.convertToServerSpec(wildcard));
+              }
+            } else if (preFilter.type === 'regexpr') {
+              const regExpr: RegExprFilter = <RegExprFilter>preFilter;
+              if (regExpr.expr) {
+                tempFilters.push(FilterUtil.convertToServerSpec(regExpr));
+              }
             }
-          } else if (preFilter.type === 'measure_position') {
-            const limitation: MeasurePositionFilter = <MeasurePositionFilter>preFilter;
-            if (limitation.position && limitation.aggregation && limitation.field && 0 < limitation.value) {
-              tempFilters.push(FilterUtil.convertToServerSpec(limitation));
-            }
-          } else if (preFilter.type === 'wildcard') {
-            const wildcard: WildCardFilter = <WildCardFilter>preFilter;
-            if (wildcard.contains && wildcard.value && wildcard.value.length > 0) {
-              tempFilters.push(FilterUtil.convertToServerSpec(wildcard));
-            }
-          } else if (preFilter.type === 'regexpr') {
-            const regExpr: RegExprFilter = <RegExprFilter>preFilter;
-            if (regExpr.expr) {
-              tempFilters.push(FilterUtil.convertToServerSpec(regExpr));
-            }
-          }
-        });
+          });
+        }
         param.filters = param.filters.concat(tempFilters);
-        ( param.targetField ) && ( param.targetField.type = 'dimension' );
+        (param.targetField) && (param.targetField.type = 'dimension');
 
         param.sortBy = (sortBy) ? sortBy : 'COUNT';
         param.searchWord = (searchWord) ? searchWord : '';
@@ -323,8 +325,8 @@ export class DatasourceService extends AbstractService {
               if ((LogicalType.TIMESTAMP.toString() === field.type.toUpperCase()
                 || LogicalType.TIMESTAMP.toString() === field.subType
                 || LogicalType.TIMESTAMP.toString() === field.subRole) && field.format) {
-                const dsField:Field = dataSourceFields.find( item => item.name === field.name );
-                if( dsField && dsField.format && TimezoneService.DISABLE_TIMEZONE_KEY === dsField.format['timeZone'] ) {
+                const dsField: Field = dataSourceFields.find(item => item.name === field.name);
+                if (dsField && dsField.format && TimezoneService.DISABLE_TIMEZONE_KEY === dsField.format['timeZone']) {
                   delete field.format['timeZone'];
                   delete field.format['locale'];
                 } else {
@@ -349,8 +351,8 @@ export class DatasourceService extends AbstractService {
             if ((LogicalType.TIMESTAMP.toString() === column.type.toUpperCase()
               || LogicalType.TIMESTAMP.toString() === column.subType
               || LogicalType.TIMESTAMP.toString() === column.subRole) && column.format) {
-              const dsField:Field = dataSourceFields.find( item => item.name === column.name );
-              if( dsField && dsField.format && TimezoneService.DISABLE_TIMEZONE_KEY === dsField.format['timeZone'] ) {
+              const dsField: Field = dataSourceFields.find(item => item.name === column.name);
+              if (dsField && dsField.format && TimezoneService.DISABLE_TIMEZONE_KEY === dsField.format['timeZone']) {
                 delete column.format['timeZone'];
                 delete column.format['locale'];
               } else {
@@ -365,8 +367,8 @@ export class DatasourceService extends AbstractService {
             if ((LogicalType.TIMESTAMP.toString() === row.type.toUpperCase()
               || LogicalType.TIMESTAMP.toString() === row.subType
               || LogicalType.TIMESTAMP.toString() === row.subRole) && row.format) {
-              const dsField:Field = dataSourceFields.find( item => item.name === row.name );
-              if( dsField && dsField.format && TimezoneService.DISABLE_TIMEZONE_KEY === dsField.format['timeZone'] ) {
+              const dsField: Field = dataSourceFields.find(item => item.name === row.name);
+              if (dsField && dsField.format && TimezoneService.DISABLE_TIMEZONE_KEY === dsField.format['timeZone']) {
                 delete row.format['timeZone'];
                 delete row.format['locale'];
               } else {

--- a/discovery-frontend/src/app/page/page.component.ts
+++ b/discovery-frontend/src/app/page/page.component.ts
@@ -741,11 +741,6 @@ export class PageComponent extends AbstractPopupComponent implements OnInit, OnD
       // 서버에 저장될필요 없는 파라미터 제거
       param.configuration = DashboardUtil.convertPageWidgetSpecToServer(param.configuration);
 
-      // 필터 설정
-      for (let filter of param.configuration.filters) {
-        filter = FilterUtil.convertToServerSpecForDashboard(filter);
-      }
-
       const pageConf: PageWidgetConfiguration = param.configuration as PageWidgetConfiguration;
       // 미니맵 범위 저장
       if (!_.isEmpty(this.chart.saveDataZoomRange())) pageConf.chart.chartZooms = this.chart.saveDataZoomRange();
@@ -804,11 +799,6 @@ export class PageComponent extends AbstractPopupComponent implements OnInit, OnD
 
       // 서버에 저장될필요 없는 파라미터 제거
       param.configuration = DashboardUtil.convertPageWidgetSpecToServer(param.configuration);
-
-      // 필터 설정
-      for (let filter of param.configuration.filters) {
-        filter = FilterUtil.convertToServerSpecForDashboard(filter);
-      }
 
       const pageConf: PageWidgetConfiguration = param.configuration as PageWidgetConfiguration;
       // 미니맵 범위 저장
@@ -1950,10 +1940,6 @@ export class PageComponent extends AbstractPopupComponent implements OnInit, OnD
 
       // 스펙 변경
       widget.configuration = DashboardUtil.convertPageWidgetSpecToServer(widget.configuration);
-      // 필터 설정
-      for (let filter of widget.configuration.filters) {
-        filter = FilterUtil.convertToServerSpecForDashboard(filter);
-      }
 
       this.loadingShow();
       this.widgetService.updateWidget(this.widget.id, widget).then((page: Widget) => {


### PR DESCRIPTION
### Description
I didn't set an advanced filter but I found unnecessary advanced filter specification when saving configuration spec.

**Related Issue** : #1472 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
* Go to 'Dashbard' and Chart widget.
* add the filter edit view on widget using "+" on filter panel
* select any filter and crate any chart.
* turn on developer tools and move the network tab
* Save widget and you can see "/api/widgets" response

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
