### PR TITLE
#1489 add prefix 'anonymous' if column label is empty.

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcConnectionService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcConnectionService.java
@@ -149,6 +149,7 @@ public class JdbcConnectionService {
   private static final Logger LOGGER = LoggerFactory.getLogger(JdbcConnectionService.class);
 
   private static final String RESULTSET_COLUMN_PREFIX = SelectQueryBuilder.TEMP_TABLE_NAME + ".";
+  private static final String ANONYMOUS_COLUMN_PREFIX = "anonymous";
 
   private static final String[] RESULTSET_TABLE_TYPES = new String[]{"TABLE", "VIEW"};
   private static final String[] RESULTSET_TABLE_TYPES_PRESTO = new String[]{"TABLE"};
@@ -2060,6 +2061,10 @@ public class JdbcConnectionService {
     for (int i = 1; i <= colNum; i++) {
 
       String columnLabel = metaData.getColumnLabel(i);
+
+      if(StringUtils.isEmpty(columnLabel)){
+        columnLabel = ANONYMOUS_COLUMN_PREFIX + i;
+      }
 
       String fieldName;
       String tableName;


### PR DESCRIPTION
### Description
In the case of mysql, a blank column name is returned if there is no column name.
So if it is an empty column name, convert it to an 'anonymous' column name.
![metatron_discovery 2](https://user-images.githubusercontent.com/3770446/53932253-0efdaf00-40dc-11e9-997e-f77cd899360a.png)

**Related Issue** : #1489 

### How Has This Been Tested?
1. goto mysql workbench
2. execute query
```
select "1", "a", ""
union select "2", "b", ""
union select "3", "", "blank"
union select "4", " ", "space";
```

3. see result

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
