### PR TITLE
F#1489 A sort error occurs if the data grid contains blanks

### DIFF
--- a/discovery-frontend/src/app/common/component/grid/grid.component.ts
+++ b/discovery-frontend/src/app/common/component/grid/grid.component.ts
@@ -1069,16 +1069,12 @@ export class GridComponent implements AfterViewInit, OnDestroy {
                   const field = cols[index].sortCol.field;
                   const sign = cols[index].sortAsc ? 1 : -1;
 
-                  if (_.isNil(row1[field])) {
-                    row1[field] = "";
-                  } else {
-                    row1[field].replace("", " ");
+                  if (_.isNil(row1[field]) || row1[field] === '') {
+                    row1[field] = " ";
                   }
 
-                  if (_.isNil(row2[field])) {
-                    row2[field] = "";
-                  } else {
-                    row2[field].replace("", " ");
+                  if (_.isNil(row2[field]) || row2[field] === '') {
+                    row2[field] = " ";
                   }
 
                   const value1 = row1[field];

--- a/discovery-frontend/src/app/common/component/grid/grid.component.ts
+++ b/discovery-frontend/src/app/common/component/grid/grid.component.ts
@@ -1068,6 +1068,19 @@ export class GridComponent implements AfterViewInit, OnDestroy {
                 for (let index: number = 0; index < cols.length; index += 1) {
                   const field = cols[index].sortCol.field;
                   const sign = cols[index].sortAsc ? 1 : -1;
+
+                  if (_.isNil(row1[field])) {
+                    row1[field] = "";
+                  } else {
+                    row1[field].replace("", " ");
+                  }
+
+                  if (_.isNil(row2[field])) {
+                    row2[field] = "";
+                  } else {
+                    row2[field].replace("", " ");
+                  }
+
                   const value1 = row1[field];
                   const value2 = row2[field];
                   const result = (value1 === value2 ? 0 : (value1 > value2 ? 1 : -1)) * sign;

--- a/discovery-frontend/src/assets/grid/slick.grid.override.css
+++ b/discovery-frontend/src/assets/grid/slick.grid.override.css
@@ -77,7 +77,6 @@
 
 :host /deep/ .slick-sort-indicator {
   float: inherit;
-  margin: 0;
   width: 7px;
   height: 4px;
   display: inline-block;
@@ -93,18 +92,15 @@
 
 :host /deep/ .slick-sort-indicator-asc {
   position: absolute;
-  top: 10px;
-  right: 9px;
   width: 7px;
   height: 4px;
 }
 
 :host /deep/ .slick-sort-indicator-desc {
   position: absolute;
-  top: 15px;
-  right: 9px;
   width: 7px;
   height: 4px;
+  margin-top:0;
   background-position: left -5px;
 }
 


### PR DESCRIPTION
### Description
- 워크벤치의 데이터 그리드에 공백이 포함되어 있으면 정렬 오류가 발생한다
헤더를 클릭할 때 정렬 결과가 부정확하다 그리고 헤더를 클릭할 때 화살표 아이콘의 위치가 잘못된다.

**Related Issue** : #1489 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
 - 워크벤치 화면에서 아래 쿼리 실행 후 [수정 결과](https://github.com/metatron-app/metatron-discovery/issues/1489#issuecomment-469116107)와 같이 나오는지 확인한다
```sql
select "1", "a"
union select "2", "b"
union select "3", "";
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
