### PR TITLE
Remove useless terms on bottoms of accounts mail

### DIFF
--- a/discovery-server/src/main/resources/templates/api/email/user_reset_password.html
+++ b/discovery-server/src/main/resources/templates/api/email/user_reset_password.html
@@ -122,8 +122,6 @@
     </tr>
     <tr>
         <td style="padding:44px 0 44px 0; background-color:#ddd; text-align:center; color:#707070; font-size:12px;">
-            <a href="/app/terms" th:href="${baseUrl} + '/app/terms'" style="color:#909090; font-size:12px; text-decoration:none;" th:text="#{message.app.mail.terms}">Terms of service</a>
-            <a href="/app/privacy" th:href="${baseUrl} + '/app/privacy'" style="margin-left:10px; margin-right:38px; color:#909090; font-size:12px; text-decoration:none;" th:text="#{message.app.mail.privacy}"><em style="display:inline-block; position:relative; top:2px; margin-right:10px; height:11px; border-left:1px solid #909090;"></em>Privacy Policy</a>
             COPYRIGHT © <span th:text="${title}">Metatron</span>. All Right Reserved.
         </td>
     </tr>

--- a/discovery-server/src/main/resources/templates/api/email/user_reset_password_by_admin.html
+++ b/discovery-server/src/main/resources/templates/api/email/user_reset_password_by_admin.html
@@ -129,8 +129,6 @@
         </tr>
         <tr>
             <td style="padding:44px 0 44px 0; background-color:#ddd; text-align:center; color:#707070; font-size:12px;">
-                <a href="/app/terms" th:href="${baseUrl} + '/app/terms'" style="color:#909090; font-size:12px; text-decoration:none;" th:text="#{message.app.mail.terms}">Terms of service</a>
-                <a href="/app/privacy" th:href="${baseUrl} + '/app/privacy'" style="margin-left:10px; margin-right:38px; color:#909090; font-size:12px; text-decoration:none;" th:text="#{message.app.mail.privacy}"><em style="display:inline-block; position:relative; top:2px; margin-right:10px; height:11px; border-left:1px solid #909090;"></em>Privacy Policy</a>
                 COPYRIGHT © <span th:text="${title}">Metatron</span>. All Right Reserved.
             </td>
         </tr>

--- a/discovery-server/src/main/resources/templates/api/email/user_signup_approved.html
+++ b/discovery-server/src/main/resources/templates/api/email/user_signup_approved.html
@@ -105,8 +105,6 @@
     </tr>
     <tr>
         <td style="padding:44px 0 44px 0; background-color:#ddd; text-align:center; color:#707070; font-size:12px;">
-            <a href="/app/terms" th:href="${baseUrl} + '/app/terms'" style="color:#909090; font-size:12px; text-decoration:none;" th:text="#{message.app.mail.terms}">Terms of service</a>
-            <a href="/app/privacy" th:href="${baseUrl} + '/app/privacy'" style="margin-left:10px; margin-right:38px; color:#909090; font-size:12px; text-decoration:none;" th:text="#{message.app.mail.privacy}"><em style="display:inline-block; position:relative; top:2px; margin-right:10px; height:11px; border-left:1px solid #909090;"></em>Privacy Policy</a>
             COPYRIGHT © <span th:text="${title}">Metatron</span>. All Right Reserved.
         </td>
     </tr>

--- a/discovery-server/src/main/resources/templates/api/email/user_signup_approved_by_admin.html
+++ b/discovery-server/src/main/resources/templates/api/email/user_signup_approved_by_admin.html
@@ -128,8 +128,6 @@
     </tr>
     <tr>
         <td style="padding:44px 0 44px 0; background-color:#ddd; text-align:center; color:#707070; font-size:12px;">
-            <a href="/app/terms" th:href="${baseUrl} + '/app/terms'" style="color:#909090; font-size:12px; text-decoration:none;" th:text="#{message.app.mail.terms}">Terms of service</a>
-            <a href="/app/privacy" th:href="${baseUrl} + '/app/privacy'" style="margin-left:10px; margin-right:38px; color:#909090; font-size:12px; text-decoration:none;" th:text="#{message.app.mail.privacy}"><em style="display:inline-block; position:relative; top:2px; margin-right:10px; height:11px; border-left:1px solid #909090;"></em>Privacy Policy</a>
             COPYRIGHT © <span th:text="${title}">Metatron</span>. All Right Reserved.
         </td>
     </tr>

--- a/discovery-server/src/main/resources/templates/api/email/user_signup_denied.html
+++ b/discovery-server/src/main/resources/templates/api/email/user_signup_denied.html
@@ -123,8 +123,6 @@
         </tr>
         <tr>
             <td style="padding:44px 0 44px 0; background-color:#ddd; text-align:center; color:#707070; font-size:12px;">
-                <a href="/app/terms" th:href="${baseUrl} + '/app/terms'" style="color:#909090; font-size:12px; text-decoration:none;" th:text="#{message.app.mail.terms}">Terms of service</a>
-                <a href="/app/privacy" th:href="${baseUrl} + '/app/privacy'" style="margin-left:10px; margin-right:38px; color:#909090; font-size:12px; text-decoration:none;" th:text="#{message.app.mail.privacy}"><em style="display:inline-block; position:relative; top:2px; margin-right:10px; height:11px; border-left:1px solid #909090;"></em>Privacy Policy</a>
                 COPYRIGHT © <span th:text="${title}">Metatron</span>. All Right Reserved.
             </td>
         </tr>

--- a/discovery-server/src/main/resources/templates/api/email/user_signup_request.html
+++ b/discovery-server/src/main/resources/templates/api/email/user_signup_request.html
@@ -105,8 +105,6 @@
         </tr>
         <tr>
             <td style="padding:44px 0 44px 0; background-color:#ddd; text-align:center; color:#707070; font-size:12px;">
-                <a href="/app/terms" th:href="${baseUrl} + '/app/terms'" style="color:#909090; font-size:12px; text-decoration:none;" th:text="#{message.app.mail.terms}">Terms of service</a>
-                <a href="/app/privacy" th:href="${baseUrl} + '/app/privacy'" style="margin-left:10px; margin-right:38px; color:#909090; font-size:12px; text-decoration:none;" th:text="#{message.app.mail.privacy}"><em style="display:inline-block; position:relative; top:2px; margin-right:10px; height:11px; border-left:1px solid #909090;"></em>Privacy Policy</a>
                 COPYRIGHT © <span th:text="${title}">Metatron</span>. All Right Reserved.
             </td>
         </tr>


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Remove useless terms on bottoms of accounts mail.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
N/A, just for clearity.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Send account mail by actions as follow:
- Create an account by an admin user.
- Send request for register an account
- Approve request for registration
- Deny for registration
- Reset password

2. Check the bottom of E-mail that disappeared 'Privacy' and 'Terms of service'.

#### Need additional checks?
No.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
It just removes the thymeleaf lines, so don't need to be added some test codes.