### PR TITLE
#1380 changed new column order of window rules

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DfWindow.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DfWindow.java
@@ -179,7 +179,7 @@ public class DfWindow extends DataFrame {
             if(!args.isEmpty()) {
                 String refColName = args.get(0).toString();
                 newColName = newColName + "_" + refColName;
-                newColPosition = getColnoByColName(refColName) + 1;
+                newColPosition = getColnoByColName(refColName) + i;
             }
 
             //column type


### PR DESCRIPTION
### Description
Changed new column order of windows rules so that the new columns are located in the order of expressions user entered.

**Related Issue** : https://github.com/metatron-app/metatron-discovery/issues/1380

### How Has This Been Tested?
Run locally.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
