### PR TITLE
#1541 In Hive snapshots, dataprep array type is store as Hive arrays

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/ColumnDescription.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/ColumnDescription.java
@@ -61,6 +61,34 @@ public class ColumnDescription implements Serializable {
     this.arrColDesc = arrColDesc;
   }
 
+  public ColumnType hasUniformSubType() {
+    ColumnType prev = ColumnType.UNKNOWN;
+
+    for (ColumnDescription colDesc : arrColDesc) {
+      switch (colDesc.getType()) {
+        case STRING:
+        case LONG:
+        case DOUBLE:
+        case BOOLEAN:
+        case TIMESTAMP:
+          if (prev == ColumnType.UNKNOWN) {
+            prev = colDesc.getType();
+          } else {
+            if (prev != colDesc.getType()) {
+              return ColumnType.UNKNOWN;
+            }
+          }
+          break;
+        case ARRAY:
+        case MAP:
+          return ColumnType.UNKNOWN;
+        case UNKNOWN:
+          assert false : colDesc;
+      }
+    }
+    return prev;
+  }
+
   public Map<String, ColumnDescription> getMapColDesc() {
     return mapColDesc;
   }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/TeddyOrcWriter.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/TeddyOrcWriter.java
@@ -16,21 +16,28 @@ package app.metatron.discovery.domain.dataprep.teddy;
 
 import app.metatron.discovery.domain.dataprep.entity.PrSnapshot;
 import app.metatron.discovery.domain.dataprep.entity.PrSnapshot.HIVE_FILE_COMPRESSION;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hive.ql.exec.vector.*;
-import org.apache.orc.CompressionKind;
-import org.apache.orc.OrcFile;
-import org.apache.orc.TypeDescription;
-import org.apache.orc.Writer;
-import org.joda.time.DateTime;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.DoubleColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.ListColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.StructColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.orc.CompressionKind;
+import org.apache.orc.OrcFile;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.TypeDescription.Category;
+import org.apache.orc.Writer;
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TeddyOrcWriter {
   private static Logger LOGGER = LoggerFactory.getLogger(TeddyOrcWriter.class);
@@ -53,6 +60,66 @@ public class TeddyOrcWriter {
     return null;  // cannot reach here
   }
 
+  // TODO: distinguish MISMATCHED, MISSING, VALID
+  private boolean setList(ListColumnVector listColVector, ColumnType subType, int pos, List list) {
+    if (list == null) {
+      listColVector.isNull[pos] = true;
+      listColVector.noNulls = false;
+      return false;   // MISSING
+    }
+
+    if (listColVector.childCount + list.size() > listColVector.child.isNull.length) {
+      listColVector.child.ensureSize(listColVector.childCount * 2, true);
+    }
+    listColVector.lengths[pos] = list.size();
+    listColVector.offsets[pos] = listColVector.childCount;
+
+    ColumnVector colVector = listColVector.child;
+
+    for (int i = 0; i < listColVector.lengths[pos]; ++i) {
+      Object obj = list.get(i);
+
+      switch (subType) {
+        case STRING:
+          if(!(obj instanceof  String)){    // MISMATCHED
+            return false;
+          }
+          byte[] bytes = toBytes((String) obj);
+          ((BytesColumnVector) colVector).setVal(pos, bytes, 0, bytes.length);
+          break;
+        case LONG:
+          if(!(obj instanceof  Long)){
+            return false;
+          }
+          ((LongColumnVector) colVector).vector[pos] = (Long) obj;
+          break;
+        case DOUBLE:
+          if(!(obj instanceof  Double)){
+            return false;
+          }
+          ((DoubleColumnVector) colVector).vector[pos] = (Double) obj;
+          break;
+        case BOOLEAN:
+          if(!(obj instanceof  Boolean)){
+            return false;
+          }
+          ((LongColumnVector) colVector).vector[pos] = (Boolean) obj ? 1 : 0;
+          break;
+        case TIMESTAMP:
+          if(!(obj instanceof  DateTime)){
+            return false;
+          }
+          ((TimestampColumnVector) colVector).time[pos] = ((DateTime) obj).getMillis();
+          ((TimestampColumnVector) colVector).nanos[pos] = 0;
+          break;
+        default:
+          assert false : subType;
+      }
+    }
+    return true;
+  }
+
+  // TODO: distinguish MISMATCHED, MISSING, VALID
   private boolean setBatch(int pos, ColumnVector colVector, ColumnType colType, ColumnDescription colDesc, Object obj) {
     //null check
     if(obj == null)
@@ -92,6 +159,11 @@ public class TeddyOrcWriter {
         ((TimestampColumnVector) colVector).nanos[pos] = 0;
         break;
       case ARRAY:
+        ColumnType uniformSubType = colDesc.hasUniformSubType();
+        if (uniformSubType != ColumnType.UNKNOWN) {
+          setList((ListColumnVector) colVector, uniformSubType, pos, (List) obj);
+          break;
+        }
         ColumnVector[] fields = ((StructColumnVector) colVector).fields;
         for (int i = 0; i < fields.length; i++) {
           ColumnDescription subColDesc = colDesc.getArrColDesc().get(i);
@@ -114,7 +186,7 @@ public class TeddyOrcWriter {
     return true;
   }
 
-  private void addField(TypeDescription typeDescription, String colName, ColumnType colType, ColumnDescription subColDesc) {
+  private void addField(TypeDescription typeDescription, String colName, ColumnType colType, ColumnDescription colDesc) {
     switch (colType) {
       case STRING:
         typeDescription.addField(colName, TypeDescription.createString());
@@ -131,21 +203,46 @@ public class TeddyOrcWriter {
       case TIMESTAMP:
         typeDescription.addField(colName, TypeDescription.createTimestamp());
         break;
-      case ARRAY:   // 이 ARRAY는 ORC의 LIST와는 다르다. STRUCT로 구현된다.
+      case MAP:     // The dataprep's map type becomes ORC/HIVE's struct type.
         TypeDescription structType = new TypeDescription(TypeDescription.Category.STRUCT);
-        for (int i = 0; i < subColDesc.getArrColDesc().size(); i++) {
-          ColumnDescription childColDesc = subColDesc.getArrColDesc().get(i);
-          addField(structType, "c" + i, childColDesc.getType(), childColDesc);
-        }
-        typeDescription.addField(colName, structType);
-        break;
-      case MAP:     // 이 MAP은 ORC의 MAP과는 다르다. 역시 STRUCT로 구현된다.
-        structType = new TypeDescription(TypeDescription.Category.STRUCT);
-        for (String key : subColDesc.getMapColDesc().keySet()) {
-          ColumnDescription childColDesc = subColDesc.getMapColDesc().get(key);
+        for (String key : colDesc.getMapColDesc().keySet()) {
+          ColumnDescription childColDesc = colDesc.getMapColDesc().get(key);
           addField(structType, key, childColDesc.getType(), childColDesc);
         }
         typeDescription.addField(colName, structType);
+        break;
+      case ARRAY:   // If all elements are the same type, it becomes ORC/HIVE's array. Or it becomes struct.
+        ColumnType uniformSubType = colDesc.hasUniformSubType();
+        if (uniformSubType != ColumnType.UNKNOWN) {
+          TypeDescription listType = null;
+          switch (uniformSubType) {
+            case STRING:
+              listType = TypeDescription.createList(TypeDescription.createString());
+              break;
+            case LONG:
+              listType = TypeDescription.createList(TypeDescription.createLong());
+              break;
+            case DOUBLE:
+              listType = TypeDescription.createList(TypeDescription.createDouble());
+              break;
+            case BOOLEAN:
+              listType = TypeDescription.createList(TypeDescription.createBoolean());
+              break;
+            case TIMESTAMP:
+              listType = TypeDescription.createList(TypeDescription.createTimestamp());
+              break;
+            default:
+              assert false : uniformSubType;
+          }
+          typeDescription.addField(colName, listType);
+        } else {
+          structType = new TypeDescription(TypeDescription.Category.STRUCT);
+          for (int i = 0; i < colDesc.getArrColDesc().size(); i++) {
+            ColumnDescription childColDesc = colDesc.getArrColDesc().get(i);
+            addField(structType, "c" + i, childColDesc.getType(), childColDesc);
+          }
+          typeDescription.addField(colName, structType);
+        }
         break;
       case UNKNOWN:
         assert false : String.format("colName=%s colType=%s", colName, colType.name());


### PR DESCRIPTION
### Description
We used to store the arrays as struct type in Hive snapshots.
Now we use Hive array type when the sub-types are all the same, like string, string, string or long, long, long, ...

When the sub-type are mixed, we ㅗave no choice but to store as struct type.

**Related Issue** : https://github.com/metatron-app/metatron-discovery/issues/1541


### How Has This Been Tested?
1. Import and wrangle [sales_well_renamed.csv.txt](https://github.com/metatron-app/metatron-discovery/files/2966020/sales_well_renamed.csv.txt)
2. Select division and market columns by clicking with shift.
3. Nest via context menu or entering transform rules on the bottom of the main transform page.
4. Make sure that the type should be array.
5. Click "Snapshot button"
6. Select Hive snapshot. (by default, we use ORC type)
7. Click the new snapshot to see details.
8. See the new division_1 columns has been stored as array. like this 
![스크린샷 2019-03-14 오후 8 00 59](https://user-images.githubusercontent.com/42257727/54352076-26b4d480-4694-11e9-917b-859bdef03975.png)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
