### PR TITLE
#1540 Modify column dictionary and code table icon click event

### DIFF
--- a/discovery-frontend/src/app/meta-data-management/detail/component/column-schema/column-schema.component.ts
+++ b/discovery-frontend/src/app/meta-data-management/detail/component/column-schema/column-schema.component.ts
@@ -132,9 +132,9 @@ export class ColumnSchemaComponent extends AbstractComponent implements OnInit, 
   @ViewChildren(DatetimeValidPopupComponent)
   private readonly _datetimePopupComponentList: QueryList<DatetimeValidPopupComponent>;
 
-  @Output()
+  @Output('chooseCodeTableEvent')
   private readonly _chooseCodeTableEvent = new EventEmitter();
-  @Output()
+  @Output('chooseDictionaryEvent')
   private readonly _chooseDictionaryEvent = new EventEmitter();
 
   /**


### PR DESCRIPTION
### Description
메타데이터 > 컬럼 스키마 화면의 `컬럼 딕셔너리`, `코드 테이블` 아이콘 클릭시 팝업이 열리지 않는 문제를 수정합니다

**Related Issue** : <!--- Please link to the issue here. -->
#1540 

### How Has This Been Tested?
1. 메타데이터 > 컬럼 스키마 화면으로 이동
2. 컬럼 딕셔너리 아이콘과 코드 테이블 아이콘을 클릭했을 때 팝업이 열리는지 확인합니다


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->

![bug_fix_1540](https://user-images.githubusercontent.com/41019113/56411937-7141f600-62bd-11e9-93a8-fc143e8ee025.gif)
