### PR TITLE
#1504 Icon overlaps the last column of query result

### DIFF
--- a/discovery-frontend/src/app/workbench/workbench.component.html
+++ b/discovery-frontend/src/app/workbench/workbench.component.html
@@ -488,9 +488,11 @@
                 </div>
 
                 <!-- buttons -->
-                <div class="ddp-ui-buttons" *ngIf="visibleResultTab.result && visibleResultTab.result.fields">
+                <div *ngIf="visibleResultTab.result && visibleResultTab.result.fields"
+                     class="ddp-ui-buttons" >
                   <!-- Paging -->
-                  <div class="ddp-wrap-btn-link" [hidden]="visibleResultTab.message">
+                  <div [class.type-opacity]="hideResultButtons" [hidden]="visibleResultTab.message"
+                       class="ddp-wrap-btn-link" >
                     <a *ngIf="visibleResultTab.isShowPrevBtn()"
                        (click)="changeResultPage( visibleResultTab, 'PREV' )"
                        href="javascript:" class="ddp-box-page" >
@@ -505,7 +507,7 @@
                   <!-- // Paging -->
 
                   <!-- Result Search -->
-                  <div class="ddp-wrap-btn-link">
+                  <div [class.type-opacity]="hideResultButtons" class="ddp-wrap-btn-link">
                     <!-- search link -->
                     <a (click)="toggleResultSearchLayer($event)"
                        [ngClass]="{'ddp-selected':isSearchLink, 'ddp-value': searchText.trim() != '' }"

--- a/discovery-frontend/src/app/workbench/workbench.component.ts
+++ b/discovery-frontend/src/app/workbench/workbench.component.ts
@@ -446,6 +446,11 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
     this._splitVertical = undefined;
     this._deactiveHorizontalSlider();
 
+    if (this._gridScrollEvtSub) {
+      this._gridScrollEvtSub.unsubscribe();
+      this._gridScrollEvtSub = undefined;
+    }
+
     // this.webSocketCheck(() => {});
     (this._subscription) && (this._subscription.unsubscribe());     // Socket 응답 해제
 
@@ -959,6 +964,8 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
    */
   public changeResultTabHandler(selectedTabId: string) {
 
+    this.hideResultButtons = false;
+
     let selectedTab: ResultTab = null;
     const currentEditorResultTabs: ResultTab[] = this._getCurrentEditorResultTabs();
     currentEditorResultTabs.forEach((tabItem: ResultTab) => {
@@ -1308,6 +1315,7 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
   /**
    * run query
    * @param {string} resultTabId
+   * @param {boolean} retry
    */
   public runQueries(resultTabId: string, retry: boolean = false) {
     const resultTab: ResultTab = this._getResultTab(resultTabId);
@@ -1320,7 +1328,7 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
     resultTab.initialize();
     resultTab.executeTimer();
     this.runningResultTabId = resultTab.id;
-
+    this.hideResultButtons = false;
 
     this.workbenchService.runSingleQueryWithInvalidQuery(resultTab.queryEditor, additionalParams)
       .then((result) => {
@@ -2492,9 +2500,11 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
       const $gridCanvas = $('.grid-canvas');
       this._gridScrollEvtSub
         = this.gridComponent.grid.onScroll.subscribe((data1, data2) => {
-        if (data2.scrollTop > $gridViewport.height()) {
-          this.hideResultButtons = (data2.scrollTop > ($gridCanvas.height() - $gridViewport.height() - 30 ));
+        if ( 0 < data2.scrollTop ) {
+          this.hideResultButtons = (data2.scrollTop > ($gridCanvas.height() - $gridViewport.height() - 10 ));
           this.safelyDetectChanges();
+        } else if( 0 === data2.scrollTop ) {
+          this.hideResultButtons = false;
         }
       });
     }

--- a/discovery-frontend/src/app/workbench/workbench.component.ts
+++ b/discovery-frontend/src/app/workbench/workbench.component.ts
@@ -76,6 +76,8 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
   // 에디터 행수
   private MAX_LINES: number = 20;
 
+  private _gridScrollEvtSub: any;
+
   // 그리드
   @ViewChild('main')
   private gridComponent: GridComponent;
@@ -347,6 +349,8 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
   public supportSaveAsHiveTable: boolean = false;
 
   public connTargetImgUrl: string = '';
+
+  public hideResultButtons: boolean = false;
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Constructor
@@ -2480,6 +2484,19 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
         .RowSelectionActivate(true)
         .build()
       );
+      if (this._gridScrollEvtSub) {
+        this._gridScrollEvtSub.unsubscribe();
+        this._gridScrollEvtSub = undefined;
+      }
+      const $gridViewport = $('.slick-viewport');
+      const $gridCanvas = $('.grid-canvas');
+      this._gridScrollEvtSub
+        = this.gridComponent.grid.onScroll.subscribe((data1, data2) => {
+        if (data2.scrollTop > $gridViewport.height()) {
+          this.hideResultButtons = (data2.scrollTop > ($gridCanvas.height() - $gridViewport.height() - 30 ));
+          this.safelyDetectChanges();
+        }
+      });
     }
 
     if (this.searchText !== '') {

--- a/discovery-frontend/src/assets/css/polaris.v2.page.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.page.css
@@ -6963,8 +6963,11 @@ table.ddp-table-simple tr td .ddp-ui-time {width:100%; color:#90969f; font-size:
 .ddp-btn-allcheck:hover:before {background-position:-47px top;}
 .ddp-box-query-result .ddp-wrap-result .ddp-ui-buttons {position:absolute; bottom:40px; right:10px;  float:right; padding:10px 0 0 0;}
 .ddp-box-query-result .ddp-wrap-result .ddp-wrap-btn-link {float:left;border:1px solid #b6b9c2; border-radius:2px; background-color:#fff;}
+
+.ddp-box-query-result .ddp-wrap-result .ddp-wrap-btn-link.type-opacity {opacity:0.2;}
+.ddp-wrap-btn-link.type-opacity a.ddp-btn-link.ddp-selected .ddp-box-searching {opacity:1;}
 .ddp-box-query-result .ddp-wrap-result .ddp-wrap-btn-link + .ddp-wrap-btn-link {margin-left:9px;}
-.ddp-box-query-result .ddp-wrap-result .ddp-wrap-btn-link .ddp-box-page {display:inline-block; float:left; width:75px; height:30px; padding:8px 0; color:#90969f; font-size:13px; text-align:center; box-sizing:border-box;}
+.ddp-box-query-result .ddp-wrap-result .ddp-wrap-btn-link .ddp-box-page {display:inline-block; float:left; width:75px; height:30px; margin-top:0; padding:8px 0; color:#90969f; font-size:13px; text-align:center; box-sizing:border-box; border:none;}
 .ddp-box-query-result .ddp-wrap-result .ddp-wrap-btn-link .ddp-box-page + .ddp-box-page {border-left:1px solid #b6b9c2}
 .ddp-box-query-result .ddp-wrap-result .ddp-wrap-btn-link .ddp-box-page:hover {background-color:#e7e7ea;}
 .ddp-box-query-result .ddp-wrap-result .ddp-wrap-btn-link .ddp-box-page .ddp-icon-prev,


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
워크벤치 쿼리 결과에서 마지막 row 의 마지막 column 값이 확인 불가함

**Related Issue** : #1504 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 워크벤치에서 쿼리 실행합니다.
2. 쿼리 결과가 표시된 후 스크롤을 제일 아래로 내렸을 떄 아이콘 이미지가 숨겨지는지 ( 흐릿하게 ) 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
