### PR TITLE
error display time due to processing time zone (backward compatibility for changing time format)

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/format/ContinuousTimeFormat.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/format/ContinuousTimeFormat.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import app.metatron.discovery.query.druid.limits.PivotColumn;
 import app.metatron.discovery.util.EnumUtils;
@@ -30,6 +31,12 @@ public class ContinuousTimeFormat extends TimeFieldFormat implements FieldFormat
   TimeUnit unit;
 
   ByTimeUnit byUnit;
+
+  /**
+   * set original format, if unit is NONE
+   */
+  @JsonIgnore
+  String originalFormat;
 
   @JsonCreator
   public ContinuousTimeFormat(@JsonProperty("discontinuous") Boolean discontinuous,
@@ -56,6 +63,10 @@ public class ContinuousTimeFormat extends TimeFieldFormat implements FieldFormat
 
   public ContinuousTimeFormat(Boolean discontinuous, String unit, String byUnit, String filteringType) {
     this(discontinuous, unit, byUnit, null, null, filteringType);
+  }
+
+  public void setOriginalFormat(String originalFormat) {
+    this.originalFormat = originalFormat;
   }
 
   public Boolean getDiscontinuous() {
@@ -85,12 +96,15 @@ public class ContinuousTimeFormat extends TimeFieldFormat implements FieldFormat
   @JsonIgnore
   @Override
   public String getFormat() {
+    if (unit == TimeUnit.NONE && StringUtils.isNotEmpty(originalFormat)) {
+      return originalFormat;
+    }
     return BooleanUtils.isTrue(discontinuous) ? unit.discontFormat(byUnit) : unit.format();
   }
 
   @Override
   public boolean enableSortField() {
-    return BooleanUtils.isFalse(discontinuous) && unit != TimeUnit.YEAR;
+    return BooleanUtils.isFalse(discontinuous) && (unit != TimeUnit.YEAR || unit != TimeUnit.NONE);
   }
 
   @Override

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/format/TimeFieldFormat.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/format/TimeFieldFormat.java
@@ -66,6 +66,11 @@ public abstract class TimeFieldFormat {
     this.filteringType = EnumUtils.getUpperCaseEnum(FilteringType.class, filteringType);
   }
 
+  public void setUTC() {
+    timeZone = "UTC";
+    locale = "en";
+  }
+
   public String selectTimezone() {
     if (DISABLE_TIMEZONE.equalsIgnoreCase(timeZone)) {
       return "UTC";

--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/AbstractQueryBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/AbstractQueryBuilder.java
@@ -79,6 +79,7 @@ import app.metatron.discovery.domain.workbook.configurations.field.MapField;
 import app.metatron.discovery.domain.workbook.configurations.field.MeasureField;
 import app.metatron.discovery.domain.workbook.configurations.field.UserDefinedField;
 import app.metatron.discovery.domain.workbook.configurations.filter.*;
+import app.metatron.discovery.domain.workbook.configurations.format.ContinuousTimeFormat;
 import app.metatron.discovery.domain.workbook.configurations.format.TimeFieldFormat;
 import app.metatron.discovery.domain.workbook.configurations.format.UnixTimeFormat;
 import app.metatron.discovery.domain.workbook.configurations.widget.shelf.MapViewLayer;
@@ -406,6 +407,12 @@ public abstract class AbstractQueryBuilder {
                                           timeFormat.getLocale());
 
     } else {
+      if (timeFormat instanceof ContinuousTimeFormat
+          && ((ContinuousTimeFormat) timeFormat).getUnit() == TimeFieldFormat.TimeUnit.NONE) {
+        // convert original time format, if unit is NONE
+        ((ContinuousTimeFormat) timeFormat).setOriginalFormat(originalTimeFormat.getFormat());
+      }
+
       timeFormatFunc = new TimeFormatFunc("\"" + fieldName + "\"",
                                           originalTimeFormat.getFormat(),
                                           originalTimeFormat.selectTimezone(),

--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/queries/GroupByQueryBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/queries/GroupByQueryBuilder.java
@@ -256,6 +256,11 @@ public class GroupByQueryBuilder extends AbstractQueryBuilder {
             TimeFieldFormat originalTimeFormat = (TimeFieldFormat) datasourceField.getFormatObject();
             TimeFieldFormat timeFormat = (TimeFieldFormat) format;
 
+            if (datasourceField.backwardTime()) {
+              originalTimeFormat.setUTC();
+              timeFormat.setUTC();
+            }
+
             // set time format using function
             String innerFieldName = aliasName + Query.POSTFIX_INNER_FIELD;
 
@@ -319,8 +324,18 @@ public class GroupByQueryBuilder extends AbstractQueryBuilder {
 
       } else if (field instanceof TimestampField) {
 
+        app.metatron.discovery.domain.datasource.Field datasourceField = this.metaFieldMap.get(fieldName);
+        TimeFieldFormat originalTimeFormat = (TimeFieldFormat) datasourceField.getFormatObject();
+
         TimestampField timestampField = (TimestampField) field;
         TimeFieldFormat timeFormat = (TimeFieldFormat) timestampField.getFormat();
+        if (timeFormat == null) {
+          timeFormat = originalTimeFormat;
+        }
+
+        if (datasourceField.backwardTime()) {
+          timeFormat.setUTC();
+        }
 
         // set time format using function
         String innerFieldName = aliasName + Query.POSTFIX_INNER_FIELD;

--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/queries/SelectQueryBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/queries/SelectQueryBuilder.java
@@ -188,6 +188,11 @@ public class SelectQueryBuilder extends AbstractQueryBuilder {
               TimeFieldFormat originalTimeFormat = (TimeFieldFormat) originalFormat;
               TimeFieldFormat timeFormat = (TimeFieldFormat) format;
 
+              if (datasourceField.backwardTime()) {
+                originalTimeFormat.setUTC();
+                timeFormat.setUTC();
+              }
+
               TimeFormatFunc timeFormatFunc = createTimeFormatFunc(fieldName, originalTimeFormat, timeFormat);
 
               dimensions.add(new ExpressionDimension(aliasName, timeFormatFunc.toExpression()));
@@ -222,6 +227,10 @@ public class SelectQueryBuilder extends AbstractQueryBuilder {
         TimeFieldFormat timeFormat = (TimeFieldFormat) timestampField.getFormat();
         if (timeFormat == null) {
           timeFormat = originalTimeFormat;
+        }
+
+        if (datasourceField.backwardTime()) {
+          timeFormat.setUTC();
         }
 
         TimeFormatFunc timeFormatFunc = new TimeFormatFunc(timestampField.getPredefinedColumn(dataSource instanceof MappingDataSource),


### PR DESCRIPTION
### Description
fix error display time due to processing time zone (backward compatibility for changing time format)

**Related Issue** : #1660 

### How Has This Been Tested?
1. ingestion from spec([sample_datehour_ingestion_spec.json.txt](https://github.com/metatron-app/metatron-discovery/files/2968987/sample_datehour_ingestion_spec.json.txt)) and orignal file([sample_ingestion_datehour.csv.txt](https://github.com/metatron-app/metatron-discovery/files/2968984/sample_ingestion_datehour.csv.txt))
2. Check whether creating datasource on coodinator console (named by test_datehour_datasource)
3. Create datasource from "metatron Engine"  (find "test_datehour_datasource")
4. Create workbook, dashboard linked  "test_datehour_datasource", create chart
5. Make sure it appears the same as the original time value  

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
