### PR TITLE
#1812 uploaded Excel file's CSV filenames use UUID instead of Excel's name

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetFileService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetFileService.java
@@ -66,6 +66,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -858,17 +859,15 @@ public class PrepDatasetFileService {
     }
 
     public String moveExcelToCsv(String excelStrUri, String sheetName, String delimiter) {
-        String csvStrUri = null;
-
-        int idx = excelStrUri.lastIndexOf(".");
-        csvStrUri = excelStrUri.substring(0, idx) + ".csv";
+        String excelFilename = PrepUtil.getFileNameFromStrUri(excelStrUri);
+        String csvFileName = UUID.randomUUID() + "csv";
+        String csvStrUri = excelStrUri.replace(excelFilename, csvFileName);
 
         return moveExcelToCsv(csvStrUri, excelStrUri, sheetName, delimiter);
     }
 
     public String moveExcelToCsv(String csvStrUri, String excelStrUri, String sheetName, String delimiter) {
         try {
-            URI excelUri = new URI(excelStrUri);
             String extensionType = FilenameUtils.getExtension(excelStrUri);
 
             Workbook wb;

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepUtil.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepUtil.java
@@ -71,4 +71,8 @@ public class PrepUtil {
 
     return hadoopConf;
   }
+
+  public static String getFileNameFromStrUri(String strUri) {
+    return strUri.substring(strUri.lastIndexOf('/') + 1, strUri.length());
+  }
 }


### PR DESCRIPTION
### Description
When an Excel file is uploaded for I.DS, a CSV file is generate to ease the rest of jobs.
The naming was just replacing xlsx into csv, for the debugging purpose.
But, now, 2 or more CSV can be generated for one Excel file.
So, it'll be more appropriate to use random file name like UUID instead. 

**Related Issue** : https://github.com/metatron-app/metatron-discovery/issues/1812


### How Has This Been Tested?
Run locally according to https://github.com/metatron-app/metatron-discovery/issues/1812.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
