### PR TITLE
#1840 add "second" granularity for timestamp column

### DIFF
--- a/discovery-frontend/src/app/common/component/chart/type/map-chart/map-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/map-chart/map-chart.component.ts
@@ -2412,9 +2412,11 @@ export class MapChartComponent extends BaseChart implements AfterViewInit {
 
     let rangeList = [];
     let featureList = [];
-    _.each(data.features, (feature) => {
-      featureList.push(feature.properties)
-    });
+    if( data ) {
+      _.each(data.features, (feature) => {
+        featureList.push(feature.properties)
+      });
+    }
 
     let featuresGroup = _.groupBy(featureList, ChartUtil.getFieldAlias(layer.color.column, this.shelf.layers[this.getUiMapOption().layerNum].fields, layer.color.aggregationType));
     _.each(Object.keys(featuresGroup), (column, index) => {

--- a/discovery-frontend/src/app/dashboard/filters/component/timeUnit-select.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/component/timeUnit-select.component.ts
@@ -59,7 +59,7 @@ export class TimeUnitSelectComponent extends AbstractComponent implements OnInit
     { name: 'Year', unit: 'YEAR' }
   ];
   */
-  public dpContinuousList: string[] = ['Minute', 'Hour', 'Day', 'Week', 'Month', 'Year', 'None'];
+  public dpContinuousList: string[] = ['Second', 'Minute', 'Hour', 'Day', 'Week', 'Month', 'Year', 'None'];
   public dpDiscontinuousList: any[] = [
     { name: 'Day by week', unit: 'DAY', byUnit: 'WEEK' },
     { name: 'Day by month', unit: 'DAY', byUnit: 'MONTH' },

--- a/discovery-frontend/src/app/page/chart-style/secondary-indicator.component.ts
+++ b/discovery-frontend/src/app/page/chart-style/secondary-indicator.component.ts
@@ -780,9 +780,9 @@ export class SecondaryIndicatorComponent extends BaseOptionComponent {
     let score: number = 0;
     switch (granularity) {
       // 초단위 제거 요청으로 주석처리
-      // case String(GranularityType.SECOND):
-      //   score = 1;
-      //   break;
+      case String(GranularityType.SECOND):
+        score = 1;
+        break;
       case String(GranularityType.MINUTE):
         score = 2;
         break;

--- a/discovery-frontend/src/app/page/page-pivot/page-pivot.component.ts
+++ b/discovery-frontend/src/app/page/page-pivot/page-pivot.component.ts
@@ -1847,7 +1847,7 @@ export class PagePivotComponent extends AbstractComponent implements OnInit, OnD
     // timestamp 타입 리스트 설정
     this.timestampTypeList = [
       // 초단위 제거 요청으로 주석처리
-      // { label: 'Second', id: GranularityType.SECOND, discontinuous: false },
+      {label: 'Second', id: GranularityType.SECOND, discontinuous: false},
       {label: 'Minute', id: GranularityType.MINUTE, discontinuous: false},
       {label: 'Hour', id: GranularityType.HOUR, discontinuous: false},
       {label: 'Day', id: GranularityType.DAY, discontinuous: false},
@@ -2695,9 +2695,9 @@ export class PagePivotComponent extends AbstractComponent implements OnInit, OnD
       let score: number = 0;
       switch (granularity) {
         // 초단위 제거 요청으로 주석처리
-        // case String(GranularityType.SECOND):
-        //   score = 1;
-        //   break;
+        case String(GranularityType.SECOND):
+          score = 1;
+          break;
         case String(GranularityType.MINUTE):
           score = 2;
           break;

--- a/discovery-frontend/src/app/page/page-pivot/pivot-context.component.html
+++ b/discovery-frontend/src/app/page/page-pivot/pivot-context.component.html
@@ -251,16 +251,16 @@
           </div>
           <ul class="ddp-list-popup">
             <!-- 초단위 제거 요청으로 주석처리 -->
-            <!--<li (click)="onChangeGranularity(false, 'SECOND')" [class.ddp-selected]="isGranularitySelected(editingField, false, 'SECOND')"-->
-            <!--*ngIf="isUseGranularity(false, 'SECOND')"-->
-            <!--[class.ddp-disabled]="-1 !== editingField.granularityList.indexOf('SECOND')">-->
-            <!--<a href="javascript:">-->
-            <!--{{'msg.page.li.second' | translate}}-->
-            <!--<div class="ddp-data-info">-->
-            <!--May 8, 2015 14:05:30-->
-            <!--</div>-->
-            <!--</a>-->
-            <!--</li>-->
+            <li (click)="onChangeGranularity(false, 'SECOND')" [class.ddp-selected]="isGranularitySelected(editingField, false, 'SECOND')"
+                *ngIf="isUseGranularity(false, 'SECOND')"
+                [class.ddp-disabled]="-1 !== editingField.granularityList.indexOf('SECOND')">
+              <a href="javascript:">
+                {{'msg.page.li.second' | translate}}
+                <div class="ddp-data-info">
+                  May 8, 2015 14:05:30
+                </div>
+              </a>
+            </li>
             <!-- //초단위 제거 요청으로 주석처리 -->
             <li (click)="onChangeGranularity(false, 'MINUTE')" [class.ddp-selected]="isGranularitySelected(editingField, false, 'MINUTE')"
                 *ngIf="isUseGranularity(false, 'MINUTE')"
@@ -349,16 +349,16 @@
           </div>
           <ul class="ddp-list-popup">
             <!-- 초단위 제거 요청으로 주석처리 -->
-            <!--<li (click)="onChangeGranularity(true, 'SECOND')" [class.ddp-selected]="isGranularitySelected(editingField, true, 'SECOND')"-->
-            <!--*ngIf="isUseGranularity(true, 'SECOND')"-->
-            <!--[class.ddp-disabled]="-1 !== editingField.granularityList.indexOf('SECOND')">-->
-            <!--<a href="javascript:">-->
-            <!--{{'msg.page.li.second' | translate}}-->
-            <!--<div class="ddp-data-info">-->
-            <!--14:05:30 (by minute)-->
-            <!--</div>-->
-            <!--</a>-->
-            <!--</li>-->
+            <li (click)="onChangeGranularity(true, 'SECOND')" [class.ddp-selected]="isGranularitySelected(editingField, true, 'SECOND')"
+                *ngIf="isUseGranularity(true, 'SECOND')"
+                [class.ddp-disabled]="-1 !== editingField.granularityList.indexOf('SECOND')">
+              <a href="javascript:">
+                {{'msg.page.li.second' | translate}}
+                <div class="ddp-data-info">
+                  14:05:30 (by minute)
+                </div>
+              </a>
+            </li>
             <!-- //초단위 제거 요청으로 주석처리 -->
             <li (click)="onChangeGranularity(true, 'MINUTE')" [class.ddp-selected]="isGranularitySelected(editingField, true, 'MINUTE')"
                 *ngIf="isUseGranularity(true, 'MINUTE')"

--- a/discovery-frontend/src/app/page/page-pivot/pivot-context.component.ts
+++ b/discovery-frontend/src/app/page/page-pivot/pivot-context.component.ts
@@ -540,9 +540,9 @@ export class PivotContextComponent extends AbstractComponent implements OnInit, 
       let score: number = 0;
       switch (granularity) {
         // 초단위 제거 요청으로 주석처리
-        // case String(GranularityType.SECOND):
-        //   score = 1;
-        //   break;
+        case String(GranularityType.SECOND):
+          score = 1;
+          break;
         case String(GranularityType.MINUTE):
           score = 2;
           break;


### PR DESCRIPTION
### Description
Currently, granularity units for the timestamp column are configured to minutes. Given the nature of the real-time data source, it should be expressed in seconds.

**Related Issue** : #1840 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 차트 생성 화면으로 이동합니다.
2. 선반 설정에서 granularity 설정에서 초 단위가 선택이 되는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
