### PR TITLE
F#1599 wrong stage idx after redo

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DfMerge.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DfMerge.java
@@ -53,17 +53,26 @@ public class DfMerge extends DataFrame {
     }
 
     // 마지막 목적 컬럼까지만 추가 하기 위해
-    int newColPos = 0;
+    int lastColPos = 0;
     for(String colName : targetColNames) {
-      newColPos = prevDf.getColnoByColName(colName) > newColPos ? prevDf.getColnoByColName(colName) : newColPos;
+      lastColPos = prevDf.getColnoByColName(colName) > lastColPos ? prevDf.getColnoByColName(colName) : lastColPos;
     }
-    newColPos++;
 
-    this.addColumnWithDfAll(prevDf);
+    for (int colno = 0; colno < prevDf.getColCnt(); colno++) {
+      String colName = prevDf.getColName(colno);
+      if (targetColNames.contains(colName)) {
+        continue;
+      }
+      addColumnWithDf(prevDf, colno);
+    }
+
+    // target columns will not be dropped.
+    int newColPos = lastColPos - targetColNames.size() + 1;
+
     newColName = this.addColumn(newColPos, newColName, ColumnType.STRING);  // 중간 삽입
     this.interestedColNames.add(newColName);
 
-    preparedArgs.add(newColPos);
+    preparedArgs.add(lastColPos);
     preparedArgs.add(targetColNames);
     preparedArgs.add(with);
     preparedArgs.add(newColName);
@@ -73,7 +82,7 @@ public class DfMerge extends DataFrame {
   @Override
   public List<Row> gather(DataFrame prevDf, List<Object> preparedArgs, int offset, int length, int limit) throws InterruptedException, TeddyException {
     List<Row> rows = new ArrayList<>();
-    int newColPos = (int) preparedArgs.get(0);
+    int lastColPos = (int) preparedArgs.get(0);
     List<String> targetColNames = (List<String>) preparedArgs.get(1);
     String with = (String) preparedArgs.get(2);
     String newColName = (String) preparedArgs.get(3);
@@ -86,7 +95,11 @@ public class DfMerge extends DataFrame {
       Row newRow = new Row();
 
       // 마지막 목적 컬럼까지만 추가
-      for (colno = 0; colno < newColPos; colno++) {
+      for (colno = 0; colno < lastColPos; colno++) {
+        String colName = prevDf.getColName(colno);
+        if (targetColNames.contains(colName)) {
+          continue;
+        }
         newRow.add(prevDf.getColName(colno), row.get(colno));
       }
 
@@ -100,7 +113,7 @@ public class DfMerge extends DataFrame {
       newRow.add(newColName, sb.toString());
 
       // 나머지 추가
-      for (colno = newColPos; colno < prevDf.getColCnt(); colno++) {
+      for (colno = lastColPos + 1; colno < prevDf.getColCnt(); colno++) {
         newRow.add(prevDf.getColName(colno), row.get(colno));
       }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/Revision.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/Revision.java
@@ -41,16 +41,8 @@ public class Revision {
     curStageIdx = until - 1;
   }
 
-  public Revision(Revision rev) {
-    this(rev, rev.size());
-  }
-
   public int getCurStageIdx() {
     return curStageIdx;
-  }
-
-  public int getCurStageCnt() {
-    return dfs.size();
   }
 
   public void setCurStageIdx(Integer curStageIdx) {

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/TeddyImpl.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/TeddyImpl.java
@@ -375,6 +375,27 @@ public class TeddyImpl {
     return valids;
   }
 
+  private boolean looksLikeHeadered(DataFrame df) {
+    if (df.rows.size() == 0) {
+      return false;
+    }
+
+    Set<Object> strSet = new HashSet();
+    for (int i = 0; i < df.getColCnt(); i++) {
+      Object obj = df.rows.get(0).get(i);
+      if (obj == null || !(obj instanceof String)) {
+        return false;
+      }
+
+      if (strSet.contains(obj)) {
+        return false;
+      }
+      strSet.add(obj);
+    }
+
+    return true;
+  }
+
   // Get header and settype rule strings via inspecting 100 rows.
   public List<String> getAutoTypingRules(DataFrame df) throws TeddyException {
     String[] ruleStrings = new String[3];
@@ -395,7 +416,7 @@ public class TeddyImpl {
     //If all column types of row 0 elements is String and predicted column types is not all String.
     //Then add Header rule and change column name.
     if(Collections.frequency(columnTypesRow0, ColumnType.STRING) == df.colCnt &&
-            Collections.frequency(columnTypes, ColumnType.STRING) != df.colCnt) {
+        Collections.frequency(columnTypes, ColumnType.STRING) != df.colCnt && looksLikeHeadered(df)) {
       String ruleString = "header rownum: 1";
 
       setTypeRules.add(ruleString);

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/TeddyImpl.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/TeddyImpl.java
@@ -100,11 +100,6 @@ public class TeddyImpl {
     return rs.get().getCurStageIdx();
   }
 
-  public int getCurStageCnt(String dsId) {
-    RevisionSet rs = revisionSetCache.get(dsId);
-    return rs.get().getCurStageCnt();
-  }
-
   public int getRevCnt(String dsId) {
     return revisionSetCache.get(dsId).revs.size();
   }
@@ -251,6 +246,7 @@ public class TeddyImpl {
     // replace with the new, updated DF
     DataFrame newDf = apply(rev.get(stageIdx - 1), ruleString, jsonRuleString);
     newRev.add(newDf);
+    newRev.setCurStageIdx(stageIdx);
 
     appendNewDfs(newRev, rev, stageIdx + 1);
 


### PR DESCRIPTION
### Description
1. Fixed wrong stageIdx after UPDATE (also after REDO)
2. Remove the original columns after merge transformation
3. Prevent auto-header when there's duplication or numbers or nulls on the 1st line.

**Related Issue** : https://github.com/metatron-app/metatron-discovery/issues/1599


### How Has This Been Tested?
1. Check https://github.com/metatron-app/metatron-discovery/issues/1599 please.
2. Open the dataset of https://github.com/metatron-app/metatron-discovery/issues/1599 -> merge **itemNo**, **speed** -> the new column should be located before **weight** and **itemNo**, **speed** are removed.
3. Import & wrangle [header_test.csv.txt](https://github.com/metatron-app/metatron-discovery/files/2952136/header_test.csv.txt) -> header transformation should be applied.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


