### PR TITLE
#1517 fix an error in retrieving the list of movable workspaces

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourceRepositoryImpl.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourceRepositoryImpl.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 import com.querydsl.core.types.SubQueryExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 
@@ -126,10 +127,13 @@ public class DataSourceRepositoryImpl extends QueryDslRepositorySupport implemen
   @Override
   public List<String> findIdsByWorkbookInNotPublic(String workbookId) {
     QDashBoard qDashBoard = QDashBoard.dashBoard;
+    QDataSource qDataSource = qDashBoard.dataSources.any();
 
-    JPQLQuery query = from(qDashBoard).select(qDashBoard.dataSources.any().id).distinct()
+    // FixMe: Query generation is complicated by null processing of "published" columns
+    JPQLQuery query = from(qDashBoard).select(qDataSource.id).distinct()
                                       .where(qDashBoard.workBook.id.eq(workbookId),
-                                             qDashBoard.dataSources.any().published.ne(true));
+                                             Expressions.anyOf(qDataSource.published.isNull(),
+                                                               qDataSource.published.isFalse()));
 
     return query.fetch();
 

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/workspace/WorkspaceRestIntegrationTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/workspace/WorkspaceRestIntegrationTest.java
@@ -372,16 +372,13 @@ public class WorkspaceRestIntegrationTest extends AbstractRestIntegrationTest {
   @Sql({"/sql/test_import_workspace_list.sql"})
   public void workspaceListImportAvailable() throws JsonProcessingException {
 
-    String workbookId = "wb-001";
-//    String workbookId = "wb-002";
+    //    String workbookId = "wb-001";
+    String workbookId = "wb-002";
 
     // @formatter:off
     given()
       .auth().oauth2(oauth_token)
       .contentType(ContentType.JSON)
-//      .accept("application/x-spring-data-verbose+json")
-//      .param("publicType", "private")
-//      .param("nameContains", "test")
 //      .param("excludes", "ws-02")
       .param("projection", "forTreeView")
 //      .param("size", "10")
@@ -391,8 +388,7 @@ public class WorkspaceRestIntegrationTest extends AbstractRestIntegrationTest {
     .when()
       .get("/api/workspaces/import/books/{workbookId}/available", workbookId)
     .then()
-//      .statusCode(HttpStatus.SC_OK)
-//      .body("_embedded.workspaces.length", greaterThan(0))
+      .statusCode(HttpStatus.SC_OK)
       .log().all();
     // @formatter:on
   }

--- a/discovery-server/src/test/resources/sql/test_import_workspace_list.sql
+++ b/discovery-server/src/test/resources/sql/test_import_workspace_list.sql
@@ -10,7 +10,7 @@ INSERT INTO workspace_member(id, member_id, member_type, member_role, ws_id) VAL
 
 INSERT INTO datasource(id, ds_name, ds_engine_name, ds_owner_id, ds_desc, ds_type, ds_conn_type, ds_granularity, ds_src_type, ds_status, ds_published, ds_linked_workspaces, version, created_time, created_by, modified_time, modified_by) values
 ('ds-test-01', 'test1', 'test1', 'polaris', 'test1 data', 'MASTER', 'ENGINE', 'DAY', 'IMPORT', 'ENABLED', TRUE, 0, 1.0, NOW(), 'polaris',  NOW(), 'polaris'),
-('ds-test-02', 'test2', 'test2', 'polaris', 'test2 data', 'MASTER', 'ENGINE', 'DAY', 'IMPORT', 'ENABLED', FALSE, 2, 1.0, NOW(), 'polaris',  NOW(), 'polaris');
+('ds-test-02', 'test2', 'test2', 'polaris', 'test2 data', 'MASTER', 'ENGINE', 'DAY', 'IMPORT', 'ENABLED', NULL, 2, 1.0, NOW(), 'polaris',  NOW(), 'polaris');
 
 INSERT INTO datasource_workspace(ws_id, ds_id) VALUES
 ('ws-0001', 'ds-test-01'),
@@ -34,8 +34,8 @@ INSERT INTO PUBLIC.DASHBOARD(ID, CREATED_BY, CREATED_TIME, MODIFIED_BY, MODIFIED
 ('db-003', 'polaris', now(), 'polaris', now(), 0, '{"dataSource":{"type": "default", "name": "test2"}}', NULL, NULL, 'dashboard-test3', NULL, 2, NULL, 'wb-002'),
 ('db-004', 'polaris', now(), 'polaris', now(), 0, '{"dataSource":{"type": "default", "name": "test2"}}', NULL, NULL, 'dashboard-test4', NULL, 3, NULL, 'wb-002');
 INSERT INTO PUBLIC.DATASOURCE_DASHBOARD(DASHBOARD_ID, DS_ID) VALUES
-('db-001', 'ds-37'),
-('db-002', 'ds-37'),
+('db-001', 'ds-gis-37'),
+('db-002', 'ds-gis-37'),
 ('db-003', 'ds-test-01'),
 ('db-004', 'ds-test-02');
 


### PR DESCRIPTION
### Description
When you move a workbook, you can see the workspaces that can be moved. 
However, the workspace that can not be moved was searched and It was fixed.

**Related Issue** : #1512 

### How Has This Been Tested?
1. Create workbooks and dashboards from datasource published only to your personal workspace.
2. Select the workbook you created and click the "move selection" button at the bottom.
3. Confirm that no workspaces other than your personal workspaces appear.

#### Need additional checks?
- If datasources in your workbook is an open data only, you should see a list of workspaces that I have edit permission.
- If the data source in the workbook is not open data and is published to the workspace you want to move, that workspace must also be listed. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Additional Context<!-- if not appropriate, remove this topic. -->
