### PR TITLE
#1901 filter; if two table has same column names, it cannot apply to both table

### DIFF
--- a/discovery-frontend/src/app/dashboard/filters/configure-filters-select.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/configure-filters-select.component.ts
@@ -456,7 +456,9 @@ export class ConfigureFiltersSelectComponent extends AbstractFilterPopupComponen
 
     // 필드 설정
     fields.forEach((field: Field) => {
-      let boardFilter: Filter = boardFilters.find(filter => field.name === filter.field);
+      let boardFilter: Filter = boardFilters.find( filter => {
+        return field.name === filter.field && filter.dataSource === field.dataSource;
+      });
 
       // 타임스탬프 필드 여부
       field['isTimestamp'] = ('user_expr' !== field.type && (<Field>field).logicalType === LogicalType.TIMESTAMP);

--- a/discovery-frontend/src/app/dashboard/update-dashboard.component.ts
+++ b/discovery-frontend/src/app/dashboard/update-dashboard.component.ts
@@ -289,7 +289,7 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
     this.subscriptions.push(
       this.broadCaster.on<any>('CHANGE_FILTER_SELECTOR').subscribe(data => {
         this.dashboard = DashboardUtil.updateWidget(this.dashboard, data.widget);
-        this.dashboard = DashboardUtil.updateBoardFilter(this.dashboard, data.filter);
+        this.dashboard = DashboardUtil.updateBoardFilter(this.dashboard, data.filter)[0];
       })
     );
 
@@ -1222,10 +1222,16 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
     this._changeChartFilterToGlobalFilter(filter);
 
     // 대시보드 필터 업데이트
-    this.dashboard = DashboardUtil.updateBoardFilter(this.dashboard, filter, true);
+    const updateResult:[Dashboard, boolean] = DashboardUtil.updateBoardFilter(this.dashboard, filter, true);
+    this.dashboard = updateResult[0];
 
     this._organizeAllFilters(true).then(() => {
       this._syncFilterWidget();
+
+      if( updateResult[1] ) {
+        // append New Filter
+        this.openIndexFilterPanel = DashboardUtil.getFilterWidgets(this.dashboard).length - 1;
+      }
 
       this._configFilterComp.close();
       this.hideBoardLoading();


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
동일한 필드명을 가지는 두개의 데이터 소스를 이용하여 대시보드를 생성할 경우, 각각의 데이터소스에서 동일한 필드명에 대한 필터를 생성할 수 없습니다. 

**Related Issue** : #1901  <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 동일한 필드명(ex:category) 이 있는 두 개의 데이터소스(sales_A,sales_B)를 이용하여 대시보드를 생성합니다.
2. 대시보드 편집 화면에서 sales_A 데이터소스를 이용하여 category 필드에 대한 필터를 생성합니다.
3. 다시 필터 생성 화면을 띄워 sales_B 데이터소스를 이용하여 category 필드를 생성합니다.
4. 필터가 정상 동작 하는지 확인합니다.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
