### PR TITLE
#1868 Fix connection parameter in create datasource

### DIFF
--- a/discovery-frontend/src/app/data-storage/component/connection/connection.component.ts
+++ b/discovery-frontend/src/app/data-storage/component/connection/connection.component.ts
@@ -137,7 +137,7 @@ export class ConnectionComponent extends AbstractComponent {
   public setConnectionInput(connection: Dataconnection | ConnectionParam): void {
     this.hostname = StringUtil.isNotEmpty(connection.hostname) ?connection.hostname : undefined;
     this.port = connection.port || undefined;
-    this.catalog = StringUtil.isNotEmpty(connection.catalog) ?connection.hostname : undefined;
+    this.catalog = StringUtil.isNotEmpty(connection.catalog) ?connection.catalog : undefined;
     this.database = StringUtil.isNotEmpty(connection.database) ?connection.database : undefined;
     this.sid = StringUtil.isNotEmpty(connection.sid) ?connection.sid : undefined;
     this.url = StringUtil.isNotEmpty(connection.url) ?connection.url : undefined;


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
데이터소스 생성 > 데이터베이스로 생성 에서 기존에 생성된 데이터커넥션을 이용할 때,
해당 커넥션이 catalog가 존재하는경우, 커넥션 불러오기가 제대로 표기되지 않던 현상 수정

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#1868 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 데이터소스 생성 > 데이터베이스로 생성
2. 데이터 커넥션 선택화면에서 catalog를 사용하는 커넥션 프리셋 선택
3. 2에서 선택된 커넥션 정보가 화면에 제대로 표시되는지 확인

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project. _it will be added soon_
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
