### PR TITLE
#1948 date function for incremental ingestion

### DIFF
--- a/discovery-common/src/main/java/app/metatron/discovery/extension/dataconnection/jdbc/dialect/JdbcDialect.java
+++ b/discovery-common/src/main/java/app/metatron/discovery/extension/dataconnection/jdbc/dialect/JdbcDialect.java
@@ -244,5 +244,5 @@ public interface JdbcDialect extends ExtensionPoint {
   String getQuotedFieldName(JdbcConnectInformation connectInfo, String fieldName);
   String getDefaultTimeFormat(JdbcConnectInformation connectInfo);
   String getCharToDateStmt(JdbcConnectInformation connectInfo, String timeStr, String timeFormat);
-  String getCurrentTimeStamp(JdbcConnectInformation connectInfo);
+  String getCharToUnixTimeStmt(JdbcConnectInformation connectInfo, String timeStr);
 }

--- a/discovery-extensions/mssql-connection/src/main/java/app/metatron/discovery/MssqlConnectionExtension.java
+++ b/discovery-extensions/mssql-connection/src/main/java/app/metatron/discovery/MssqlConnectionExtension.java
@@ -1,22 +1,18 @@
 package app.metatron.discovery;
 
+import org.apache.commons.lang3.StringUtils;
 import org.pf4j.Extension;
 import org.pf4j.Plugin;
 import org.pf4j.PluginWrapper;
-import org.apache.commons.lang3.StringUtils;
 
 import java.sql.SQLException;
 import java.sql.Timestamp;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 import app.metatron.discovery.common.exception.FunctionWithException;
 import app.metatron.discovery.extension.dataconnection.jdbc.JdbcConnectInformation;
 import app.metatron.discovery.extension.dataconnection.jdbc.accessor.AbstractJdbcDataAccessor;
 import app.metatron.discovery.extension.dataconnection.jdbc.dialect.JdbcDialect;
-import app.metatron.discovery.extension.dataconnection.jdbc.exception.JdbcDataConnectionErrorCodes;
-import app.metatron.discovery.extension.dataconnection.jdbc.exception.JdbcDataConnectionException;
 
 /**
  *
@@ -415,23 +411,13 @@ public class MssqlConnectionExtension extends Plugin {
     @Override
     public String getCharToDateStmt(JdbcConnectInformation connectInfo, String timeStr, String timeFormat) {
       StringBuilder builder = new StringBuilder();
-      builder.append("TO_DATE('").append(timeStr).append("', ");
-
-      builder.append("'");
-      if(DEFAULT_FORMAT.equals(timeFormat)) {
-        builder.append(getDefaultTimeFormat(connectInfo));
-      } else {
-        builder.append(timeFormat).append("'");
-      }
-      builder.append("'");
-      builder.append(") ");
-
+      builder.append("CAST(").append(timeStr).append(" as DATETIME) ");
       return builder.toString();
     }
 
     @Override
-    public String getCurrentTimeStamp(JdbcConnectInformation connectInfo) {
-      return "TO_CHAR(NOW(), '" + getDefaultTimeFormat(connectInfo) + "') AS TIMESTAMP";
+    public String getCharToUnixTimeStmt(JdbcConnectInformation connectInfo, String timeStr) {
+      return "CAST(DATEDIFF(s, '1970-01-01', CAST(" + timeStr + " as DATETIME)) as BIGINT)";
     }
   }
 }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/DruidDialect.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/DruidDialect.java
@@ -280,17 +280,29 @@ public class DruidDialect implements JdbcDialect {
 
   @Override
   public String getDefaultTimeFormat(JdbcConnectInformation connectInfo) {
-    return "%Y-%m-%d %T";
+    return "yyyy-MM-dd HH:mm:ss";
   }
 
   @Override
   public String getCharToDateStmt(JdbcConnectInformation connectInfo, String timeStr, String timeFormat) {
-    throw new RuntimeException("Druid data connection is not support 'getCharToDateStmt'");
+    StringBuilder builder = new StringBuilder();
+    builder.append("TIME_PARSE(");
+    builder.append(timeStr);
+    builder.append(", '");
+
+    if(DEFAULT_FORMAT.equals(timeFormat)) {
+      builder.append(getDefaultTimeFormat(connectInfo));
+    } else {
+      builder.append(timeFormat);
+    }
+    builder.append("') ");
+
+    return builder.toString();
   }
 
   @Override
-  public String getCurrentTimeStamp(JdbcConnectInformation connectInfo) {
-    throw new RuntimeException("Druid data connection is not support 'getCurrentTimeStamp'");
+  public String getCharToUnixTimeStmt(JdbcConnectInformation connectInfo, String timeStr) {
+    return "TIMESTAMP_TO_MILLIS(TIME_PARSE(" + timeStr + ")) / 1000";
   }
 
   /**

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/HiveDialect.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/HiveDialect.java
@@ -317,16 +317,15 @@ public class HiveDialect implements JdbcDialect {
   @Override
   public String getCharToDateStmt(JdbcConnectInformation connectInfo, String timeStr, String timeFormat) {
     StringBuilder builder = new StringBuilder();
-    builder.append("cast(").append(timeStr).append(" as date) ");
-
-//    builder.append("'");
-//    if(DEFAULT_FORMAT.equals(timeFormat)) {
-//      builder.append(getDefaultTimeFormat(connectInfo));
-//    } else {
-//      builder.append(timeFormat).append("'");
-//    }
-//    builder.append("'");
-//    builder.append(") ");
+    builder.append("from_unixtime(unix_timestamp(" + timeStr + ", ");
+    builder.append("'");
+    if(DEFAULT_FORMAT.equals(timeFormat)) {
+      builder.append(getDefaultTimeFormat(connectInfo));
+    } else {
+      builder.append(timeFormat);
+    }
+    builder.append("'");
+    builder.append(")) ");
 
     return builder.toString();
   }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/HiveDialect.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/HiveDialect.java
@@ -317,23 +317,23 @@ public class HiveDialect implements JdbcDialect {
   @Override
   public String getCharToDateStmt(JdbcConnectInformation connectInfo, String timeStr, String timeFormat) {
     StringBuilder builder = new StringBuilder();
-    builder.append("unix_timestamp('").append(timeStr).append("', ");
+    builder.append("cast(").append(timeStr).append(" as date) ");
 
-    builder.append("'");
-    if(DEFAULT_FORMAT.equals(timeFormat)) {
-      builder.append(getDefaultTimeFormat(connectInfo));
-    } else {
-      builder.append(timeFormat).append("'");
-    }
-    builder.append("'");
-    builder.append(") ");
+//    builder.append("'");
+//    if(DEFAULT_FORMAT.equals(timeFormat)) {
+//      builder.append(getDefaultTimeFormat(connectInfo));
+//    } else {
+//      builder.append(timeFormat).append("'");
+//    }
+//    builder.append("'");
+//    builder.append(") ");
 
     return builder.toString();
   }
 
   @Override
-  public String getCurrentTimeStamp(JdbcConnectInformation connectInfo) {
-    return "DATE_FORMAT(current_timestamp,'" + getDefaultTimeFormat(connectInfo) + "') AS TIMESTAMP1";
+  public String getCharToUnixTimeStmt(JdbcConnectInformation connectInfo, String timeStr) {
+    return "unix_timestamp(" + timeStr +", '" + getDefaultTimeFormat(connectInfo) + "')";
   }
 
   /**

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/MySQLDialect.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/MySQLDialect.java
@@ -343,23 +343,13 @@ public class MySQLDialect implements JdbcDialect {
   @Override
   public String getCharToDateStmt(JdbcConnectInformation connectInfo, String timeStr, String timeFormat) {
     StringBuilder builder = new StringBuilder();
-    builder.append("STR_TO_DATE('").append(timeStr).append("', ");
-
-    builder.append("'");
-    if(DEFAULT_FORMAT.equals(timeFormat)) {
-      builder.append(getDefaultTimeFormat(connectInfo));
-    } else {
-      builder.append(timeFormat).append("'");
-    }
-    builder.append("'");
-    builder.append(") ");
-
+    builder.append("CAST(").append(timeStr).append(" AS DATETIME) ");
     return builder.toString();
   }
 
   @Override
-  public String getCurrentTimeStamp(JdbcConnectInformation connectInfo) {
-    return "DATE_FORMAT(NOW(),'" + getDefaultTimeFormat(connectInfo) + "') AS TIMESTAMP";
+  public String getCharToUnixTimeStmt(JdbcConnectInformation connectInfo, String timeStr) {
+    return "UNIX_TIMESTAMP(CAST(" + timeStr + " AS DATE))";
   }
 
   /**

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/PostgresqlDialect.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/PostgresqlDialect.java
@@ -375,23 +375,18 @@ public class PostgresqlDialect implements JdbcDialect {
   @Override
   public String getCharToDateStmt(JdbcConnectInformation connectInfo, String timeStr, String timeFormat) {
     StringBuilder builder = new StringBuilder();
-    builder.append("TO_DATE('").append(timeStr).append("', ");
+    builder.append("TO_DATE(").append(timeStr).append(", ");
 
     builder.append("'");
     if(DEFAULT_FORMAT.equals(timeFormat)) {
       builder.append(getDefaultTimeFormat(connectInfo));
     } else {
-      builder.append(timeFormat).append("'");
+      builder.append(timeFormat);
     }
     builder.append("'");
     builder.append(") ");
 
     return builder.toString();
-  }
-
-  @Override
-  public String getCurrentTimeStamp(JdbcConnectInformation connectInfo) {
-    return "TO_CHAR(NOW(), '" + getDefaultTimeFormat(connectInfo) + "') AS TIMESTAMP";
   }
 
   @Override
@@ -405,6 +400,11 @@ public class PostgresqlDialect implements JdbcDialect {
   @Override
   public String getQuotedFieldName(JdbcConnectInformation connectInfo, String fieldName) {
     return fieldName;
+  }
+
+  @Override
+  public String getCharToUnixTimeStmt(JdbcConnectInformation connectInfo, String timeStr) {
+    return "extract(epoch from to_date(" + timeStr + ", 'YYYY-MM-DD HH24:MI:SS'))";
   }
 
   /**

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/PrestoDialect.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/PrestoDialect.java
@@ -22,7 +22,9 @@ import org.springframework.stereotype.Component;
 
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import app.metatron.discovery.common.exception.FunctionWithException;
 import app.metatron.discovery.extension.dataconnection.jdbc.JdbcConnectInformation;
@@ -350,7 +352,9 @@ public class PrestoDialect implements JdbcDialect {
 
   @Override
   public String getQuotedFieldName(JdbcConnectInformation connectInfo, String fieldName) {
-    return fieldName;
+    return Arrays.stream(fieldName.split("\\."))
+                 .map(spliced -> "\"" + spliced + "\"")
+                 .collect(Collectors.joining("."));
   }
 
   @Override

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/PrestoDialect.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/PrestoDialect.java
@@ -177,7 +177,10 @@ public class PrestoDialect implements JdbcDialect {
       builder.append(" FROM ( ");
       builder.append("   SELECT schema_name, ROW_NUMBER() OVER (PARTITION BY CURRENT_DATE ORDER BY schema_name) ROWNUM ");
       builder.append("   FROM information_schema.schemata ");
-      builder.append("   WHERE catalog_name = '" + catalog + "' ");
+      builder.append("   WHERE 1=1 ");
+      if(StringUtils.isNotEmpty(catalog)){
+        builder.append("     AND catalog_name = '" + catalog + "' ");
+      }
 
       if(excludeSchemas != null){
         builder.append(" AND schema_name NOT IN ( ");
@@ -194,7 +197,10 @@ public class PrestoDialect implements JdbcDialect {
 
       builder.append(" SELECT schema_name ");
       builder.append(" FROM information_schema.schemata ");
-      builder.append(" WHERE catalog_name = '" + catalog + "' ");
+      builder.append(" WHERE 1=1 ");
+      if(StringUtils.isNotEmpty(catalog)){
+        builder.append("   AND catalog_name = '" + catalog + "' ");
+      }
 
       if(excludeSchemas != null){
         builder.append(" AND schema_name NOT IN ( ");
@@ -217,7 +223,10 @@ public class PrestoDialect implements JdbcDialect {
 
     builder.append(" SELECT COUNT(schema_name) ");
     builder.append(" FROM information_schema.schemata ");
-    builder.append(" WHERE catalog_name = '" + catalog + "' ");
+    builder.append(" WHERE 1=1 ");
+    if(StringUtils.isNotEmpty(catalog)){
+      builder.append(" AND catalog_name = '" + catalog + "' ");
+    }
     if(StringUtils.isNotEmpty(schemaNamePattern)){
       builder.append(" AND schema_name LIKE '%" + schemaNamePattern + "%' ");
     }
@@ -249,7 +258,10 @@ public class PrestoDialect implements JdbcDialect {
       builder.append(" FROM ( ");
       builder.append("   SELECT table_name, table_type, ROW_NUMBER() OVER (PARTITION BY CURRENT_DATE ORDER BY table_name) ROWNUM ");
       builder.append("   FROM information_schema.tables ");
-      builder.append("   WHERE table_catalog = '" + catalog + "' ");
+      builder.append("   WHERE 1=1 ");
+      if(StringUtils.isNotEmpty(catalog)){
+        builder.append("     AND table_catalog = '" + catalog + "' ");
+      }
       builder.append("     AND table_schema LIKE '%" + schema + "%' ");
       if(StringUtils.isNotEmpty(tableNamePattern)){
         builder.append("   AND table_name LIKE '%" + tableNamePattern + "%' ");
@@ -260,7 +272,10 @@ public class PrestoDialect implements JdbcDialect {
 
       builder.append(" SELECT table_name name, table_type type ");
       builder.append(" FROM information_schema.tables ");
-      builder.append(" WHERE catalog_name = '" + catalog + "' ");
+      builder.append(" WHERE 1=1 ");
+      if(StringUtils.isNotEmpty(catalog)){
+        builder.append("  AND table_catalog = '" + catalog + "' ");
+      }
       builder.append("   AND table_schema LIKE '%" + schema + "%' ");
       if(StringUtils.isNotEmpty(tableNamePattern)){
         builder.append(" AND table_name LIKE '%" + tableNamePattern + "%' ");
@@ -282,7 +297,10 @@ public class PrestoDialect implements JdbcDialect {
 
     builder.append(" SELECT COUNT(table_name) ");
     builder.append(" FROM information_schema.tables ");
-    builder.append(" WHERE catalog_name = '" + catalog + "' ");
+    builder.append(" WHERE 1=1 ");
+    if(StringUtils.isNotEmpty(catalog)){
+      builder.append("   AND table_catalog = '" + catalog + "' ");
+    }
     builder.append("   AND table_schema LIKE '%" + schema + "%' ");
     if(StringUtils.isNotEmpty(tableNamePattern)){
       builder.append(" AND table_name LIKE '%" + tableNamePattern + "%' ");
@@ -322,6 +340,11 @@ public class PrestoDialect implements JdbcDialect {
     if(StringUtils.isEmpty(schema)) {
       return table;
     }
+
+    if(StringUtils.isEmpty(catalog)){
+      return schema + "." + table;
+    }
+
     return catalog + "." + schema + "." + table;
   }
 
@@ -338,13 +361,13 @@ public class PrestoDialect implements JdbcDialect {
   @Override
   public String getCharToDateStmt(JdbcConnectInformation connectInfo, String timeStr, String timeFormat) {
     StringBuilder builder = new StringBuilder();
-    builder.append("unix_timestamp('").append(timeStr).append("', ");
 
+    builder.append("parse_datetime(").append(timeStr).append(", ");
     builder.append("'");
     if(DEFAULT_FORMAT.equals(timeFormat)) {
       builder.append(getDefaultTimeFormat(connectInfo));
     } else {
-      builder.append(timeFormat).append("'");
+      builder.append(timeFormat);
     }
     builder.append("'");
     builder.append(") ");
@@ -353,8 +376,8 @@ public class PrestoDialect implements JdbcDialect {
   }
 
   @Override
-  public String getCurrentTimeStamp(JdbcConnectInformation connectInfo) {
-    return "format_datetime(current_timestamp,'" + getDefaultTimeFormat(connectInfo) + "') AS TIMESTAMP1";
+  public String getCharToUnixTimeStmt(JdbcConnectInformation connectInfo, String timeStr) {
+    return "to_unixtime(cast(" + timeStr + " as timestamp))";
   }
 
   /**

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourceErrorCodes.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourceErrorCodes.java
@@ -30,6 +30,7 @@ public enum DataSourceErrorCodes implements ErrorCodes {
   INGESTION_FILE_EXCEL_CONVERSION_ERROR("error.datasource.ingestion.file.excel.conversion"), // Failed to convert Excel file. Please check if the format is supported by metatron.
   INGESTION_JDBC_QUERY_EXECUTION_ERROR("error.datasource.ingestion.jdbc.query.execution"), // An error occurred while querying the data. Please check the query syntax or constraints in the DB Server.
   INGESTION_JDBC_FETCH_RESULT_ERROR("error.datasource.ingestion.jdbc.fetch.result"), // An error occurred in processing the result.
+  INGESTION_JDBC_EMPTY_RESULT_ERROR("error.datasource.ingestion.jdbc.empty.result"), // Result is empty.
   INGESTION_JDBC_INCREMENTAL_TIME_ERROR("error.datasource.ingestion.jdbc.incremental.time"), // No time information to use for incremental ingestion job
   INGESTION_ENGINE_ACCESS_ERROR("error.datasource.ingestion.engine.access"), // Failed to access to the engine. Please contact your system administrator.
   INGESTION_ENGINE_TASK_CREATION_ERROR("error.datasource.ingestion.engine.creation.task"), // No ingestion task was created on the engine for an unknown reason.

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourceEventHandler.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourceEventHandler.java
@@ -293,7 +293,8 @@ public class DataSourceEventHandler {
           .forJob(jobKey)
           .usingJobData(map)
           .withSchedule(CronScheduleBuilder
-                            .cronSchedule(((BatchIngestionInfo) info).getPeriod().getCronExpr()))
+                            .cronSchedule(((BatchIngestionInfo) info).getPeriod().getCronExpr())
+                            .withMisfireHandlingInstructionDoNothing())
           .build();
       // @formatter:on
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourceEventHandler.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourceEventHandler.java
@@ -85,11 +85,11 @@ import app.metatron.discovery.domain.datasource.ingestion.jdbc.LinkIngestionInfo
 import app.metatron.discovery.domain.datasource.ingestion.job.IngestionJobRunner;
 import app.metatron.discovery.domain.engine.DruidEngineMetaRepository;
 import app.metatron.discovery.domain.engine.EngineIngestionService;
+import app.metatron.discovery.domain.mdm.Metadata;
 import app.metatron.discovery.domain.mdm.MetadataService;
 import app.metatron.discovery.domain.workspace.Workspace;
 import app.metatron.discovery.util.AuthUtils;
 import app.metatron.discovery.util.PolarisUtils;
-import app.metatron.discovery.domain.mdm.Metadata;
 
 import static app.metatron.discovery.domain.datasource.DataSource.ConnectionType.ENGINE;
 import static app.metatron.discovery.domain.datasource.DataSource.ConnectionType.LINK;
@@ -293,8 +293,7 @@ public class DataSourceEventHandler {
           .forJob(jobKey)
           .usingJobData(map)
           .withSchedule(CronScheduleBuilder
-                            .cronSchedule(((BatchIngestionInfo) info).getPeriod().getCronExpr())
-                            .withMisfireHandlingInstructionDoNothing())
+                            .cronSchedule(((BatchIngestionInfo) info).getPeriod().getCronExpr()))
           .build();
       // @formatter:on
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcConnectionService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcConnectionService.java
@@ -928,7 +928,7 @@ public class JdbcConnectionService {
 
     // 결과 셋이 없는 경우 처리
     File file = new File(resultFileName);
-    if (!file.exists() && file.length() == 0) {
+    if (!file.exists() || file.length() == 0) {
       return null;
     }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/ingestion/jdbc/SelectQueryBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/ingestion/jdbc/SelectQueryBuilder.java
@@ -137,7 +137,6 @@ public class SelectQueryBuilder {
   }
 
   public SelectQueryBuilder query(JdbcIngestionInfo ingestionInfo, JdbcConnectInformation connectInformation) {
-
     if (ingestionInfo.getDataType() == TABLE) {
       StringBuilder selectAllQuery = new StringBuilder();
       selectAllQuery.append("SELECT * FROM ");
@@ -149,6 +148,19 @@ public class SelectQueryBuilder {
     } else {
       this.query = getRefinedQuery(ingestionInfo.getQuery());
     }
+    return this;
+  }
+
+  public SelectQueryBuilder query(String schema, JdbcIngestionInfo.DataType dataType, String value) {
+    if (dataType == JdbcIngestionInfo.DataType.TABLE) {
+      StringBuilder selectAllQuery = new StringBuilder();
+      selectAllQuery.append("SELECT * FROM ");
+      selectAllQuery.append(jdbcDialect.getTableName(connectInformation, connectInformation.getCatalog(), schema, value));
+      this.query = selectAllQuery.toString();
+    } else {
+      this.query = value;
+    }
+
     return this;
   }
 
@@ -189,20 +201,6 @@ public class SelectQueryBuilder {
       return targetStrIndex;
     }
     return -1;
-  }
-
-  public SelectQueryBuilder query(String schema, JdbcIngestionInfo.DataType dataType, String value) {
-
-    if (dataType == JdbcIngestionInfo.DataType.TABLE) {
-      StringBuilder selectAllQuery = new StringBuilder();
-      selectAllQuery.append("SELECT * FROM ");
-      selectAllQuery.append(jdbcDialect.getTableName(connectInformation, connectInformation.getCatalog(), schema, value));
-      this.query = selectAllQuery.toString();
-    } else {
-      this.query = value;
-    }
-
-    return this;
   }
 
   public SelectQueryBuilder limit(int initial, int limit) {

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/ingestion/jdbc/SelectQueryBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/ingestion/jdbc/SelectQueryBuilder.java
@@ -16,14 +16,17 @@ package app.metatron.discovery.domain.datasource.ingestion.jdbc;
 
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.StringJoiner;
 
+import app.metatron.discovery.common.datasource.DataType;
 import app.metatron.discovery.common.datasource.LogicalType;
-import app.metatron.discovery.domain.dataconnection.dialect.HiveDialect;
 import app.metatron.discovery.domain.datasource.Field;
+import app.metatron.discovery.domain.workbook.configurations.format.UnixTimeFormat;
 import app.metatron.discovery.extension.dataconnection.jdbc.JdbcConnectInformation;
 import app.metatron.discovery.extension.dataconnection.jdbc.dialect.JdbcDialect;
+import app.metatron.discovery.util.TimeUnits;
 
 import static app.metatron.discovery.domain.datasource.ingestion.jdbc.JdbcIngestionInfo.DataType.TABLE;
 
@@ -56,23 +59,34 @@ public class SelectQueryBuilder {
 
     StringBuilder builder = new StringBuilder();
     builder.append("WHERE ");
-    if (field.getLogicalType() == LogicalType.STRING) {
-      // 어떻게 할지 확인할것!
-      // Text 일경우 구현이 괭장히 어려움
-    }
+
     if (field.getLogicalType() == LogicalType.TIMESTAMP) {
-      if (jdbcDialect instanceof HiveDialect) {
-        builder.append("unix_timestamp(").append(field.getName()).append(", '").append(field.getTimeFormat()).append("')");
+      String projectionName = getProjectionName(field);
+
+      if(field.getFormatObject() instanceof UnixTimeFormat){
+        builder.append(projectionName);
+        builder.append(" >= ");
+        builder.append(jdbcDialect.getCharToUnixTimeStmt(connectInformation, "'" + lastIncremetalTime + "'"));
+
+        if(((UnixTimeFormat) field.getFormatObject()).getUnit() == TimeUnits.MILLISECOND){
+          builder.append(" * 1000 ");
+        }
       } else {
-        builder.append(field.getName()).append(" ");
+        if(field.getType() == DataType.STRING){
+          String strToDateStmt = jdbcDialect.getCharToDateStmt(connectInformation, projectionName, field.getTimeFormat());
+          builder.append(strToDateStmt).append(" ");
+        } else {
+          builder.append(projectionName);
+          builder.append(" ");
+        }
+
+        builder.append(">= ");
+        builder.append(jdbcDialect.getCharToDateStmt(connectInformation, "'" + lastIncremetalTime + "'", JdbcDialect.DEFAULT_FORMAT));
+        builder.append(" ");
       }
     } else {
       throw new RuntimeException("Invalid timestamp type.");
     }
-
-    builder.append(">= ");
-    builder.append(jdbcDialect.getCharToDateStmt(connectInformation, lastIncremetalTime, JdbcDialect.DEFAULT_FORMAT));
-    builder.append(" ");
 
     incremental = builder.toString();
 
@@ -110,16 +124,15 @@ public class SelectQueryBuilder {
   }
 
   private String getProjectionName(Field field) {
+    String fieldName = StringUtils.isEmpty(field.getOriginalName())
+        ? field.getName()
+        : field.getOriginalName();
 
-    // 기존 컬럼외 추가로 지정한 TIME
-    if ("current_datetime".equals(field.getName()) && field.getRole() == Field.FieldRole.TIMESTAMP) {
-      return jdbcDialect.getCurrentTimeStamp(connectInformation);
-    }
+    String projectionName = StringUtils.contains(fieldName, ".")
+        ? StringUtils.substring(fieldName, StringUtils.lastIndexOf(fieldName, ".") + 1, fieldName.length())
+        : fieldName;
 
-    return jdbcDialect.getQuotedFieldName(connectInformation,
-                                          StringUtils.isEmpty(field.getOriginalName())
-                                                ? field.getName()
-                                                : field.getOriginalName());
+    return jdbcDialect.getQuotedFieldName(connectInformation, projectionName);
 
   }
 
@@ -134,11 +147,48 @@ public class SelectQueryBuilder {
                                                      ingestionInfo.getQuery()));
       this.query = selectAllQuery.toString();
     } else {
-      this.query = ingestionInfo.getQuery();
+      this.query = getRefinedQuery(ingestionInfo.getQuery());
+    }
+    return this;
+  }
+
+  public String getRefinedQuery(String query){
+    // split line separator
+    String[] queryByLine = StringUtils.split(query, System.lineSeparator());
+
+    List<String> semicolonRemoved = new ArrayList<>();
+    int lineCount = queryByLine.length;
+    for(int i = 0; i < lineCount; ++i) {
+      String newSql = queryByLine[i];
+
+      //find last line with semicolon
+      int validSemicolonIdx = getValidIndex(newSql, ";");
+      //remove semicolon
+      while (validSemicolonIdx >= 0) {
+        newSql = StringUtils.replaceFirst(newSql, ";", "");
+        validSemicolonIdx = getValidIndex(newSql, ";");
+      }
+      semicolonRemoved.add(newSql);
     }
 
+    return StringUtils.join(semicolonRemoved, System.lineSeparator());
+  }
 
-    return this;
+  public int getValidIndex(String query, String targetStr){
+    int targetStrIndex = StringUtils.indexOf(query, targetStr);
+    int hyphenIndex = StringUtils.indexOf(query, "--");
+    int sharpIndex = StringUtils.indexOf(query, "#");
+    int commentIndex = (hyphenIndex >= 0 && sharpIndex >= 0)
+        ? Math.min(hyphenIndex, sharpIndex)
+        : Math.max(hyphenIndex, sharpIndex);
+
+    //last line
+    if(targetStrIndex > -1 && commentIndex > -1 && targetStrIndex < commentIndex){
+      return targetStrIndex;
+    } else if(targetStrIndex > -1 && commentIndex < 0){
+      return targetStrIndex;
+    }
+    return -1;
   }
 
   public SelectQueryBuilder query(String schema, JdbcIngestionInfo.DataType dataType, String value) {
@@ -193,7 +243,9 @@ public class SelectQueryBuilder {
     }
     selectQuery.append(projection);
     selectQuery.append(" FROM ( ");
+    selectQuery.append(System.lineSeparator());
     selectQuery.append(query);
+    selectQuery.append(System.lineSeparator());
     if (connectInformation.getImplementor().equals("ORACLE")
         || connectInformation.getImplementor().equals("TIBERO")) {
       selectQuery.append(" ) ");

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/ingestion/job/JdbcIngestionJob.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/ingestion/job/JdbcIngestionJob.java
@@ -56,6 +56,7 @@ import app.metatron.discovery.spec.druid.ingestion.IngestionSpec;
 import app.metatron.discovery.spec.druid.ingestion.IngestionSpecBuilder;
 
 import static app.metatron.discovery.domain.datasource.DataSourceErrorCodes.INGESTION_COMMON_ERROR;
+import static app.metatron.discovery.domain.datasource.DataSourceErrorCodes.INGESTION_JDBC_EMPTY_RESULT_ERROR;
 import static app.metatron.discovery.domain.datasource.DataSourceErrorCodes.INGESTION_JDBC_FETCH_RESULT_ERROR;
 import static app.metatron.discovery.domain.datasource.DataSourceErrorCodes.INGESTION_JDBC_QUERY_EXECUTION_ERROR;
 import static app.metatron.discovery.domain.datasource.ingestion.jdbc.BatchIngestionInfo.IngestionScope.INCREMENTAL;
@@ -134,7 +135,7 @@ public class JdbcIngestionJob extends AbstractIngestionJob implements IngestionJ
     }
 
     if (CollectionUtils.isEmpty(csvFiles)) {
-      throw new DataSourceIngestionException(INGESTION_JDBC_FETCH_RESULT_ERROR, "Empty result of query.");
+      throw new DataSourceIngestionException(INGESTION_JDBC_EMPTY_RESULT_ERROR, "Empty result of query.");
     }
 
     File tempFile = new File(csvFiles.get(0));

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/QueryEditorService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/QueryEditorService.java
@@ -46,7 +46,6 @@ import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -203,11 +202,49 @@ public class QueryEditorService {
     return queryResults;
   }
 
+  public List<String> multiLineQuerySplitter(String query){
+    List<String> queryList = new ArrayList<>();
+    String[] strByLine = StringUtils.split(query, System.lineSeparator());
+
+    StringBuilder stringBuilder = new StringBuilder();
+    int lineCount = strByLine.length;
+    for(int i = 0; i < lineCount; ++i){
+      String byLine = strByLine[i];
+
+      stringBuilder.append(byLine);
+
+      int semiColonIndex = StringUtils.indexOf(byLine, ";");
+      int hyphenIndex = StringUtils.indexOf(byLine, "--");
+      int sharpIndex = StringUtils.indexOf(byLine, "#");
+      int commentIndex = (hyphenIndex >= 0 && sharpIndex >= 0)
+          ? Math.min(hyphenIndex, sharpIndex)
+          : Math.max(hyphenIndex, sharpIndex);
+
+      //semicolon before comment
+      if(semiColonIndex > -1 && commentIndex > -1 && semiColonIndex < commentIndex){
+        queryList.add(stringBuilder.toString());
+        stringBuilder = new StringBuilder();
+      } else if(semiColonIndex > -1 && commentIndex < 0){
+        queryList.add(stringBuilder.toString());
+        stringBuilder = new StringBuilder();
+      } else if(i < lineCount - 1){
+        stringBuilder.append(System.lineSeparator());
+      }
+    }
+
+    if(StringUtils.isNotEmpty(stringBuilder.toString())){
+      queryList.add(stringBuilder.toString());
+    }
+
+    return queryList;
+  }
+
   public List<String> getSubstitutedQueryList(String queryStr, Workbench workbench) {
     List<String> returnList = new ArrayList<>();
 
     //1. semicolon split
-    List<String> queryList = Arrays.asList(queryStr.split(";"));
+//    List<String> queryList = Arrays.asList(queryStr.split(";"));
+    List<String> queryList = multiLineQuerySplitter(queryStr);
 
 
     //2. GlobalVar replace

--- a/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/AbstractSpecBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/AbstractSpecBuilder.java
@@ -233,6 +233,7 @@ public class AbstractSpecBuilder {
         case TIMESTAMP:
         case STRING:
         case TEXT:
+        case BOOLEAN:
           dimenstionSchemas.add(dimensionfield.getName());
           break;
         case INTEGER:

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/datasource/ingestion/jdbc/SelectQueryBuilderTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/datasource/ingestion/jdbc/SelectQueryBuilderTest.java
@@ -1,0 +1,564 @@
+package app.metatron.discovery.domain.datasource.ingestion.jdbc;
+
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import app.metatron.discovery.common.datasource.DataType;
+import app.metatron.discovery.common.datasource.LogicalType;
+import app.metatron.discovery.domain.dataconnection.DataConnection;
+import app.metatron.discovery.domain.dataconnection.DataConnectionHelper;
+import app.metatron.discovery.domain.dataconnection.dialect.DruidDialect;
+import app.metatron.discovery.domain.dataconnection.dialect.HiveDialect;
+import app.metatron.discovery.domain.dataconnection.dialect.MySQLDialect;
+import app.metatron.discovery.domain.dataconnection.dialect.PostgresqlDialect;
+import app.metatron.discovery.domain.dataconnection.dialect.PrestoDialect;
+import app.metatron.discovery.domain.datasource.Field;
+import app.metatron.discovery.extension.dataconnection.jdbc.dialect.JdbcDialect;
+
+/**
+ *
+ */
+public class SelectQueryBuilderTest
+//    extends AbstractIntegrationTest
+{
+
+  static {
+    System.setProperty("pf4j.pluginsDir", "../discovery-distribution/extensions");
+  }
+
+  @Test
+  public void incrementalQueryTest(){
+    String sql = "select * -- asdas;\n" +
+        "-- aasfs;d;a;s\n" +
+        "from book ;; ; ; -- asda; \n" +
+        "-- asda;s;d; \n" +
+        "# asda;s;d \n" +
+        "-- asda;s;d;";
+
+    //create incremental query
+    BatchIngestionInfo batchIngestionInfo = new BatchIngestionInfo();
+    batchIngestionInfo.setQuery(sql);
+    batchIngestionInfo.setMaxLimit(1000);
+
+    List<Field> fields = new ArrayList<>();
+    fields.add(new Field("type", DataType.STRING, 0));
+    fields.add(new Field("created_by", DataType.STRING, 1));
+    fields.add(new Field("created_time", DataType.TIMESTAMP, Field.FieldRole.TIMESTAMP, 2));
+
+    DataConnection realConnection = new DataConnection("MYSQL");
+
+    String incrementalQuery = new SelectQueryBuilder(realConnection, new MySQLDialect())
+        .projection(fields)
+        .query(batchIngestionInfo, realConnection)
+        .incremental(fields.get(2), DateTime.now().toString(JdbcDialect.CURRENT_DATE_FORMAT))
+        .limit(0, batchIngestionInfo.getMaxLimit())
+        .build();
+
+    System.out.println(incrementalQuery);
+
+  }
+
+  @Test
+  public void timestampFieldPresto(){
+    String implementor = "PRESTO";
+
+    String limitDateStr = "2018-07-01 00:00:00";
+    String sql = "select \n" +
+        "  eventtime as msUnix, \n" +
+        "  eventtime / 1000 as secUnix, \n" +
+        "  from_unixtime(floor(eventtime/1000)) as timestampTimestamp, \n" +
+        "  format_datetime(from_unixtime(floor(eventtime/1000)), 'yyyy-MM-dd HH:mm:ss.SSS') as strTimestamp\n" +
+        "from default.lineage";
+    //create incremental query
+    BatchIngestionInfo batchIngestionInfo = new BatchIngestionInfo();
+    batchIngestionInfo.setQuery(sql);
+    batchIngestionInfo.setMaxLimit(1000);
+
+    List<Field> fields = new ArrayList<>();
+
+    Field msUnixTime = new Field("msUnix", DataType.INTEGER, Field.FieldRole.TIMESTAMP, 0);
+    msUnixTime.setLogicalType(LogicalType.TIMESTAMP);
+    msUnixTime.setFormat("{  \n" +
+                                 "            \"type\":\"time_unix\",\n" +
+                                 "            \"timeZone\":\"UTC\",\n" +
+                                 "            \"locale\":\"en\",\n" +
+                                 "            \"unit\":\"MILLISECOND\",\n" +
+                                 "            \"format\":\"yyyy-MM-dd HH:mm:ss\"\n" +
+                                 "         }");
+    fields.add(msUnixTime);
+
+    Field secondUnixTime = new Field("secUnix", DataType.LONG, Field.FieldRole.TIMESTAMP, 1);
+    secondUnixTime.setLogicalType(LogicalType.TIMESTAMP);
+    secondUnixTime.setFormat("{  \n" +
+                                 "            \"type\":\"time_unix\",\n" +
+                                 "            \"timeZone\":\"UTC\",\n" +
+                                 "            \"locale\":\"en\",\n" +
+                                 "            \"unit\":\"SECOND\",\n" +
+                                 "            \"format\":\"yyyy-MM-dd HH:mm:ss\"\n" +
+                                 "         }");
+    fields.add(secondUnixTime);
+
+    Field timestampTimestamp = new Field("timestampTimestamp", DataType.TIMESTAMP, Field.FieldRole.TIMESTAMP, 2);
+    timestampTimestamp.setLogicalType(LogicalType.TIMESTAMP);
+    timestampTimestamp.setFormat("{  \n" +
+                                     "            \"type\":\"time_format\",\n" +
+                                     "            \"format\":\"yyyy-MM-dd HH:mm:ss.S\",\n" +
+                                     "            \"timeZone\":\"Asia/Seoul\",\n" +
+                                     "            \"locale\":\"en\"\n" +
+                                     "         }");
+    fields.add(timestampTimestamp);
+
+    Field strTimestamp = new Field("strTimestamp", DataType.STRING, Field.FieldRole.TIMESTAMP, 3);
+    strTimestamp.setLogicalType(LogicalType.TIMESTAMP);
+    strTimestamp.setFormat("{  \n" +
+                               "            \"type\":\"time_format\",\n" +
+                               "            \"format\":\"yyyy-MM-dd HH:mm:ss.SSS\",\n" +
+                               "            \"timeZone\":\"Asia/Seoul\",\n" +
+                               "            \"locale\":\"en\"\n" +
+                               "         }");
+    fields.add(strTimestamp);
+
+    printIncrementalQuery(implementor, fields, batchIngestionInfo, limitDateStr);
+  }
+
+  @Test
+  public void timestampFieldHive(){
+    String implementor = "HIVE";
+
+    String limitDateStr = "2018-07-01 00:00:00";
+    String sql = "select \n" +
+        "  eventtime as msUnix, \n" +
+        "  floor(eventtime / 1000) as secUnix, \n" +
+        "  from_unixtime(floor(eventtime/1000)) as timestampTimestamp, \n" +
+        "    date_Format(from_unixtime(floor(eventtime/1000)), 'yyyy-MM-dd HH:mm:ss.SSS') as strTimestamp\n" +
+        "from default.lineage";
+    //create incremental query
+    BatchIngestionInfo batchIngestionInfo = new BatchIngestionInfo();
+    batchIngestionInfo.setQuery(sql);
+    batchIngestionInfo.setMaxLimit(1000);
+
+    List<Field> fields = new ArrayList<>();
+
+    Field msUnixTime = new Field("msUnix", DataType.INTEGER, Field.FieldRole.TIMESTAMP, 0);
+    msUnixTime.setLogicalType(LogicalType.TIMESTAMP);
+    msUnixTime.setFormat("{  \n" +
+                             "            \"type\":\"time_unix\",\n" +
+                             "            \"timeZone\":\"UTC\",\n" +
+                             "            \"locale\":\"en\",\n" +
+                             "            \"unit\":\"MILLISECOND\",\n" +
+                             "            \"format\":\"yyyy-MM-dd HH:mm:ss\"\n" +
+                             "         }");
+    fields.add(msUnixTime);
+
+    Field secondUnixTime = new Field("secUnix", DataType.LONG, Field.FieldRole.TIMESTAMP, 1);
+    secondUnixTime.setLogicalType(LogicalType.TIMESTAMP);
+    secondUnixTime.setFormat("{  \n" +
+                                 "            \"type\":\"time_unix\",\n" +
+                                 "            \"timeZone\":\"UTC\",\n" +
+                                 "            \"locale\":\"en\",\n" +
+                                 "            \"unit\":\"SECOND\",\n" +
+                                 "            \"format\":\"yyyy-MM-dd HH:mm:ss\"\n" +
+                                 "         }");
+    fields.add(secondUnixTime);
+
+    Field timestampTimestamp = new Field("timestampTimestamp", DataType.TIMESTAMP, Field.FieldRole.TIMESTAMP, 2);
+    timestampTimestamp.setLogicalType(LogicalType.TIMESTAMP);
+    timestampTimestamp.setFormat("{  \n" +
+                                     "            \"type\":\"time_format\",\n" +
+                                     "            \"format\":\"yyyy-MM-dd HH:mm:ss.S\",\n" +
+                                     "            \"timeZone\":\"Asia/Seoul\",\n" +
+                                     "            \"locale\":\"en\"\n" +
+                                     "         }");
+    fields.add(timestampTimestamp);
+
+    Field strTimestamp = new Field("strTimestamp", DataType.STRING, Field.FieldRole.TIMESTAMP, 3);
+    strTimestamp.setLogicalType(LogicalType.TIMESTAMP);
+    strTimestamp.setFormat("{  \n" +
+                               "            \"type\":\"time_format\",\n" +
+                               "            \"format\":\"yyyy-MM-dd HH:mm:ss.SSS\",\n" +
+                               "            \"timeZone\":\"Asia/Seoul\",\n" +
+                               "            \"locale\":\"en\"\n" +
+                               "         }");
+    fields.add(strTimestamp);
+
+    printIncrementalQuery(implementor, fields, batchIngestionInfo, limitDateStr);
+  }
+
+  @Test
+  public void timestampFieldMySQL(){
+    String implementor = "MYSQL";
+
+    String limitDateStr = "2019-04-01 00:00:00";
+    String sql = "select \n" +
+        "UNIX_TIMESTAMP(created_time) * 1000 as msUnix, \n" +
+        "UNIX_TIMESTAMP(created_time) as secUnix,\n" +
+        "created_time as timestampTimestamp,\n" +
+        "DATE_FORMAT(created_time, '%Y-%m-%d %T') as strTimestamp\n" +
+        "from polaris.book";
+    //create incremental query
+    BatchIngestionInfo batchIngestionInfo = new BatchIngestionInfo();
+    batchIngestionInfo.setQuery(sql);
+    batchIngestionInfo.setMaxLimit(1000);
+
+    List<Field> fields = new ArrayList<>();
+
+    Field msUnixTime = new Field("msUnix", DataType.INTEGER, Field.FieldRole.TIMESTAMP, 0);
+    msUnixTime.setLogicalType(LogicalType.TIMESTAMP);
+    msUnixTime.setFormat("{  \n" +
+                             "            \"type\":\"time_unix\",\n" +
+                             "            \"timeZone\":\"UTC\",\n" +
+                             "            \"locale\":\"en\",\n" +
+                             "            \"unit\":\"MILLISECOND\",\n" +
+                             "            \"format\":\"yyyy-MM-dd HH:mm:ss\"\n" +
+                             "         }");
+    fields.add(msUnixTime);
+
+    Field secondUnixTime = new Field("secUnix", DataType.LONG, Field.FieldRole.TIMESTAMP, 1);
+    secondUnixTime.setLogicalType(LogicalType.TIMESTAMP);
+    secondUnixTime.setFormat("{  \n" +
+                                 "            \"type\":\"time_unix\",\n" +
+                                 "            \"timeZone\":\"UTC\",\n" +
+                                 "            \"locale\":\"en\",\n" +
+                                 "            \"unit\":\"SECOND\",\n" +
+                                 "            \"format\":\"yyyy-MM-dd HH:mm:ss\"\n" +
+                                 "         }");
+    fields.add(secondUnixTime);
+
+    Field timestampTimestamp = new Field("timestampTimestamp", DataType.TIMESTAMP, Field.FieldRole.TIMESTAMP, 2);
+    timestampTimestamp.setLogicalType(LogicalType.TIMESTAMP);
+    timestampTimestamp.setFormat("{  \n" +
+                                     "            \"type\":\"time_format\",\n" +
+                                     "            \"format\":\"yyyy-MM-dd HH:mm:ss.S\",\n" +
+                                     "            \"timeZone\":\"Asia/Seoul\",\n" +
+                                     "            \"locale\":\"en\"\n" +
+                                     "         }");
+    fields.add(timestampTimestamp);
+
+    Field strTimestamp = new Field("strTimestamp", DataType.STRING, Field.FieldRole.TIMESTAMP, 3);
+    strTimestamp.setLogicalType(LogicalType.TIMESTAMP);
+    strTimestamp.setFormat("{  \n" +
+                               "            \"type\":\"time_format\",\n" +
+                               "            \"format\":\"yyyy-MM-dd HH:mm:ss.SSS\",\n" +
+                               "            \"timeZone\":\"Asia/Seoul\",\n" +
+                               "            \"locale\":\"en\"\n" +
+                               "         }");
+    fields.add(strTimestamp);
+
+    printIncrementalQuery(implementor, fields, batchIngestionInfo, limitDateStr);
+  }
+
+  @Test
+  public void timestampFieldPostgresql(){
+    String implementor = "POSTGRESQL";
+
+    String limitDateStr = "2007-05-13 00:00:00";
+    String sql = "SELECT \n" +
+        "extract(epoch from payment_date) * 1000 as msUnix\n" +
+        ", extract(epoch from payment_date) as secUnix\n" +
+        ", payment_date as timestampTimestamp\n" +
+        ", to_char(payment_date, 'YYYY-MM-DD HH24:MI:SS') as strTimestamp\n" +
+        "FROM public.payment";
+    //create incremental query
+    BatchIngestionInfo batchIngestionInfo = new BatchIngestionInfo();
+    batchIngestionInfo.setQuery(sql);
+    batchIngestionInfo.setMaxLimit(10000);
+
+    List<Field> fields = new ArrayList<>();
+
+    Field msUnixTime = new Field("msUnix", DataType.INTEGER, Field.FieldRole.TIMESTAMP, 0);
+    msUnixTime.setLogicalType(LogicalType.TIMESTAMP);
+    msUnixTime.setFormat("{  \n" +
+                             "            \"type\":\"time_unix\",\n" +
+                             "            \"timeZone\":\"UTC\",\n" +
+                             "            \"locale\":\"en\",\n" +
+                             "            \"unit\":\"MILLISECOND\",\n" +
+                             "            \"format\":\"yyyy-MM-dd HH:mm:ss\"\n" +
+                             "         }");
+    fields.add(msUnixTime);
+
+    Field secondUnixTime = new Field("secUnix", DataType.LONG, Field.FieldRole.TIMESTAMP, 1);
+    secondUnixTime.setLogicalType(LogicalType.TIMESTAMP);
+    secondUnixTime.setFormat("{  \n" +
+                                 "            \"type\":\"time_unix\",\n" +
+                                 "            \"timeZone\":\"UTC\",\n" +
+                                 "            \"locale\":\"en\",\n" +
+                                 "            \"unit\":\"SECOND\",\n" +
+                                 "            \"format\":\"yyyy-MM-dd HH:mm:ss\"\n" +
+                                 "         }");
+    fields.add(secondUnixTime);
+
+    Field timestampTimestamp = new Field("timestampTimestamp", DataType.TIMESTAMP, Field.FieldRole.TIMESTAMP, 2);
+    timestampTimestamp.setLogicalType(LogicalType.TIMESTAMP);
+    timestampTimestamp.setFormat("{  \n" +
+                                     "            \"type\":\"time_format\",\n" +
+                                     "            \"format\":\"yyyy-MM-dd HH:mm:ss.S\",\n" +
+                                     "            \"timeZone\":\"Asia/Seoul\",\n" +
+                                     "            \"locale\":\"en\"\n" +
+                                     "         }");
+    fields.add(timestampTimestamp);
+
+    Field strTimestamp = new Field("strTimestamp", DataType.STRING, Field.FieldRole.TIMESTAMP, 3);
+    strTimestamp.setLogicalType(LogicalType.TIMESTAMP);
+    strTimestamp.setFormat("{  \n" +
+                               "            \"type\":\"time_format\",\n" +
+                               "            \"format\":\"yyyy-MM-dd HH:mm:ss.SSS\",\n" +
+                               "            \"timeZone\":\"Asia/Seoul\",\n" +
+                               "            \"locale\":\"en\"\n" +
+                               "         }");
+    fields.add(strTimestamp);
+
+    printIncrementalQuery(implementor, fields, batchIngestionInfo, limitDateStr);
+  }
+
+  @Test
+  public void timestampFieldDruid(){
+    String implementor = "DRUID";
+
+    String limitDateStr = "2014-11-02 00:00:00";
+    String sql = "SELECT \n" +
+        "TIMESTAMP_TO_MILLIS(TIME_PARSE(\"ShipDate\", 'yyyy. MM. dd.')) as msUnix\n" +
+        ", TIMESTAMP_TO_MILLIS(TIME_PARSE(\"ShipDate\", 'yyyy. MM. dd.')) / 1000 as secUnix\n" +
+        ", TIME_PARSE(\"ShipDate\", 'yyyy. MM. dd.') as timestampTimestamp\n" +
+        ", TIME_FORMAT(TIME_PARSE(\"ShipDate\", 'yyyy. MM. dd.'), 'yyyy-MM-dd HH:mm:ss') as strTimestamp\n" +
+        "FROM druid.\"sales_geo\"";
+    //create incremental query
+    BatchIngestionInfo batchIngestionInfo = new BatchIngestionInfo();
+    batchIngestionInfo.setQuery(sql);
+    batchIngestionInfo.setMaxLimit(1000);
+
+    List<Field> fields = new ArrayList<>();
+
+    Field msUnixTime = new Field("msUnix", DataType.INTEGER, Field.FieldRole.TIMESTAMP, 0);
+    msUnixTime.setLogicalType(LogicalType.TIMESTAMP);
+    msUnixTime.setFormat("{  \n" +
+                             "            \"type\":\"time_unix\",\n" +
+                             "            \"timeZone\":\"UTC\",\n" +
+                             "            \"locale\":\"en\",\n" +
+                             "            \"unit\":\"MILLISECOND\",\n" +
+                             "            \"format\":\"yyyy-MM-dd HH:mm:ss\"\n" +
+                             "         }");
+    fields.add(msUnixTime);
+
+    Field secondUnixTime = new Field("secUnix", DataType.LONG, Field.FieldRole.TIMESTAMP, 1);
+    secondUnixTime.setLogicalType(LogicalType.TIMESTAMP);
+    secondUnixTime.setFormat("{  \n" +
+                                 "            \"type\":\"time_unix\",\n" +
+                                 "            \"timeZone\":\"UTC\",\n" +
+                                 "            \"locale\":\"en\",\n" +
+                                 "            \"unit\":\"SECOND\",\n" +
+                                 "            \"format\":\"yyyy-MM-dd HH:mm:ss\"\n" +
+                                 "         }");
+    fields.add(secondUnixTime);
+
+    Field timestampTimestamp = new Field("timestampTimestamp", DataType.TIMESTAMP, Field.FieldRole.TIMESTAMP, 2);
+    timestampTimestamp.setLogicalType(LogicalType.TIMESTAMP);
+    timestampTimestamp.setFormat("{  \n" +
+                                     "            \"type\":\"time_format\",\n" +
+                                     "            \"format\":\"yyyy-MM-dd HH:mm:ss.S\",\n" +
+                                     "            \"timeZone\":\"Asia/Seoul\",\n" +
+                                     "            \"locale\":\"en\"\n" +
+                                     "         }");
+    fields.add(timestampTimestamp);
+
+    Field strTimestamp = new Field("strTimestamp", DataType.STRING, Field.FieldRole.TIMESTAMP, 3);
+    strTimestamp.setLogicalType(LogicalType.TIMESTAMP);
+    strTimestamp.setFormat("{  \n" +
+                               "            \"type\":\"time_format\",\n" +
+                               "            \"format\":\"yyyy-MM-dd HH:mm:ss\",\n" +
+                               "            \"timeZone\":\"Asia/Seoul\",\n" +
+                               "            \"locale\":\"en\"\n" +
+                               "         }");
+    fields.add(strTimestamp);
+
+    printIncrementalQuery(implementor, fields, batchIngestionInfo, limitDateStr);
+  }
+
+  @Test
+  public void timestampFieldMSSQL(){
+    String implementor = "MSSQL";
+
+    String limitDateStr = "2017-04-21 00:00:00";
+    String sql = "SELECT \n" +
+        "(CAST(DATEDIFF(s, '1970-01-01 00:00:00', time) as BIGINT) * 1000) as msUnix\n" +
+        ", DATEDIFF(s, '1970-01-01 00:00:00', time) as secUnix\n" +
+        ", convert(datetime, time) as timestampTimestamp\n" +
+        ", CONVERT(NVARCHAR(max), time + ' 00:00:00', 126) as strTimestamp\n" +
+        "FROM dbo.sample_ingestion";
+    //create incremental query
+    BatchIngestionInfo batchIngestionInfo = new BatchIngestionInfo();
+    batchIngestionInfo.setQuery(sql);
+    batchIngestionInfo.setMaxLimit(1000);
+
+    List<Field> fields = new ArrayList<>();
+
+    Field msUnixTime = new Field("msUnix", DataType.INTEGER, Field.FieldRole.TIMESTAMP, 0);
+    msUnixTime.setLogicalType(LogicalType.TIMESTAMP);
+    msUnixTime.setFormat("{  \n" +
+                             "            \"type\":\"time_unix\",\n" +
+                             "            \"timeZone\":\"UTC\",\n" +
+                             "            \"locale\":\"en\",\n" +
+                             "            \"unit\":\"MILLISECOND\",\n" +
+                             "            \"format\":\"yyyy-MM-dd HH:mm:ss\"\n" +
+                             "         }");
+    fields.add(msUnixTime);
+
+    Field secondUnixTime = new Field("secUnix", DataType.LONG, Field.FieldRole.TIMESTAMP, 1);
+    secondUnixTime.setLogicalType(LogicalType.TIMESTAMP);
+    secondUnixTime.setFormat("{  \n" +
+                                 "            \"type\":\"time_unix\",\n" +
+                                 "            \"timeZone\":\"UTC\",\n" +
+                                 "            \"locale\":\"en\",\n" +
+                                 "            \"unit\":\"SECOND\",\n" +
+                                 "            \"format\":\"yyyy-MM-dd HH:mm:ss\"\n" +
+                                 "         }");
+    fields.add(secondUnixTime);
+
+    Field timestampTimestamp = new Field("timestampTimestamp", DataType.TIMESTAMP, Field.FieldRole.TIMESTAMP, 2);
+    timestampTimestamp.setLogicalType(LogicalType.TIMESTAMP);
+    timestampTimestamp.setFormat("{  \n" +
+                                     "            \"type\":\"time_format\",\n" +
+                                     "            \"format\":\"yyyy-MM-dd HH:mm:ss.S\",\n" +
+                                     "            \"timeZone\":\"Asia/Seoul\",\n" +
+                                     "            \"locale\":\"en\"\n" +
+                                     "         }");
+    fields.add(timestampTimestamp);
+
+    Field strTimestamp = new Field("strTimestamp", DataType.STRING, Field.FieldRole.TIMESTAMP, 3);
+    strTimestamp.setLogicalType(LogicalType.TIMESTAMP);
+    strTimestamp.setFormat("{  \n" +
+                               "            \"type\":\"time_format\",\n" +
+                               "            \"format\":\"yyyy-MM-dd HH:mm:ss.SSS\",\n" +
+                               "            \"timeZone\":\"Asia/Seoul\",\n" +
+                               "            \"locale\":\"en\"\n" +
+                               "         }");
+    fields.add(strTimestamp);
+
+    printIncrementalQuery(implementor, fields, batchIngestionInfo, limitDateStr);
+  }
+
+
+
+  public DataConnection getDataConnection(String implementor){
+    return new DataConnection(implementor);
+  }
+
+  public JdbcDialect getDialect(String implementor){
+    switch (implementor){
+      case "PRESTO" : return new PrestoDialect();
+      case "HIVE" : return new HiveDialect();
+      case "MYSQL" : return new MySQLDialect();
+      case "POSTGRESQL" : return new PostgresqlDialect();
+      case "DRUID" : return new DruidDialect();
+      case "MSSQL" : case "TIBERO" : case "ORACLE" :
+        return DataConnectionHelper.lookupDialect(implementor);
+    }
+
+    return null;
+  }
+
+  @Test
+  public void timestampFieldHive2(){
+    String implementor = "HIVE";
+
+    String limitDateStr = "2018-07-01 00:00:00";
+    String sql = "Select * from default.lineage;";
+
+    //create incremental query
+    BatchIngestionInfo batchIngestionInfo = new BatchIngestionInfo();
+    batchIngestionInfo.setDataType(JdbcIngestionInfo.DataType.QUERY);
+    batchIngestionInfo.setQuery(sql);
+    batchIngestionInfo.setMaxLimit(1000);
+
+    List<Field> fields = new ArrayList<>();
+
+    Field msUnixTime = new Field("lineage.eventtime", DataType.INTEGER, Field.FieldRole.TIMESTAMP, 0);
+    msUnixTime.setLogicalType(LogicalType.TIMESTAMP);
+    msUnixTime.setFormat("{  \n" +
+                             "            \"type\":\"time_unix\",\n" +
+                             "            \"timeZone\":\"UTC\",\n" +
+                             "            \"locale\":\"en\",\n" +
+                             "            \"unit\":\"MILLISECOND\",\n" +
+                             "            \"format\":\"yyyy-MM-dd HH:mm:ss\"\n" +
+                             "         }");
+    fields.add(msUnixTime);
+//
+//    Field secondUnixTime = new Field("secUnix", DataType.LONG, Field.FieldRole.TIMESTAMP, 1);
+//    secondUnixTime.setLogicalType(LogicalType.TIMESTAMP);
+//    secondUnixTime.setFormat("{  \n" +
+//                                 "            \"type\":\"time_unix\",\n" +
+//                                 "            \"timeZone\":\"UTC\",\n" +
+//                                 "            \"locale\":\"en\",\n" +
+//                                 "            \"unit\":\"SECOND\",\n" +
+//                                 "            \"format\":\"yyyy-MM-dd HH:mm:ss\"\n" +
+//                                 "         }");
+//    fields.add(secondUnixTime);
+//
+//    Field timestampTimestamp = new Field("timestampTimestamp", DataType.TIMESTAMP, Field.FieldRole.TIMESTAMP, 2);
+//    timestampTimestamp.setLogicalType(LogicalType.TIMESTAMP);
+//    timestampTimestamp.setFormat("{  \n" +
+//                                     "            \"type\":\"time_format\",\n" +
+//                                     "            \"format\":\"yyyy-MM-dd HH:mm:ss.S\",\n" +
+//                                     "            \"timeZone\":\"Asia/Seoul\",\n" +
+//                                     "            \"locale\":\"en\"\n" +
+//                                     "         }");
+//    fields.add(timestampTimestamp);
+
+//    Field strTimestamp = new Field("sch_index_query_top_daily.rankday", DataType.STRING, Field.FieldRole.TIMESTAMP, 3);
+//    strTimestamp.setLogicalType(LogicalType.TIMESTAMP);
+//    strTimestamp.setFormat("{  \n" +
+//                               "            \"type\":\"time_format\",\n" +
+//                               "            \"format\":\"yyyyMMdd\",\n" +
+//                               "            \"timeZone\":\"Asia/Seoul\",\n" +
+//                               "            \"locale\":\"en\"\n" +
+//                               "         }");
+//    fields.add(strTimestamp);
+
+    printIncrementalQuery(implementor, fields, batchIngestionInfo, limitDateStr);
+  }
+
+  @Test
+  public void timestampFieldHiveTable(){
+    String implementor = "HIVE";
+
+    String limitDateStr = "2018-07-01 00:00:00";
+    String sql = "default.lineage;";
+
+    //create incremental query
+    BatchIngestionInfo batchIngestionInfo = new BatchIngestionInfo();
+    batchIngestionInfo.setDataType(JdbcIngestionInfo.DataType.TABLE);
+    batchIngestionInfo.setQuery(sql);
+    batchIngestionInfo.setMaxLimit(1000);
+
+    List<Field> fields = new ArrayList<>();
+
+    Field msUnixTime = new Field("lineage.eventtime", DataType.INTEGER, Field.FieldRole.TIMESTAMP, 0);
+    msUnixTime.setLogicalType(LogicalType.TIMESTAMP);
+    msUnixTime.setFormat("{  \n" +
+                             "            \"type\":\"time_unix\",\n" +
+                             "            \"timeZone\":\"UTC\",\n" +
+                             "            \"locale\":\"en\",\n" +
+                             "            \"unit\":\"MILLISECOND\",\n" +
+                             "            \"format\":\"yyyy-MM-dd HH:mm:ss\"\n" +
+                             "         }");
+    fields.add(msUnixTime);
+
+    printIncrementalQuery(implementor, fields, batchIngestionInfo, limitDateStr);
+  }
+
+  public void printIncrementalQuery(String implementor, List<Field> fields, BatchIngestionInfo batchIngestionInfo, String targetDate){
+    for(Field field : fields){
+      System.out.println("-- " + implementor + "(" + field.getName() + ")");
+      String incrementalQuery = new SelectQueryBuilder(getDataConnection(implementor), getDialect(implementor))
+          .projection(fields)
+          .query(batchIngestionInfo, null)
+          .incremental(field, targetDate)
+          .limit(0, batchIngestionInfo.getMaxLimit())
+          .build();
+
+      System.out.println(incrementalQuery + ";");
+    }
+  }
+}

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/datasource/ingestion/jdbc/SelectQueryBuilderTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/datasource/ingestion/jdbc/SelectQueryBuilderTest.java
@@ -452,11 +452,9 @@ public class SelectQueryBuilderTest
       case "MYSQL" : return new MySQLDialect();
       case "POSTGRESQL" : return new PostgresqlDialect();
       case "DRUID" : return new DruidDialect();
-      case "MSSQL" : case "TIBERO" : case "ORACLE" :
+      case "MSSQL" : case "TIBERO" : case "ORACLE" : default :
         return DataConnectionHelper.lookupDialect(implementor);
     }
-
-    return null;
   }
 
   @Test


### PR DESCRIPTION
### Description
Re-verify the query builder for incremental ingestion for each DB type.
Below is a sample of each Where Clause for each format of Timestamp Field.

```
//1. If the field of the timestamp role is unixtime
//Presto
//sec : secUnix >= to_unixtime(cast('2018-07-01 00:00:00' as timestamp))
//ms : msUnix >= to_unixtime(cast('2018-07-01 00:00:00' as timestamp)) * 1000

//Hive
//sec : secUnix >= unix_timestamp('2018-07-01 00:00:00', 'yyyy-MM-dd HH:mm:ss')
//ms : msUnix >= unix_timestamp('2018-07-01 00:00:00', 'yyyy-MM-dd HH:mm:ss') * 1000

//MySQL
//sec : secUnix >= UNIX_TIMESTAMP('2018-07-01 00:00:00');
//ms : msUnix >= UNIX_TIMESTAMP('2018-07-01 00:00:00') * 1000;

//MSSQL
//sec : secUnix >= CAST(DATEDIFF(s, '1970-01-01', CAST('2017-04-21 00:00:00' as DATETIME)) as BIGINT)
//ms : msUnix >= CAST(DATEDIFF(s, '1970-01-01', CAST('2017-04-21 00:00:00' as DATETIME)) as BIGINT) * 1000

//POSTGRESQL
//sec : secUnix >= extract(epoch from to_date('2007-05-13 00:00:00', 'YYYY-MM-DD HH24:MI:SS'))
//ms : msUnix >= extract(epoch from to_date('2007-05-13 00:00:00', 'YYYY-MM-DD HH24:MI:SS')) * 1000

//Druid
//sec : secUnix >= TIMESTAMP_TO_MILLIS(TIME_PARSE('2014-11-02 00:00:00')) / 1000
//ms : msUnix >= TIMESTAMP_TO_MILLIS(TIME_PARSE('2014-11-02 00:00:00'))

//2. If the field of the timestamp role is timestamp
//Presto
//querytime >= parse_datetime('2018-07-01 00:00:00', 'yyyy-MM-dd HH:mm:ss')

//Hive
//`querytime` >= from_unixtime(unix_timestamp('2018-07-01 00:00:00', 'yyyy-MM-dd HH:mm:ss')

//MySQL
//querytime >= CAST('2019-04-01 00:00:00' AS DATETIME)

//MSSQL
//querytime >= CAST('2017-04-21 00:00:00' as DATETIME)

//POSTGRESQL
//querytime >= TO_DATE('2007-05-13 00:00:00', 'YYYY-MM-DD HH24:MI:SS')

//Druid
//querytime >= TIME_PARSE('2014-11-02 00:00:00', 'yyyy-MM-dd HH:mm:ss')


//3. If the field of the timestamp role is String
//Presto
//parse_datetime(strTimestamp, 'yyyy-MM-dd HH:mm:ss.SSS')  >= parse_datetime('2018-07-01 00:00:00', 'yyyy-MM-dd HH:mm:ss') --> for joda time

//Hive
//from_unixtime(unix_timestamp(`strTimestamp`, 'yyyy-MM-dd HH:mm:ss.SSS')  >= from_unixtime(unix_timestamp('2018-07-01 00:00:00', 'yyyy-MM-dd HH:mm:ss')

//MySQL
//CAST(strTimestamp AS DATETIME)  >= CAST('2019-04-01 00:00:00' AS DATETIME)

//MSSQL
//CAST(strTimestamp as DATETIME)  >= CAST('2017-04-21 00:00:00' as DATETIME)

//POSTGRESQL
/TODO

//Druid
//TIME_PARSE(strTimestamp, 'yyyy-MM-dd HH:mm:ss')  >= TIME_PARSE('2014-11-02 00:00:00', 'yyyy-MM-dd HH:mm:ss')
```

**Related Issue** : #1948 , #1978, #1391 


### How Has This Been Tested?
1. Create incremental ingestion data sources for each DB type.
(Hive, Presto, Druid, PostgreSQL, MySQL, MSSQL)
2. DataSource Detail > Check if there is an error in history.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
