### PR TITLE
#1444 Multiple filter selection error

### DIFF
--- a/discovery-frontend/src/app/dashboard/filters/component/filter-multi-select/filter-multi-select.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/component/filter-multi-select/filter-multi-select.component.ts
@@ -12,16 +12,16 @@
  * limitations under the License.
  */
 
-import { Component, ElementRef, EventEmitter, Injector, Input, OnInit, Output, ViewChild } from '@angular/core';
-import { AbstractComponent } from '../../../../common/component/abstract.component';
-import { Alert } from '../../../../common/util/alert.util';
-import { Candidate } from '../../../../domain/workbook/configurations/filter/inclusion-filter';
-import { isNullOrUndefined } from 'util';
+import {Component, ElementRef, EventEmitter, Injector, Input, OnInit, Output, ViewChild} from '@angular/core';
+import {AbstractComponent} from '../../../../common/component/abstract.component';
+import {Alert} from '../../../../common/util/alert.util';
+import {Candidate} from '../../../../domain/workbook/configurations/filter/inclusion-filter';
+import {isNullOrUndefined} from 'util';
 
 @Component({
   selector: 'component-filter-multi-select',
   templateUrl: './filter-multi-select.component.html',
-  host: { '(document:click)': 'onClickHost($event)' }
+  host: {'(document:click)': 'onClickHost($event)'}
 })
 export class FilterMultiSelectComponent extends AbstractComponent implements OnInit {
 
@@ -54,7 +54,7 @@ export class FilterMultiSelectComponent extends AbstractComponent implements OnI
 
   // 기본 메시지
   @Input()
-  public unselectedMessage = this.translateService.instant( 'msg.comm.ui.list.all' );
+  public unselectedMessage = this.translateService.instant('msg.comm.ui.list.all');
 
   // 비활성화 여부
   @Input()
@@ -119,7 +119,7 @@ export class FilterMultiSelectComponent extends AbstractComponent implements OnI
     super.ngOnInit();
 
     // array check
-    ( isNullOrUndefined( this.selectedArray ) )  && ( this.selectedArray = [] );
+    (isNullOrUndefined(this.selectedArray)) && (this.selectedArray = []);
 
     this.updateView(this.selectedArray);
   }
@@ -136,8 +136,8 @@ export class FilterMultiSelectComponent extends AbstractComponent implements OnI
    * Returns whether Item is selected.
    * @param targetItem
    */
-  public isSelectedItem( targetItem:any ) {
-    return this.selectedArray && this.selectedArray.some(item => item.name === targetItem.name );
+  public isSelectedItem(targetItem: any) {
+    return this.selectedArray && this.selectedArray.some(item => item.name === targetItem.name);
   } // function - isSelectedItem
 
   /**
@@ -155,13 +155,13 @@ export class FilterMultiSelectComponent extends AbstractComponent implements OnI
   public selected(item: any, $event: any) {
 
     // 모형 모드일 때는 기능 동작을 하지 않는다
-    if( this.isMockup ) {
+    if (this.isMockup) {
       Alert.info(this.translateService.instant('msg.board.alert.not-select-editmode'));
       return;
     }
 
-    if (this.isSelectedItem( item )) {
-      const idx = this.selectedArray.indexOf(item);
+    if (this.isSelectedItem(item)) {
+      const idx = this.selectedArray.findIndex(arrItem => arrItem.name === item.name);
       this.selectedArray.splice(idx, 1);
     } else {
       this.selectedArray.push(item);
@@ -177,7 +177,7 @@ export class FilterMultiSelectComponent extends AbstractComponent implements OnI
   public checkAll($event?) {
 
     // 모형 모드일 때는 기능 동작을 하지 않는다
-    if( this.isMockup ) {
+    if (this.isMockup) {
       Alert.info(this.translateService.instant('msg.board.alert.not-select-editmode'));
       return;
     }
@@ -196,7 +196,7 @@ export class FilterMultiSelectComponent extends AbstractComponent implements OnI
    * 외부영역 클릭
    * @param {MouseEvent} event
    */
-  public onClickHost(event:MouseEvent) {
+  public onClickHost(event: MouseEvent) {
     // 현재 element 내부에서 생긴 이벤트가 아닌경우 hide 처리
     if (!this.elementRef.nativeElement.contains(event.target)) {
       if (this.isShowSelectList && this.array && this.array.length) {
@@ -234,12 +234,12 @@ export class FilterMultiSelectComponent extends AbstractComponent implements OnI
    * @param selectedArray
    */
   public updateView(selectedArray: any) {
-    if (selectedArray == null || selectedArray.length === 0)  {
+    if (selectedArray == null || selectedArray.length === 0) {
       this.viewText = this.unselectedMessage;
-    } else if ( selectedArray.length === this.array.length ) {
-      this.viewText = this.translateService.instant( 'msg.comm.ui.list.all' );
+    } else if (selectedArray.length === this.array.length) {
+      this.viewText = this.translateService.instant('msg.comm.ui.list.all');
     } else {
-      this.viewText = selectedArray.map( item => item.name ).join(',');
+      this.viewText = selectedArray.map(item => item.name).join(',');
     }
   } // function - updateView
 
@@ -274,9 +274,9 @@ export class FilterMultiSelectComponent extends AbstractComponent implements OnI
       const $dropboxTop = $ddpOffSetEl.offset();
       const $dropboxWidth = $ddpOffSetEl.width();
       $ddpOffSetEl.find('.ddp-drop').css({
-        top : $dropboxTop.top,
-        left : $dropboxTop.left,
-        width : $dropboxWidth
+        top: $dropboxTop.top,
+        left: $dropboxTop.left,
+        width: $dropboxWidth
       });
     }
   } // function - _setViewListPosition


### PR DESCRIPTION
### Description
다중 필터 선택 변경 시, All 항목 선택 오류 발생함

**Related Issue** : #1444 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 다중선택 필터에서 전체 값보다 1건이 적게 미리 값을 설정하고 대시보드를 저장합니다. (2개인 경우 1개를 미리 선택해둠)
2. 해당 대시보드 접근 후 위젯에서 필터를 선택하여 전체값이 선택되고 난 뒤
3. 원래 선택되어 있던 값을 체크해제 할 시 정상적으로 동작하는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
