### PR TITLE
#1717 Fix ruleIdx when sending rename transform api

### DIFF
--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/multiple-rename-popup.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/multiple-rename-popup.component.ts
@@ -127,7 +127,7 @@ export class MultipleRenamePopupComponent extends AbstractComponent implements O
         this.gridData.data = this.gridData.data.splice(0,50);
         this.typeDesc = result.gridResponse.colDescs;
         this._setColumns(this.gridData.fields);
-        this.currentIdx = result.transformRules.length + 1;
+        this.currentIdx = result.transformRules.length-1;
 
         // open popup
         this.isPopupOpen = true;
@@ -135,7 +135,6 @@ export class MultipleRenamePopupComponent extends AbstractComponent implements O
         // Grid component is undefined;
         this.safelyDetectChanges();
         this._updateGrid(this.gridData.fields, this.gridData.data);
-
 
 
       })
@@ -321,12 +320,6 @@ export class MultipleRenamePopupComponent extends AbstractComponent implements O
       }
     });
 
-
-    // close popup
-    this.isPopupOpen = false;
-    this.subTitle = '';
-    this.indexForName = 1;
-
     let param = null;
 
     if (originals.length > 0) {
@@ -342,6 +335,11 @@ export class MultipleRenamePopupComponent extends AbstractComponent implements O
       }
 
     }
+
+    // close popup
+    this.isPopupOpen = false;
+    this.subTitle = '';
+    this.indexForName = 1;
 
     // If nothing is changed, returns null
     this.renameMultiColumns.emit(param);


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
When rename popup is opened via snapshot create popup and is in edit mode
transform API is failed due to wrong ruleIdx.

룰을 수정하는 중에 스냅샷 생성 팝업에서 Rename을 하려고 하면 ruleIdx가 틀려서 룰이 적용되지 않음

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#1717 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Check #1717 for details.
1 . Go to dataflow main grid
2 . Add at least 3 ~ 5 rules. (any)
3 . Change one column to '컬럼1'
4 . 
![image](https://user-images.githubusercontent.com/42233517/54901203-14029100-4f19-11e9-92a0-fcab98252a90.png)
5 . Rename rule should be applied at the end of the rule. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
