### PR TITLE
F#0 Modifying the font color when the metadata has no explanation

### DIFF
--- a/discovery-frontend/src/app/meta-data-management/metadata/metadata-detail-information.component.html
+++ b/discovery-frontend/src/app/meta-data-management/metadata/metadata-detail-information.component.html
@@ -32,6 +32,7 @@
             <!-- data -->
             <div class="ddp-data-description">
               <div class="ddp-txt-description"
+                   [class.ddp-nodata]="metadataModelService.getMetadata().description.length === 0"
                    [innerHtml]="getDescription(metadataModelService.getMetadata().description)">
               </div>
               <a href="javascript:" class="ddp-btn-edit"

--- a/discovery-frontend/src/assets/css/polaris.v2.page.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.page.css
@@ -5268,6 +5268,7 @@ table.ddp-table-detail tbody tr td .ddp-ui-summary ul.ddp-list-sub li a {color:#
 .ddp-edit-description.ddp-line:after {position:absolute; bottom:0; left:0; right:0;border-bottom:1px dotted #ccc; content:'';}
 .ddp-edit-description .ddp-box-textarea {display:none;}
 .ddp-edit-description .ddp-txt-description {position:relative; top:-3px;  font-size:13px; line-height:18px; cursor:pointer;}
+.ddp-edit-description .ddp-txt-description.ddp-nodata {color:#b7bac1;}
 .ddp-edit-description .ddp-data-description {position:relative; padding-bottom:30px;}
 .ddp-edit-description .ddp-data-description:hover .ddp-btn-edit {display:inline-block;}
 .ddp-edit-description .ddp-data-description .ddp-btn-edit {display:none; padding:4px 7px; position:absolute; bottom:0; left:0;  height:21px; color:#91969e; font-size:12px; font-style:italic; background-color:#f3f3f4; box-sizing:border-box;}


### PR DESCRIPTION
### Description
 - 메타데이터 인포메이션 화면에서 설명이 작성되지 않았을 경우 기본문구로 “No description”을 노출되고 있는데 
실제 사용자가 입력한 내용은 아니라서 시각적으로 구분 되도록 폰트 톤다운 처리합니다

### How Has This Been Tested?
 - 메타데이터 인포메이션 화면에서 설명이 없는 경우 폰트 톤다운 처리가 되었는지 확인한다

![2019-03-07 3 18 49](https://user-images.githubusercontent.com/41019113/53936318-c7cbea00-40ec-11e9-867e-ccf7fdaf82c5.png)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
