### PR TITLE
Fix datasource setter when engine's granulraity is set NONE or null

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourceService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourceService.java
@@ -132,10 +132,10 @@ public class DataSourceService {
     dataSource.setConnType(DataSource.ConnectionType.ENGINE);
     dataSource.setDsType(DataSource.DataSourceType.MASTER);
 
-    dataSource.setGranularity(segmentMetaData.getQueryGranularity() == null ? DataSource.GranularityType.NONE
+    dataSource.setGranularity(isEmptyGranularity(segmentMetaData.getQueryGranularity())? DataSource.GranularityType.NONE
         : getGranularityType(segmentMetaData.getQueryGranularity()));
 
-    dataSource.setSegGranularity(segmentMetaData.getSegmentGranularity() == null ? DataSource.GranularityType.DAY
+    dataSource.setSegGranularity(isEmptyGranularity(segmentMetaData.getSegmentGranularity()) ? DataSource.GranularityType.DAY
         : getGranularityType(segmentMetaData.getSegmentGranularity()));
 
     dataSource.setStatus(DataSource.Status.ENABLED);
@@ -146,6 +146,16 @@ public class DataSourceService {
     metadataService.saveFromDataSource(importedDataSource);
 
     return importedDataSource;
+  }
+
+  private boolean isEmptyGranularity(Granularity granularity) {
+    if (granularity == null) {
+      return true;
+    } else if (granularity instanceof SimpleGranularity && ((SimpleGranularity) granularity).getValue() == null) {
+      return true;
+    } else {
+      return false;
+    }
   }
 
   public DataSource.GranularityType getGranularityType(Granularity granularity) {

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/datasource/DataSourceServiceTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/datasource/DataSourceServiceTest.java
@@ -19,13 +19,20 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.jdbc.Sql;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.List;
 
 import app.metatron.discovery.AbstractIntegrationTest;
 import app.metatron.discovery.common.GlobalObjectMapper;
+import app.metatron.discovery.domain.engine.model.SegmentMetaDataResponse;
 import app.metatron.discovery.domain.workbook.configurations.filter.Filter;
 import app.metatron.discovery.domain.workbook.configurations.filter.InclusionFilter;
 import app.metatron.discovery.domain.workbook.configurations.filter.IntervalFilter;
+import app.metatron.discovery.query.druid.Granularity;
+import app.metatron.discovery.query.druid.granularities.SimpleGranularity;
+
+import static org.junit.Assert.assertTrue;
 
 public class DataSourceServiceTest extends AbstractIntegrationTest {
 
@@ -94,6 +101,21 @@ public class DataSourceServiceTest extends AbstractIntegrationTest {
     System.out.println(dataSourceService.getMatchedTemporaries(dataSourceId, combineFilters));
 
 
+  }
+
+  @Test
+  public void getEmptyGranularityTest() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+
+    DataSourceService dsService = new DataSourceService();
+
+    SegmentMetaDataResponse segmentMetaData = new SegmentMetaDataResponse();
+    segmentMetaData.setQueryGranularity(new SimpleGranularity(null));
+
+    Method isEmptyGranularity = dsService.getClass().getDeclaredMethod("isEmptyGranularity", Granularity.class);
+    isEmptyGranularity.setAccessible(true);
+
+    boolean result = (Boolean) isEmptyGranularity.invoke(dsService, segmentMetaData.getQueryGranularity());
+    assertTrue(result);
   }
 
 }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Can not set a NONE granularity when importing a datasource from druid (not through metatron discovery).


**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#1760 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

1. I've added a unit test for null granularity

2. For manual testing,
2-1. Create a datasource with NONE granularity into druid (not through metatron discovery)
```
"granularitySpec": {
        "type": "uniform",
        "segmentGranularity": "HOUR",
        "queryGranularity": "NONE",
        "intervals": [
          "2018-09-24/2019-03-25"
        ]
      }
```
2-2. Import the above datasource into metatron discovery.
2-3. Imported successfully.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)