### PR TITLE
Set delimiter properly on CSV file parser

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/ingestion/file/CsvFileFormat.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/ingestion/file/CsvFileFormat.java
@@ -47,7 +47,7 @@ public class CsvFileFormat implements FileFormat {
   @JsonIgnore
   public boolean isDefaultCsvMode() {
     return DEFAULT_DELIMITER.equals(delimiter)
-        && DEFAULT_LINE_SEPARATOR.equals(DEFAULT_LINE_SEPARATOR)
+        && DEFAULT_LINE_SEPARATOR.equals(lineSeparator)
         ? true : false;
   }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/AbstractSpecBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/AbstractSpecBuilder.java
@@ -303,22 +303,13 @@ public class AbstractSpecBuilder {
 
           CsvFileFormat csvFormat = (CsvFileFormat) fileFormat;
 
-          if (!csvFormat.isDefaultCsvMode()) {
-            csvStreamParser.setTimestampSpec(timestampSpec);
-            csvStreamParser.setDimensionsSpec(dimensionsSpec);
-            csvStreamParser.setColumns(columns);
-            csvStreamParser.setDelimiter(csvFormat.getDelimiter());
+          csvStreamParser.setTimestampSpec(timestampSpec);
+          csvStreamParser.setDimensionsSpec(dimensionsSpec);
+          csvStreamParser.setColumns(columns);
+          csvStreamParser.setDelimiter(csvFormat.getDelimiter());
+          csvStreamParser.setRecordSeparator(csvFormat.getLineSeparator());
 
-            parser = csvStreamParser;
-          } else {
-            csvStreamParser.setTimestampSpec(timestampSpec);
-            csvStreamParser.setDimensionsSpec(dimensionsSpec);
-            csvStreamParser.setColumns(columns);
-            csvStreamParser.setDelimiter(csvFormat.getDelimiter());
-            csvStreamParser.setRecordSeparator(csvFormat.getLineSeparator());
-
-            parser = csvStreamParser;
-          }
+          parser = csvStreamParser;
         } else {
           csvStreamParser.setTimestampSpec(timestampSpec);
           csvStreamParser.setDimensionsSpec(dimensionsSpec);

--- a/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/parser/CsvStreamParser.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/parser/CsvStreamParser.java
@@ -16,6 +16,8 @@
 
 package app.metatron.discovery.spec.druid.ingestion.parser;
 
+import com.fasterxml.jackson.annotation.JsonRawValue;
+
 import java.util.List;
 
 public class CsvStreamParser implements Parser {
@@ -26,12 +28,14 @@ public class CsvStreamParser implements Parser {
 
   List<String> columns;
 
+  @JsonRawValue
   String delimiter;
 
   Character quoteCharacter;
 
   Character escapeCharacter;
 
+  @JsonRawValue
   String recordSeparator;
 
   String nullString;
@@ -89,7 +93,11 @@ public class CsvStreamParser implements Parser {
   }
 
   public void setDelimiter(String delimiter) {
-    this.delimiter = delimiter;
+    if (!delimiter.startsWith("\"")){
+      this.delimiter = "\"" + delimiter + "\"";
+    } else {
+      this.delimiter = delimiter;
+    }
   }
 
   public Character getQuoteCharacter() {
@@ -113,7 +121,11 @@ public class CsvStreamParser implements Parser {
   }
 
   public void setRecordSeparator(String recordSeparator) {
-    this.recordSeparator = recordSeparator;
+    if (!recordSeparator.startsWith("\"")){
+      this.recordSeparator = "\"" + recordSeparator + "\"";
+    } else {
+      this.recordSeparator = recordSeparator;
+    }
   }
 
   public String getNullString() {


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
CSV ingestion spec's delimiter is inserted two of backslash when using characters that contain a backslash.

For example, when using \n for the delimiter, it will be generated \\n
We don't like to this situation and just want to pass by the same as the input.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Create datasource with a CSV file.
2. Check ingestion spec and delimiter is set properly (not with double backslash)
```json
"delimiter": "\t",
"recordSeparator": "\n",
````

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Additional Context<!-- if not appropriate, remove this topic. -->
