### PR TITLE
#1651 upload files to finaldestination

### DIFF
--- a/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-selectfile.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-selectfile.component.ts
@@ -123,9 +123,7 @@ export class CreateDatasetSelectfileComponent extends AbstractPopupComponent imp
       this.fileLocations = [];
       if(this.uploadNegoParams.storage_types && this.uploadNegoParams.storage_types.length > 0){
         this.uploadNegoParams.storage_types.forEach((storage_type)=>{
-          // FIXME: The storage type is currently LOCAL.
-          if( storage_type === 'LOCAL' )
-            this.fileLocations.push( { 'value': storage_type, 'label': storage_type } );
+          this.fileLocations.push( { 'value': storage_type, 'label': storage_type } );
         })
       } else {
         this.fileLocations.push( { 'value': 'LOCAL', 'label': 'LOCAL' } );

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepProperties.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepProperties.java
@@ -31,6 +31,7 @@ public class PrepProperties {
   public static final String LOCAL_BASE_DIR       = "polaris.dataprep.localBaseDir";
   public static final String HADOOP_CONF_DIR      = "polaris.dataprep.hadoopConfDir";
   public static final String STAGING_BASE_DIR     = "polaris.dataprep.stagingBaseDir";
+  public static final String S3_BASE_DIR          = "polaris.dataprep.s3BaseDir";
 
   public static final String SAMPLING_CORES       = "polaris.dataprep.sampling.cores";
   public static final String SAMPLING_TIMEOUT     = "polaris.dataprep.sampling.timeout";
@@ -56,6 +57,7 @@ public class PrepProperties {
 
   public String localBaseDir;
   public String stagingBaseDir;
+  public String s3BaseDir;
   public String hadoopConfDir;
   public SamplingInfo sampling;
   public EtlInfo etl;
@@ -95,6 +97,13 @@ public class PrepProperties {
       throw PrepException.create(PrepErrorCodes.PREP_INVALID_CONFIG_CODE, PrepMessageKey.MSG_DP_ALERT_STAGING_BASE_DIR_NOT_CONFIGURED, "StagingDir not configured");
     }
     return stagingBaseDir;
+  }
+
+  public String getS3BaseDir(boolean mandatory) {
+    if (mandatory && s3BaseDir == null) {
+      throw PrepException.create(PrepErrorCodes.PREP_INVALID_CONFIG_CODE, PrepMessageKey.MSG_DP_ALERT_STAGING_BASE_DIR_NOT_CONFIGURED, "S3Dir not configured");
+    }
+    return s3BaseDir;
   }
 
   // sampling, etl cannot be null (see init())
@@ -290,8 +299,20 @@ public class PrepProperties {
     }
   }
 
+  public void setS3BaseDir(String s3BaseDir) {
+    if(null!=s3BaseDir && 1<s3BaseDir.length() && true==s3BaseDir.endsWith(File.separator)) {
+      this.s3BaseDir = s3BaseDir.substring(0,s3BaseDir.length());
+    } else {
+      this.s3BaseDir = s3BaseDir;
+    }
+  }
+
   public String getStagingBaseDir() {
     return stagingBaseDir;
+  }
+
+  public String getS3BaseDir() {
+    return s3BaseDir;
   }
 
   public String getHadoopConfDir() {
@@ -336,7 +357,7 @@ public class PrepProperties {
 
   @Override
   public String toString() {
-    return String.format("PrepProperties{localBaseDir=%s stagingBaseDir=%s hadoopConfDir=%s sampling=%s etl=%s}",
-                                         localBaseDir, stagingBaseDir, hadoopConfDir, sampling, etl);
+    return String.format("PrepProperties{localBaseDir=%s stagingBaseDir=%s s3BaseDir=%s hadoopConfDir=%s sampling=%s etl=%s}",
+                                         localBaseDir, stagingBaseDir, s3BaseDir, hadoopConfDir, sampling, etl);
   }
 }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/entity/PrUploadFile.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/entity/PrUploadFile.java
@@ -1,0 +1,129 @@
+package app.metatron.discovery.domain.dataprep.entity;
+
+import app.metatron.discovery.domain.AbstractHistoryEntity;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.apache.commons.io.FilenameUtils;
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.*;
+import javax.validation.constraints.Size;
+
+@Entity
+@Table(name = "pr_upload_file")
+public class PrUploadFile extends AbstractHistoryEntity {
+
+  @JsonFormat(shape = JsonFormat.Shape.OBJECT)
+  public enum STORAGE_TYPE {
+    LOCAL,
+    HDFS,
+    S3,
+    BLOB,
+    FTP;
+
+    @JsonValue
+    public String toJson() {
+      return name();
+    }
+  }
+
+  @Id
+  @GeneratedValue(generator = "uuid")
+  @GenericGenerator(name = "uuid", strategy = "uuid2")
+  @Column(name = "upload_id")
+  private String uploadId;
+
+  @Size(max = 2000)
+  @Column(name = "orig_filename")
+  private String originalFilename;
+
+  @Size(max = 2000)
+  @Column(name = "local_uri")
+  private String localUri;
+
+  @Size(max = 2000)
+  @Column(name = "file_uri")
+  private String fileUri;
+
+  @Column(name = "rest_chunk")
+  Integer restChunk;
+
+  @Column(name = "file_size")
+  Long fileSize;
+
+  @Column(name = "storage_type")
+  STORAGE_TYPE storageType;
+
+  public PrUploadFile() {
+  }
+
+  // getter property
+  public String getFilename() {
+    String filename = this.uploadId;
+
+    String extensionType = FilenameUtils.getExtension(this.originalFilename);
+    if(extensionType!=null && 0<extensionType.length()) {
+      filename = filename + "." + extensionType.toLowerCase();
+    }
+
+    return filename;
+  }
+
+  public String getUploadId() {
+    return uploadId;
+  }
+
+  public void setUploadId(String uploadId) {
+    this.uploadId = uploadId;
+  }
+
+  public String getOriginalFilename() {
+    return originalFilename;
+  }
+
+  public void setOriginalFilename(String originalFilename) {
+    this.originalFilename = originalFilename;
+  }
+
+  public String getLocalUri() {
+    return localUri;
+  }
+
+  public void setLocalUri(String localUri) {
+    this.localUri = localUri;
+  }
+
+  public String getFileUri() {
+    return fileUri;
+  }
+
+  public void setFileUri(String fileUri) {
+    this.fileUri = fileUri;
+  }
+
+  public Integer getRestChunk() {
+    return restChunk;
+  }
+
+  public void setRestChunk(Integer restChunk) {
+    this.restChunk = restChunk;
+  }
+
+  public Long getFileSize() {
+    return fileSize;
+  }
+
+  public void setFileSize(Long fileSize) {
+    this.fileSize = fileSize;
+  }
+
+  public STORAGE_TYPE getStorageType() {
+    return storageType;
+  }
+
+  public void setStorageType(STORAGE_TYPE storageType) {
+    this.storageType = storageType;
+  }
+}
+
+

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/repository/PrUploadFileRepository.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/repository/PrUploadFileRepository.java
@@ -1,0 +1,9 @@
+package app.metatron.discovery.domain.dataprep.repository;
+
+import app.metatron.discovery.domain.dataprep.entity.PrUploadFile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PrUploadFileRepository extends JpaRepository<PrUploadFile,String> {
+
+}
+

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/service/PrDatasetController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/service/PrDatasetController.java
@@ -648,6 +648,8 @@ public class PrDatasetController {
 
             response = this.datasetFileService.uploadFileChunk( uploadFile, chunkIdx, chunkSize, file );
 
+            this.uploadFileRepository.saveAndFlush(uploadFile);
+
             if(uploadFile.getRestChunk()==0) {
                 if (uploadFile.getStorageType() == PrUploadFile.STORAGE_TYPE.LOCAL) {
                     // just ok.

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/service/PrDatasetService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/service/PrDatasetService.java
@@ -129,8 +129,6 @@ public class PrDatasetService {
         String csvStrUri = null;
         if(dataset.getFileFormat() == PrDataset.FILE_FORMAT.EXCEL) {
             csvStrUri = this.datasetFilePreviewService.moveExcelToCsv(storedUri, sheetName, delimiter);
-        //} else if(dataset.getFileFormat() == PrDataset.FILE_FORMAT.JSON) {
-        //    csvStrUri = this.datasetFilePreviewService.moveJsonToCsv(storedUri, null, delimiter);
         }
         if(csvStrUri!=null) {
             dataset.setStoredUri(csvStrUri);

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/storage/StorageProperties.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/storage/StorageProperties.java
@@ -18,18 +18,18 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 import java.io.Serializable;
-import java.util.List;
-import java.util.Map;
 
 @Component
 @ConfigurationProperties(prefix = "polaris.storage")
 public class StorageProperties {
 
   public enum StorageType{
-    STAGEDB
+    STAGEDB,
+    S3
   }
 
   StageDBConnection stagedb;
+  S3Connection s3;
 
   public StorageProperties() {
   }
@@ -150,6 +150,35 @@ public class StorageProperties {
 
     public void setMetastorePassword(String metastorePassword) {
       this.metastorePassword = metastorePassword;
+    }
+  }
+
+  public S3Connection getS3() {
+    return s3;
+  }
+
+  public void setS3(S3Connection s3) {
+    this.s3 = s3;
+  }
+
+  public static class S3Connection implements Serializable {
+    String bucket;
+    String region;
+
+    public String getBucket() {
+      return bucket;
+    }
+
+    public void setBucket(String bucket) {
+      this.bucket = bucket;
+    }
+
+    public String getRegion() {
+      return region;
+    }
+
+    public void setRegion(String region) {
+      this.region = region;
     }
   }
 }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Uploaded files are stored locally on the server until now.
but now, those will be copied to final destination when uploading the files

**Related Issue** : <!--- Please link to the issue here. -->
[#1651](https://github.com/metatron-app/metatron-discovery/issues/1651)

### How Has This Been Tested?
1. When uploading files, 
The upload location should be selectable as LOCAL or HDFS if you set the settings 
'localBasedIr', 'stagingBaseDir'

2. Atfer the dataset was created
The file should be saved in the location you choose. LOCAL or HDFS
You can check the file location in the dataset details

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
