### PR TITLE
#1735 create new directory without schema problem

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetFileService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetFileService.java
@@ -182,13 +182,54 @@ public class PrepDatasetFileService {
 
     private String prefixColumnName = "column";
 
+    private void mkdirsIfNotExist(String dirUri) {
+        boolean result = false;
+
+        URI uri = null;
+        try {
+            uri = new URI(dirUri);
+        } catch (URISyntaxException e) {
+            e.printStackTrace();
+            throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_MALFORMED_URI_SYNTAX, dirUri);
+        }
+
+        switch (uri.getScheme()) {
+            case "hdfs":
+                Configuration conf = PrepUtil.getHadoopConf(prepProperties.getHadoopConfDir(true));
+                if (conf == null) {
+                    throw PrepException.create(PrepErrorCodes.PREP_INVALID_CONFIG_CODE, PrepMessageKey.MSG_DP_ALERT_REQUIRED_PROPERTY_MISSING, HADOOP_CONF_DIR);
+                }
+                Path path = new Path(uri);
+
+                FileSystem hdfsFs = null;
+                try {
+                    hdfsFs = FileSystem.get(conf);
+                    if (!hdfsFs.exists(path)) {
+                        result = hdfsFs.mkdirs(path);
+                    }
+                    hdfsFs.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                    throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_CANNOT_GET_HDFS_FILE_SYSTEM, dirUri);
+                }
+                break;
+
+            case "file":
+                File file = new File(uri);
+                if(!file.exists()){
+                    file.mkdirs();
+                }
+                break;
+
+            default:
+                throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_UNSUPPORTED_URI_SCHEME, dirUri);
+        }
+    }
+
     private String getPathS3Base(String filename) {
         if(null==fileDatasetUploadS3Path) {
             fileDatasetUploadS3Path = prepProperties.getS3BaseDir(true) + File.separator + PrepProperties.dirUpload;
-            File tempPath = new File(fileDatasetUploadS3Path);
-            if(!tempPath.exists()){
-                tempPath.mkdirs();
-            }
+            mkdirsIfNotExist(fileDatasetUploadS3Path);
         }
 
         String pathStr = fileDatasetUploadS3Path + File.separator + filename;
@@ -198,11 +239,8 @@ public class PrepDatasetFileService {
     private String getPathStagingBase(String filename) {
         if(null==fileDatasetUploadStagingPath) {
             fileDatasetUploadStagingPath = prepProperties.getStagingBaseDir(true) + File.separator + PrepProperties.dirUpload;
-            File tempPath = new File(fileDatasetUploadStagingPath);
-            if(!tempPath.exists()){
-                tempPath.mkdirs();
-            }
         }
+        mkdirsIfNotExist(fileDatasetUploadStagingPath);
 
         String pathStr = fileDatasetUploadStagingPath + File.separator + filename;
         return pathStr;
@@ -214,10 +252,13 @@ public class PrepDatasetFileService {
             if(fileDatasetUploadLocalPath.startsWith("file://")==false) {
                 fileDatasetUploadLocalPath = "file://" + fileDatasetUploadLocalPath;
             }
+            mkdirsIfNotExist(fileDatasetUploadLocalPath);
+            /*
             File tempPath = new File(fileDatasetUploadLocalPath);
             if(!tempPath.exists()){
                 tempPath.mkdirs();
             }
+            */
         }
 
         String pathStr = fileDatasetUploadLocalPath + File.separator + filename;


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
if localBaseDir or stagingBaseDir is not exist
Invalid directory created because File url has not URI schema
So this has been replaced by a scheme-sensitive way

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
[#1735](https://github.com/metatron-app/metatron-discovery/issues/1735)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Set the nonexistent path to localBaseDir or stagingBaseDir
2. Start the server 
3. upload a file to the destination

'file:' or 'hdfs:' should not be created and file upload should succeed

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
