### PR TITLE
fix map chart error

### DIFF
--- a/discovery-frontend/src/app/common/component/chart/type/map-chart/map-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/map-chart/map-chart.component.ts
@@ -933,7 +933,7 @@ export class MapChartComponent extends BaseChart implements AfterViewInit {
     this.changeDetect.detectChanges();
 
     // Map data place fit
-    if ((this.drawByType == EventType.CHANGE_PIVOT && isLogicalType && this.shelf.layers[layerIndex].fields[this.shelf.layers[layerIndex].fields.length - 1].field.logicalType != null) && 'Infinity'.indexOf(source.getExtent()[0]) == -1 &&
+    if (( (this.drawByType == EventType.CHART_TYPE || this.drawByType == EventType.CHANGE_PIVOT) && isLogicalType && this.shelf.layers[layerIndex].fields[this.shelf.layers[layerIndex].fields.length - 1].field.logicalType != null) && 'Infinity'.indexOf(source.getExtent()[0]) == -1 &&
       (_.isUndefined(this.uiOption['layers'][layerIndex]['changeCoverage']) || this.uiOption['layers'][layerIndex]['changeCoverage'])) {
       this.olmap.getView().fit(source.getExtent());
     } else {

--- a/discovery-frontend/src/app/common/constant/common.constant.ts
+++ b/discovery-frontend/src/app/common/constant/common.constant.ts
@@ -76,4 +76,6 @@ export class CommonConstant {
 
   public static PROP_MAP_CONFIG:string = 'METATRON_PROP_MAP_CONFIG';
 
+  public static MAP_ANALYSIS_LAYER_NAME:string = 'SpatialAnalysisLayer';
+
 }

--- a/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
+++ b/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
@@ -70,6 +70,7 @@ import {GridOption} from "../../../common/component/grid/grid.option";
 import {Pivot} from "../../../domain/workbook/configurations/pivot";
 import {MapChartComponent} from '../../../common/component/chart/type/map-chart/map-chart.component';
 import {Shelf, ShelfLayers} from "../../../domain/workbook/configurations/shelf/shelf";
+import {CommonConstant} from "../../../common/constant/common.constant";
 
 declare let $;
 
@@ -740,17 +741,17 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
    */
   public getDataSourceName(): string {
     let strName: string = '';
-    if (this.widget ) {
-      const widgetConf:PageWidgetConfiguration = this.widget.configuration;
-      if( ChartType.MAP === widgetConf.chart.type && widgetConf.shelf.layers ) {
+    if (this.widget) {
+      const widgetConf: PageWidgetConfiguration = this.widget.configuration;
+      if (ChartType.MAP === widgetConf.chart.type && widgetConf.shelf.layers) {
         strName = widgetConf.shelf.layers.reduce((acc, currVal) => {
-          const dsInfo:Datasource = this.widget.dashBoard.dataSources.find( item => item.engineName === currVal.ref );
-          if( dsInfo ) {
-            acc = ( '' === acc ) ? acc + dsInfo.name : acc + ',' + dsInfo.name;
+          const dsInfo: Datasource = this.widget.dashBoard.dataSources.find(item => item.engineName === currVal.ref);
+          if (dsInfo) {
+            acc = ('' === acc) ? acc + dsInfo.name : acc + ',' + dsInfo.name;
           }
           return acc;
-        }, '' );
-      } else if( widgetConf.dataSource ) {
+        }, '');
+      } else if (widgetConf.dataSource) {
         const widgetDataSource: Datasource
           = DashboardUtil.getDataSourceFromBoardDataSource(this.widget.dashBoard, widgetConf.dataSource);
         (widgetDataSource) && (strName = widgetDataSource.name);
@@ -1211,7 +1212,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
    * @param {PageWidget} widget
    * @private
    */
-  private _setCommonConfig(widget : PageWidget ) {
+  private _setCommonConfig(widget: PageWidget) {
 
     this.isMissingDataSource = false;
 
@@ -1320,14 +1321,14 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
     }
 
     if (ChartType.MAP === this.widgetConfiguration.chart.type) {
-      let targetDs:Datasource;
-      if( 'multi' === boardConf.dataSource.type ) {
-        const targetBoardDs:BoardDataSource = boardConf.dataSource.dataSources.find( item => {
+      let targetDs: Datasource;
+      if ('multi' === boardConf.dataSource.type) {
+        const targetBoardDs: BoardDataSource = boardConf.dataSource.dataSources.find(item => {
           return item.engineName === this.widgetConfiguration.shelf.layers[0].ref
         });
-        targetDs = DashboardUtil.getDataSourceFromBoardDataSource( this.widget.dashBoard, targetBoardDs );
+        targetDs = DashboardUtil.getDataSourceFromBoardDataSource(this.widget.dashBoard, targetBoardDs);
       } else {
-        targetDs = DashboardUtil.getDataSourceFromBoardDataSource( this.widget.dashBoard, boardConf.dataSource );
+        targetDs = DashboardUtil.getDataSourceFromBoardDataSource(this.widget.dashBoard, boardConf.dataSource);
       }
 
       if (isNullOrUndefined(this.widgetConfiguration.chart['lowerCorner']) && targetDs.summary) {
@@ -1357,9 +1358,11 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
     const uiCloneQuery = _.cloneDeep(query);
 
     if (ChartType.MAP === this.widgetConfiguration.chart.type) {
-      if( this.widgetConfiguration.shelf.layers.some( layer => {
-        return isNullOrUndefined(this.widget.dashBoard.dataSources.find( item => item.engineName === layer.ref ));
-      }) ) {
+      if (this.widgetConfiguration.shelf.layers
+        .filter(layer => layer.name !== CommonConstant.MAP_ANALYSIS_LAYER_NAME)
+        .some(layer => {
+          return isNullOrUndefined(this.widget.dashBoard.dataSources.find(item => item.engineName === layer.ref));
+        })) {
         this.isMissingDataSource = true;
         this._showError({code: 'GB0000', details: this.translateService.instant('msg.board.error.missing-datasource')});
         this.updateComplete();
@@ -1502,7 +1505,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
   /**
    * 서버시에 필요없는 ui에서만 사용되는 파라미터 제거
    */
-  private _makeSearchQueryParam(cloneQuery) : SearchQueryRequest {
+  private _makeSearchQueryParam(cloneQuery): SearchQueryRequest {
 
     // 선반 데이터 설정
     for (let field of _.concat(cloneQuery.pivot.columns, cloneQuery.pivot.rows, cloneQuery.pivot.aggregations)) {
@@ -1580,7 +1583,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
    * @returns {string}
    * @private
    */
-  private _findParentWidgetId(widgetId :string, relations : DashboardPageRelation[]): string {
+  private _findParentWidgetId(widgetId: string, relations: DashboardPageRelation[]): string {
     let parentId: string = '';
 
     relations.some(item => {
@@ -1608,7 +1611,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
    * @return {string}
    * @private
    */
-  private _findChildWidgetIds(widgetId : string, relations : DashboardPageRelation[], isCollect : boolean = false ): string[] {
+  private _findChildWidgetIds(widgetId: string, relations: DashboardPageRelation[], isCollect: boolean = false): string[] {
     let childIds: string[] = [];
 
     relations.forEach(item => {
@@ -1633,14 +1636,14 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
    * 고급분석 예측선 활성화 여부 검사
    * @returns {boolean}
    */
-  private isAnalysisPredictionEnabled() : boolean {
+  private isAnalysisPredictionEnabled(): boolean {
     return !_.isUndefined(this.widgetConfiguration.analysis) && !_.isEmpty(this.widgetConfiguration.analysis);
   }
 
   /**
    * 고급분석 예측선을 사용안하는 경우 처리
    */
-  private predictionLineDisabled() : void {
+  private predictionLineDisabled(): void {
     this.chart.analysis = null;
     this.chart.resultData = this.resultData;
   }
@@ -1648,8 +1651,8 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
   /**
    * 고급분석 예측선 API 호출
    */
-  private getAnalysis() : void {
-    if (this.isAnalysisPredictionEnabled() ) {
+  private getAnalysis(): void {
+    if (this.isAnalysisPredictionEnabled()) {
       Promise
         .resolve()
         .then(() => {

--- a/discovery-frontend/src/app/page/page-pivot/map/map-page-pivot.component.ts
+++ b/discovery-frontend/src/app/page/page-pivot/map/map-page-pivot.component.ts
@@ -39,6 +39,7 @@ import {Alert} from '../../../common/util/alert.util';
 import {ChartUtil} from '../../../common/component/chart/option/util/chart-util';
 import {OptionGenerator} from "../../../common/component/chart/option/util/option-generator";
 import {isNullOrUndefined} from "util";
+import {CommonConstant} from "../../../common/constant/common.constant";
 
 @Component({
   selector: 'map-page-pivot',
@@ -811,7 +812,7 @@ export class MapPagePivotComponent extends PagePivotComponent {
     this.uiOption = value;
 
     let layers = {
-      name: 'SpatialAnalysisLayer',
+      name: CommonConstant.MAP_ANALYSIS_LAYER_NAME,
       ref: '',
       fields: _.cloneDeep(this.shelf.layers[this.uiOption.analysis.layerNum].fields)
     };
@@ -822,7 +823,7 @@ export class MapPagePivotComponent extends PagePivotComponent {
     // layer 생성 (page.component에서 uiOption 전체를 생성함, layer만 추가 하기, 추가 layer 생성하기 위해서 0번째를 복사)
     let addUiOptionLayer = OptionGenerator.initUiOption(this.uiOption)['layers'][0];
     // layer name setting
-    addUiOptionLayer.name = 'SpatialAnalysisLayer';
+    addUiOptionLayer.name = CommonConstant.MAP_ANALYSIS_LAYER_NAME;
 
     this.uiOption.layers.push(addUiOptionLayer);
     // 0 ~ 1 은 multi-layer, 그래서 공간연산 layer 값은 2
@@ -840,7 +841,7 @@ export class MapPagePivotComponent extends PagePivotComponent {
 
       let uiOption = this.uiOption;
       this.shelf.layers.forEach( (layer) => {
-        if(layer.name === 'SpatialAnalysisLayer') {
+        if(layer.name === CommonConstant.MAP_ANALYSIS_LAYER_NAME) {
           layer.fields.push(_.cloneDeep(field));
           layer.fields.forEach( (field) => {
             if( uiOption['analysis']['operation']['aggregation']['column'] == field.name ){

--- a/discovery-frontend/src/app/page/page-pivot/page-pivot.component.ts
+++ b/discovery-frontend/src/app/page/page-pivot/page-pivot.component.ts
@@ -507,13 +507,6 @@ export class PagePivotComponent extends AbstractComponent implements OnInit, OnD
       return field.name === targetField.name && targetField.role === field.role;
     });
 
-    // GEO data is only usable in map chart
-    if (targetField.logicalType && -1 !== targetField.logicalType.toString().indexOf('GEO')) {
-      shelf.splice(idx, 1);
-      Alert.warning(this.translateService.instant('msg.storage.ui.list.geo.block.other.charts'));
-      return;
-    }
-
     if (idx > -1) {
       let field;
 

--- a/discovery-frontend/src/app/page/page.component.ts
+++ b/discovery-frontend/src/app/page/page.component.ts
@@ -2455,14 +2455,6 @@ export class PageComponent extends AbstractPopupComponent implements OnInit, OnD
       }
       return;
 
-      // other charts
-    } else {
-
-      // GEO data is only usable in map chart
-      if (targetField.logicalType && -1 !== targetField.logicalType.toString().indexOf('GEO')) {
-        Alert.warning(this.translateService.instant('msg.storage.ui.list.geo.block.other.charts'));
-        return;
-      }
     }
 
     // 이미 들어가있는 선반을 찾는다.


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
1. 연산행 레이어가 추가되었을 때 맵차트가 대시보드에서 그려지지 않는 문제가 있습니다.
2. Geo 데이터를 선택하면 Geo 데이터는 맵차트를 이용해야 한다고 경고창이 나옵니다.

**Related Issue** : #1463 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 차트 생성 페이지로 이동합니다.
2. Geo 데이터를 선반에 옮겼을 때, 그릴 수 있는 차트 표시로 지도 차트가 표시되는지 확인합니다.
3. 연산행 레이어를 생성하고 저장 한 후, 대시보드에서 맵 차트가 표시되는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
