### PR TITLE
Fix some translations in dataprep

### DIFF
--- a/discovery-frontend/src/app/data-preparation/dataset/add-dataset-dataflow.component.html
+++ b/discovery-frontend/src/app/data-preparation/dataset/add-dataset-dataflow.component.html
@@ -14,7 +14,7 @@
 
     <div class="ddp-ui-popup-contents">
       <div class="ddp-data-dataset">
-        <span class="ddp-txt-label">Dataset:</span> {{datasetName}}
+        <span class="ddp-txt-label">{{'msg.comm.menu.manage.prep.set' | translate}}:</span> {{datasetName}}
       </div>
       <div class="ddp-ui-dataset-new">
 
@@ -45,8 +45,8 @@
                 </colgroup>
                 <thead>
                 <tr>
-                  <th (click)="changeOrder('dfName')">
-                    Name
+                  <th class="ddp-cursor" (click)="changeOrder('dfName')">
+                    {{'msg.comm.ui.name' | translate}}
                     <em class="ddp-icon-array-default2" *ngIf="selectedContentSort.key !== 'dfName' || selectedContentSort.sort === 'default'"></em>
                     <em class="ddp-icon-array-asc2" *ngIf="selectedContentSort.key === 'dfName' && selectedContentSort.sort === 'asc'"></em>
                     <em class="ddp-icon-array-des2" *ngIf="selectedContentSort.key === 'dfName' && selectedContentSort.sort === 'desc'"></em>
@@ -54,7 +54,7 @@
                   <th>
                     {{'msg.comm.menu.manage.prep.set' | translate}}
                   </th>
-                  <th (click)="changeOrder('modifiedTime')">
+                  <th class="ddp-cursor" (click)="changeOrder('modifiedTime')">
                     {{'msg.comm.ui.list.last' | translate}}
                     <em class="ddp-icon-array-default2" *ngIf="selectedContentSort.key !== 'modifiedTime' || selectedContentSort.sort === 'default'"></em>
                     <em class="ddp-icon-array-asc2" *ngIf="selectedContentSort.key === 'modifiedTime' && selectedContentSort.sort === 'asc'"></em>
@@ -79,11 +79,15 @@
                 <tr *ngFor="let item of dataflows" (click)="selectDataflow(item)" [ngClass]="{'ddp-selected': selectedDataflowId === item.dfId}">
 
                   <td>
-                    <div class=" ddp-txt-long">
+                    <div class=" ddp-txt-long" *ngIf="!item.dfDesc; else yesDfDesc">
                       {{item.dfName}}
-                      <span class="ddp-txt-colortype" *ngIf="item.dfDesc" title="{{item.dfDesc}}">- {{item.dfDesc}}</span>
-                      <em class="ddp-icon-global"></em>
                     </div>
+                    <ng-template #yesDfDesc>
+                      <div class=" ddp-txt-long" title="{{item.dfName}} - {{item.dfDesc}}">
+                        {{item.dfName}}
+                        <span class="ddp-txt-colortype">- {{item.dfDesc}}</span>
+                      </div>
+                    </ng-template>
                   </td>
                   <td>
                     <div class="ddp-wrap-detaildata">

--- a/discovery-frontend/src/app/data-preparation/dataset/add-dataset-dataflow.component.html
+++ b/discovery-frontend/src/app/data-preparation/dataset/add-dataset-dataflow.component.html
@@ -79,7 +79,7 @@
                 <tr *ngFor="let item of dataflows" (click)="selectDataflow(item)" [ngClass]="{'ddp-selected': selectedDataflowId === item.dfId}">
 
                   <td>
-                    <div class=" ddp-txt-long" *ngIf="!item.dfDesc; else yesDfDesc">
+                    <div class=" ddp-txt-long" title="{{item.dfName}}" *ngIf="!item.dfDesc; else yesDfDesc">
                       {{item.dfName}}
                     </div>
                     <ng-template #yesDfDesc>

--- a/discovery-frontend/src/app/data-preparation/dataset/add-dataset-dataflow.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataset/add-dataset-dataflow.component.ts
@@ -179,8 +179,8 @@ export class AddDatasetDataflowComponent extends AbstractComponent implements On
   public getDataflowLength() {
 
     let result : number = 0;
-    if (this.dataflows) {
-      result = this.dataflows.length;
+    if (this.pageResult) {
+      result = this.pageResult.totalElements;
     }
     return result;
   }

--- a/discovery-frontend/src/app/data-preparation/dataset/dataset-detail.component.html
+++ b/discovery-frontend/src/app/data-preparation/dataset/dataset-detail.component.html
@@ -199,9 +199,15 @@
             </div>
             <!-- //data -->
             <!-- 플로우 설명 이름 -->
-            <div class="ddp-wrap-detailname">
-              <span class="ddp-data-detailname">{{item.dfName}}</span> <span class="ddp-data-summary" *ngIf="item.dfDesc">- {{item.dfDesc}}</span>
+            <div class="ddp-wrap-detailname" *ngIf="!item.dfDesc; else yesDfDesc" title="{{item.dfName}}">
+              <span class="ddp-data-detailname">{{item.dfName}}</span>
             </div>
+            <ng-template #yesDfDesc>
+              <div class="ddp-wrap-detailname" title="{{item.dfName}} - {{item.dfDesc}}">
+                <span class="ddp-data-detailname">{{item.dfName}}</span>
+                <span class="ddp-data-summary">- {{item.dfDesc}}</span>
+              </div>
+            </ng-template>
             <!-- //플로우 설명 이름 -->
           </li>
         </ul>

--- a/discovery-frontend/src/assets/css/metatron/popup/metatron.popup.99Preperation_dataset.css
+++ b/discovery-frontend/src/assets/css/metatron/popup/metatron.popup.99Preperation_dataset.css
@@ -7,7 +7,7 @@
 .popup-prep-dataset .ddp-ui-popup-contents {padding-top:170px;}
 .popup-prep-dataset .ddp-ui-dataset-new .ddp-wrap-viewtable {bottom:33px;}
 .popup-prep-dataset .ddp-type-top-option .ddp-ui-rightoption .ddp-data-total {position:relative; top:6px;}
-.popup-prep-dataset .ddp-ui-popup-contents .ddp-data-dataset {position:absolute; top:104px; left:50px; right:50px; padding:15px 20px; background-color:#f6f6f7; font-size:14px; color:#35393f;}
+.popup-prep-dataset .ddp-ui-popup-contents .ddp-data-dataset {position:absolute; top:104px; left:50px; right:50px; padding:15px 20px; background-color:#f6f6f7; font-size:14px; color:#35393f; white-space:nowrap; text-overflow:ellipsis; overflow:hidden;}
 .popup-prep-dataset .ddp-ui-popup-contents .ddp-data-dataset .ddp-txt-label {color:#90969f; font-size:14px;}
 /**************************************************************
   popup : 99_데이터프리퍼레이션_02데이터셋_01생성완료_popup

--- a/discovery-frontend/src/assets/css/polaris.v2.component.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.component.css
@@ -521,11 +521,11 @@ ul.ddp-list-typebasic.ddp-view li.ddp-selected a .ddp-icon-plus {display:block;}
 .ddp-cursor {cursor: pointer;}
 .ddp-mgb20 {margin-bottom:20px !important;}
 .ddp-mgl10 {margin-left:10px !important;}
-.ddp-index { position: fixed; left: 0; right: 0;  bottom: 0; top: 0; z-index: 9999;}
+.ddp-index {position: fixed; left: 0; right: 0;  bottom: 0; top: 0; z-index: 9999;}
 .ddp-show {display:block !important;}
 .ddp-none {display:none !important;}
 .ddp-border-none {border:none !important;}
-
+.ddp-txt-ellipsis {white-space:nowrap; text-overflow:ellipsis; overflow:hidden;}
 .ddp-null {color:#b8bac2 !important;font-style:italic !important;}
 .ddp-null * {color:#b8bac2 !important; font-style:italic !important;;}
 .ddp-empty {background:blue !important; opacity:0.2 !important;}

--- a/discovery-frontend/src/assets/i18n/ko.json
+++ b/discovery-frontend/src/assets/i18n/ko.json
@@ -1333,7 +1333,7 @@
   "msg.dp.alert.no.backtick.colname": "컬럼 이름에 back quote를 사용할 수 없습니다.",
   "msg.dp.alert.duplicate.colname" : "이미 사용중입니다",
   "msg.dp.alert.empty.column" : "컬럼 이름을 입력하세요",
-  "msg.dp.ui.list.my.file": "파일",
+  "msg.dp.ui.list.my.file": "My file",
   "msg.dp.th.sheet.name" : "시트 이름",
   "msg.dp.alert.dataset.fail.to.create" : "데이터셋 생성 실패",
   "msg.dp.alert.num.fail.dataset" : "{{value}}개의 데이터셋 생성이 실패하였습니다",


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Some words are not translated in korean.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
No issue

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1 . Go to dataset list
2 . Click one dataset
3 . Click add `Add to existing dataflow`
![image](https://user-images.githubusercontent.com/42233517/55052181-548a1800-509b-11e9-8784-bbafaaec7b8b.png)
4. Check if name and dataset is translated properly

------ 
1 . Change browser setting to korean
2. Go to dataset list -> click new dataset -> check if 파일 is changed to  My file
![image](https://user-images.githubusercontent.com/42233517/55052271-a632a280-509b-11e9-802e-80ff2e259270.png)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
