### PR TITLE
Extend the maximum number of csv file's columns

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/util/CsvProcessor.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/util/CsvProcessor.java
@@ -45,6 +45,7 @@ public class CsvProcessor {
   File targetFile;
 
   private static int MAX_HEADER_NAME = 50;
+  private static int MAX_CSV_COLUMNS = 2048;
 
   Integer csvMaxCharsPerColumn;
 
@@ -77,6 +78,7 @@ public class CsvProcessor {
     if(csvMaxCharsPerColumn != null && csvMaxCharsPerColumn > 0){
       settings.setMaxCharsPerColumn(csvMaxCharsPerColumn);
     }
+    settings.setMaxColumns(MAX_CSV_COLUMNS);
 
     RowListProcessor rowProcessor = new RowListProcessor();
     settings.setProcessor(rowProcessor);

--- a/discovery-server/src/main/java/app/metatron/discovery/util/csv/CsvTemplate.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/util/csv/CsvTemplate.java
@@ -28,6 +28,8 @@ public class CsvTemplate {
 
   Integer csvMaxCharsPerColumn;
 
+  private static int MAX_CSV_COLUMNS = 2048;
+
   public CsvTemplate(File targetFile) {
     this.targetFile = targetFile;
   }
@@ -47,6 +49,7 @@ public class CsvTemplate {
     if(csvMaxCharsPerColumn != null && csvMaxCharsPerColumn > 0){
       settings.setMaxCharsPerColumn(csvMaxCharsPerColumn);
     }
+    settings.setMaxColumns(MAX_CSV_COLUMNS);
 
     RowListProcessor rowProcessor = new RowListProcessor();
     settings.setProcessor(rowProcessor);


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Extend the number of csv file's columns. 
It is increased from 512 to 2048.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#1748 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Create a csv file with over 1000 columns
2. Go to 'Management' > 'Data storage' > 'Datasource' Menu and create a datasource with above csv file.
3. Datasource is created successfully.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Additional Context<!-- if not appropriate, remove this topic. -->
This is a first aid measure that discussed with mates.
**It is necessary to manage within the configuration** so will be cleared soon.