### PR TITLE
#1570 JupyterBuilder.java Invalid SPARK_HOME setting

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/notebook/connector/JupyterBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/notebook/connector/JupyterBuilder.java
@@ -52,11 +52,12 @@ public abstract class JupyterBuilder implements JupyterAction {
      */
     private String getSparkHome() {
         String path;
-        if (System.getProperty("spark.home.dir") == null && System.getProperty("spark.home.dir").isEmpty()) {
+        String sparkHome = System.getenv("METATRON_SPARK_HOME");
+        if (null == sparkHome || sparkHome.isEmpty()) {
             LOGGER.warn("METATRON_SPARK_HOME is not set.");
             path = DEFAULT_SPARK_HOME;
         } else {
-            path = System.getProperty("spark.home.dir") + File.separator + "bin" + File.separator;
+            path = sparkHome + File.separator + "bin" + File.separator;
         }
         LOGGER.info("METATRON_SPARK_HOME = " + path);
         return path;


### PR DESCRIPTION
### Description
Jupyter Notebook is not created.

**Related Issue** : #1570 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 워크북에서 주피터 노트북 설정
2. 노트북 버튼 생성
3. 주피터 노트북 생성이 정상적으로 되는지 확인

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
