### PR TITLE
Fix row number error in file datasource create

### DIFF
--- a/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/file-create-component/file-select/file-select.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/file-create-component/file-select/file-select.component.ts
@@ -299,7 +299,7 @@ export class FileSelectComponent extends AbstractPopupComponent implements OnIni
       return;
     }
     // file data 조회
-    this._setFileDetail();
+    this._setFileDetail(true);
   }
 
   /**
@@ -312,7 +312,7 @@ export class FileSelectComponent extends AbstractPopupComponent implements OnIni
       return;
     }
     // file data 조회
-    this._setFileDetail();
+    this._setFileDetail(true);
   }
 
 

--- a/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/file-create-component/file-select/file-select.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/file-create-component/file-select/file-select.component.ts
@@ -74,7 +74,7 @@ export class FileSelectComponent extends AbstractPopupComponent implements OnIni
   public uploader: FileUploader;
 
   // 그리드 row
-  public rowNum: number = 100;
+  public rowNum: number;
 
   // csv 파일 구분자
   public delimiter: string = ',';
@@ -136,7 +136,7 @@ export class FileSelectComponent extends AbstractPopupComponent implements OnIni
         // 업로드한 파일 정보 세팅
         this._setFileResult(this._uploadResult);
         // set file detail data
-        this._setFileDetail();
+        this._setFileDetail(true);
       }
     };
 
@@ -263,7 +263,7 @@ export class FileSelectComponent extends AbstractPopupComponent implements OnIni
       // change selected sheet
       this.fileResult.selectedSheet = sheet;
       // set file detail
-      this._setFileDetail();
+      this._setFileDetail(true);
     }
   }
 
@@ -274,7 +274,7 @@ export class FileSelectComponent extends AbstractPopupComponent implements OnIni
     // change first header row flag
     this.isFirstHeaderRow = !this.isFirstHeaderRow;
     // set file detail
-    this._setFileDetail();
+    this._setFileDetail(true);
   }
 
   /**
@@ -473,9 +473,10 @@ export class FileSelectComponent extends AbstractPopupComponent implements OnIni
 
   /**
    * Set file detail data
+   * @param {boolean} initRowNum
    * @private
    */
-  private _setFileDetail(): void {
+  private _setFileDetail(initRowNum?: boolean): void {
     // init selected file detail data
     this.selectedFileDetailData = undefined;
     // grid hide
@@ -486,6 +487,8 @@ export class FileSelectComponent extends AbstractPopupComponent implements OnIni
     }
     // 로딩 show
     this.loadingShow();
+    // if init row num
+    initRowNum && (this.rowNum = 100);
     // 파일 조회
     this.datasourceService.getDatasourceFile(this.fileResult.fileKey, this._getFileParams())
       .then((result: FileDetail) => {


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
파일 데이터소스 생성화면에서 기존 파일에서 새로운파일로 업로드시 기존에 적용된 row 가 바뀌지 않던 현상 수정
아래와 같은 초기화 반영
```
파일 변경시 100 row 로 조회 => 결과가 100미만이면  row 를 다시 최대 max값(100) 으로 수정
head column 체크시 100 row 로 조회  => 결과가 100미만이면 row 를 다시 최대 max값(100) 으로 수정
```

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
release test

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 파일 데이터소스 생성
2. 생성할 파일 업로드 (업로드 성공후 row 확인)
3. 파일 변경 또는 하단의 use column head 체크
4. row가 이전 값으로 고정되지 않는것 확인 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project. _it will be added soon_
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
