### PR TITLE
Fix css in code table detail and column dictionary popup

### DIFF
--- a/discovery-frontend/src/app/meta-data-management/component/choose-column-dictionary/choose-column-dictionary.component.html
+++ b/discovery-frontend/src/app/meta-data-management/component/choose-column-dictionary/choose-column-dictionary.component.html
@@ -50,7 +50,7 @@
               <table class="ddp-table-form ddp-table-type2">
                 <colgroup>
                   <col width="20%">
-                  <col width="20%">
+                  <col width="30%">
                   <col width="*">
                 </colgroup>
                 <thead>
@@ -80,7 +80,7 @@
               <table class="ddp-table-form ddp-table-type2 ddp-cursor ddp-inherit">
                 <colgroup>
                   <col width="20%">
-                  <col width="20%">
+                  <col width="30%">
                   <col width="*">
                 </colgroup>
                 <tbody>

--- a/discovery-frontend/src/assets/css/polaris.v2.page.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.page.css
@@ -8177,6 +8177,7 @@ table.ddp-table-type2 tbody tr td table.ddp-table-code tr td {background:none; c
 
 .ddp-wrap-codetable {position:relative; width:666px;}
 .ddp-wrap-codetable .ddp-box-code {margin-bottom:10px;}
+.ddp-wrap-codetable .ddp-txt-right .ddp-btn-pop { margin-left:4px;}
 .ddp-wrap-codetable .ddp-list-option {position:absolute; top:-7px; right:0;}
 
 .ddp-wrap-codetable .ddp-list-option  .ddp-btn-line-s {font-size:12px;}


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Code table detail page : No margin between two buttons
Column dictionary popup : Column name hiding behind rows.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
No issue

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1 . Go to metadata -> code table ->  detail page ->  
![image](https://user-images.githubusercontent.com/42233517/56339833-c103bd00-61ea-11e9-90ce-4f100f3f445a.png)
Check if there's marging between two buttons.

 2 . [BROWSER LANGUAGE MUST BE ENGLISH!] Go to metadata detail -> column schema tab
![image](https://user-images.githubusercontent.com/42233517/56339866-e98bb700-61ea-11e9-8189-bd9c31befb46.png)
![image](https://user-images.githubusercontent.com/42233517/56339883-ff00e100-61ea-11e9-87a3-637f467dd397.png)
Check if second column name is shown with no error


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
