### PR TITLE
#fn use ordered map for JSON snapshot. bug-fix on CSV snapshot.

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/TeddyExecutor.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/TeddyExecutor.java
@@ -35,7 +35,9 @@ import app.metatron.discovery.domain.datasource.connection.jdbc.*;
 import app.metatron.discovery.prep.parser.exceptions.RuleException;
 import app.metatron.discovery.prep.parser.preparation.RuleVisitorParser;
 import app.metatron.discovery.prep.parser.preparation.rule.Rule;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.collect.Maps;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.io.FilenameUtils;
@@ -244,7 +246,7 @@ public class TeddyExecutor {
         try {
             for (int rowno = 0; rowno < df.rows.size(); cancelCheck(ssId, ++rowno)) {
                 Row row = df.rows.get(rowno);
-                Map<String, Object> jsonRow = new HashMap<>();
+                Map<String, Object> jsonRow = new LinkedHashMap<>();
 
                 for (int colno = 0; colno < df.getColCnt(); ++colno) {
                     if(df.getColType(colno).equals(ColumnType.TIMESTAMP)) {


### PR DESCRIPTION
### Description
1. A JSON snapshot now keeps the column order of the W.DS.
2. CSV snapshots do not lose their headers.

**Related Issue** : None

### How Has This Been Tested?
Run locally.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
