### PR TITLE
#1827 Fix unselect rows and column method in grid component

### DIFF
--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/edit-rule-grid.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/edit-rule-grid.component.ts
@@ -352,26 +352,18 @@ export class EditRuleGridComponent extends AbstractComponent implements OnInit, 
     if (!isNull(this._gridComp.getGridCore())) {
       switch (direction) {
         case 'COL' :
-          if (this._selectedColumns.length > 0) {
-            this._gridComp.columnAllUnSelection();
-            this._selectedColumns = [];
-          }
+          this._gridComp.columnAllUnSelection();
+          this._selectedColumns = [];
           break;
         case 'ROW' :
-          if (0 < this._selectedRows.length) {
-            this._gridComp.rowAllUnSelection();
-            this._selectedRows = [];
-          }
+          this._gridComp.rowAllUnSelection();
+          this._selectedRows = [];
           break;
         default :
-          if (0 < this._selectedRows.length) {
-            this._gridComp.rowAllUnSelection();
-            this._selectedRows = [];
-          }
-          if (this._selectedColumns.length > 0) {
-            this._gridComp.columnAllUnSelection();
-            this._selectedColumns = [];
-          }
+          this._gridComp.rowAllUnSelection();
+          this._selectedRows = [];
+          this._gridComp.columnAllUnSelection();
+          this._selectedColumns = [];
       }
     }
   } // function - unSelectionAll
@@ -490,8 +482,7 @@ export class EditRuleGridComponent extends AbstractComponent implements OnInit, 
           this._applyChart(this._barCharts[i], options)
         }
       }
-      this._gridComp.rowAllUnSelection();
-      this._selectedRows = [];
+      this.unSelectionAll('ROW');
 
     }
 
@@ -829,7 +820,7 @@ export class EditRuleGridComponent extends AbstractComponent implements OnInit, 
   public onContextMenuItemClick(data) {
 
     if (data.more) {
-      this._gridComp.columnAllUnSelection();
+      this.unSelectionAll('COL');
 
       this._selectedColumns = data.more.col;
 
@@ -1117,8 +1108,7 @@ export class EditRuleGridComponent extends AbstractComponent implements OnInit, 
 
         // 현재 선택되어있는 column/row refresh
         if (this._selectedColumns.length > 0) {
-          this._gridComp.columnAllUnSelection();
-          this._selectedRows = [];
+          this.unSelectionAll('COL');
         }
 
         // 현재 선택되어있는 바 차트 refresh

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/scroll-loading-grid.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/scroll-loading-grid.component.ts
@@ -456,6 +456,7 @@ export class ScrollLoadingGridComponent implements OnInit, AfterViewInit, OnDest
   public rowAllUnSelection(scope: any = null): void {
     const fnScope: any = scope === null ? this : scope;
     fnScope._grid.setSelectedRows([]);
+    this.__selectedRows = [];
   }
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Fix unselecting rows and columns logic from grid component

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#1827 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1 . Go to dataflow main grid (use dataset with at least 500 rows)
2 . Click histogram -> context menu -> delete
![image](https://user-images.githubusercontent.com/42233517/55787605-9ed6b480-5af1-11e9-8111-f8455399116c.png)
3 . Scroll down again and again. No rows should be selected


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
