### PR TITLE
#1894 fix to work when only local system is configured

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetFileService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetFileService.java
@@ -140,11 +140,11 @@ public class PrepDatasetFileService {
                         throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE,
                             PrepMessageKey.MSG_DP_ALERT_UNKOWN_ERROR, "Excel files should have converted as CSV");
                     case "json":
-                        Configuration conf = PrepUtil.getHadoopConf(prepProperties.getHadoopConfDir(true));
+                        Configuration conf = PrepUtil.getHadoopConf(prepProperties.getHadoopConfDir(false));
                         result = PrepJsonUtil.countJson(storedUri, limitRows, conf);
                         break;
                     default:
-                        conf = PrepUtil.getHadoopConf(prepProperties.getHadoopConfDir(true));
+                        conf = PrepUtil.getHadoopConf(prepProperties.getHadoopConfDir(false));
                         String delimiterCol = dataset.getDelimiter();
                         result = PrepCsvUtil.countCsv(storedUri, delimiterCol, limitRows, conf);
                 }
@@ -470,7 +470,7 @@ public class PrepDatasetFileService {
     private Map<String, Object> getResponseMapFromJson(String storedUri, int limitRows, Integer columnCount, boolean autoTyping) throws TeddyException {
         Map<String, Object> responseMap = Maps.newHashMap();
         List<DataFrame> gridResponses = Lists.newArrayList();
-        Configuration hadoopConf = PrepUtil.getHadoopConf(prepProperties.getHadoopConfDir(true));
+        Configuration hadoopConf = PrepUtil.getHadoopConf(prepProperties.getHadoopConfDir(false));
 
         DataFrame df = new DataFrame("df_for_preview");
         df.setByGridWithJson(PrepJsonUtil.parseJson(storedUri, limitRows, columnCount, hadoopConf));
@@ -488,7 +488,7 @@ public class PrepDatasetFileService {
     private Map<String, Object> getResponseMapFromCsv(String storedUri, int limitRows, String delimiterCol, Integer columnCount, boolean autoTyping) throws TeddyException {
         Map<String, Object> responseMap = Maps.newHashMap();
         List<DataFrame> gridResponses = Lists.newArrayList();
-        Configuration hadoopConf = PrepUtil.getHadoopConf(prepProperties.getHadoopConfDir(true));
+        Configuration hadoopConf = PrepUtil.getHadoopConf(prepProperties.getHadoopConfDir(false));
 
         DataFrame df = new DataFrame("df_for_preview");
         df.setByGrid(PrepCsvUtil.parse(storedUri, delimiterCol, limitRows, columnCount, hadoopConf));

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepUtil.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepUtil.java
@@ -55,6 +55,10 @@ public class PrepUtil {
   }
 
   public static Configuration getHadoopConf(String hadoopConfDir) {
+    if (hadoopConfDir == null) {
+      return null;
+    }
+
     String coreSite = hadoopConfDir + File.separator + "core-site.xml";
     String hdfsSite = hadoopConfDir + File.separator + "hdfs-site.xml";
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/service/PrSnapshotController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/service/PrSnapshotController.java
@@ -207,7 +207,7 @@ public class PrSnapshotController {
                     }
 
                     // We generated JSON snapshots to have ".json" at the end of the URI.
-                    Configuration hadoopConf = PrepUtil.getHadoopConf(prepProperties.getHadoopConfDir(true));
+                    Configuration hadoopConf = PrepUtil.getHadoopConf(prepProperties.getHadoopConfDir(false));
                     if (storedUri.endsWith(".json")) {
                         PrepJsonParseResult result = PrepJsonUtil.parseJson(snapshot.getStoredUri(), 10000, null, hadoopConf);
                         gridResponse.setByGridWithJson(result);

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/TeddyImpl.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/TeddyImpl.java
@@ -267,7 +267,7 @@ public class TeddyImpl {
 
   public DataFrame loadFileDataset(String dsId, String strUri, String delimiter, Integer columnCount, String dsName) {
     DataFrame df = new DataFrame(dsName);   // join, union등에서 dataset 이름을 제공하기위해 dsName 추가
-    Configuration hadoopConf = PrepUtil.getHadoopConf(prepProperties.getHadoopConfDir(true));
+    Configuration hadoopConf = PrepUtil.getHadoopConf(prepProperties.getHadoopConfDir(false));
     int samplingRows = prepProperties.getSamplingLimitRows();
 
     String extensionType = FilenameUtils.getExtension(strUri);


### PR DESCRIPTION
### Description
Data preparation has been designed to work on the local file system without Hadoop or Hive.
But, when I ran without hadoop configuration, an error popped out.
For more description, take a look at the related issue.

**Related Issue** : https://github.com/metatron-app/metatron-discovery/issues/1894

### How Has This Been Tested?
Ran locally.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
