### PR TITLE
#1784 line chart custom color initialized

### DIFF
--- a/discovery-frontend/src/app/common/component/chart/base-chart.ts
+++ b/discovery-frontend/src/app/common/component/chart/base-chart.ts
@@ -1920,10 +1920,30 @@ export abstract class BaseChart extends AbstractComponent implements OnInit, OnD
       }
     }
 
-    // color mapping값 설정
-    if (this.uiOption.color && isNullOrUndefined(this.uiOption.color['mapping'])) {
-      this.uiOption.color = this.setMapping();
+    // color mapping값 설정 - S
+    // 이전값 임시 저장
+    let prevMappingList: { alias: string, color: string }[] = [];
+    if (this.uiOption.color && this.uiOption.color && this.uiOption.color['mappingArray']) {
+      prevMappingList = this.uiOption.color['mappingArray'];
     }
+    // 매핑값 초기화
+    this.uiOption.color = this.setMapping();
+    // 이전값 재적용
+    if (0 < prevMappingList.length) {
+      const currColorMapObj = this.uiOption.color['mapping'];
+      const currColorMapList = this.uiOption.color['mappingArray'];
+      prevMappingList.forEach(prev => {
+        currColorMapList.some(curr => {
+          if (curr.alias === prev.alias) {
+            curr.color = prev.color;
+            return true;
+          }
+          return false;
+        });
+        (currColorMapObj[prev.alias]) && (currColorMapObj[prev.alias] = prev.color);
+      });
+    }
+    // color mapping값 설정 - E
   }
 
   /**

--- a/discovery-frontend/src/app/common/component/chart/base-chart.ts
+++ b/discovery-frontend/src/app/common/component/chart/base-chart.ts
@@ -23,7 +23,7 @@ import {
   UIChartColor,
   UIChartColorByDimension,
   UIChartColorBySeries,
-  UIChartColorByValue,
+  UIChartColorByValue, UIChartColorGradationByValue,
   UIChartZoom,
   UIOption
 } from './option/ui-option';
@@ -40,12 +40,14 @@ import {
   ChartPivotType,
   ChartSelectMode,
   ChartType,
+  ColorCustomMode,
   ColorRangeType,
   DataZoomRangeType,
   EventType,
   SeriesType,
   ShelveFieldType,
-  ShelveType, UIChartDataLabelDisplayType
+  ShelveType,
+  UIChartDataLabelDisplayType
 } from './option/define/common';
 import {Field as AbstractField, Field} from '../../../domain/workbook/configurations/field/field';
 
@@ -61,14 +63,14 @@ import {CommonOptionConverter} from './option/converter/common-option-converter'
 import {ToolOptionConverter} from './option/converter/tool-option-converter';
 import {LegendOptionConverter} from './option/converter/legend-option-converter';
 import {analysis} from '../../../page/component/value/analysis';
-import {ColorRange, UIChartColorGradationByValue} from './option/ui-option/ui-color';
+import {ColorRange} from './option/ui-option/ui-color';
 import {UIScatterChart} from './option/ui-option/ui-scatter-chart';
-import UI = OptionGenerator.UI;
 import {UIChartAxisGrid} from "./option/ui-option/ui-axis";
 import {TooltipOptionConverter} from './option/converter/tooltip-option-converter';
 import {Shelf} from '../../../domain/workbook/configurations/shelf/shelf';
 import {fromEvent} from 'rxjs';
-import {map, debounceTime} from 'rxjs/operators';
+import {debounceTime, map} from 'rxjs/operators';
+import UI = OptionGenerator.UI;
 
 declare let echarts: any;
 
@@ -1869,17 +1871,49 @@ export abstract class BaseChart extends AbstractComponent implements OnInit, OnD
     // 색상지정 기준 필드리스트 설정(measure list)
     this.uiOption = this.setMeasureList();
 
+/*
     // color by measure일때 eventType이 있는경우 (min / max가 바뀌는경우) 색상 설정값 초기화
     if (!_.isEmpty(this.drawByType) && this.uiOption.color && ChartColorType.MEASURE == this.uiOption.color.type) {
       delete (<UIChartColorByValue>this.uiOption.color).ranges;
       delete (<UIChartColorGradationByValue>this.uiOption.color).visualGradations;
       delete (<UIChartColorByValue>this.uiOption.color).customMode;
 
-
       const colorList = <any>ChartColorList[this.uiOption.color['schema']];
 
       // ranges가 초기화
       this.uiOption.color['ranges'] = ColorOptionConverter.setMeasureColorRange(this.uiOption, this.data, colorList);
+    }
+*/
+
+    if (!_.isEmpty(this.drawByType) && this.uiOption.color && (<UIChartColorByValue>this.uiOption.color).customMode ) {
+      let colorList = [];
+      const colrObj:UIChartColorByValue = <UIChartColorByValue>this.uiOption.color;
+      switch( colrObj.customMode ) {
+        case ColorCustomMode.SECTION:
+          colorList = colrObj.ranges.map( item => item.color ).reverse();
+          this.uiOption.color['ranges'] = ColorOptionConverter.setMeasureColorRange(this.uiOption, this.data, colorList);
+          break;
+        case ColorCustomMode.GRADIENT :
+          const prevMaxVal:number = colrObj.ranges[colrObj.ranges.length - 1]['value'];
+          const currMaxVal:number = this.uiOption.maxValue;
+          const resetRange:Function = ( item ) => {
+            if( item['value'] ) {
+              if( item['value'] < prevMaxVal ) {
+                item['value'] = currMaxVal * (item['value'] / prevMaxVal );
+              } else {
+                item['value'] = currMaxVal;
+              }
+            }
+            return item;
+          };
+          this.uiOption.color['ranges'] = colrObj['ranges'].map( item => resetRange(item) );
+          this.uiOption.color['visualGradations'] = colrObj['visualGradations'].map( item => resetRange(item) );
+          break;
+        default:
+          // ranges 초기화
+          colorList = <any>ChartColorList[this.uiOption.color['schema']];
+          this.uiOption.color['ranges'] = ColorOptionConverter.setMeasureColorRange(this.uiOption, this.data, colorList);
+      }
     }
 
     // color mapping값 설정

--- a/discovery-frontend/src/app/common/component/chart/base-chart.ts
+++ b/discovery-frontend/src/app/common/component/chart/base-chart.ts
@@ -71,6 +71,7 @@ import {Shelf} from '../../../domain/workbook/configurations/shelf/shelf';
 import {fromEvent} from 'rxjs';
 import {debounceTime, map} from 'rxjs/operators';
 import UI = OptionGenerator.UI;
+import {isNullOrUndefined} from "util";
 
 declare let echarts: any;
 
@@ -1412,7 +1413,7 @@ export abstract class BaseChart extends AbstractComponent implements OnInit, OnD
 
   protected convertDataZoom(isKeepRange?: boolean): BaseOption {
 
-    if( this.uiOption.chartZooms && this.uiOption.chartZooms[0].auto ) {
+    if (this.uiOption.chartZooms && this.uiOption.chartZooms[0].auto) {
       ////////////////////////////////////////////////////////
       // 데이터줌 설정
       ////////////////////////////////////////////////////////
@@ -1871,43 +1872,43 @@ export abstract class BaseChart extends AbstractComponent implements OnInit, OnD
     // 색상지정 기준 필드리스트 설정(measure list)
     this.uiOption = this.setMeasureList();
 
-/*
-    // color by measure일때 eventType이 있는경우 (min / max가 바뀌는경우) 색상 설정값 초기화
-    if (!_.isEmpty(this.drawByType) && this.uiOption.color && ChartColorType.MEASURE == this.uiOption.color.type) {
-      delete (<UIChartColorByValue>this.uiOption.color).ranges;
-      delete (<UIChartColorGradationByValue>this.uiOption.color).visualGradations;
-      delete (<UIChartColorByValue>this.uiOption.color).customMode;
+    /*
+        // color by measure일때 eventType이 있는경우 (min / max가 바뀌는경우) 색상 설정값 초기화
+        if (!_.isEmpty(this.drawByType) && this.uiOption.color && ChartColorType.MEASURE == this.uiOption.color.type) {
+          delete (<UIChartColorByValue>this.uiOption.color).ranges;
+          delete (<UIChartColorGradationByValue>this.uiOption.color).visualGradations;
+          delete (<UIChartColorByValue>this.uiOption.color).customMode;
 
-      const colorList = <any>ChartColorList[this.uiOption.color['schema']];
+          const colorList = <any>ChartColorList[this.uiOption.color['schema']];
 
-      // ranges가 초기화
-      this.uiOption.color['ranges'] = ColorOptionConverter.setMeasureColorRange(this.uiOption, this.data, colorList);
-    }
-*/
+          // ranges가 초기화
+          this.uiOption.color['ranges'] = ColorOptionConverter.setMeasureColorRange(this.uiOption, this.data, colorList);
+        }
+    */
 
-    if (!_.isEmpty(this.drawByType) && this.uiOption.color && (<UIChartColorByValue>this.uiOption.color).customMode ) {
+    if (!_.isEmpty(this.drawByType) && this.uiOption.color && (<UIChartColorByValue>this.uiOption.color).customMode) {
       let colorList = [];
-      const colrObj:UIChartColorByValue = <UIChartColorByValue>this.uiOption.color;
-      switch( colrObj.customMode ) {
+      const colrObj: UIChartColorByValue = <UIChartColorByValue>this.uiOption.color;
+      switch (colrObj.customMode) {
         case ColorCustomMode.SECTION:
-          colorList = colrObj.ranges.map( item => item.color ).reverse();
+          colorList = colrObj.ranges.map(item => item.color).reverse();
           this.uiOption.color['ranges'] = ColorOptionConverter.setMeasureColorRange(this.uiOption, this.data, colorList);
           break;
         case ColorCustomMode.GRADIENT :
-          const prevMaxVal:number = colrObj.ranges[colrObj.ranges.length - 1]['value'];
-          const currMaxVal:number = this.uiOption.maxValue;
-          const resetRange:Function = ( item ) => {
-            if( item['value'] ) {
-              if( item['value'] < prevMaxVal ) {
-                item['value'] = currMaxVal * (item['value'] / prevMaxVal );
+          const prevMaxVal: number = colrObj.ranges[colrObj.ranges.length - 1]['value'];
+          const currMaxVal: number = this.uiOption.maxValue;
+          const resetRange: Function = (item) => {
+            if (item['value']) {
+              if (item['value'] < prevMaxVal) {
+                item['value'] = Math.round(currMaxVal * (item['value'] / prevMaxVal));
               } else {
                 item['value'] = currMaxVal;
               }
             }
             return item;
           };
-          this.uiOption.color['ranges'] = colrObj['ranges'].map( item => resetRange(item) );
-          this.uiOption.color['visualGradations'] = colrObj['visualGradations'].map( item => resetRange(item) );
+          this.uiOption.color['ranges'] = colrObj['ranges'].map(item => resetRange(item));
+          this.uiOption.color['visualGradations'] = colrObj['visualGradations'].map(item => resetRange(item));
           break;
         default:
           // ranges 초기화
@@ -1920,7 +1921,9 @@ export abstract class BaseChart extends AbstractComponent implements OnInit, OnD
     }
 
     // color mapping값 설정
-    // this.uiOption.color = this.setMapping();
+    if (this.uiOption.color && isNullOrUndefined(this.uiOption.color['mapping'])) {
+      this.uiOption.color = this.setMapping();
+    }
   }
 
   /**

--- a/discovery-frontend/src/app/common/component/chart/base-chart.ts
+++ b/discovery-frontend/src/app/common/component/chart/base-chart.ts
@@ -1911,13 +1911,16 @@ export abstract class BaseChart extends AbstractComponent implements OnInit, OnD
           break;
         default:
           // ranges 초기화
+          delete (<UIChartColorByValue>this.uiOption.color).ranges;
+          delete (<UIChartColorGradationByValue>this.uiOption.color).visualGradations;
+          delete (<UIChartColorByValue>this.uiOption.color).customMode;
           colorList = <any>ChartColorList[this.uiOption.color['schema']];
           this.uiOption.color['ranges'] = ColorOptionConverter.setMeasureColorRange(this.uiOption, this.data, colorList);
       }
     }
 
     // color mapping값 설정
-    this.uiOption.color = this.setMapping();
+    // this.uiOption.color = this.setMapping();
   }
 
   /**

--- a/discovery-frontend/src/app/page/chart-style/color-option.component.ts
+++ b/discovery-frontend/src/app/page/chart-style/color-option.component.ts
@@ -498,8 +498,24 @@ export class ColorOptionComponent extends BaseOptionComponent implements OnInit,
    * 사용자 색상설정 show
    */
   public showUserColorSet() {
+    const colorObj:UIChartColorBySeries = <UIChartColorBySeries>this.uiOption.color;
     // color setting show / hide 값 반대로 설정
-    (<UIChartColorBySeries>this.uiOption.color).settingUseFl = !(<UIChartColorBySeries>this.uiOption.color).settingUseFl;
+    colorObj.settingUseFl = !colorObj.settingUseFl;
+    // if( !colorObj.settingUseFl ) {
+    //   const colorList = ChartColorList[colorObj.schema];
+    //
+    //   // 기존 컬러 리스트로 초기화
+    //   const currColorMapObj = colorObj.mapping;
+    //   const currColorMapList = colorObj.mappingArray;
+    //   currColorMapList.forEach((item,idx) => {
+    //     item['color'] = colorList[idx];
+    //     (currColorMapObj[item['alias']]) && (currColorMapObj[item['alias']] = colorList[idx]);
+    //   });
+    //
+    //   // 차트 업데이트
+    //   this.uiOption.color = colorObj;
+    //   this.update();
+    // }
   }
 
   /**

--- a/discovery-frontend/src/app/page/chart-style/color-option.component.ts
+++ b/discovery-frontend/src/app/page/chart-style/color-option.component.ts
@@ -162,6 +162,8 @@ export class ColorOptionComponent extends BaseOptionComponent implements OnInit,
   // range list for view
   public rangesViewList = [];
 
+  public resultData: Object;
+
   // constructor
   constructor(protected elementRef: ElementRef,
               protected injector: Injector,
@@ -189,7 +191,16 @@ export class ColorOptionComponent extends BaseOptionComponent implements OnInit,
   public pivot: Pivot;
 
   @Input('resultData')
-  public resultData: Object;
+  public set setResultData(resultData: Object) {
+    this.resultData = resultData;
+    if (resultData && resultData['data'] && resultData['data']['info'] && this.uiOption) {
+      const tmpInfo = resultData['data']['info'];
+      const tmpValFormat = this.uiOption.valueFormat;
+      const minValue = this.checkMinZero(tmpInfo['minValue'], tmpInfo['minValue']);
+      this.minValue = FormatOptionConverter.getDecimalValue(minValue, tmpValFormat.decimal, tmpValFormat.useThousandsSep);
+      this.maxValue = FormatOptionConverter.getDecimalValue(tmpInfo['maxValue'], tmpValFormat.decimal, tmpValFormat.useThousandsSep);
+    }
+  }
 
   @Input('uiOption')
   public set setUiOption(uiOption: UIOption) {
@@ -570,10 +581,10 @@ export class ColorOptionComponent extends BaseOptionComponent implements OnInit,
       // color by measure일때
     } else if (this.uiOption.color.type == ChartColorType.MEASURE) {
 
-      const index = this.rangesViewList.indexOf(item);
+      const index = this.rangesViewList.findIndex( rangeItem => rangeItem.color === item.color );
+
       // 선택된 색상으로 설정
       (<UIChartColorByValue>this.uiOption.color).ranges[index].color = colorCode;
-
 
       // 그리드라면
       if( _.eq(this.uiOption.type, ChartType.GRID) ) {


### PR DESCRIPTION
### Description
If you change the line chart to Custom Color and then add dimension, the color will return to the initial palette.

**Related Issue** : #1784 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. create line chart
2. color setting > cusom color setting
3. change color
4. add dimension

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
