### PR TITLE
transform snapshot uses JSON parser

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/json/PrepJsonUtil.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/json/PrepJsonUtil.java
@@ -129,7 +129,8 @@ public class PrepJsonUtil {
         for(int i=0; i<result.maxColCnt; i++ ) {
           String colName = result.colNames.get(i);
           if( jsonRow.containsKey(colName) == true ) {
-            row[i] = jsonRow.get(colName).toString();
+            Object obj = jsonRow.get(colName);
+            row[i] = (obj==null)?null:obj.toString();
           }
         }
         result.grid.add(row);

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/TeddyExecutor.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/TeddyExecutor.java
@@ -17,7 +17,6 @@ package app.metatron.discovery.domain.dataprep.teddy;
 import app.metatron.discovery.common.GlobalObjectMapper;
 import app.metatron.discovery.domain.dataprep.csv.PrepCsvParseResult;
 import app.metatron.discovery.domain.dataprep.csv.PrepCsvUtil;
-import app.metatron.discovery.domain.dataprep.json.PrepJsonUtil;
 import app.metatron.discovery.domain.dataprep.entity.PrSnapshot;
 import app.metatron.discovery.domain.dataprep.entity.PrSnapshot.HIVE_FILE_COMPRESSION;
 import app.metatron.discovery.domain.dataprep.entity.PrSnapshot.HIVE_FILE_FORMAT;
@@ -25,6 +24,8 @@ import app.metatron.discovery.domain.dataprep.exceptions.PrepErrorCodes;
 import app.metatron.discovery.domain.dataprep.exceptions.PrepException;
 import app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey;
 import app.metatron.discovery.domain.dataprep.jdbc.PrepJdbcService;
+import app.metatron.discovery.domain.dataprep.json.PrepJsonParseResult;
+import app.metatron.discovery.domain.dataprep.json.PrepJsonUtil;
 import app.metatron.discovery.domain.dataprep.service.PrSnapshotService;
 import app.metatron.discovery.domain.dataprep.teddy.exceptions.IllegalColumnNameForHiveException;
 import app.metatron.discovery.domain.dataprep.teddy.exceptions.JdbcQueryFailedException;
@@ -37,6 +38,7 @@ import app.metatron.discovery.prep.parser.preparation.rule.Rule;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Maps;
 import org.apache.commons.csv.CSVPrinter;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
@@ -55,7 +57,10 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import javax.sql.DataSource;
-import java.io.*;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.sql.Connection;
@@ -512,6 +517,18 @@ public class TeddyExecutor {
         cache.put(dsId, df);
     }
 
+    private void loadJsonFile(String dsId, String strUri, String delimiter) throws URISyntaxException {
+        DataFrame df = new DataFrame();
+
+        LOGGER.info("loadJsonFile(): dsId={} strUri={} delemiter={}", dsId, strUri, delimiter);
+
+        PrepJsonParseResult result = PrepJsonUtil.parseJSON(strUri, delimiter, limitRows, conf);
+        df.setByGridWithJson(result);
+
+        LOGGER.info("loadJsonFile(): done");
+        cache.put(dsId, df);
+    }
+
     public String createStage0(Map<String, Object> datasetInfo) throws Throwable {
         String newFullDsId = UUID.randomUUID().toString();
 
@@ -524,7 +541,14 @@ public class TeddyExecutor {
         String importType = (String) datasetInfo.get("importType");
         switch (importType) {
             case "UPLOAD":
-                loadCsvFile(newFullDsId, (String) datasetInfo.get("storedUri"), (String) datasetInfo.get("delimiter"));
+                String storedUri = (String) datasetInfo.get("storedUri");
+                String extensionType = FilenameUtils.getExtension(storedUri).toLowerCase();
+                String delimiter = (String) datasetInfo.get("delimiter");
+                if(extensionType.equals("json")) {
+                    loadJsonFile(newFullDsId, storedUri, delimiter);
+                } else {
+                    loadCsvFile(newFullDsId, storedUri, delimiter);
+                }
                 break;
 
             case "DATABASE":


### PR DESCRIPTION
### Description
JSON property can have a null value.
When creating a snapshot in json this caused a null exception when creating a snapshot in json

**Related Issue** :
[#1455](https://github.com/metatron-app/metatron-discovery/issues/1455)

### How Has This Been Tested?
1. edit rule on dataflow
2. using set rule makes any column to have a null value
3. make a snapshot

and

1. create a dataset with JSON file
2. create a dataflow with the dataset
3. create a snapshot with them

Both must be successful.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
