### PR TITLE
Should not be set delimiter on default csv

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/AbstractSpecBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/AbstractSpecBuilder.java
@@ -306,8 +306,11 @@ public class AbstractSpecBuilder {
           csvStreamParser.setTimestampSpec(timestampSpec);
           csvStreamParser.setDimensionsSpec(dimensionsSpec);
           csvStreamParser.setColumns(columns);
-          csvStreamParser.setDelimiter(csvFormat.getDelimiter());
-          csvStreamParser.setRecordSeparator(csvFormat.getLineSeparator());
+
+          if(!csvFormat.isDefaultCsvMode()) {
+            csvStreamParser.setDelimiter(csvFormat.getDelimiter());
+            csvStreamParser.setRecordSeparator(csvFormat.getLineSeparator());
+          }
 
           parser = csvStreamParser;
         } else {


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
We only need to set delimiter and line separator on the not default CSV file.
Otherwise, in cases not through UI like JDBC or hadoop, it can defect.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#1807 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)