### PR TITLE
#1494 convert TIMESTAMP field's datatype to STRING

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/QueryEditorService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/QueryEditorService.java
@@ -15,6 +15,7 @@
 package app.metatron.discovery.domain.workbench;
 
 import app.metatron.discovery.common.GlobalObjectMapper;
+import app.metatron.discovery.common.datasource.DataType;
 import app.metatron.discovery.common.exception.ResourceNotFoundException;
 import app.metatron.discovery.domain.audit.Audit;
 import app.metatron.discovery.domain.audit.AuditRepository;
@@ -412,6 +413,14 @@ public class QueryEditorService {
 
     //2. get field info from resultset
     List<Field> fieldList = jdbcConnectionService.getFieldList(resultSet, false);
+
+    //we don't know about timestamp's format...
+    //so convert to STRING type for Temporary datasource
+    if(fieldList != null) {
+      fieldList.stream()
+               .filter(field -> field.getType() == DataType.TIMESTAMP)
+               .forEach(field -> field.setType(DataType.STRING));
+    }
 
     //3. write csv
     int rowNumber = jdbcConnectionService.writeResultSetToCSV(


### PR DESCRIPTION
### Description
We do not know the date format for the timestamp type.
So, when creating a temporary data source, convert it to STRING type and process it.

**Related Issue** : 
#1494 

### How Has This Been Tested?
1. goto workbench
2. execute query contains timestamp field.
3. click chart preview button
4. see chart preview without error

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
