### PR TITLE
#1681 name after W.DS not I.DS

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/service/PrDataflowController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/service/PrDataflowController.java
@@ -371,7 +371,7 @@ public class PrDataflowController {
 
                     if (autoCreate) {
                         for (String newId : newIds) {
-                            PrepTransformResponse response = this.transformService.create(newId, dataflow.getDfId(), true);
+                            PrepTransformResponse response = this.transformService.create(newId, dataflow.getDfId(), null);
                         }
                     }
                 }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/service/PrDataflowService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/service/PrDataflowService.java
@@ -50,7 +50,7 @@ public class PrDataflowService {
                 }
             }
             for(PrDataset dataset : importedDatasets) {
-                PrepTransformResponse response = this.transformService.create(dataset.getDsId(), dataflow.getDfId(), true);
+                PrepTransformResponse response = this.transformService.create(dataset.getDsId(), dataflow.getDfId(), null);
             }
         } catch (Exception e) {
             LOGGER.error("afterCreate(): caught an exception: ", e);

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformController.java
@@ -55,7 +55,7 @@ public class PrepTransformController {
     LOGGER.trace("create(): start");
 
     try {
-      response = transformService.create(importedDsId, request.getDfId(), true);
+      response = transformService.create(importedDsId, request.getDfId(), null);
     } catch (Exception e) {
       LOGGER.error("create(): caught an exception: ", e);
       throw PrepException.create(PrepErrorCodes.PREP_TRANSFORM_ERROR_CODE, e);


### PR DESCRIPTION
### Description
Currently, a cloned dataset is named after the upstream I.DS.
Now, it will be named after the W.DS that is being cloned.

**Related Issue** : https://github.com/metatron-app/metatron-discovery/issues/1681

### How Has This Been Tested?
1. Click a W.DS in the dataflow detail (chart) page.
2. Click the context menu on the right panel.
3. Clone
4. The new W.DS will be named as <W.DS> (1)
5. If the name exists, <W.DS> (2) will be.
6. If exists, then +1 (again & again)
7. TMI, 100,000 is the limit. Cloning will fail with assertion.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
