### PR TITLE
#1912 do not check upstream's column name for hive snapshot

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
@@ -996,15 +996,6 @@ public class PrepTransformService {
     } catch (IllegalColumnNameForHiveException e) {
       throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_TEDDY_ILLEGAL_COLUMN_NAME_FOR_HIVE, e.getMessage());
     }
-
-    List<String> upstreamDsIds = getUpstreamDsIds(dsId);
-    for (String upsteramDsId : upstreamDsIds) {
-      PrDataset dataset = datasetRepository.findRealOne(datasetRepository.findOne(upsteramDsId));
-      if (dataset.getDsType() == IMPORTED) {
-        continue;
-      }
-      checkHiveNamingRule(upsteramDsId);
-    }
   }
 
   // FIXME: What is this functions for?


### PR DESCRIPTION
### Description
Removed unnecessary column name check while snapshot generation.
We do not need to check middle datasets. Only the final dataset matters.

**Related Issue** : https://github.com/metatron-app/metatron-discovery/issues/1912

### How Has This Been Tested?
Run locally.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
