### PR TITLE
F#1613 attribute typo in csv file format delimiter

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/HiveTableInformation.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/HiveTableInformation.java
@@ -74,7 +74,7 @@ public class HiveTableInformation {
             delimiter = "\t";
           }
           CsvFileFormat csvFileFormat = new CsvFileFormat();
-          csvFileFormat.setDelimeter(delimiter);
+          csvFileFormat.setDelimiter(delimiter);
           return csvFileFormat;
         default:
           return null;

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/ingestion/file/CsvFileFormat.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/ingestion/file/CsvFileFormat.java
@@ -23,19 +23,19 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("csv")
 public class CsvFileFormat implements FileFormat {
 
-  public static final String DEFAULT_DELIMETER = ",";
+  public static final String DEFAULT_DELIMITER = ",";
 
   public static final String DEFAULT_LINE_SEPARATOR = "\n";
 
-  String delimeter = DEFAULT_DELIMETER;
+  String delimiter = DEFAULT_DELIMITER;
 
   String lineSeparator = DEFAULT_LINE_SEPARATOR;
 
   public CsvFileFormat() {
   }
 
-  public CsvFileFormat(String delimeter, String lineSeparator) {
-    this.delimeter = delimeter;
+  public CsvFileFormat(String delimiter, String lineSeparator) {
+    this.delimiter = delimiter;
     this.lineSeparator = lineSeparator;
   }
 
@@ -46,17 +46,17 @@ public class CsvFileFormat implements FileFormat {
 
   @JsonIgnore
   public boolean isDefaultCsvMode() {
-    return DEFAULT_DELIMETER.equals(delimeter)
+    return DEFAULT_DELIMITER.equals(delimiter)
         && DEFAULT_LINE_SEPARATOR.equals(DEFAULT_LINE_SEPARATOR)
         ? true : false;
   }
 
-  public String getDelimeter() {
-    return delimeter;
+  public String getDelimiter() {
+    return delimiter;
   }
 
-  public void setDelimeter(String delimeter) {
-    this.delimeter = delimeter;
+  public void setDelimiter(String delimiter) {
+    this.delimiter = delimiter;
   }
 
   public String getLineSeparator() {

--- a/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/AbstractSpecBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/AbstractSpecBuilder.java
@@ -281,6 +281,7 @@ public class AbstractSpecBuilder {
             csvStreamParser.setDimensionsSpec(dimensionsSpec);
             csvStreamParser.setColumns(columns);
             csvStreamParser.setDelimiter(csvFormat.getDelimiter());
+            csvStreamParser.setRecordSeparator(csvFormat.getLineSeparator());
 
             parser = csvStreamParser;
           }

--- a/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/AbstractSpecBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/AbstractSpecBuilder.java
@@ -245,7 +245,7 @@ public class AbstractSpecBuilder {
           parseSpec.setDimensionsSpec(dimensionsSpec);
           parseSpec.setColumns(columns);
 
-          parseSpec.setDelimiter(csvFormat.getDelimeter());
+          parseSpec.setDelimiter(csvFormat.getDelimiter());
           parseSpec.setListDelimiter(csvFormat.getLineSeparator());
 
           parser = new StringParser(parseSpec);
@@ -273,14 +273,14 @@ public class AbstractSpecBuilder {
             csvStreamParser.setTimestampSpec(timestampSpec);
             csvStreamParser.setDimensionsSpec(dimensionsSpec);
             csvStreamParser.setColumns(columns);
-            csvStreamParser.setDelimiter(csvFormat.getDelimeter());
+            csvStreamParser.setDelimiter(csvFormat.getDelimiter());
 
             parser = csvStreamParser;
           } else {
             csvStreamParser.setTimestampSpec(timestampSpec);
             csvStreamParser.setDimensionsSpec(dimensionsSpec);
             csvStreamParser.setColumns(columns);
-            csvStreamParser.setDelimiter(csvFormat.getDelimeter());
+            csvStreamParser.setDelimiter(csvFormat.getDelimiter());
 
             parser = csvStreamParser;
           }


### PR DESCRIPTION
### Description
fix typo in CsvFileFormat.java
delimeter -> delimiter

**Related Issue** : #1613 

### How Has This Been Tested?
1. create datasource with tab delimiter csv file
[geo_seoul_roads.csv.zip](https://github.com/metatron-app/metatron-discovery/files/2944497/geo_seoul_roads.csv.zip)
2. change delimter to '\t'
3. uncheck "use the first row as head"
4. create datasource
5. after creation, see data tab

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
