### PR TITLE
Fixed an issue where filters were not applied in map charts.

### DIFF
--- a/discovery-frontend/src/app/dashboard/filters/configure-filters-update.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/configure-filters-update.component.ts
@@ -17,7 +17,7 @@ import {Component, ElementRef, EventEmitter, Injector, OnDestroy, OnInit, Output
 import {AbstractFilterPopupComponent} from 'app/dashboard/filters/abstract-filter-popup.component';
 import {Filter} from '../../domain/workbook/configurations/filter/filter';
 import {Dashboard} from '../../domain/dashboard/dashboard';
-import {ConnectionType, Datasource, Field, FieldRole, LogicalType} from '../../domain/datasource/datasource';
+import {ConnectionType, Datasource, Field, FieldRole} from '../../domain/datasource/datasource';
 import {CustomField} from '../../domain/workbook/configurations/field/custom-field';
 import {InclusionFilter} from '../../domain/workbook/configurations/filter/inclusion-filter';
 import {ConfigureFiltersInclusionComponent} from './inclusion-filter/configure-filters-inclusion.component';
@@ -86,7 +86,7 @@ export class ConfigureFiltersUpdateComponent extends AbstractFilterPopupComponen
   public dataSource: Datasource;
 
   @Output()
-  public goToSelectField: EventEmitter<any> = new EventEmitter();
+  public goToSelectField: EventEmitter<Filter> = new EventEmitter();
 
   @Output()
   public done: EventEmitter<Filter> = new EventEmitter();
@@ -148,7 +148,7 @@ export class ConfigureFiltersUpdateComponent extends AbstractFilterPopupComponen
    * Back Button 클릭 이벤트 핸들러
    */
   public clickBtnBack() {
-    this.goToSelectField.emit();
+    this.goToSelectField.emit(this.targetFilter);
   } // function - clickBtnBack
 
   /**

--- a/discovery-frontend/src/app/dashboard/filters/configure-filters.component.html
+++ b/discovery-frontend/src/app/dashboard/filters/configure-filters.component.html
@@ -13,4 +13,4 @@
   -->
 
 <app-config-filter-select (setFilter)="setFilter($event)"></app-config-filter-select>
-<app-config-filter-update (done)="emitUpdateFilter($event)" (goToSelectField)="showSelectFieldComp()"></app-config-filter-update>
+<app-config-filter-update (done)="emitUpdateFilter($event)" (goToSelectField)="showSelectFieldComp($event)"></app-config-filter-update>

--- a/discovery-frontend/src/app/dashboard/filters/configure-filters.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/configure-filters.component.ts
@@ -136,11 +136,12 @@ export class ConfigureFiltersComponent extends AbstractFilterPopupComponent impl
 
   /**
    * 필드 선택 컴포넌트를 연다.
+   * @param {Filter} selectedFilter
    */
-  public showSelectFieldComp() {
+  public showSelectFieldComp(selectedFilter:Filter) {
     const dataSources:Datasource[] = DashboardUtil.getMainDataSources( this._board );
     this._selectFieldComp.open(
-      this._board.configuration, dataSources, this._getTargetDataSource( dataSources, this._widget ),
+      this._board.configuration, dataSources, dataSources.find( ds => ds.engineName === selectedFilter.dataSource ),
       this._chartFilters, this._widget
     );
     this._updateFilterComp.close();


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
1. 대시보드 화면에서 맵차트에 글로벌 필터가 적용되지 않는 문제가 있습니다.
2. 필터 추가 화면에서 필드를 선택한 후 다시 되돌아가면 이전에 선택했던 데이터소스가 아닌 다른 데이터소스가 선택되어 있는 경우가 있습니다.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 지도차트를 생성 한 후 대시보드에서 글로벌 필터가 적용되는지 확인합니다.
2. 필터 추가 화면에서 데이터소스를 변경하고 필드를 선택한 후에 다시 필드 선택 화면으로 되돌아 갔을 때, 이전에 보았던 데이터소스의 필드 목록이 나오는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
