### PR TITLE
#1665 Remove alert when fetching staging db returns error

### DIFF
--- a/discovery-frontend/src/app/data-preparation/component/create-snapshot-popup.component.ts
+++ b/discovery-frontend/src/app/data-preparation/component/create-snapshot-popup.component.ts
@@ -39,6 +39,7 @@ export class CreateSnapshotPopup extends AbstractPopupComponent implements OnIni
    |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
   private uriFileFormat: UriFileFormat;
 
+  private _isDataprepStagingEnabled: boolean = true;
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Public Variables
    |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
@@ -321,7 +322,7 @@ export class CreateSnapshotPopup extends AbstractPopupComponent implements OnIni
    * Check if staging is enabled
    */
   public isStagingEnabled() :boolean {
-    return StorageService.isEnableStageDB
+    return StorageService.isEnableStageDB && this._isDataprepStagingEnabled
   }
 
 
@@ -493,15 +494,14 @@ export class CreateSnapshotPopup extends AbstractPopupComponent implements OnIni
    */
   private _getStagingDb() {
     this.dbList = [];
-    if (this.isStagingEnabled()) {
-      this._connectionService.getDatabaseForHive().then((data) => {
-        if (data['databases']) {
-          this.dbList = data['databases'];
-        }
-      }).catch((error) => {
-        this.commonExceptionHandler(error);
-      });
-    }
+    this._connectionService.getDatabaseForHive().then((data) => {
+      if (data['databases']) {
+        this.dbList = data['databases'];
+      }
+    }).catch((error) => {
+      console.info('error -> ', error);
+      this._isDataprepStagingEnabled = false;
+    });
   }
 
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Even when `/stagedb` returns Hive is configured,
`/connections/query/hive/databases` returns error.
When  `/connections/query/hive/databases` returns error do not show alerts, instead remove hive option from snapshot create popup

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#1665 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Check if hive option is removed from create snapshot popup when 
`/connections/query/hive/databases` returs error

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
