### PR TITLE
#1638 save scroll position in rename

### DIFF
--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/multiple-rename-popup.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/multiple-rename-popup.component.ts
@@ -26,7 +26,6 @@ import {AbstractComponent} from "../../../../../common/component/abstract.compon
 import {header, SlickGridHeader} from "../../../../../common/component/grid/grid.header";
 import {Field} from "../../../../../domain/data-preparation/pr-dataset";
 import {GridOption} from "../../../../../common/component/grid/grid.option";
-import {GridComponent} from "../../../../../common/component/grid/grid.component";
 import {ScrollLoadingGridComponent} from "./edit-rule-grid/scroll-loading-grid.component";
 import {ScrollLoadingGridModel} from "./edit-rule-grid/scroll-loading-grid.model";
 import {isNullOrUndefined} from "util";
@@ -43,9 +42,6 @@ export class MultipleRenamePopupComponent extends AbstractComponent implements O
   |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
   @Output()
   private renameMultiColumns = new EventEmitter();
-
-  @ViewChild(GridComponent)
-  private gridComponent: GridComponent;
 
   @ViewChild(ScrollLoadingGridComponent)
   private _gridComp: ScrollLoadingGridComponent;
@@ -72,6 +68,10 @@ export class MultipleRenamePopupComponent extends AbstractComponent implements O
   public currentIdx: number;
 
   public typeDesc: any;
+
+  private _$gridElm: any;
+
+  private _savedViewPort: { top: number, left: number };
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
   | Constructor
@@ -343,8 +343,11 @@ export class MultipleRenamePopupComponent extends AbstractComponent implements O
         column.isEditing = false;
       }
 
+      this._savePosition();
       // 그리드 업데이트
       this._updateGrid(this.gridData.fields, this.gridData.data);
+
+      this._moveToSavedPosition();
     }
 
   }
@@ -464,6 +467,8 @@ export class MultipleRenamePopupComponent extends AbstractComponent implements O
       0,
       0
     );
+
+    this._$gridElm = this._gridComp.getGridJQueryObject();
   }
 
 
@@ -544,6 +549,26 @@ export class MultipleRenamePopupComponent extends AbstractComponent implements O
     return strFormatVal;
   } // function - _setFieldFormatter
 
+
+  /**
+   * Save scroll position
+   */
+  private _savePosition() {
+    const viewPort = this._$gridElm.find('.slick-viewport').get(0);
+    this._savedViewPort = {
+      top: viewPort.scrollTop,
+      left: viewPort.scrollLeft
+    };
+  }
+
+  /**
+   * Move to saved scroll position
+   */
+  public _moveToSavedPosition() {
+    const $viewPort = this._$gridElm.find('.slick-viewport');
+    $viewPort.scrollTop(this._savedViewPort.top);
+    $viewPort.scrollLeft(this._savedViewPort.left);
+  }
 
 
 }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Save scroll position when grid changes

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#1638 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1 . Use dataset with more than 20 columns
2. Go to dataflow main grid
3. Open multi column rename popup
4. 
![image](https://user-images.githubusercontent.com/42233517/54400893-661d0880-4708-11e9-9490-c1d65e806910.png)

5 . Check if scroll position is saved even after grid is reloaded.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
