### PR TITLE
Save button activation error when editing profile image

### DIFF
--- a/discovery-frontend/src/app/dashboard/component/update-dashboard/datasource-panel.component.ts
+++ b/discovery-frontend/src/app/dashboard/component/update-dashboard/datasource-panel.component.ts
@@ -256,7 +256,7 @@ export class DatasourcePanelComponent extends AbstractComponent implements OnIni
 
     // 페이징 목록
     let start: number = (this.dimPage - 1) * this.DIM_PAGE_SIZE;
-    let end: number = (this.dimPage * this.DIM_PAGE_SIZE) - 1;
+    let end: number = (this.dimPage * this.DIM_PAGE_SIZE);
     this.displayDimensions = this.dimensionFields.slice(start, end);
   } // function - prevDimPage
 
@@ -272,7 +272,7 @@ export class DatasourcePanelComponent extends AbstractComponent implements OnIni
 
     // 페이징 목록
     let start: number = (this.dimPage - 1) * this.DIM_PAGE_SIZE;
-    let end: number = (this.dimPage * this.DIM_PAGE_SIZE) - 1;
+    let end: number = (this.dimPage * this.DIM_PAGE_SIZE);
     this.displayDimensions = this.dimensionFields.slice(start, end);
   } // function - nextDimPage
 
@@ -288,7 +288,7 @@ export class DatasourcePanelComponent extends AbstractComponent implements OnIni
 
     // 페이징 목록
     let start: number = (this.meaPage - 1) * this.MEA_PAGE_SIZE;
-    let end: number = (this.meaPage * this.MEA_PAGE_SIZE) - 1;
+    let end: number = (this.meaPage * this.MEA_PAGE_SIZE);
     this.displayMeasures = this.measureFields.slice(start, end);
   } // function - prevMeaPage
 
@@ -304,7 +304,7 @@ export class DatasourcePanelComponent extends AbstractComponent implements OnIni
 
     // 페이징 목록
     let start: number = (this.meaPage - 1) * this.MEA_PAGE_SIZE;
-    let end: number = (this.meaPage * this.MEA_PAGE_SIZE) - 1;
+    let end: number = (this.meaPage * this.MEA_PAGE_SIZE);
     this.displayMeasures = this.measureFields.slice(start, end);
   } // function - nextMeaPage
 
@@ -495,7 +495,7 @@ export class DatasourcePanelComponent extends AbstractComponent implements OnIni
       if (this.DIM_PAGE_SIZE < dimensionFields.length) {
         this.dimPage = 1;
         this.dimTotalPage = Math.ceil(dimensionFields.length / this.DIM_PAGE_SIZE);
-        this.displayDimensions = dimensionFields.slice(0, this.DIM_PAGE_SIZE - 1);
+        this.displayDimensions = dimensionFields.slice(0, this.DIM_PAGE_SIZE);
       } else {
         this.dimPage = 1;
         this.dimTotalPage = 1;
@@ -505,7 +505,7 @@ export class DatasourcePanelComponent extends AbstractComponent implements OnIni
       if (this.MEA_PAGE_SIZE < measureFields.length) {
         this.meaPage = 1;
         this.meaTotalPage = Math.ceil(measureFields.length / this.MEA_PAGE_SIZE);
-        this.displayMeasures = measureFields.slice(0, this.MEA_PAGE_SIZE - 1);
+        this.displayMeasures = measureFields.slice(0, this.MEA_PAGE_SIZE);
       } else {
         this.meaPage = 1;
         this.meaTotalPage = 1;

--- a/discovery-frontend/src/app/layout/layout/component/gnb/gnb.component.ts
+++ b/discovery-frontend/src/app/layout/layout/component/gnb/gnb.component.ts
@@ -32,10 +32,7 @@ export class GnbComponent extends AbstractComponent implements OnInit, OnDestroy
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Protected Variables
    |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
-
-  //
   protected defaultPhotoSrc = '/assets/images/img_photo.png';
-
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Public Variables
@@ -96,10 +93,13 @@ export class GnbComponent extends AbstractComponent implements OnInit, OnDestroy
 
   /**
    * 사용자 정보 수정 완료
-   * @param event
+   * @param userData
    */
-  public updatedUser(event): void {
-    this.user = event;
+  public updatedUser(userData): void {
+    this.user.imageUrl = '';
+    this.safelyDetectChanges();
+    this.user = userData;
+    this.safelyDetectChanges();
   }
 
   /**

--- a/discovery-frontend/src/app/user/profile/profile.component.html
+++ b/discovery-frontend/src/app/user/profile/profile.component.html
@@ -16,13 +16,13 @@
   <em class="ddp-bg-popup"></em>
   <div class="ddp-ui-popup">
     <div class="ddp-ui-popup-title">
-            <span class="ddp-txt-title-name">
-              {{'msg.comm.ui.profile.title' | translate}}
-            </span>
+      <span class="ddp-txt-title-name">
+        {{'msg.comm.ui.profile.title' | translate}}
+      </span>
 
       <div class="ddp-ui-pop-buttons">
         <a (click)="close()" href="javascript:" class="ddp-btn-pop" >{{'msg.comm.btn.close' | translate}}</a>
-        <a (click)="done()" [class.ddp-disabled]="!isPhoneChanged && !isEmailChanged && !isFullNameChanged"
+        <a (click)="done()" [class.ddp-disabled]="!isPhoneChanged && !isEmailChanged && !isFullNameChanged && !isImageChanged"
            href="javascript:" class="ddp-btn-pop ddp-bg-black" >{{'msg.comm.btn.save' | translate}}</a>
       </div>
     </div>
@@ -46,9 +46,9 @@
           </label>
           <!-- photo -->
           <div class="ddp-wrap-photo">
-                        <span class="ddp-data-user-photo">
-                            <img src="{{getProfileImage()}}" #profileImage>
-                        </span>
+            <span class="ddp-data-user-photo">
+                <img src="{{getProfileImage()}}" #profileImage>
+            </span>
             <div class="ddp-ui-file-button" fileHover>
               <a href="javascript:" class="ddp-btn-small">
                 <input type="file"

--- a/discovery-frontend/src/app/user/profile/profile.component.ts
+++ b/discovery-frontend/src/app/user/profile/profile.component.ts
@@ -148,6 +148,11 @@ export class ProfileComponent extends AbstractComponent implements OnInit, OnDes
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
   | Public Method
   |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
+  public get isImageChanged(): boolean {
+    const userImage = isNullOrUndefined(this.user.imageUrl) ? '' : this.user.imageUrl.trim();
+    return this._imageUrl !== userImage;
+  } // function - isImageChanged
+
   /**
    * Phone 변경 여부
    */
@@ -189,7 +194,7 @@ export class ProfileComponent extends AbstractComponent implements OnInit, OnDes
    */
   public done(): void {
     // 프로필 수정이 가능하다면
-    if ((this.isPhoneChanged || this.isEmailChanged || this.isFullNameChanged) && this.doneValidation()) {
+    if ((this.isPhoneChanged || this.isEmailChanged || this.isFullNameChanged || this.isImageChanged) && this.doneValidation()) {
       // 로딩 show
       this.loadingShow();
       // 프로필 사진이 있으면 프로필사진 업로드부터 시행
@@ -227,6 +232,7 @@ export class ProfileComponent extends AbstractComponent implements OnInit, OnDes
 
         reader.onload = (event: any) => {
           this.profileImage.nativeElement.src = event.target.result;
+          this._imageUrl = event.target.result;   // 이미지 변경을 인식하기 위한 임시 적용
         };
         reader.readAsDataURL($event.target.files[0]);
       } else {


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
1. 사용자 프로필 이미지를 수정하였을 때 저장 버튼이 활성화되지 않는 오류가 있습니다.
2. 대시보드내 데이터소스 패널에서 10번째 필드가 표시되지 않는 오류가 있습니다.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 상단 메뉴에서 이미지를 불러오고 저장 버튼이 활성화 되는지 확인합니다.
2. 저장 후 프로필 이미지가 바로 변경되어 표시되는지 확인합니다.
3. 대시보드 편집화면에서 데이터소스 패널을 열어 필드 목록이 제대로 표시되는지 확인합니다.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
