### PR TITLE
fix dashboard critical issues in ie

### DIFF
--- a/discovery-frontend/src/app/common/component/input/input.component.ts
+++ b/discovery-frontend/src/app/common/component/input/input.component.ts
@@ -134,7 +134,7 @@ export class InputComponent implements OnInit, OnDestroy {
     }
 
     if ('' !== this.optionalStyle) {
-      this._styleElm.nativeElement.style = this.optionalStyle;
+      this._styleElm.nativeElement.setAttribute( 'style', this.optionalStyle );
     }
     if ('' === this.inputClass) {
       switch (this.compType) {

--- a/discovery-frontend/src/app/common/service/image.service.ts
+++ b/discovery-frontend/src/app/common/service/image.service.ts
@@ -12,13 +12,13 @@
  * limitations under the License.
  */
 
-import { Injectable, Injector } from '@angular/core';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
 import * as $ from 'jquery';
-import { FileUploader } from 'ng2-file-upload';
-import { CommonConstant } from '../constant/common.constant';
-import { CookieConstant } from 'app/common/constant/cookie.constant';
-import { CookieService } from 'ng2-cookies';
+import {Injectable, Injector} from '@angular/core';
+import {HttpClient, HttpHeaders} from '@angular/common/http';
+import {FileUploader} from 'ng2-file-upload';
+import {CommonConstant} from '../constant/common.constant';
+import {CookieConstant} from 'app/common/constant/cookie.constant';
+import {CookieService} from 'ng2-cookies';
 
 declare const html2canvas: any;
 
@@ -59,8 +59,8 @@ export class ImageService {
         reject('element not found.');
       }
 
-      setTimeout( () => {
-        html2canvas($element.get(0), { useCORS:true, allowTaint: true, logging: false }).then((result) => {
+      setTimeout(() => {
+        html2canvas($element.get(0), {useCORS: true, allowTaint: true, logging: false}).then((result) => {
           const dataUrl = result.toDataURL('image/jpeg');
           const byteString = atob(dataUrl.split(',')[1]);
 
@@ -72,10 +72,15 @@ export class ImageService {
             ia[i] = byteString.charCodeAt(i);
           }
 
-          const blobData = new Blob([ab], { 'type': mimeString });
+          console.info( '>>>>>>> mimeString' );
+
+          const blobData = new Blob([ab], {'type': mimeString});
+
+          console.info( '>>>>>>> blobData' );
+
           resolve(blobData);
         }).catch(err => reject(err));
-      }, 500 );
+      }, 500);
 
     });
   } // function - getBlob
@@ -99,7 +104,7 @@ export class ImageService {
         reject('element not found.');
       }
 
-      html2canvas($element.get(0)).then((result) => {
+      html2canvas($element.get(0), {useCORS: true, allowTaint: true, logging: false}).then((result) => {
         const dataUrl = result.toDataURL('image/jpeg');
         resolve(dataUrl);
       }).catch(err => reject(err));
@@ -125,26 +130,37 @@ export class ImageService {
       throw new Error('element not found.');
     }
 
-    setTimeout( () => {
-      this.getBase64(element).then((data) => {
-        // a 태그 만들기
-        const link = document.createElement('a');
-        // 해당 태그에 url 설정
-        link.href = data;
+    setTimeout(() => {
 
-        // 파일 이름 설정
-        link.download = fileName;
+      const agent = navigator.userAgent.toLowerCase();
+      if ( (navigator.appName == 'Netscape' && agent.indexOf('trident') != -1) || (agent.indexOf("msie") != -1)) {
+        // is IE
+        this.getBlob(element).then((data) => {
+          window.navigator.msSaveBlob(data, fileName);
+        });
+      } else {
+        // Other browser
+        this.getBase64(element).then((data) => {
 
-        // 해당 차트 링크를 설정
-        document.body.appendChild(link);
+          // a 태그 만들기
+          const link = document.createElement('a');
+          // 해당 태그에 url 설정
+          link.href = data;
 
-        // 다운로드 trigger
-        link.click();
+          // 파일 이름 설정
+          link.download = fileName;
 
-        // 해당 링크 제거
-        document.body.removeChild(link);
-      });
-    }, 500 );
+          // 해당 차트 링크를 설정
+          document.body.appendChild(link);
+
+          // 다운로드 trigger
+          link.click();
+
+          // 해당 링크 제거
+          document.body.removeChild(link);
+        });
+      }
+    }, 500);
   } // function - downloadFromElement
 
 
@@ -163,9 +179,9 @@ export class ImageService {
       'Accept': 'image/webp,image/apng,image/*,*/*;',
       'Content-Type': 'application/octet-binary',
       'Authorization': this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN_TYPE)
-      + ' ' + this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN)
+        + ' ' + this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN)
     });
-    return this._http.get(imgUrl, { headers: headers, responseType: 'blob' }).toPromise();
+    return this._http.get(imgUrl, {headers: headers, responseType: 'blob'}).toPromise();
   } // function - downloadImageFromUrl
 
   /**

--- a/discovery-frontend/src/app/dashboard/component/dashboard-datasource-combo.component.html
+++ b/discovery-frontend/src/app/dashboard/component/dashboard-datasource-combo.component.html
@@ -46,7 +46,6 @@
           </a>
         </li>
       </ul>
-      <!--<a href="javascript:" class="ddp-btn-more">+ more</a>-->
     </div>
     <!-- // 목록 영역 -->
     <!-- 데이터소스 수정 링크 -->

--- a/discovery-frontend/src/app/dashboard/update-dashboard.component.ts
+++ b/discovery-frontend/src/app/dashboard/update-dashboard.component.ts
@@ -722,8 +722,24 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
     (0 < cntWidgetComps) && (this.resizeToFitScreenForSave());
 
     // 위젯 업데이트 후 작동
-    CommonUtil.waterfallPromise(promises).then(() => {
+    if( 0 < promises.length ) {
+      CommonUtil.waterfallPromise(promises).then(() => {
 
+        if (0 < cntWidgetComps) {
+          // 이미지 업로드 - 임시적으로 채운 화면인 인식되기 위해
+          this._uploadDashboardImage(this.dashboard)
+            .then(result => this._callUpdateDashboardService(result['imageUrl']))
+            .catch(() => this._callUpdateDashboardService(null));
+        } else {
+          this._callUpdateDashboardService(null);
+        }
+
+      }).catch((error) => {
+        console.error(error);
+        Alert.error(this.translateService.instant('msg.board.alert.widget.apply.error'));
+        this.hideBoardLoading();     // 로딩 hide
+      });
+    } else {
       if (0 < cntWidgetComps) {
         // 이미지 업로드 - 임시적으로 채운 화면인 인식되기 위해
         this._uploadDashboardImage(this.dashboard)
@@ -732,12 +748,8 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
       } else {
         this._callUpdateDashboardService(null);
       }
+    }
 
-    }).catch((error) => {
-      console.error(error);
-      Alert.error(this.translateService.instant('msg.board.alert.widget.apply.error'));
-      this.hideBoardLoading();     // 로딩 hide
-    });
   } // function - updateDashboard
 
   /**

--- a/discovery-frontend/src/app/page/page.component.html
+++ b/discovery-frontend/src/app/page/page.component.html
@@ -29,8 +29,8 @@
                   {{'msg.page.ui.panel.title' | translate}}
                   <span class="ddp-data-det">
                 {{'msg.page.ui.num.dimensions.measures' | translate : {
-                    dimensions: getSelectedDataItemsCnt(dimensions),
-                    measures: getSelectedDataItemsCnt(measures)
+                    dimensions: getCntShelfItem('DIMENSION'),
+                    measures: getCntShelfItem('MEASURE')
                   } }}
                 </span>
                   <em class="ddp-icon-drop-view"></em>

--- a/discovery-frontend/src/app/page/page.component.ts
+++ b/discovery-frontend/src/app/page/page.component.ts
@@ -2301,18 +2301,31 @@ export class PageComponent extends AbstractPopupComponent implements OnInit, OnD
   /**
    * 데이터패널에서 선택된 dimension /measure 개수 return
    */
-  public getSelectedDataItemsCnt(items: Field[]): number {
+  public getCntShelfItem(type: 'DIMENSION' | 'MEASURE'): number {
 
-    // 선택된 아이템 변수
-    let selectedItems = [];
-
-    // pivot 정보가 있는 아이템만 설정
-    selectedItems = items.filter((item) => {
-      if (item.pivot && item.pivot.length > 0) return item;
-    });
-
-    return selectedItems.length;
-  }
+    let cntShelfItems = 0;
+    const strType:string = type.toLowerCase();
+    if( ChartType.MAP === this.widgetConfiguration.chart.type ) {
+      // 선택된 아이템 변수 - shelf 정보가 있는 아이템만 설정
+      this.shelf.layers.forEach( layer => {
+        cntShelfItems = cntShelfItems + layer.fields.filter( field => {
+          return strType === field.type && field.field.dataSource === this.dataSource.engineName;
+        }).length;
+      });
+    } else {
+      // 선택된 아이템 변수 - pivot 정보가 있는 아이템만 설정
+      cntShelfItems = cntShelfItems + this.pivot.rows.filter(row => {
+        return strType === row.type && row.field.dataSource === this.dataSource.engineName;
+      }).length;
+      cntShelfItems = cntShelfItems + this.pivot.columns.filter(col => {
+        return strType === col.type && col.field.dataSource === this.dataSource.engineName;
+      }).length;
+      cntShelfItems = cntShelfItems + this.pivot.aggregations.filter(aggr => {
+        return strType === aggr.type && aggr.field.dataSource === this.dataSource.engineName;
+      }).length;
+    }
+    return cntShelfItems;
+  } // function - getCntShelfItem
 
   /**
    * 차트 데이터가 없을시 No Data 노출
@@ -2500,7 +2513,7 @@ export class PageComponent extends AbstractPopupComponent implements OnInit, OnD
     if (isDimension) {
 
       // map chart validation
-      if ( ( targetField.logicalType && targetField.logicalType.toString().indexOf('GEO') != -1 )
+      if ((targetField.logicalType && targetField.logicalType.toString().indexOf('GEO') != -1)
         && !_.eq(this.selectChart, '')) {
         Alert.warning(this.translateService.instant('msg.board.ui.invalid-pivot'));
         return;
@@ -3450,7 +3463,7 @@ export class PageComponent extends AbstractPopupComponent implements OnInit, OnD
           if (targetField) {
             // geo column validation 체크
             if (!_.eq(this.selectChart, ChartType.MAP) && !_.eq(this.selectChart, '')
-              && ( targetField.logicalType && targetField.logicalType.toString().indexOf('GEO') != -1 ) ) {
+              && (targetField.logicalType && targetField.logicalType.toString().indexOf('GEO') != -1)) {
               if (info.target === 'column') {
                 this.invalidGeoData(this.pivot.columns);
               } else if (info.target === 'row') {

--- a/discovery-frontend/src/polyfills.ts
+++ b/discovery-frontend/src/polyfills.ts
@@ -49,6 +49,9 @@ import 'core-js/es6/map';
 import 'core-js/es6/weak-map';
 import 'core-js/es6/set';
 
+import 'core-js/es6/promise';
+import 'core-js/es7/promise';
+
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
1. 대시보드 생성후 -> 편집화면 진입 -> 위젯 이 없는 상태에서 Done 버튼 클릭시 오류 발생
2. 대시보드 편집 화면 우측 패널 > 데이터 패널 내 dimension/measure 컬럼 정보가 나타나지 않음
3. 대시보드 데이터 소스 View 팝업내 데이터 그리드 /컬럼 상세 정보가 나타나지 않음
4. 대시보드 내 위젯 이미지 다운로드 안됨

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 위젯 이 없는 상태 대시보드 저장이 되는지 확인합니다.
2. 대시보드 편집 화면 우측 패널에서 필드 목록이 표시되는지 확인합니다.
3. 데이터 소스 View 팝업 내 데이터 그리드가 표시되는지 확인합니다.
4. 대시보드 내 위젯 이미지 다운로드가 되는지 확인합니다.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
