### PR TITLE
Support various type of delimiter on hive ingestion

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/KeepAsUnescapeSerializer.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/KeepAsUnescapeSerializer.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.metatron.discovery;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import org.apache.commons.lang3.StringEscapeUtils;
+
+import java.io.IOException;
+
+public class KeepAsUnescapeSerializer extends JsonSerializer<String> {
+  @Override
+  public void serialize(String s, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+
+    jsonGenerator.writeObject(StringEscapeUtils.unescapeJava(s));
+
+  }
+}

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/ingestion/file/CsvFileFormat.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/ingestion/file/CsvFileFormat.java
@@ -27,7 +27,7 @@ public class CsvFileFormat implements FileFormat {
 
   public static final String DEFAULT_LINE_SEPARATOR = "\n";
 
-  String delimiter = DEFAULT_DELIMITER;
+  String delimiter;
 
   String lineSeparator = DEFAULT_LINE_SEPARATOR;
 

--- a/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/AbstractSpecBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/AbstractSpecBuilder.java
@@ -281,6 +281,8 @@ public class AbstractSpecBuilder {
           parseSpec.setDimensionsSpec(dimensionsSpec);
           parseSpec.setColumns(columns);
 
+          parseSpec.setListDelimiter(csvFormat.getLineSeparator());
+
           parser = new StringParser(parseSpec);
         } else {
           TsvParseSpec parseSpec = new TsvParseSpec();

--- a/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/AbstractSpecBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/AbstractSpecBuilder.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
@@ -281,11 +282,16 @@ public class AbstractSpecBuilder {
         parseSpec.setColumns(columns);
 
         // Hive's default delimiter is not a comma
-        if (ingestionInfo instanceof HiveIngestionInfo && csvFormat.isDefaultCsvMode()) {
-          parseSpec.setDelimiter("\u0001");
+        if (StringUtils.isEmpty(csvFormat.getDelimiter())) {
+          if (ingestionInfo instanceof HiveIngestionInfo) {
+            parseSpec.setDelimiter("\u0001");
+          } else {
+            parseSpec.setDelimiter(CsvFileFormat.DEFAULT_DELIMITER);
+          }
         } else {
           parseSpec.setDelimiter(csvFormat.getDelimiter());
         }
+
         parseSpec.setListDelimiter(csvFormat.getLineSeparator());
 
         parser = new StringParser(parseSpec);
@@ -311,6 +317,10 @@ public class AbstractSpecBuilder {
           csvStreamParser.setTimestampSpec(timestampSpec);
           csvStreamParser.setDimensionsSpec(dimensionsSpec);
           csvStreamParser.setColumns(columns);
+
+          if (StringUtils.isEmpty(csvFormat.getDelimiter())) {
+            csvFormat.setDelimiter(CsvFileFormat.DEFAULT_DELIMITER);
+          }
 
           if (!csvFormat.isDefaultCsvMode()) {
             csvStreamParser.setDelimiter(csvFormat.getDelimiter());

--- a/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/AbstractSpecBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/AbstractSpecBuilder.java
@@ -275,13 +275,17 @@ public class AbstractSpecBuilder {
       if (hadoopIngestion) {
         CsvFileFormat csvFormat = (CsvFileFormat) fileFormat;
 
-        // CsvParseSpec with Default CSV has an error on the druid. So all ingestion with hadoop use TsvParseSpec.
         TsvParseSpec parseSpec = new TsvParseSpec();
         parseSpec.setTimestampSpec(timestampSpec);
         parseSpec.setDimensionsSpec(dimensionsSpec);
         parseSpec.setColumns(columns);
 
-        parseSpec.setDelimiter(csvFormat.getDelimiter());
+        // Hive's default delimiter is not a comma
+        if (ingestionInfo instanceof HiveIngestionInfo && csvFormat.isDefaultCsvMode()) {
+          parseSpec.setDelimiter("\u0001");
+        } else {
+          parseSpec.setDelimiter(csvFormat.getDelimiter());
+        }
         parseSpec.setListDelimiter(csvFormat.getLineSeparator());
 
         parser = new StringParser(parseSpec);

--- a/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/AbstractSpecBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/AbstractSpecBuilder.java
@@ -275,26 +275,16 @@ public class AbstractSpecBuilder {
       if (hadoopIngestion) {
         CsvFileFormat csvFormat = (CsvFileFormat) fileFormat;
 
-        if (csvFormat.isDefaultCsvMode()) {
-          CsvParseSpec parseSpec = new CsvParseSpec();
-          parseSpec.setTimestampSpec(timestampSpec);
-          parseSpec.setDimensionsSpec(dimensionsSpec);
-          parseSpec.setColumns(columns);
+        // CsvParseSpec with Default CSV has an error on the druid. So all ingestion with hadoop use TsvParseSpec.
+        TsvParseSpec parseSpec = new TsvParseSpec();
+        parseSpec.setTimestampSpec(timestampSpec);
+        parseSpec.setDimensionsSpec(dimensionsSpec);
+        parseSpec.setColumns(columns);
 
-          parseSpec.setListDelimiter(csvFormat.getLineSeparator());
+        parseSpec.setDelimiter(csvFormat.getDelimiter());
+        parseSpec.setListDelimiter(csvFormat.getLineSeparator());
 
-          parser = new StringParser(parseSpec);
-        } else {
-          TsvParseSpec parseSpec = new TsvParseSpec();
-          parseSpec.setTimestampSpec(timestampSpec);
-          parseSpec.setDimensionsSpec(dimensionsSpec);
-          parseSpec.setColumns(columns);
-
-          parseSpec.setDelimiter(csvFormat.getDelimiter());
-          parseSpec.setListDelimiter(csvFormat.getLineSeparator());
-
-          parser = new StringParser(parseSpec);
-        }
+        parser = new StringParser(parseSpec);
       } else {
 
         CsvStreamParser csvStreamParser = new CsvStreamParser();

--- a/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/parser/CsvParseSpec.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/parser/CsvParseSpec.java
@@ -14,13 +14,18 @@
 
 package app.metatron.discovery.spec.druid.ingestion.parser;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
 import java.util.List;
+
+import app.metatron.discovery.KeepAsUnescapeSerializer;
 
 /**
  * Created by kyungtaak on 2016. 6. 17..
  */
 public class CsvParseSpec extends TimeAndDimsParseSpec implements ParseSpec {
 
+  @JsonSerialize(using = KeepAsUnescapeSerializer.class)
   String listDelimiter;
 
   List<String> columns;

--- a/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/parser/TsvParseSpec.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/parser/TsvParseSpec.java
@@ -14,13 +14,21 @@
 
 package app.metatron.discovery.spec.druid.ingestion.parser;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
 import java.util.List;
+
+import app.metatron.discovery.KeepAsUnescapeSerializer;
 
 /**
  * Created by kyungtaak on 2017. 3. 30..
  */
 public class TsvParseSpec extends CsvParseSpec implements ParseSpec {
 
+  @JsonSerialize(using = KeepAsUnescapeSerializer.class)
   String delimiter;
 
   public TsvParseSpec() {
@@ -37,5 +45,10 @@ public class TsvParseSpec extends CsvParseSpec implements ParseSpec {
 
   public void setDelimiter(String delimiter) {
     this.delimiter = delimiter;
+  }
+
+  @Override
+  public String toString() {
+    return ToStringBuilder.reflectionToString(this, ToStringStyle.JSON_STYLE);
   }
 }

--- a/discovery-server/src/test/java/app/metatron/discovery/spec/druid/ingestion/parser/ParseSpecTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/spec/druid/ingestion/parser/ParseSpecTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.metatron.discovery.spec.druid.ingestion.parser;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import app.metatron.discovery.domain.datasource.ingestion.file.CsvFileFormat;
+
+public class ParseSpecTest {
+
+  @Test
+  public void checkDelimiterOnSpec() {
+
+    CsvFileFormat csvFileFormat = new CsvFileFormat();
+
+    csvFileFormat.setDelimiter("\u0001");
+    csvFileFormat.setLineSeparator("\n");
+
+    TsvParseSpec tsvParseSpec = new TsvParseSpec();
+
+    tsvParseSpec.setListDelimiter(csvFileFormat.getLineSeparator());
+    tsvParseSpec.setDelimiter(csvFileFormat.getDelimiter());
+
+    System.out.println(tsvParseSpec.toString());
+    Assert.assertSame("\u0001", tsvParseSpec.getDelimiter());
+
+  }
+
+}


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Make it possible to specify a delimiter other than a comma or a tab when ingest by stagingDB.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#1979 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
0. I add some unit testing code.

1. Create a table that delimited by a special character.
For example, using this configuration on your DDL : 
`FIELDS TERMINATED BY '\u0001'`

2. Create a datasource with the above table.
3. Create successfully.

#### Need additional checks?
The whole type of datasource ingestion needs to be testing.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
I think it only defects on StagingDB but you can advise about more point can be affected.