### PR TITLE
add my shared workspace to data connection filter

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/DataConnectionFilterService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/DataConnectionFilterService.java
@@ -221,7 +221,7 @@ public class DataConnectionFilterService {
 
         //my public workspace
         List<Workspace> publicWorkspaces
-                = workspaceService.getPublicWorkspaces(false, false, false, null);
+                = workspaceService.getPublicWorkspaces(false, null, false, null);
         for(Workspace workspace : publicWorkspaces){
           criterion.addFilter(new ListFilter(criterionKey, "workspace",
                   workspace.getId(), workspace.getName()));

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/DataConnectionFilterService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/DataConnectionFilterService.java
@@ -212,6 +212,7 @@ public class DataConnectionFilterService {
         //allow search
         criterion.setSearchable(true);
 
+        //published workspace
         criterion.addFilter(new ListFilter(criterionKey, "published", "true", "msg.storage.ui.criterion.open-data"));
 
         //my private workspace
@@ -219,10 +220,18 @@ public class DataConnectionFilterService {
         criterion.addFilter(new ListFilter(criterionKey, "workspace",
                 myWorkspace.getId(), myWorkspace.getName()));
 
-        //my public workspace
-        List<Workspace> publicWorkspaces
-                = workspaceService.getPublicWorkspaces(false, null, false, null);
-        for(Workspace workspace : publicWorkspaces){
+        //owner public workspace not published
+        List<Workspace> ownerPublicWorkspaces
+            = workspaceService.getPublicWorkspaces(false, true, false, null);
+        for(Workspace workspace : ownerPublicWorkspaces){
+          criterion.addFilter(new ListFilter(criterionKey, "workspace",
+                                             workspace.getId(), workspace.getName()));
+        }
+
+        //member public workspace not published
+        List<Workspace> memberPublicWorkspaces
+                = workspaceService.getPublicWorkspaces(false, false, false, null);
+        for(Workspace workspace : memberPublicWorkspaces){
           criterion.addFilter(new ListFilter(criterionKey, "workspace",
                   workspace.getId(), workspace.getName()));
         }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourceService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourceService.java
@@ -437,7 +437,7 @@ public class DataSourceService {
 
         //my public workspace
         List<Workspace> publicWorkspaces
-            = workspaceService.getPublicWorkspaces(false, false, false, null);
+            = workspaceService.getPublicWorkspaces(false, null, false, null);
         for (Workspace workspace : publicWorkspaces) {
           criterion.addFilter(new ListFilter(criterionKey, "workspace",
                                              workspace.getId(), workspace.getName()));

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourceService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourceService.java
@@ -428,6 +428,7 @@ public class DataSourceService {
         //allow search
         criterion.setSearchable(true);
 
+        //published workspace
         criterion.addFilter(new ListFilter(criterionKey, "published", "true", "msg.storage.ui.criterion.open-data"));
 
         //my private workspace
@@ -435,10 +436,18 @@ public class DataSourceService {
         criterion.addFilter(new ListFilter(criterionKey, "workspace",
                                            myWorkspace.getId(), myWorkspace.getName()));
 
-        //my public workspace
-        List<Workspace> publicWorkspaces
-            = workspaceService.getPublicWorkspaces(false, null, false, null);
-        for (Workspace workspace : publicWorkspaces) {
+        //owner public workspace not published
+        List<Workspace> ownerPublicWorkspaces
+            = workspaceService.getPublicWorkspaces(false, true, false, null);
+        for(Workspace workspace : ownerPublicWorkspaces){
+          criterion.addFilter(new ListFilter(criterionKey, "workspace",
+                                             workspace.getId(), workspace.getName()));
+        }
+
+        //member public workspace not published
+        List<Workspace> memberPublicWorkspaces
+            = workspaceService.getPublicWorkspaces(false, false, false, null);
+        for (Workspace workspace : memberPublicWorkspaces) {
           criterion.addFilter(new ListFilter(criterionKey, "workspace",
                                              workspace.getId(), workspace.getName()));
         }


### PR DESCRIPTION
### Description
The data connection filter condition is missing a shared workspace that I am the owner

**Related Issue** : 

### How Has This Been Tested?
1. goto data connection
2. click publish filter dropdown.
3. see workspace that my shared workspace


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
