### PR TITLE
Fix field length in datasource create snapshot preview 

### DIFF
--- a/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/snapshot-source/snapshot-preview.component.html
+++ b/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/snapshot-source/snapshot-preview.component.html
@@ -64,7 +64,7 @@
         {{'msg.storage.ui.dsource.preview.summary' | translate}}
       </dt>
       <dd>
-        {{sourceData.fieldData.length}} {{'msg.comm.detail.rows' | translate}} <br/>
+        {{snapshotData.totalLines || 0}} {{'msg.comm.detail.rows' | translate}} <br/>
         {{sourceData.fieldList.length}} {{'msg.comm.detail.columns' | translate}}
       </dd>
     </dl>


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
데이터소스 생성 화면에서 스냅샷 미리보기의 row 수가 제대로 표시되지 않던현상 수정

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
통합테스트

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 데이터소스 생성 > 스냅샷으로 생성
2. row가 10000건이 넘어가는 스냅샷 선택
3. 우측에 열리는 preview에서 row수가 올바르게 표시되는지 확인

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project. _it will be added soon_
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
