### PR TITLE
#1492 bug-fix on BOM of UTF-8

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/csv/PrepCsvUtil.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/csv/PrepCsvUtil.java
@@ -37,7 +37,7 @@ public class PrepCsvUtil {
     BOMInputStream bis = new BOMInputStream(is, true, ByteOrderMark.UTF_8, ByteOrderMark.UTF_16LE, ByteOrderMark.UTF_16BE, ByteOrderMark.UTF_32LE, ByteOrderMark.UTF_32BE);
 
     try {
-      if (bis.hasBOM() == false) {
+      if (bis.hasBOM() == false || bis.hasBOM(ByteOrderMark.UTF_8)) {
         charset = "UTF-8";
       } else if (bis.hasBOM(ByteOrderMark.UTF_16LE) || bis.hasBOM(ByteOrderMark.UTF_16BE)) {
         charset = "UTF-16";


### PR DESCRIPTION
### Description
Currently, when the file has a BOM of UTF-8, it cannot be read.
This is because, typically, for UTF-8, there is no BOM.

Anyway, it has been fixed.
Please refer to the issue below. It contains a sample file attached and a detailed bug scenario.

**Related Issue** : https://github.com/metatron-app/metatron-discovery/issues/1492

### How Has This Been Tested?
Ran locally.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
