### PR TITLE
#1911 Change default quote in druid jdbc

### DIFF
--- a/discovery-common/src/main/java/app/metatron/discovery/extension/dataconnection/jdbc/dialect/JdbcDialect.java
+++ b/discovery-common/src/main/java/app/metatron/discovery/extension/dataconnection/jdbc/dialect/JdbcDialect.java
@@ -198,7 +198,7 @@ public interface JdbcDialect extends ExtensionPoint {
   /**
    * Connection
    */
-  boolean isSupportImplementor(JdbcConnectInformation connectInfo, String implementor);
+  boolean isSupportImplementor(String implementor);
   String getDriverClass(JdbcConnectInformation connectInfo);
   String getConnectorClass(JdbcConnectInformation connectInfo);
   String getDataAccessorClass(JdbcConnectInformation connectInfo);

--- a/discovery-extensions/mssql-connection/src/main/java/app/metatron/discovery/MssqlConnectionExtension.java
+++ b/discovery-extensions/mssql-connection/src/main/java/app/metatron/discovery/MssqlConnectionExtension.java
@@ -95,7 +95,7 @@ public class MssqlConnectionExtension extends Plugin {
     }
 
     @Override
-    public boolean isSupportImplementor(JdbcConnectInformation connectInfo, String implementor) {
+    public boolean isSupportImplementor(String implementor) {
       return implementor.toUpperCase().equals(getImplementor().toUpperCase());
     }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/DataConnectionHelper.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/DataConnectionHelper.java
@@ -87,20 +87,6 @@ public class DataConnectionHelper {
     jdbcConnectors = this.jdbcConnectors0;
     defaultConnector = this.defaultConnector0;
     pluginManager = this.pluginManager0;
-
-
-    //add JdbcDialect bean
-    //if dialect is null, look up in extension
-//    try{
-//      List<Class<JdbcDialect>> dialectClass = pluginManager.getExtensionClasses(JdbcDialect.class);
-//      for(Class<JdbcDialect> cls : dialectClass){
-//        AutowireCapableBeanFactory factory = applicationContext.getAutowireCapableBeanFactory();
-//        BeanDefinitionRegistry registry = (BeanDefinitionRegistry) factory;
-//        registry.registerBeanDefinition(cls.getSimpleName(), cls.newInstance());
-//      }
-//    } catch (InstantiationException | IllegalAccessException e){
-//      e.printStackTrace();
-//    }
   }
 
   public static JdbcAccessor getAccessor(JdbcConnectInformation connectInformation){
@@ -115,11 +101,15 @@ public class DataConnectionHelper {
   }
 
   public static JdbcDialect lookupDialect(JdbcConnectInformation connectInformation){
+    return lookupDialect(connectInformation.getImplementor());
+  }
+
+  public static JdbcDialect lookupDialect(String implementor){
     JdbcDialect matchedDialect = null;
 
     //look up in bean list
     for(JdbcDialect dialect : jdbcDialects){
-      if(dialect.isSupportImplementor(connectInformation, connectInformation.getImplementor())){
+      if(dialect.isSupportImplementor(implementor)){
         matchedDialect = dialect;
         break;
       }
@@ -127,7 +117,7 @@ public class DataConnectionHelper {
 
     if(matchedDialect == null){
       throw new JdbcDataConnectionException(JdbcDataConnectionErrorCodes.NOT_FOUND_SUITABLE_DIALECT,
-                                            "not found suitable JdbcDialect for " + connectInformation.getImplementor());
+                                            "not found suitable JdbcDialect for " + implementor);
     }
 
     return matchedDialect;

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/DruidDialect.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/DruidDialect.java
@@ -20,7 +20,9 @@ import org.springframework.stereotype.Component;
 
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import app.metatron.discovery.common.exception.FunctionWithException;
 import app.metatron.discovery.extension.dataconnection.jdbc.JdbcConnectInformation;
@@ -88,7 +90,7 @@ public class DruidDialect implements JdbcDialect {
    * Connection
    */
   @Override
-  public boolean isSupportImplementor(JdbcConnectInformation connectInfo, String implementor) {
+  public boolean isSupportImplementor(String implementor) {
     return implementor.toUpperCase().equals(this.getImplementor().toUpperCase());
   }
 
@@ -271,7 +273,9 @@ public class DruidDialect implements JdbcDialect {
 
   @Override
   public String getQuotedFieldName(JdbcConnectInformation connectInfo, String fieldName) {
-    return "`" + fieldName + "`";
+    return Arrays.stream(fieldName.split("\\."))
+                 .map(spliced -> "\"" + spliced + "\"")
+                 .collect(Collectors.joining("."));
   }
 
   @Override

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/HiveDialect.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/HiveDialect.java
@@ -22,10 +22,12 @@ import org.springframework.stereotype.Component;
 
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import app.metatron.discovery.common.exception.FunctionWithException;
 import app.metatron.discovery.extension.dataconnection.jdbc.JdbcConnectInformation;
@@ -116,7 +118,7 @@ public class HiveDialect implements JdbcDialect {
    * Connection
    */
   @Override
-  public boolean isSupportImplementor(JdbcConnectInformation connectInfo, String implementor) {
+  public boolean isSupportImplementor(String implementor) {
     return implementor.toUpperCase().equals(this.getImplementor().toUpperCase());
   }
 
@@ -303,7 +305,9 @@ public class HiveDialect implements JdbcDialect {
 
   @Override
   public String getQuotedFieldName(JdbcConnectInformation connectInfo, String fieldName) {
-    return "`" + fieldName + "`";
+    return Arrays.stream(fieldName.split("\\."))
+          .map(spliced -> "`" + spliced + "`")
+          .collect(Collectors.joining("."));
   }
 
   @Override

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/HiveDialect.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/HiveDialect.java
@@ -296,7 +296,6 @@ public class HiveDialect implements JdbcDialect {
    */
   @Override
   public String getTableName(JdbcConnectInformation connectInfo, String catalog, String schema, String table) {
-
     if(StringUtils.isEmpty(schema) || schema.equals(connectInfo.getDatabase())) {
       return table;
     }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/MySQLDialect.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/MySQLDialect.java
@@ -20,8 +20,10 @@ import org.springframework.stereotype.Component;
 
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import app.metatron.discovery.common.exception.FunctionWithException;
 import app.metatron.discovery.extension.dataconnection.jdbc.JdbcConnectInformation;
@@ -88,7 +90,7 @@ public class MySQLDialect implements JdbcDialect {
    * Connection
    */
   @Override
-  public boolean isSupportImplementor(JdbcConnectInformation connectInfo, String implementor) {
+  public boolean isSupportImplementor(String implementor) {
     return implementor.toUpperCase().equals(this.getImplementor().toUpperCase());
   }
 
@@ -328,7 +330,9 @@ public class MySQLDialect implements JdbcDialect {
 
   @Override
   public String getQuotedFieldName(JdbcConnectInformation connectInfo, String fieldName) {
-    return "`" + fieldName + "`";
+    return Arrays.stream(fieldName.split("\\."))
+                 .map(spliced -> "`" + spliced + "`")
+                 .collect(Collectors.joining("."));
   }
 
   @Override

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/PostgresqlDialect.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/PostgresqlDialect.java
@@ -89,7 +89,7 @@ public class PostgresqlDialect implements JdbcDialect {
    * Connection
    */
   @Override
-  public boolean isSupportImplementor(JdbcConnectInformation connectInfo, String implementor) {
+  public boolean isSupportImplementor(String implementor) {
     return implementor.toUpperCase().equals(this.getImplementor().toUpperCase());
   }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/PrestoDialect.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/PrestoDialect.java
@@ -91,7 +91,7 @@ public class PrestoDialect implements JdbcDialect {
    * Connection
    */
   @Override
-  public boolean isSupportImplementor(JdbcConnectInformation connectInfo, String implementor) {
+  public boolean isSupportImplementor(String implementor) {
     return implementor.toUpperCase().equals(this.getImplementor().toUpperCase());
   }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/query/expression/NativeProjection.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/query/expression/NativeProjection.java
@@ -19,6 +19,8 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -33,6 +35,7 @@ import app.metatron.discovery.extension.dataconnection.jdbc.dialect.JdbcDialect;
 import app.metatron.discovery.extension.dataconnection.jdbc.exception.JdbcDataConnectionException;
 
 public class NativeProjection {
+  private static final Logger LOGGER = LoggerFactory.getLogger(NativeProjection.class);
 
   /**
    * Projection list
@@ -578,7 +581,9 @@ public class NativeProjection {
       if(jdbcDialect != null){
         return jdbcDialect.getQuotedFieldName(null, columnName);
       }
-    } catch (JdbcDataConnectionException e){}
+    } catch (JdbcDataConnectionException e){
+      LOGGER.debug("no suitable dialect for quote : {}", implementor);
+    }
 
     return Arrays.stream(columnName.split("\\."))
             .map(spliced -> "`" + spliced + "`")

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/query/expression/NativeProjection.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/query/expression/NativeProjection.java
@@ -573,7 +573,7 @@ public class NativeProjection {
     switch (implementor){
       case "MSSQL": case "POSTGRESQL": case "PRESTO":
         return columnName;
-      case "ORACLE": case "TIBERO":
+      case "ORACLE": case "TIBERO": case "DRUID":
         return Arrays.stream(columnName.split("\\."))
                 .map(spliced -> "\"" + spliced + "\"")
                 .collect(Collectors.joining("."));

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcConnectionService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcConnectionService.java
@@ -418,6 +418,7 @@ public class JdbcConnectionService {
     Preconditions.checkNotNull(realConnection, "connection info. required.");
 
     JdbcAccessor jdbcDataAccessor = DataConnectionHelper.getAccessor(realConnection);
+    JdbcDialect jdbcDialect = jdbcDataAccessor.getDialect();
     Connection connection = jdbcDataAccessor.getConnection();
 
     List<String> tempCsvFiles = Lists.newArrayList();
@@ -428,8 +429,9 @@ public class JdbcConnectionService {
     if (ingestionInfo.getDataType() == JdbcIngestionInfo.DataType.TABLE) {
       String database = ingestionInfo.getDatabase();
       String table = ingestionInfo.getQuery();
-      String tableName = (!table.contains(".") && database != null) ? database + "." + table : table;
-      nativeCriteria.addTable(tableName, table);
+      String tableName = jdbcDialect.getTableName(realConnection, realConnection.getCatalog(), database, table);
+      String tableAlias = jdbcDialect.getTableName(realConnection, realConnection.getCatalog(), null, table);
+      nativeCriteria.addTable(tableName, tableAlias);
     } else {
       nativeCriteria.addSubQuery(StringUtils.replaceAll(ingestionInfo.getQuery(), ";", ""));
     }
@@ -557,6 +559,7 @@ public class JdbcConnectionService {
     Preconditions.checkNotNull(realConnection, "connection info. required.");
 
     JdbcAccessor jdbcDataAccessor = DataConnectionHelper.getAccessor(realConnection);
+    JdbcDialect jdbcDialect = jdbcDataAccessor.getDialect();
     Connection connection = jdbcDataAccessor.getConnection();
 
     List<String> tempCsvFiles = Lists.newArrayList();
@@ -567,8 +570,9 @@ public class JdbcConnectionService {
     if (ingestionInfo.getDataType() == JdbcIngestionInfo.DataType.TABLE) {
       String database = ingestionInfo.getDatabase();
       String table = ingestionInfo.getQuery();
-      String tableName = (!table.contains(".") && database != null) ? database + "." + table : table;
-      nativeCriteria.addTable(tableName, table);
+      String tableName = jdbcDialect.getTableName(realConnection, realConnection.getCatalog(), database, table);
+      String tableAlias = jdbcDialect.getTableName(realConnection, realConnection.getCatalog(), null, table);
+      nativeCriteria.addTable(tableName, tableAlias);
       queryString = nativeCriteria.toSQL();
     } else {
       queryString = ingestionInfo.getQuery();
@@ -765,6 +769,7 @@ public class JdbcConnectionService {
     Preconditions.checkNotNull(realConnection, "connection info. required.");
 
     JdbcAccessor jdbcDataAccessor = DataConnectionHelper.getAccessor(realConnection);
+    JdbcDialect jdbcDialect = jdbcDataAccessor.getDialect();
     Connection connection = jdbcDataAccessor.getConnection(ingestionInfo.getDatabase(),true);
 
     NativeCriteria nativeCriteria = new NativeCriteria(jdbcDataConnection.getImplementor());
@@ -780,7 +785,11 @@ public class JdbcConnectionService {
       nativeProjection.addAggregateProjection(targetFieldName, "maxTime", NativeProjection.AggregateProjection.MAX);
       nativeCriteria.setProjection(nativeProjection);
       if (ingestionInfo.getDataType() == JdbcIngestionInfo.DataType.TABLE) {
-        nativeCriteria.addTable(ingestionInfo.getQuery(), ingestionInfo.getQuery());
+        String database = ingestionInfo.getDatabase();
+        String table = ingestionInfo.getQuery();
+        String tableName = jdbcDialect.getTableName(realConnection, realConnection.getCatalog(), database, table);
+        String tableAlias = jdbcDialect.getTableName(realConnection, realConnection.getCatalog(), null, table);
+        nativeCriteria.addTable(tableName, tableAlias);
       } else {
         nativeCriteria.addSubQuery(ingestionInfo.getQuery());
       }
@@ -789,7 +798,11 @@ public class JdbcConnectionService {
       nativeProjection.addAggregateProjection(targetFieldName, "count", NativeProjection.AggregateProjection.COUNT);
       nativeCriteria.setProjection(nativeProjection);
       if (ingestionInfo.getDataType() == JdbcIngestionInfo.DataType.TABLE) {
-        nativeCriteria.addTable(ingestionInfo.getQuery(), ingestionInfo.getQuery());
+        String database = ingestionInfo.getDatabase();
+        String table = ingestionInfo.getQuery();
+        String tableName = jdbcDialect.getTableName(realConnection, realConnection.getCatalog(), database, table);
+        String tableAlias = jdbcDialect.getTableName(realConnection, realConnection.getCatalog(), null, table);
+        nativeCriteria.addTable(tableName, tableAlias);
       } else {
         nativeCriteria.addSubQuery(ingestionInfo.getQuery());
       }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
We need to change default quote for druid JDBC according to calcite spec.

Because the default identifier quoting character is double-quote("), so back-quote(`) would be an error without additional configuration.

- As-Is: using ` for quote
- To-Be: changed \\" for quote


**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#1911 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Create a data connection with the druid.
2. Create datasource with the above connection. **(as linked type)**
3. Create a dashboard with the above datasource.
4. Databoard created successfully.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Additional Context<!-- if not appropriate, remove this topic. -->
