### PR TITLE
Fix setting parameter name (timezone -> timeZone)

### DIFF
--- a/discovery-frontend/src/app/common/component/chart/type/label-chart/label-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/label-chart/label-chart.component.ts
@@ -17,32 +17,46 @@
  */
 
 import {
-  AfterViewInit, Component, ElementRef, Injector, OnInit, OnDestroy, HostListener,
-  ViewChild, Input
+  AfterViewInit,
+  Component,
+  ElementRef,
+  HostListener,
+  Injector,
+  Input,
+  OnDestroy,
+  OnInit,
+  ViewChild
 } from '@angular/core';
-import { BaseChart } from '../../base-chart';
+import {BaseChart} from '../../base-chart';
 import {BaseOption} from "../../option/base-option";
 import {
-  ChartType, ShelveType, ShelveFieldType, LabelLayoutType, LabelSecondaryIndicatorMarkType, LabelSecondaryIndicatorType,
-  LabelSecondaryIndicatorPeriod
+  ChartType,
+  LabelLayoutType,
+  LabelSecondaryIndicatorMarkType,
+  LabelSecondaryIndicatorPeriod,
+  LabelSecondaryIndicatorType,
+  ShelveFieldType,
+  ShelveType
 } from '../../option/define/common';
 import {OptionGenerator} from '../../option/util/option-generator';
 import {Pivot} from "../../../../../domain/workbook/configurations/pivot";
 import * as _ from 'lodash';
 import {UIChartFormatItem} from '../../option/ui-option';
-import UI = OptionGenerator.UI;
 import {FormatOptionConverter} from "../../option/converter/format-option-converter";
 import {
-  UILabelChart, UILabelChartSeries, UILabelIcon, UILabelAnnotation,
+  UILabelAnnotation,
+  UILabelChart,
+  UILabelChartSeries,
+  UILabelIcon,
   UILabelSecondaryIndicator
 } from "../../option/ui-option/ui-label-chart";
 import {DatasourceService} from "../../../../../datasource/service/datasource.service";
 import {TimeCompareRequest} from "../../../../../domain/datasource/data/time-compare-request";
 import {SearchQueryRequest} from "../../../../../domain/datasource/data/search-query-request";
 import {PageWidget} from "../../../../../domain/dashboard/widget/page-widget";
-import {FieldRole, LogicalType, Field} from "../../../../../domain/datasource/datasource";
-import { Field as AbstractField } from '../../../../../domain/workbook/configurations/field/field';
-import {TimestampField, GranularityType} from "../../../../../domain/workbook/configurations/field/timestamp-field";
+import {Field, FieldRole, LogicalType} from "../../../../../domain/datasource/datasource";
+import {Field as AbstractField} from '../../../../../domain/workbook/configurations/field/field';
+import {TimestampField} from "../../../../../domain/workbook/configurations/field/timestamp-field";
 
 export class KPI {
   public show: boolean;
@@ -642,7 +656,7 @@ export class LabelChartComponent extends BaseChart implements OnInit, OnDestroy,
         query.measures = measures;
         query.timeUnit = String(option.secondaryIndicators[num].rangeUnit);
         query.value = 1;
-        query.timezone = "Asia/Seoul";
+        query.timeZone = "Asia/Seoul";
 
         //////////////////////////////
         // 데이터 조회

--- a/discovery-frontend/src/app/dashboard/util/filter.util.ts
+++ b/discovery-frontend/src/app/dashboard/util/filter.util.ts
@@ -28,7 +28,10 @@ import {
   MeasurePositionFilter,
   PositionType
 } from '../../domain/workbook/configurations/filter/measure-position-filter';
-import {ContainsType, WildCardFilter} from '../../domain/workbook/configurations/filter/wild-card-filter';
+import {
+  ContainsType,
+  WildCardFilter
+} from '../../domain/workbook/configurations/filter/wild-card-filter';
 import {Datasource, Field} from '../../domain/datasource/datasource';
 import {BoardDataSource, Dashboard} from '../../domain/dashboard/dashboard';
 import {Filter} from '../../domain/workbook/configurations/filter/filter';
@@ -312,9 +315,9 @@ export class FilterUtil {
     else if (FilterUtil.isTimeRelativeFilter(filter)) {
       const timeRelativeFilter: TimeRelativeFilter = <TimeRelativeFilter>filter;
       if (timeRelativeFilter.clzField && timeRelativeFilter.clzField.format && TimezoneService.DISABLE_TIMEZONE_KEY === timeRelativeFilter.clzField.format.timeZone) {
-        delete timeRelativeFilter.timezone;
+        delete timeRelativeFilter.timeZone;
       } else {
-        (timeRelativeFilter.timezone) || (timeRelativeFilter.timezone = moment.tz.guess());
+        (timeRelativeFilter.timeZone) || (timeRelativeFilter.timeZone = moment.tz.guess());
       }
     } // end if - time_relative
 
@@ -322,7 +325,7 @@ export class FilterUtil {
     let keyMap: string[];
     switch (filter.type) {
       case 'interval' :
-        keyMap = ['selector', 'startDate', 'endDate', 'intervals', 'timezone',
+        keyMap = ['selector', 'startDate', 'endDate', 'intervals', 'timeZone',
           'locale', 'format', 'rrule', 'relValue', 'timeUnit'];
         break;
       case 'include' :
@@ -338,7 +341,7 @@ export class FilterUtil {
         keyMap = [];
         break;
       case 'time_relative' :
-        keyMap = ['relTimeUnit', 'tense', 'value', 'timeUnit', 'byTimeUnit', 'discontinuous', 'timezone'];
+        keyMap = ['relTimeUnit', 'tense', 'value', 'timeUnit', 'byTimeUnit', 'discontinuous', 'timeZone'];
         break;
       case 'time_range' :
         keyMap = ['intervals', 'timeUnit', 'byTimeUnit', 'discontinuous'];
@@ -398,9 +401,9 @@ export class FilterUtil {
     else if (FilterUtil.isTimeRelativeFilter(filter)) {
       const timeRelativeFilter: TimeRelativeFilter = <TimeRelativeFilter>filter;
       if (timeRelativeFilter.clzField && timeRelativeFilter.clzField.format && TimezoneService.DISABLE_TIMEZONE_KEY === timeRelativeFilter.clzField.format.timeZone) {
-        delete timeRelativeFilter.timezone;
+        delete timeRelativeFilter.timeZone;
       } else {
-        (timeRelativeFilter.timezone) || (timeRelativeFilter.timezone = moment.tz.guess());
+        (timeRelativeFilter.timeZone) || (timeRelativeFilter.timeZone = moment.tz.guess());
       }
     } // end if - time_relative
 
@@ -408,7 +411,7 @@ export class FilterUtil {
     let keyMap: string[];
     switch (filter.type) {
       case 'interval' :
-        keyMap = ['selector', 'startDate', 'endDate', 'intervals', 'timezone',
+        keyMap = ['selector', 'startDate', 'endDate', 'intervals', 'timeZone',
           'locale', 'format', 'rrule', 'relValue', 'timeUnitUI', 'timeUnit', 'byTimeUnit',
           'minTime', 'maxTime', 'valueList', 'candidateValues', 'discontinuous', 'granularity'];
         break;
@@ -425,7 +428,7 @@ export class FilterUtil {
         keyMap = [];
         break;
       case 'time_relative' :
-        keyMap = ['relTimeUnit', 'tense', 'value', 'timeUnit', 'byTimeUnit', 'discontinuous', 'timezone'];
+        keyMap = ['relTimeUnit', 'tense', 'value', 'timeUnit', 'byTimeUnit', 'discontinuous', 'timeZone'];
         break;
       case 'time_range' :
         keyMap = ['intervals', 'timeUnit', 'byTimeUnit', 'discontinuous'];

--- a/discovery-frontend/src/app/domain/datasource/data/time-compare-request.ts
+++ b/discovery-frontend/src/app/domain/datasource/data/time-compare-request.ts
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-import { Field } from '../../workbook/configurations/field/field';
+import {Field} from '../../workbook/configurations/field/field';
 import {SearchQueryRequest} from "./search-query-request";
 
 export class TimeCompareRequest extends SearchQueryRequest {
@@ -40,6 +40,6 @@ export class TimeCompareRequest extends SearchQueryRequest {
   /**
    * UI 상 타입존 지정
    */
-  timezone: string;
+  timeZone: string;
 
 }

--- a/discovery-frontend/src/app/domain/workbook/configurations/filter/time-relative-filter.ts
+++ b/discovery-frontend/src/app/domain/workbook/configurations/filter/time-relative-filter.ts
@@ -13,9 +13,9 @@
  */
 
 import * as _ from 'lodash';
-import { TimeFilter } from './time-filter';
-import { Field } from '../../../datasource/datasource';
-import { TimeUnit } from '../field/timestamp-field';
+import {TimeFilter} from './time-filter';
+import {Field} from '../../../datasource/datasource';
+import {TimeUnit} from '../field/timestamp-field';
 
 declare let moment : any;
 
@@ -24,12 +24,12 @@ export class TimeRelativeFilter extends TimeFilter {
   public tense: TimeRelativeTense;
   public relTimeUnit: TimeUnit;
   public value: number;
-  public timezone: string;
+  public timeZone: string;
 
   constructor(field: Field) {
     super(field);
     this.type = 'time_relative';
-    this.timezone = moment.tz.guess();
+    this.timeZone = moment.tz.guess();
   }
 
   public toServerSpec() {


### PR DESCRIPTION
### Description
relative filter 처리시 time zone 속성 명이 잘못 전달 되어 time zone 연산시 문제를 일으킵니다. 

**Related Issue** : #1660 


### How Has This Been Tested?
#1661 진행 후, 대시보드내 relative time filter 내 호출중 timeZone 값이 정상적으로 전달되는지 확인

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Additional Context<!-- if not appropriate, remove this topic. -->
