### PR TITLE
#1871 change ingestion method for Point type WKT column

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/widget/shelf/LayerView.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/widget/shelf/LayerView.java
@@ -82,21 +82,15 @@ public interface LayerView extends Serializable {
       }
     }
 
-    public String toHashExpression(String fieldName, boolean isGeom) {
+    public String toHashExpression(String fieldName) {
 
       List<String> pointKeyList = LogicalType.GEO_POINT.getGeoPointKeys();
 
       StringBuilder builder = new StringBuilder();
-      if (isGeom) {
-        builder.append("geom_to_").append(method).append("(");
-        builder.append(fieldName).append(",");
-        builder.append(precision).append(")");
-      } else {
-        builder.append("to_").append(method).append("(");
-        builder.append(fieldName).append(".").append(pointKeyList.get(0)).append(",");
-        builder.append(fieldName).append(".").append(pointKeyList.get(1)).append(",");
-        builder.append(precision).append(")");
-      }
+      builder.append("to_").append(method).append("(");
+      builder.append(fieldName).append(".").append(pointKeyList.get(0)).append(",");
+      builder.append(fieldName).append(".").append(pointKeyList.get(1)).append(",");
+      builder.append(precision).append(")");
 
       return builder.toString();
     }

--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/funtions/ShapeCentroidYXFunc.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/funtions/ShapeCentroidYXFunc.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specic language governing permissions and
+ * limitations under the License.
+ */
+
+package app.metatron.discovery.query.druid.funtions;
+
+public class ShapeCentroidYXFunc {
+
+  private static final String FUNC_NAME = "shape_centroid_YX";
+
+  String shapeExpr;
+
+  public ShapeCentroidYXFunc() {
+  }
+
+  public ShapeCentroidYXFunc(String shapeExpr) {
+    this.shapeExpr = shapeExpr;
+  }
+
+  public String toExpression() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(FUNC_NAME).append("(");
+    sb.append(shapeExpr).append(")");
+    return sb.toString();
+  }
+
+}

--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/funtions/StructFunc.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/funtions/StructFunc.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specic language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specic language governing permissions and
+ * limitations under the License.
+ */
+
+package app.metatron.discovery.query.druid.funtions;
+
+public class StructFunc {
+
+  private static final String FUNC_NAME = "struct";
+
+  String[] args;
+
+  public StructFunc() {
+  }
+
+  public StructFunc(String... args) {
+    this.args = args;
+  }
+
+  public String toExpression() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(FUNC_NAME).append("(");
+
+    for (int i = 0; i < args.length; i++) {
+      if (i > 0) sb.append(",");
+      sb.append(args[i]);
+    }
+
+    sb.append(")");
+
+    return sb.toString();
+  }
+
+}

--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/queries/GroupByQueryBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/queries/GroupByQueryBuilder.java
@@ -298,13 +298,11 @@ public class GroupByQueryBuilder extends AbstractQueryBuilder {
               geoColumnName = aliasName;
             }
 
-            boolean isGeom = BooleanUtils.isNotTrue(datasourceField.getDerived());
-
             LayerView layerView = mapViewLayer.getView();
             if (layerView instanceof LayerView.ClusteringLayerView) {
               LayerView.ClusteringLayerView clusteringLayerView = (LayerView.ClusteringLayerView) layerView;
 
-              virtualColumns.put(VC_COLUMN_GEO_COORD, new ExprVirtualColumn(clusteringLayerView.toHashExpression(engineColumnName, isGeom), VC_COLUMN_GEO_COORD));
+              virtualColumns.put(VC_COLUMN_GEO_COORD, new ExprVirtualColumn(clusteringLayerView.toHashExpression(engineColumnName), VC_COLUMN_GEO_COORD));
               dimensions.add(new DefaultDimension(VC_COLUMN_GEO_COORD));
 
               aggregations.addAll(clusteringLayerView.getClusteringAggregations(engineColumnName));
@@ -315,7 +313,7 @@ public class GroupByQueryBuilder extends AbstractQueryBuilder {
             } else if (layerView instanceof LayerView.HashLayerView) {
               LayerView.HashLayerView hashLayerView = (LayerView.HashLayerView) layerView;
 
-              virtualColumns.put(VC_COLUMN_GEO_COORD, new ExprVirtualColumn(hashLayerView.toHashExpression(engineColumnName, isGeom), VC_COLUMN_GEO_COORD));
+              virtualColumns.put(VC_COLUMN_GEO_COORD, new ExprVirtualColumn(hashLayerView.toHashExpression(engineColumnName), VC_COLUMN_GEO_COORD));
               dimensions.add(new DefaultDimension(VC_COLUMN_GEO_COORD));
               postAggregations.add(new ExprPostAggregator(hashLayerView.toWktExpression(VC_COLUMN_GEO_COORD, geoColumnName)));
             }

--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/queries/SelectStreamQueryBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/queries/SelectStreamQueryBuilder.java
@@ -141,7 +141,7 @@ public class SelectStreamQueryBuilder extends AbstractQueryBuilder {
 
           String geoColumnName = geoJsonFormat ? GEOMETRY_COLUMN_NAME : aliasName;
 
-          if (datasourceField.getLogicalType() == LogicalType.GEO_POINT && datasourceField.getDerived()) {
+          if (datasourceField.getLogicalType() == LogicalType.GEO_POINT) {
             virtualColumns.put(VC_COLUMN_GEO_COORD, concatPointExprColumn(engineColumnName, VC_COLUMN_GEO_COORD));
             columns.add(VC_COLUMN_GEO_COORD);
 


### PR DESCRIPTION
### Description
When loading a WKT column of the Point type, changed to longitude latitude storage structure of struct type. As a result, the point-related query structure has been simplified.

**Related Issue** : #1871 

### How Has This Been Tested?
1. Using the below file, create datasource.
[newyork_subway_entrance.csv.txt](https://github.com/metatron-app/metatron-discovery/files/3087529/newyork_subway_entrance.csv.txt)

2. In the ingestion step, specify the "the_geom" column as the column of the point type.
![image](https://user-images.githubusercontent.com/822255/56254448-cd5d1c80-60fb-11e9-9052-238fe0cba6cb.png)

3. Make sure the ingestion is successful, and check that the actual map chart is well represented.
![image](https://user-images.githubusercontent.com/822255/56254494-f8e00700-60fb-11e9-86a4-9c8931e9db5b.png)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
