### PR TITLE
#fn add spec backward for geoshelf and fix duplicated query id

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/common/CommonLocalVariable.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/common/CommonLocalVariable.java
@@ -39,12 +39,20 @@ public class CommonLocalVariable {
     localVariable.setQueryId(queryId);
   }
 
+  public static void generateQueryId() {
+    LocalVariable localVariable = getLocalVariable();
+    localVariable.setQueryId(IdGenerator.queryId());
+  }
+
   public static String getQueryId() {
     return getLocalVariable().getQueryId();
   }
 
   public static class LocalVariable {
 
+    /**
+     * Query Id
+     */
     String queryId;
 
     public String getQueryId() {

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/engine/EngineQueryService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/engine/EngineQueryService.java
@@ -300,12 +300,14 @@ public class EngineQueryService extends AbstractQueryService implements QuerySer
                                                           .fields(mainLayer.getFields())
                                                           .filters(request.getFilters())
                                                           .limit(request.getLimits())
+                                                          .emptyQueryId()
                                                           .build();
 
       SelectStreamQuery compareLayerQuery = SelectStreamQuery.builder(request.getDataSource())
                                                              .layer(compareLayer)
                                                              .filters(request.getFilters())
                                                              .compareLayer(compareLayer.getFields(), geoSpatialAnalysis.getOperation())
+                                                             .emptyQueryId()
                                                              .build();
 
       GeoBoundaryFilterQuery geoBoundaryQuery = GeoBoundaryFilterQuery.builder()
@@ -326,8 +328,10 @@ public class EngineQueryService extends AbstractQueryService implements QuerySer
 
     } else {
 
-
       for (MapViewLayer layer : geoShelf.getLayers()) {
+
+        CommonLocalVariable.generateQueryId();
+
         if (layer.getView().needAggregation()) {
           GroupByQuery groupByQuery = GroupByQuery.builder(request.getDataSource())
                                                   .layer(layer)

--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/queries/GeoBoundaryFilterQueryBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/queries/GeoBoundaryFilterQueryBuilder.java
@@ -16,8 +16,11 @@ package app.metatron.discovery.query.druid.queries;
 
 import com.google.common.collect.Maps;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.Map;
 
+import app.metatron.discovery.common.CommonLocalVariable;
 import app.metatron.discovery.common.datasource.LogicalType;
 import app.metatron.discovery.domain.datasource.Field;
 import app.metatron.discovery.query.druid.Query;
@@ -37,9 +40,12 @@ public class GeoBoundaryFilterQueryBuilder {
 
   SpatialOperations operation;
 
-  Map<String, Object> context;
+  Map<String, Object> context = Maps.newLinkedHashMap();
+
+  String queryId;
 
   public GeoBoundaryFilterQueryBuilder() {
+    queryId = CommonLocalVariable.getQueryId();
   }
 
   public GeoBoundaryFilterQueryBuilder query(Query query) {
@@ -89,6 +95,10 @@ public class GeoBoundaryFilterQueryBuilder {
   }
 
   public GeoBoundaryFilterQuery build() {
+
+    if (StringUtils.isNotEmpty(queryId)) {
+      context.put("queryId", queryId);
+    }
 
     GeoBoundaryFilterQuery geoBoundaryQuery = new GeoBoundaryFilterQuery(
         query,

--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/queries/GroupByQueryBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/queries/GroupByQueryBuilder.java
@@ -759,6 +759,17 @@ public class GroupByQueryBuilder extends AbstractQueryBuilder {
 
   }
 
+  public GroupByQueryBuilder queryId(String queryId) {
+    this.queryId = queryId;
+    return this;
+  }
+
+  public GroupByQueryBuilder emptyQueryId() {
+    queryId = null;
+
+    return this;
+  }
+
   @Override
   public GroupByQuery build() {
 

--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/queries/SelectStreamQueryBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/queries/SelectStreamQueryBuilder.java
@@ -309,6 +309,17 @@ public class SelectStreamQueryBuilder extends AbstractQueryBuilder {
     return this;
   }
 
+  public SelectStreamQueryBuilder queryId(String queryId) {
+    this.queryId = queryId;
+    return this;
+  }
+
+  public SelectStreamQueryBuilder emptyQueryId() {
+    queryId = null;
+
+    return this;
+  }
+
   @Override
   public SelectStreamQuery build() {
 

--- a/discovery-server/src/test/resources/sql/test_gis_datasource.sql
+++ b/discovery-server/src/test/resources/sql/test_gis_datasource.sql
@@ -10,10 +10,10 @@ INSERT INTO field (id, pre_aggr_type, field_format, field_logical_type, field_na
 (10090006, 'NONE', null, 'DOUBLE', 'py', null, 'MEASURE', 5, 'FLOAT', null, 'gis_01');
 
 INSERT INTO datasource (id, created_by, created_time, modified_by, modified_time, version, ds_conn_type, datasource_contexts, ds_desc, ds_type, ds_engine_name, ds_granularity, ingestion_conf, ds_linked_workspaces, ds_name, ds_owner_id, ds_seg_granularity, ds_src_type, ds_status) VALUES
-('gis_02', 'admin', NOW(), 'unknown', NOW(), 0, 'ENGINE', null, null, 'MASTER', 'seoul_roads', 'NONE', null, 0, 'seoul roads', null, 'NONE', 'IMPORT', 'ENABLED');
+('gis_20', 'admin', NOW(), 'unknown', NOW(), 0, 'ENGINE', null, null, 'MASTER', 'seoul_roads', 'NONE', null, 0, 'seoul roads', null, 'NONE', 'IMPORT', 'ENABLED');
 
 INSERT INTO field (id, pre_aggr_type, field_format, field_logical_type, field_name, field_partitioned, field_role, seq, field_type, ref_id, ds_id) VALUES
-(10090021, 'NONE', null, 'TIMESTAMP', 'event_time', null, 'TIMESTAMP', 0, 'TIMESTAMP', null, 'gis_02'),
-(10090022, 'NONE', null, 'STRING', 'id', null, 'DIMENSION', 1, 'STRING', null, 'gis_02'),
-(10090023, 'NONE', null, 'STRING', 'name', null, 'DIMENSION', 2, 'STRING', null, 'gis_02'),
-(10090024, 'NONE', null, 'GEO_LINE', 'geom', null, 'DIMENSION', 3, 'STRING', null, 'gis_02');
+(10191221, 'NONE', null, 'TIMESTAMP', 'event_time', null, 'TIMESTAMP', 0, 'TIMESTAMP', null, 'gis_20'),
+(10191222, 'NONE', null, 'STRING', 'id', null, 'DIMENSION', 1, 'STRING', null, 'gis_20'),
+(10191223, 'NONE', null, 'STRING', 'name', null, 'DIMENSION', 2, 'STRING', null, 'gis_20'),
+(10191224, 'NONE', null, 'GEO_LINE', 'geom', null, 'DIMENSION', 3, 'STRING', null, 'gis_20');


### PR DESCRIPTION
### Description
- 맵 차트내 multiple layer 스펙을 변경하면서 기존스펙과 충돌이 발생하여 위젯 복사 및 기존 차트 스펙 저장시 오류를 발생시킵니다.
- 맵 차트내 multiple layer를 호출시 2개의 쿼리를 호출하는데, 이때 동일한 queryId 를 호출하여 간헐적으로 쿼리 수행 오류가 발생합니다. 

**Related Issue** : None

### How Has This Been Tested?
- 기존(3.2-rc2) 맵이 추가된 대시보드 내에서 대시보드 편집 후 저장 하여 정상동작합니다. 
- 멀티 레이어를 설정한 맵뷰내에서 차트를 줌인/아웃 또는 이동을 여러번(5회 이상) 진행후 오류없이 정상 동작합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Additional Context<!-- if not appropriate, remove this topic. -->
