### PR TITLE
Fixed a UI error

### DIFF
--- a/discovery-frontend/package.json
+++ b/discovery-frontend/package.json
@@ -38,7 +38,6 @@
     "air-datepicker": "2.2.3",
     "angular2-moment": "1.9.0",
     "antlr4": "4.7.2",
-    "aromanize": "^0.1.5",
     "core-js": "2.6.1",
     "dragula": "3.7.2",
     "fast-text-encoding": "1.0.0",

--- a/discovery-frontend/src/app/admin/workspace-management/component/workspaces/detail-workspace/component/linked-resources/detail-workspace-linked-resources.component.html
+++ b/discovery-frontend/src/app/admin/workspace-management/component/workspaces/detail-workspace/component/linked-resources/detail-workspace-linked-resources.component.html
@@ -46,10 +46,12 @@
           </tr>
           <tr *ngFor="let source of getDatasourceList()">
             <td>
-              <div class="ddp-txt-long ddp-global">
-                {{source.name}}
-                <span class="ddp-txt-colortype" *ngIf="source.description">-{{source.description}}</span>
-                <em class="ddp-tag-global" *ngIf="source.published">{{'msg.comm.ui.list.ds.opendata' | translate}}</em>
+              <div class="ddp-txt-long">
+                <em class="ddp-tag-global type-tag" *ngIf="source.published">{{'msg.comm.ui.list.ds.opendata' | translate}}</em>
+                <span class="ddp-data-long">
+                  {{source.name}}
+                  <span class="ddp-txt-colortype" *ngIf="source.description">-{{source.description}}</span>
+                </span>
               </div>
             </td>
             <td>
@@ -91,9 +93,11 @@
           </tr>
           <tr *ngFor="let connection of getConnectionList()">
             <td>
-              <div class=" ddp-txt-long ddp-global" [class.ddp-connection]="translateService.getBrowserLang() == 'en'">
-                {{connection.name}}
-                <em class="ddp-tag-global" *ngIf="connection.published">{{'msg.spaces.shared.detail.connection.open' | translate}}</em>
+              <div class="ddp-txt-long">
+                <em class="ddp-tag-global type-tag" *ngIf="connection.published">{{'msg.spaces.shared.detail.connection.open' | translate}}</em>
+                <span class="ddp-data-long">
+                  {{connection.name}}
+                </span>
               </div>
             </td>
             <td>

--- a/discovery-frontend/src/app/admin/workspace-management/component/workspaces/detail-workspace/component/viewer/resources-view.component.html
+++ b/discovery-frontend/src/app/admin/workspace-management/component/workspaces/detail-workspace/component/viewer/resources-view.component.html
@@ -74,10 +74,12 @@
         <tr *ngFor="let data of dataList">
           <td>
             <!-- tag global 있을 경우에만 ddp-global 추가 -->
-            <div class=" ddp-txt-long ddp-global" [class.ddp-en-connection]="data.published && isBrowserLangEng()">
-              {{data.name}}
-              <span class="ddp-txt-colortype" *ngIf="data.description">-{{data.description}}</span>
-              <em class="ddp-tag-global" *ngIf="data.published">{{getOpenLabel()}}</em>
+            <div class="ddp-txt-long">
+              <em class="ddp-tag-global type-tag" *ngIf="data.published">{{getOpenLabel()}}</em>
+              <span class="ddp-data-long">
+                {{data.name}}
+                <span class="ddp-txt-colortype" *ngIf="data.description">-{{data.description}}</span>
+              </span>
             </div>
           </td>
           <td>

--- a/discovery-frontend/src/app/admin/workspace-management/component/workspaces/shared-workspaces.component.html
+++ b/discovery-frontend/src/app/admin/workspace-management/component/workspaces/shared-workspaces.component.html
@@ -168,11 +168,10 @@
       </td>
       <td>
         <!-- ddp-tag ddp-info -->
-        <div class="ddp-type-txt" [class.ddp-tag]="workspace.published">
-          <span class="ddp-txt-long">{{workspace.name}}</span>
-          <!-- only all allowance -->
-          <em class="ddp-tag-annoymous" *ngIf="workspace.published">{{'msg.spaces.spaces.ui.allowance.tag' | translate}}</em>
-          <!-- //only all allowance -->
+        <div class="ddp-txt-long">
+          <em class="ddp-tag-global type-tag" *ngIf="workspace.published">{{'msg.spaces.spaces.ui.allowance.tag' | translate}}</em>
+          <span class="ddp-data-long" [class.ddp-global]="workspace.published">{{workspace.name}}
+          </span>
         </div>
       </td>
       <td>

--- a/discovery-frontend/src/app/dashboard/component/update-dashboard/datasource-panel.component.ts
+++ b/discovery-frontend/src/app/dashboard/component/update-dashboard/datasource-panel.component.ts
@@ -352,11 +352,6 @@ export class DatasourcePanelComponent extends AbstractComponent implements OnIni
     }
 
     if (field.useFilter) {  // 제거
-      // 필수필터이면 제거 불가능
-      if (field.role === FieldRole.TIMESTAMP && field.logicalType === LogicalType.TIMESTAMP) {
-        Alert.warning(this.translateService.instant('msg.board.alert.timestamp.del.error'));
-        return;
-      }
 
       // 추천필터 제거 볼가
       if (field.filtering) {

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-sort.component.html
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-sort.component.html
@@ -13,8 +13,6 @@
   ~  * limitations under the License.
   ~  */
   -->
-
-<script src="edit-rule-sort.component.ts"></script>
 <div class="ddp-box-part" *ngIf="isShow">
   <div class="ddp-box-title">
     {{'msg.lineage.ui.list.search.column' | translate}}<em class="ddp-icon-essential"></em>

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/multiple-rename-popup.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/multiple-rename-popup.component.ts
@@ -30,7 +30,6 @@ import {GridOption} from "../../../../../common/component/grid/grid.option";
 import {ScrollLoadingGridComponent} from "./edit-rule-grid/scroll-loading-grid.component";
 import {ScrollLoadingGridModel} from "./edit-rule-grid/scroll-loading-grid.model";
 import {isNullOrUndefined} from "util";
-import * as Aromanize from 'aromanize';
 import {DatasetService} from "../../../../dataset/service/dataset.service";
 
 declare const moment: any;
@@ -50,6 +49,271 @@ export class MultipleRenamePopupComponent extends AbstractComponent implements O
   @ViewChild(ScrollLoadingGridComponent)
   private _gridComp: ScrollLoadingGridComponent;
 
+  private _korToEngRules = {
+    hangul: {
+      /**
+       * Revised Romanization Transcription
+       */
+      'rr': {
+        // Note: giyeok (0x1100) for middle moeum is different than giyeok (0x3131) for standalone jamo
+        cho: {
+          'ᄀ': 'g', 'ᄁ': 'kk',
+          'ᄂ': 'n',
+          'ᄃ': 'd', 'ᄄ': 'tt',
+          'ᄅ': 'r',
+          'ᄆ': 'm',
+          'ᄇ': 'b', 'ᄈ': 'pp',
+          'ᄉ': 's', 'ᄊ': 'ss',
+          'ᄋ': '',
+          'ᄌ': 'j', 'ᄍ': 'jj',
+          'ᄎ': 'ch',
+          'ᄏ': 'k',
+          'ᄐ': 't',
+          'ᄑ': 'p',
+          'ᄒ': 'h'
+        },
+
+        // Note: ᅡ (0x1161) for middle moeum is different than ㅏ (0x314F) for standalone jamo
+        jung: {
+          'ᅡ': 'a', 'ᅢ': 'ae', 'ᅣ': 'ya', 'ᅤ': 'yae',
+          'ᅥ': 'eo', 'ᅦ': 'e', 'ᅧ': 'yeo', 'ᅨ': 'ye',
+          'ᅩ': 'o', 'ᅪ': 'wa', 'ᅫ': 'wae', 'ᅬ': 'oe', 'ᅭ': 'yo',
+          'ᅮ': 'u', 'ᅯ': 'wo', 'ᅰ': 'we', 'ᅱ': 'wi', 'ᅲ': 'yu',
+          'ᅳ': 'eu', 'ᅴ': 'eui', 'ᅵ': 'i'
+        },
+
+        // Note: ᆨ (0x11A8) for last jaeum (batchim) is different than ᄀ (0x1100) for first jaeum
+        // also different than ㄱ (0x3131) for standalone jamo
+        jong: {
+          'ᆨ': 'k', 'ᆨᄋ': 'g', 'ᆨᄂ': 'ngn', 'ᆨᄅ': 'ngn', 'ᆨᄆ': 'ngm', 'ᆨᄒ': 'kh',
+          'ᆩ': 'kk', 'ᆩᄋ': 'kg', 'ᆩᄂ': 'ngn', 'ᆩᄅ': 'ngn', 'ᆩᄆ': 'ngm', 'ᆩᄒ': 'kh',
+          'ᆪ': 'k', 'ᆪᄋ': 'ks', 'ᆪᄂ': 'ngn', 'ᆪᄅ': 'ngn', 'ᆪᄆ': 'ngm', 'ᆪᄒ': 'kch',
+          'ᆫ': 'n', 'ᆫᄅ': 'll',
+          'ᆬ': 'n', 'ᆬᄋ': 'nj', 'ᆬᄂ': 'nn', 'ᆬᄅ': 'nn', 'ᆬᄆ': 'nm', 'ᆬㅎ': 'nch',
+          'ᆭ': 'n', 'ᆭᄋ': 'nh', 'ᆭᄅ': 'nn',
+          'ᆮ': 't', 'ᆮᄋ': 'd', 'ᆮᄂ': 'nn', 'ᆮᄅ': 'nn', 'ᆮᄆ': 'nm', 'ᆮᄒ': 'th',
+          'ᆯ': 'l', 'ᆯᄋ': 'r', 'ᆯᄂ': 'll',
+          'ᆰ': 'k', 'ᆰᄋ': 'lg', 'ᆰᄂ': 'ngn', 'ᆰᄅ': 'ngn', 'ᆰᄆ': 'ngm', 'ᆰᄒ': 'lkh',
+          'ᆱ': 'm', 'ᆱᄋ': 'lm', 'ᆱᄂ': 'mn', 'ᆱᄅ': 'mn', 'ᆱᄆ': 'mm', 'ᆱᄒ': 'lmh',
+          'ᆲ': 'p', 'ᆲᄋ': 'lb', 'ᆲᄂ': 'mn', 'ᆲᄅ': 'mn', 'ᆲᄆ': 'mm', 'ᆲᄒ': 'lph',
+          'ᆳ': 't', 'ᆳᄋ': 'ls', 'ᆳᄂ': 'nn', 'ᆳᄅ': 'nn', 'ᆳᄆ': 'nm', 'ᆳᄒ': 'lsh',
+          'ᆴ': 't', 'ᆴᄋ': 'lt', 'ᆴᄂ': 'nn', 'ᆴᄅ': 'nn', 'ᆴᄆ': 'nm', 'ᆴᄒ': 'lth',
+          'ᆵ': 'p', 'ᆵᄋ': 'lp', 'ᆵᄂ': 'mn', 'ᆵᄅ': 'mn', 'ᆵᄆ': 'mm', 'ᆵᄒ': 'lph',
+          'ᆶ': 'l', 'ᆶᄋ': 'lh', 'ᆶᄂ': 'll', 'ᆶᄅ': 'll', 'ᆶᄆ': 'lm', 'ᆶᄒ': 'lh',
+          'ᆷ': 'm', 'ᆷᄅ': 'mn',
+          'ᆸ': 'p', 'ᆸᄋ': 'b', 'ᆸᄂ': 'mn', 'ᆸᄅ': 'mn', 'ᆸᄆ': 'mm', 'ᆸᄒ': 'ph',
+          'ᆹ': 'p', 'ᆹᄋ': 'ps', 'ᆹᄂ': 'mn', 'ᆹᄅ': 'mn', 'ᆹᄆ': 'mm', 'ᆹᄒ': 'psh',
+          'ᆺ': 't', 'ᆺᄋ': 's', 'ᆺᄂ': 'nn', 'ᆺᄅ': 'nn', 'ᆺᄆ': 'nm', 'ᆺᄒ': 'sh',
+          'ᆻ': 't', 'ᆻᄋ': 'ss', 'ᆻᄂ': 'tn', 'ᆻᄅ': 'tn', 'ᆻᄆ': 'nm', 'ᆻᄒ': 'th',
+          'ᆼ': 'ng',
+          'ᆽ': 't', 'ᆽᄋ': 'j', 'ᆽᄂ': 'nn', 'ᆽᄅ': 'nn', 'ᆽᄆ': 'nm', 'ᆽᄒ': 'ch',
+          'ᆾ': 't', 'ᆾᄋ': 'ch', 'ᆾᄂ': 'nn', 'ᆾᄅ': 'nn', 'ᆾᄆ': 'nm', 'ᆾᄒ': 'ch',
+          'ᆿ': 'k', 'ᆿᄋ': 'k', 'ᆿᄂ': 'ngn', 'ᆿᄅ': 'ngn', 'ᆿᄆ': 'ngm', 'ᆿᄒ': 'kh',
+          'ᇀ': 't', 'ᇀᄋ': 't', 'ᇀᄂ': 'nn', 'ᇀᄅ': 'nn', 'ᇀᄆ': 'nm', 'ᇀᄒ': 'th',
+          'ᇁ': 'p', 'ᇁᄋ': 'p', 'ᇁᄂ': 'mn', 'ᇁᄅ': 'mn', 'ᇁᄆ': 'mm', 'ᇁᄒ': 'ph',
+          'ᇂ': 't', 'ᇂᄋ': 'h', 'ᇂᄂ': 'nn', 'ᇂᄅ': 'nn', 'ᇂᄆ': 'mm', 'ᇂᄒ': 't'
+        }
+      },
+
+      /**
+       * Revised Romanization Transliteration
+       */
+      'rr-translit': {
+        // Note: giyeok (0x1100) for middle moeum is different than giyeok (0x3131) for standalone jamo
+        cho: {
+          'ᄀ': 'g', 'ᄁ': 'kk',
+          'ᄂ': 'n',
+          'ᄃ': 'd', 'ᄄ': 'tt',
+          'ᄅ': 'l',
+          'ᄆ': 'm',
+          'ᄇ': 'b', 'ᄈ': 'pp',
+          'ᄉ': 's', 'ᄊ': 'ss',
+          'ᄋ': '',
+          'ᄌ': 'j', 'ᄍ': 'jj',
+          'ᄎ': 'ch',
+          'ᄏ': 'k',
+          'ᄐ': 't',
+          'ᄑ': 'p',
+          'ᄒ': 'h'
+        },
+
+        // Note: ᅡ (0x1161) for middle moeum is different than ㅏ (0x314F) for standalone jamo
+        jung: {
+          'ᅡ': 'a', 'ᅢ': 'ae', 'ᅣ': 'ya', 'ᅤ': 'yae',
+          'ᅥ': 'eo', 'ᅦ': 'e', 'ᅧ': 'yeo', 'ᅨ': 'ye',
+          'ᅩ': 'o', 'ᅪ': 'oa', 'ᅫ': 'oae', 'ᅬ': 'oi', 'ᅭ': 'yo',
+          'ᅮ': 'u', 'ᅯ': 'ueo', 'ᅰ': 'ue', 'ᅱ': 'ui', 'ᅲ': 'yu',
+          'ᅳ': 'eu', 'ᅴ': 'eui', 'ᅵ': 'i'
+        },
+
+        // Note: ᆨ (0x11A8) for last jaeum (batchim) is different than ᄀ (0x1100) for first jaeum
+        // also different than ㄱ (0x3131) for standalone jamo
+        jong: {
+          'ᆨ': 'g', 'ᆨᄋ': 'g-',
+          'ᆩ': 'kk', 'ᆩᄋ': 'kk-',
+          'ᆪ': 'gs', 'ᆪᄋ': 'gs-', 'ᆪᄉ': 'gs-s',
+          'ᆫ': 'n', 'ᆫᄋ': 'n-',
+          'ᆬ': 'nj', 'ᆬᄋ': 'nj-', 'ᆬᄌ': 'nj-j',
+          'ᆭ': 'nh', 'ᆭᄋ': 'nh-',
+          'ᆮ': 'd', 'ᆮᄋ': 'd-',
+          'ᆯ': 'l', 'ᆯᄋ': 'l-',
+          'ᆰ': 'lg', 'ᆰᄋ': 'lg-',
+          'ᆱ': 'lm', 'ᆱᄋ': 'lm-',
+          'ᆲ': 'lb', 'ᆲᄋ': 'lb-',
+          'ᆳ': 'ls', 'ᆳᄋ': 'ls-', 'ᆳᄉ': 'ls-s',
+          'ᆴ': 'lt', 'ᆴᄋ': 'lt-',
+          'ᆵ': 'lp', 'ᆵᄋ': 'lp-',
+          'ᆶ': 'lh', 'ᆶᄋ': 'lh-',
+          'ᆷ': 'm', 'ᆷᄋ': 'm-',
+          'ᆸ': 'b', 'ᆸᄋ': 'b-',
+          'ᆹ': 'bs', 'ᆹᄋ': 'bs-', 'ᆹᄉ': 'bs-s',
+          'ᆺ': 's', 'ᆺᄋ': 's-', 'ᆺᄊ': 's-ss',
+          'ᆻ': 'ss', 'ᆻᄋ': 'ss-', 'ᆻᄉ': 'ss-s',
+          'ᆼ': 'ng', 'ᆼᄋ': 'ng-',
+          'ᆽ': 'j', 'ᆽᄋ': 'j-', 'ᆽᄌ': 'j-j',
+          'ᆾ': 'ch', 'ᆾᄋ': 'ch-',
+          'ᆿ': 'k', 'ᆿᄋ': 'k-',
+          'ᇀ': 't', 'ᇀᄋ': 't-',
+          'ᇁ': 'p', 'ᇁᄋ': 'p-',
+          'ᇂ': 'h', 'ᇂᄋ': 'h-'
+        }
+      },
+
+      'skats': {
+        hyphen: ' ',
+
+        // Note: giyeok (0x1100) for middle moeum is different than giyeok (0x3131) for standalone jamo
+        cho: {
+          'ᄀ': 'L', 'ᄁ': 'LL',
+          'ᄂ': 'F',
+          'ᄃ': 'B', 'ᄄ': 'BB',
+          'ᄅ': 'V',
+          'ᄆ': 'M',
+          'ᄇ': 'W', 'ᄈ': 'WW',
+          'ᄉ': 'G', 'ᄊ': 'GG',
+          'ᄋ': 'K',
+          'ᄌ': 'P', 'ᄍ': 'PP',
+          'ᄎ': 'C',
+          'ᄏ': 'X',
+          'ᄐ': 'Z',
+          'ᄑ': 'O',
+          'ᄒ': 'J',
+          ' ': '  '
+        },
+
+        // Note: ᅡ (0x1161) for middle moeum is different than ㅏ (0x314F) for standalone jamo
+        jung: {
+          'ᅡ': 'E', 'ᅢ': 'EU', 'ᅣ': 'I', 'ᅤ': 'IU',
+          'ᅥ': 'T', 'ᅦ': 'TU', 'ᅧ': 'S', 'ᅨ': 'SU',
+          'ᅩ': 'A', 'ᅪ': 'AE', 'ᅫ': 'AEU', 'ᅬ': 'AU', 'ᅭ': 'N',
+          'ᅮ': 'H', 'ᅯ': 'HT', 'ᅰ': 'HTU', 'ᅱ': 'HU', 'ᅲ': 'R',
+          'ᅳ': 'D', 'ᅴ': 'DU', 'ᅵ': 'U'
+        },
+
+        // Note: ᆨ (0x11A8) for last jaeum (batchim) is different than ᄀ (0x1100) for first jaeum
+        // also different than ㄱ (0x3131) for standalone jamo
+        jong: {
+          'ᆨ': 'L', 'ᆩ': 'LL', 'ᆪ': 'LG',
+          'ᆫ': 'F', 'ᆬ': 'FP', 'ᆭ': 'FJ',
+          'ᆮ': 'B',
+          'ᆯ': 'V', 'ᆰ': 'VL', 'ᆱ': 'VM', 'ᆲ': 'VW', 'ᆳ': 'VG', 'ᆴ': 'VZ', 'ᆵ': 'VO', 'ᆶ': 'VJ',
+          'ᆷ': 'M',
+          'ᆸ': 'W', 'ᆹ': 'WG',
+          'ᆺ': 'G', 'ᆻ': 'GG',
+          'ᆼ': 'K',
+          'ᆽ': 'P',
+          'ᆾ': 'C',
+          'ᆿ': 'X',
+          'ᇀ': 'Z',
+          'ᇁ': 'O',
+          'ᇂ': 'J'
+        }
+      },
+
+      /**
+       * Indonesian Transcription
+       */
+      'ebi': {
+        // Note: giyeok (0x1100) for middle moeum is different than giyeok (0x3131) for standalone jamo
+        cho: {
+          'ᄀ': 'gh', 'ᄁ': 'k',
+          'ᄂ': 'n',
+          'ᄃ': 'dh', 'ᄄ': 't',
+          'ᄅ': 'r',
+          'ᄆ': 'm',
+          'ᄇ': 'bh', 'ᄈ': 'p',
+          'ᄉ': 's', 'ᄊ': 's',
+          'ᄋ': '',
+          'ᄌ': 'jh', 'ᄍ': 'c',
+          'ᄎ': 'ch',
+          'ᄏ': 'kh',
+          'ᄐ': 'th',
+          'ᄑ': 'ph',
+          'ᄒ': 'h'
+        },
+
+        // Note: giyeok (0x1100) for middle moeum is different than giyeok (0x3131) for standalone jamo
+        cho2: {
+          'ᄀ': 'g', 'ᄁ': 'k',
+          'ᄂ': 'n',
+          'ᄃ': 'd', 'ᄄ': 't',
+          'ᄅ': 'r',
+          'ᄆ': 'm',
+          'ᄇ': 'b', 'ᄈ': 'p',
+          'ᄉ': 's', 'ᄊ': 's',
+          'ᄋ': '',
+          'ᄌ': 'j', 'ᄍ': 'c',
+          'ᄎ': 'ch',
+          'ᄏ': 'kh',
+          'ᄐ': 'th',
+          'ᄑ': 'ph',
+          'ᄒ': 'h'
+        },
+
+        // Note: ᅡ (0x1161) for middle moeum is different than ㅏ (0x314F) for standalone jamo
+        jung: {
+          'ᅡ': 'a', 'ᅢ': 'è', 'ᅣ': 'ya', 'ᅤ': 'yè',
+          'ᅥ': 'ö', 'ᅦ': 'é', 'ᅧ': 'yö', 'ᅨ': 'yé',
+          'ᅩ': 'o', 'ᅪ': 'wa', 'ᅫ': 'wè', 'ᅬ': 'wé', 'ᅭ': 'yo',
+          'ᅮ': 'u', 'ᅯ': 'wo', 'ᅰ': 'wé', 'ᅱ': 'wi', 'ᅲ': 'yu',
+          'ᅳ': 'eu', 'ᅴ': 'eui', 'ᅵ': 'i'
+        },
+
+        // Note: ᆨ (0x11A8) for last jaeum (batchim) is different than ᄀ (0x1100) for first jaeum
+        // also different than ㄱ (0x3131) for standalone jamo
+        jong: {
+          'ᆨ': 'k', 'ᆨᄋ': 'g', 'ᆨᄂ': 'ngn', 'ᆨᄅ': 'ngn', 'ᆨᄆ': 'ngm', 'ᆨᄒ': 'kh',
+          'ᆩ': 'k', 'ᆩᄋ': 'kg', 'ᆩᄂ': 'ngn', 'ᆩᄅ': 'ngn', 'ᆩᄆ': 'ngm', 'ᆩᄒ': 'kh',
+          'ᆪ': 'k', 'ᆪᄋ': 'ks', 'ᆪᄂ': 'ngn', 'ᆪᄅ': 'ngn', 'ᆪᄆ': 'ngm', 'ᆪᄒ': 'kch',
+          'ᆫ': 'n', 'ᆫᄅ': 'll',
+          'ᆬ': 'n', 'ᆬᄋ': 'nj', 'ᆬᄂ': 'nn', 'ᆬᄅ': 'nn', 'ᆬᄆ': 'nm', 'ᆬㅎ': 'nch',
+          'ᆭ': 'n', 'ᆭᄋ': 'nh', 'ᆭᄅ': 'nn',
+          'ᆮ': 't', 'ᆮᄋ': 'd', 'ᆮᄂ': 'nn', 'ᆮᄅ': 'nn', 'ᆮᄆ': 'nm', 'ᆮᄒ': 'th',
+          'ᆯ': 'l', 'ᆯᄋ': 'r', 'ᆯᄂ': 'll',
+          'ᆰ': 'k', 'ᆰᄋ': 'lg', 'ᆰᄂ': 'ngn', 'ᆰᄅ': 'ngn', 'ᆰᄆ': 'ngm', 'ᆰᄒ': 'lkh',
+          'ᆱ': 'm', 'ᆱᄋ': 'lm', 'ᆱᄂ': 'mn', 'ᆱᄅ': 'mn', 'ᆱᄆ': 'mm', 'ᆱᄒ': 'lmh',
+          'ᆲ': 'p', 'ᆲᄋ': 'lb', 'ᆲᄂ': 'mn', 'ᆲᄅ': 'mn', 'ᆲᄆ': 'mm', 'ᆲᄒ': 'lph',
+          'ᆳ': 't', 'ᆳᄋ': 'ls', 'ᆳᄂ': 'nn', 'ᆳᄅ': 'nn', 'ᆳᄆ': 'nm', 'ᆳᄒ': 'lsh',
+          'ᆴ': 't', 'ᆴᄋ': 'lt', 'ᆴᄂ': 'nn', 'ᆴᄅ': 'nn', 'ᆴᄆ': 'nm', 'ᆴᄒ': 'lth',
+          'ᆵ': 'p', 'ᆵᄋ': 'lp', 'ᆵᄂ': 'mn', 'ᆵᄅ': 'mn', 'ᆵᄆ': 'mm', 'ᆵᄒ': 'lph',
+          'ᆶ': 'l', 'ᆶᄋ': 'lh', 'ᆶᄂ': 'll', 'ᆶᄅ': 'll', 'ᆶᄆ': 'lm', 'ᆶᄒ': 'lh',
+          'ᆷ': 'm', 'ᆷᄅ': 'mn',
+          'ᆸ': 'p', 'ᆸᄋ': 'b', 'ᆸᄂ': 'mn', 'ᆸᄅ': 'mn', 'ᆸᄆ': 'mm', 'ᆸᄒ': 'ph',
+          'ᆹ': 'p', 'ᆹᄋ': 'ps', 'ᆹᄂ': 'mn', 'ᆹᄅ': 'mn', 'ᆹᄆ': 'mm', 'ᆹᄒ': 'psh',
+          'ᆺ': 't', 'ᆺᄋ': 'sh', 'ᆺᄂ': 'nn', 'ᆺᄅ': 'nn', 'ᆺᄆ': 'nm', 'ᆺᄒ': 'sh',
+          'ᆻ': 't', 'ᆻᄋ': 's', 'ᆻᄂ': 'nn', 'ᆻᄅ': 'nn', 'ᆻᄆ': 'nm', 'ᆻᄒ': 'th',
+          'ᆼ': 'ng',
+          'ᆽ': 't', 'ᆽᄋ': 'j', 'ᆽᄂ': 'nn', 'ᆽᄅ': 'nn', 'ᆽᄆ': 'nm', 'ᆽᄒ': 'ch',
+          'ᆾ': 't', 'ᆾᄋ': 'ch', 'ᆾᄂ': 'nn', 'ᆾᄅ': 'nn', 'ᆾᄆ': 'nm', 'ᆾᄒ': 'ch',
+          'ᆿ': 'k', 'ᆿᄋ': 'k', 'ᆿᄂ': 'ngn', 'ᆿᄅ': 'ngn', 'ᆿᄆ': 'ngm', 'ᆿᄒ': 'kh',
+          'ᇀ': 't', 'ᇀᄋ': 't', 'ᇀᄂ': 'nn', 'ᇀᄅ': 'nn', 'ᇀᄆ': 'nm', 'ᇀᄒ': 'th', 'ᇀ이': 'ch',
+          'ᇁ': 'p', 'ᇁᄋ': 'p', 'ᇁᄂ': 'mn', 'ᇁᄅ': 'mn', 'ᇁᄆ': 'mm', 'ᇁᄒ': 'ph',
+          'ᇂ': 't', 'ᇂᄋ': 'h', 'ᇂᄂ': 'nn', 'ᇂᄅ': 'nn', 'ᇂᄆ': 'mm', 'ᇂᄒ': 't'
+        }
+      }
+    }
+  };
+
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
   | Public Variables
   |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
@@ -62,7 +326,7 @@ export class MultipleRenamePopupComponent extends AbstractComponent implements O
 
   public columns: Column[] = [];
 
-  public gridData: {data : any, fields: any};
+  public gridData: { data: any, fields: any };
 
   public errorEsg: string;
 
@@ -108,13 +372,14 @@ export class MultipleRenamePopupComponent extends AbstractComponent implements O
    * Open rename component with init
    * @param dsInfo
    */
-  public init(dsInfo : {
-    gridData : {data: any, fields: any},
-    dsName : string,
+  public init(dsInfo: {
+    gridData: { data: any, fields: any },
+    dsName: string,
     typeDesc: any,
-    editInfo? : {ruleCurIdx : number, cols: string[], to : string[]},
-    isFromSnapshot?:boolean,
-    dsId?: string}) {
+    editInfo?: { ruleCurIdx: number, cols: string[], to: string[] },
+    isFromSnapshot?: boolean,
+    dsId?: string
+  }) {
 
     this.datasetName = dsInfo.dsName;
 
@@ -124,10 +389,10 @@ export class MultipleRenamePopupComponent extends AbstractComponent implements O
 
       this._getGridData(dsInfo.dsId).then((result) => {
         this.gridData = this._getGridDataFromGridResponse(result.gridResponse);
-        this.gridData.data = this.gridData.data.splice(0,50);
+        this.gridData.data = this.gridData.data.splice(0, 50);
         this.typeDesc = result.gridResponse.colDescs;
         this._setColumns(this.gridData.fields);
-        this.currentIdx = result.transformRules.length-1;
+        this.currentIdx = result.transformRules.length - 1;
 
         // open popup
         this.isPopupOpen = true;
@@ -167,8 +432,6 @@ export class MultipleRenamePopupComponent extends AbstractComponent implements O
       this._updateGrid(this.gridData.fields, this.gridData.data);
 
 
-
-
     }
 
   }
@@ -206,7 +469,7 @@ export class MultipleRenamePopupComponent extends AbstractComponent implements O
       fields: []
     };
 
-    for ( let idx = 0; idx < colCnt; idx++ ) {
+    for (let idx = 0; idx < colCnt; idx++) {
       gridData.fields.push({
         name: colNames[idx],
         type: colTypes[idx].type,
@@ -216,17 +479,14 @@ export class MultipleRenamePopupComponent extends AbstractComponent implements O
 
     gridResponse.rows.forEach((row) => {
       const obj = {};
-      for ( let idx = 0;idx < colCnt; idx++ ) {
-        obj[ colNames[idx] ] = row.objCols[idx];
+      for (let idx = 0; idx < colCnt; idx++) {
+        obj[colNames[idx]] = row.objCols[idx];
       }
       gridData.data.push(obj);
     });
 
     return gridData;
   } // function - getGridDataFromGridResponse
-
-
-
 
 
   /**
@@ -250,7 +510,7 @@ export class MultipleRenamePopupComponent extends AbstractComponent implements O
    * @param index
    * @param input
    */
-  public editItem(column : Column, index: number, input: HTMLInputElement) {
+  public editItem(column: Column, index: number, input: HTMLInputElement) {
 
     // 에러가 있을떄는 에러가 해결돼야 다른 컬럼을 수정할 수 있다
     if (isNullOrUndefined(this.errorEsg)) {
@@ -282,8 +542,8 @@ export class MultipleRenamePopupComponent extends AbstractComponent implements O
   public applyRename() {
 
     // Validation check
-    this.columns.forEach((item,index) => {
-      this.focusOut(item,index);
+    this.columns.forEach((item, index) => {
+      this.focusOut(item, index);
     });
 
     // If error return
@@ -327,7 +587,7 @@ export class MultipleRenamePopupComponent extends AbstractComponent implements O
       param = {
         op: this.op,
         ruleString: `rename col: ${originalsWithBackTick.toString()} to: ${renamedWithQuote.toString()}`,
-        uiRuleString: {name: 'rename', col:originals, to: renamed, isBuilder: true}
+        uiRuleString: {name: 'rename', col: originals, to: renamed, isBuilder: true}
       };
 
       if (this.subTitle !== '') {
@@ -362,7 +622,7 @@ export class MultipleRenamePopupComponent extends AbstractComponent implements O
       }
     } else { // 아무 키를 눌렀다면 에러 메시지 삭제
       column.isError = false;
-      this.errorEsg=null
+      this.errorEsg = null
     }
 
   }
@@ -373,7 +633,7 @@ export class MultipleRenamePopupComponent extends AbstractComponent implements O
    * @param column
    * returns trues if column name has quote (`)
    */
-  public hasBackTick(column: Column) : boolean {
+  public hasBackTick(column: Column): boolean {
 
     let result: boolean = false;
     if (-1 !== column.renamedAs.indexOf('`')) {
@@ -388,7 +648,7 @@ export class MultipleRenamePopupComponent extends AbstractComponent implements O
    * Returns true if column name is empty
    * @param column
    */
-  public isRenameInputEmpty(column: Column) : boolean {
+  public isRenameInputEmpty(column: Column): boolean {
     let result: boolean = false;
     if (column.renamedAs.trim() === '' || isNullOrUndefined(column.renamedAs)) {
       this.errorEsg = this.translateService.instant('msg.dp.alert.empty.column');
@@ -426,7 +686,7 @@ export class MultipleRenamePopupComponent extends AbstractComponent implements O
    * @param event
    * @param input
    */
-  public focusOut(column: Column, index: number, event?:FocusEvent, input?:HTMLInputElement) {
+  public focusOut(column: Column, index: number, event?: FocusEvent, input?: HTMLInputElement) {
 
     // 편집중이면
     if (column.isEditing) {
@@ -458,7 +718,7 @@ export class MultipleRenamePopupComponent extends AbstractComponent implements O
    * when update : edit
    * when append : done
    */
-  public getButtonLabel() : string {
+  public getButtonLabel(): string {
     if (this.op === 'UPDATE') {
       return this.translateService.instant('msg.comm.ui.edit')
     } else {
@@ -472,7 +732,7 @@ export class MultipleRenamePopupComponent extends AbstractComponent implements O
    * Returns true if item is editing
    * @param column
    */
-  public isEditing(column: Column) : boolean {
+  public isEditing(column: Column): boolean {
     return column.isEditing;
   }
 
@@ -496,7 +756,7 @@ export class MultipleRenamePopupComponent extends AbstractComponent implements O
    * column1 from cols is renamed to col1, column2 from cols is renamed to col2
    * @private
    */
-  private _setColumns(fields : any, cols?:string[], tos?: string[]) {
+  private _setColumns(fields: any, cols?: string[], tos?: string[]) {
     this.columns = [];
     fields.forEach((item) => {
       if (cols) {
@@ -504,21 +764,21 @@ export class MultipleRenamePopupComponent extends AbstractComponent implements O
         let idx = cols.indexOf(item.name);
         this.columns.push({
           editOriginalName: idx === -1 ? item.name : tos[idx],
-          original : item.name, renamedAs: idx === -1 ? item.name : tos[idx],
+          original: item.name, renamedAs: idx === -1 ? item.name : tos[idx],
           isError: false,
           isEditing: false
         });
       } else {
         if (this.subTitle !== '') { // Came from snapshot popup
           this.columns.push({
-            original : item.name,
-            renamedAs: this._replaceWhiteSpace(this._aromanizeKorean(item.name),'_').toLowerCase(),
+            original: item.name,
+            renamedAs: this._replaceWhiteSpace(this._korToEng(item.name), '_').toLowerCase(),
             isError: false,
             isEditing: false
           });
         } else {
           this.columns.push({
-            original : item.name,
+            original: item.name,
             renamedAs: item.name,
             isError: false,
             isEditing: false
@@ -566,25 +826,14 @@ export class MultipleRenamePopupComponent extends AbstractComponent implements O
       const renamedAs = this.columns.map((item) => item.renamedAs);
 
       if (!isNullOrUndefined(koMatched) || !otherMatched) {
-        while(-1 !== renamedAs.indexOf('column' + this.indexForName)) {
-          this.indexForName+=1;
+        while (-1 !== renamedAs.indexOf('column' + this.indexForName)) {
+          this.indexForName += 1;
         }
         this.columns[index].renamedAs = 'column' + this.indexForName;
       }
     })
 
   }
-
-
-  /**
-   * Change korean to english 안녕 --> annyeong
-   * @param name
-   * @private
-   */
-  private _aromanizeKorean(name: string): string {
-    return Aromanize.romanize(name);
-  }
-
 
   /**
    * Update grid
@@ -593,7 +842,7 @@ export class MultipleRenamePopupComponent extends AbstractComponent implements O
   private _updateGrid(fields, rows) {
 
     // 헤더정보 생성
-    const headers: header[] = fields.map((field: Field,index) => {
+    const headers: header[] = fields.map((field: Field, index) => {
       return new SlickGridHeader()
         .Id('_idProperty_')
         .Name('<span style="padding-left:20px;"><em class="' + this.getFieldTypeIconClass(field.type) + '"></em>' + this.columns[index].renamedAs + '</span>')
@@ -620,8 +869,10 @@ export class MultipleRenamePopupComponent extends AbstractComponent implements O
     this._gridComp.create(
       headers,
       new ScrollLoadingGridModel(
-        () => {},
-        () => {},
+        () => {
+        },
+        () => {
+        },
         rows
       ),
       new GridOption()
@@ -739,11 +990,152 @@ export class MultipleRenamePopupComponent extends AbstractComponent implements O
   }
 
 
+  /**
+   * Change korean to english 안녕 --> annyeong
+   * @param argText
+   * @param argRule
+   * @param argHyphen
+   * @private
+   */
+  private _korToEng(argText: string, argRule?: string, argHyphen?: string) {
+
+    // Helper functions
+    // Check if it's letter or numbers
+    let isChoseong = (char) => {
+      if (char.charCodeAt(0) >= 0x1100 && char.charCodeAt(0) <= 0x1112) {
+        return true;
+      } else {
+        return false;
+      }
+    };
+
+    // Options mapping
+    let args = {text: argText, rule: argRule, hyphen: argHyphen};
+    if (args.hyphen == null) {
+      args.hyphen = '';
+    }
+
+    let rulemap = this._korToEngRules.hangul.rr;
+    if (args.rule != null && this._korToEngRules.hangul[args.rule] != null) {
+      rulemap = this._korToEngRules.hangul[args.rule];
+    } else if (args.rule != null) {
+      throw 'Invalid rule ' + args.rule;
+    }
+
+    let rom = '';
+    let curr = null, next;
+    let skipJaeum = false; // Indicates jaeum of current iteration to be skipped
+    for (let i = 0; i <= args.text.length; i++) {
+      // If next is hangul syllable, separate it into jamo
+      // 0xAC00 is the first hangul syllable in unicode table
+      // 0x1100 is the first hangul jaeum in unicode table
+      // 0x1161 is the first hangul moeum in unicode table
+      // 0x11A8 is the first hangul batchim in unicode table
+      let nextIdx = args.text.charCodeAt(i) - 0xAC00;
+      if (!isNaN(nextIdx) && nextIdx >= 0 && nextIdx <= 11171) {
+        next = String.fromCharCode(Math.floor(nextIdx / 588) + 0x1100)
+          + String.fromCharCode(Math.floor(nextIdx % 588 / 28) + 0x1161)
+          + (nextIdx % 28 == 0 ? '' : String.fromCharCode(nextIdx % 28 + 0x11A7)); // Index 0 is reserved for nothing
+      } else {
+        next = args.text.charAt(i);
+      }
+
+      // Except for first iteration (curr is null),
+      // Curr and next contains 2 or 3 jamo, or 1 non-hangul letter
+      if (curr != null) {
+
+        var res = '';
+
+        // Choseong Jaeum
+        if (!skipJaeum) {
+          // If not the first syllable, try cho2 if defined
+          if (i > 0 && !/\s/.test(args.text.charAt(i - 2)) &&
+            rulemap['cho2'] != undefined &&
+            rulemap['cho2'][curr.charAt(0)] != undefined
+          ) {
+            res += rulemap['cho2'][curr.charAt(0)];
+          } else if (rulemap.cho[curr.charAt(0)] != undefined) {
+            res += rulemap.cho[curr.charAt(0)];
+          } else {
+            res += curr.charAt(0);
+          }
+        }
+        skipJaeum = false;
+
+        // Jungseong Moeum
+        if (curr.length > 1) {
+          if (rulemap.jung[curr.charAt(1)] != undefined) {
+            res += rulemap.jung[curr.charAt(1)];
+          } else {
+            res += curr.charAt(1);
+          }
+
+          // Add hyphen if no batchim
+          if (curr.length == 2 && isChoseong(next.charAt(0))) {
+            res += ' ';
+          }
+        }
+
+        // Jongseong Jaeum (Batchim)
+        if (curr.length > 2) {
+          // Changing sound with next jaeum + moeum
+          if (rulemap.jong[curr.charAt(2) + next.charAt(0) + next.charAt(1)] != undefined) {
+            res += rulemap.jong[curr.charAt(2) + next.charAt(0) + next.charAt(1)];
+            skipJaeum = true;
+
+            // No need to add hyphen here as it's already defined
+          }
+          // Changing sound with next jaeum
+          else if (rulemap.jong[curr.charAt(2) + next.charAt(0)] != undefined) {
+            res += rulemap.jong[curr.charAt(2) + next.charAt(0)];
+            skipJaeum = true;
+
+            // No need to add hyphen here as it's already defined
+          }
+          // Unchanging sound
+          else if (rulemap.jong[curr.charAt(2)] != undefined) {
+            res += rulemap.jong[curr.charAt(2)];
+
+            // Add hyphen
+            if (isChoseong(next.charAt(0))) {
+              res += ' ';
+            }
+          } else {
+            res += curr.charAt(2);
+
+            // Add hyphen
+            if (isChoseong(next.charAt(0))) {
+              res += ' ';
+            }
+          }
+        }
+
+        // Replace hyphen (if this is hangeul word)
+        if (curr.length > 1) {
+          if (args.hyphen == '' && rulemap['hyphen'] != null) {
+            res = res.replace(' ', rulemap['hyphen']);
+          } else {
+            // Soft hyphen
+            res = res.replace(' ', args.hyphen);
+            // Hard hyphen
+            if (args.hyphen != '') {
+              res = res.replace('-', args.hyphen);
+            }
+          }
+        }
+        rom += res;
+      }
+
+      curr = next;
+    }
+    return rom;
+  } // function - _korToEng
+
 }
 
 class Column {
   public original: string;
-  public renamedAs : string;
+  public renamedAs: string;
   public editOriginalName?: string;
   public isError: boolean;
   public isEditing: boolean;

--- a/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/column-detail-data-source/edit-config-schema.component.html
+++ b/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/column-detail-data-source/edit-config-schema.component.html
@@ -88,44 +88,44 @@
               클릭시 ddp-selected 추가
           -->
           <!--<div class="ddp-ui-setbtn ddp-selected ">-->
-            <!--<a href="javascript:" class="ddp-btn-setting"></a>-->
-            <!--<div class="ddp-wrap-popup2">-->
-                                <!--<span class="ddp-txt-label2">-->
-                                    <!--Column order setting-->
-                                <!--</span>-->
-              <!--<ul class="ddp-list-popup">-->
-                <!--<li class="ddp-selected">-->
-                  <!--<a href="javascript:">-->
-                    <!--In order of data-->
-                    <!--<em class="ddp-icon-check"></em>-->
-                  <!--</a>-->
-                <!--</li>-->
-                <!--<li>-->
-                  <!--<a href="javascript:">-->
-                    <!--A-Z-->
-                    <!--<em class="ddp-icon-check"></em>-->
-                  <!--</a>-->
-                <!--</li>-->
-                <!--<li>-->
-                  <!--<a href="javascript:">-->
-                    <!--Z-A-->
-                    <!--<em class="ddp-icon-check"></em>-->
-                  <!--</a>-->
-                <!--</li>-->
-                <!--<li>-->
-                  <!--<a href="javascript:">-->
-                    <!--High Frequency → low-->
-                    <!--<em class="ddp-icon-check"></em>-->
-                  <!--</a>-->
-                <!--</li>-->
-                <!--<li>-->
-                  <!--<a href="javascript:">-->
-                    <!--Low Frequency → high-->
-                    <!--<em class="ddp-icon-check"></em>-->
-                  <!--</a>-->
-                <!--</li>-->
-              <!--</ul>-->
-            <!--</div>-->
+          <!--<a href="javascript:" class="ddp-btn-setting"></a>-->
+          <!--<div class="ddp-wrap-popup2">-->
+          <!--<span class="ddp-txt-label2">-->
+          <!--Column order setting-->
+          <!--</span>-->
+          <!--<ul class="ddp-list-popup">-->
+          <!--<li class="ddp-selected">-->
+          <!--<a href="javascript:">-->
+          <!--In order of data-->
+          <!--<em class="ddp-icon-check"></em>-->
+          <!--</a>-->
+          <!--</li>-->
+          <!--<li>-->
+          <!--<a href="javascript:">-->
+          <!--A-Z-->
+          <!--<em class="ddp-icon-check"></em>-->
+          <!--</a>-->
+          <!--</li>-->
+          <!--<li>-->
+          <!--<a href="javascript:">-->
+          <!--Z-A-->
+          <!--<em class="ddp-icon-check"></em>-->
+          <!--</a>-->
+          <!--</li>-->
+          <!--<li>-->
+          <!--<a href="javascript:">-->
+          <!--High Frequency → low-->
+          <!--<em class="ddp-icon-check"></em>-->
+          <!--</a>-->
+          <!--</li>-->
+          <!--<li>-->
+          <!--<a href="javascript:">-->
+          <!--Low Frequency → high-->
+          <!--<em class="ddp-icon-check"></em>-->
+          <!--</a>-->
+          <!--</li>-->
+          <!--</ul>-->
+          <!--</div>-->
           <!--</div>-->
           <!--&lt;!&ndash; //setting 버튼 &ndash;&gt;-->
           <!--<a href="javascript:" class="ddp-btn-selection ddp-gray"><em class="ddp-icon-plus"></em>Add column</a>-->
@@ -164,7 +164,7 @@
           </tr>
           </thead>
           <tbody>
-          <tr *ngFor="let column of filteredFieldList">
+          <tr *ngFor="let column of filteredFieldList; let index = index;">
             <td class="ddp-txt-center">
               <span class="ddp-box-tag-value"
                     [class.ddp-measure]="column.role === FIELD_ROLE.MEASURE"
@@ -177,11 +177,14 @@
                 {{column.name}}
               </span>
             </td>
-            <td>
-              <div class="ddp-input-form">
-                <input type="text" class="ddp-txt-input" [(ngModel)]="column.logicalName">
-                <em class="ddp-bg-select"></em>
-              </div>
+            <td [ngClass]="['ddp-input-form']"
+                #nameTds
+                (click)="focusNameInput(index)">
+              <input type="text" class="ddp-txt-input"
+                     #nameInputs
+                     (blur)="blurNameInput(index)"
+                     [ngModel]="column.logicalName"
+                     (ngModelChange)="column.logicalName = $event;">
             </td>
             <td class="ddp-inherit ddp-info" [class.ddp-selected]="column.isShowTypeList || column.format?.isShowTimestampValidPopup" [ngClass]="TYPE_SELECT_LIST_WRAP_ELEMENT"
                 (click)="onChangeTypeListShowFlag(column, $event)" (clickOutside)="column.isShowTypeList = false;">
@@ -220,12 +223,14 @@
               </div>
             </td>
             <!-- description -->
-            <td>
-              <div class="ddp-input-form">
-                <input type="text" class="ddp-txt-input"
-                       [(ngModel)]="column.description">
-                <em class="ddp-bg-select"></em>
-              </div>
+            <td [ngClass]="['ddp-input-form']"
+                #descriptionTds
+                (click)="focusDescriptionInput(index)">
+              <input type="text" class="ddp-txt-input"
+                     #descriptionInputs
+                     (blur)="blurDescriptionInput(index)"
+                     [ngModel]="column.description"
+                     (ngModelChange)="column.description = $event;">
             </td>
             <!-- //description -->
           </tr>

--- a/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/column-detail-data-source/edit-config-schema.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/column-detail-data-source/edit-config-schema.component.ts
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-import {Component, ElementRef, EventEmitter, Injector, Output, QueryList, ViewChildren} from '@angular/core';
+import {Component, ElementRef, EventEmitter, Injector, Output, QueryList, Renderer, ViewChildren} from '@angular/core';
 import {
   ConnectionType,
   Datasource,
@@ -41,6 +41,7 @@ import {StorageService} from "../../../service/storage.service";
 import {DatetimeValidPopupComponent} from "../../../../shared/datasource-metadata/component/datetime-valid-popup.component";
 import Role = Type.Role;
 import {CommonUtil} from "../../../../common/util/common.util";
+import {MetadataColumn} from "../../../../domain/meta-data-management/metadata-column";
 
 @Component({
   selector: 'edit-config-schema',
@@ -106,6 +107,7 @@ export class EditConfigSchemaComponent extends AbstractComponent {
               private connectionService: DataconnectionService,
               private storageService: StorageService,
               public constant: ConstantService,
+              public renderer: Renderer,
               protected element: ElementRef,
               protected injector: Injector) {
     super(element, injector);
@@ -526,5 +528,37 @@ export class EditConfigSchemaComponent extends AbstractComponent {
         })
         .catch(error => this.commonExceptionHandler(error));
     }
+  }
+
+
+  @ViewChildren('descriptionInputs')
+  private descriptionInputs: QueryList<ElementRef>;
+
+  @ViewChildren('descriptionTds')
+  private descriptionTds: QueryList<ElementRef>;
+
+  public focusDescriptionInput(index: number) {
+
+    this.descriptionInputs.toArray()[ index ].nativeElement.focus();
+    this.renderer.setElementClass(this.descriptionTds.toArray()[ index ].nativeElement, 'ddp-selected', true);
+  }
+
+  public blurDescriptionInput(index: number) {
+    this.renderer.setElementClass(this.descriptionTds.toArray()[ index ].nativeElement, 'ddp-selected', false);
+  }
+
+  @ViewChildren('nameInputs')
+  private nameInputs: QueryList<ElementRef>;
+
+  @ViewChildren('nameTds')
+  private nameTds: QueryList<ElementRef>;
+
+  public focusNameInput(index: number) {
+    this.nameInputs.toArray()[ index ].nativeElement.focus();
+    this.renderer.setElementClass(this.nameTds.toArray()[ index ].nativeElement, 'ddp-selected', true);
+  }
+
+  public blurNameInput(index: number) {
+    this.renderer.setElementClass(this.nameTds.toArray()[ index ].nativeElement, 'ddp-selected', false);
   }
 }

--- a/discovery-frontend/src/app/layout/layout/component/gnb/gnb.component.ts
+++ b/discovery-frontend/src/app/layout/layout/component/gnb/gnb.component.ts
@@ -96,10 +96,12 @@ export class GnbComponent extends AbstractComponent implements OnInit, OnDestroy
    * @param userData
    */
   public updatedUser(userData): void {
-    this.user.imageUrl = '';
+    delete this.user.imageUrl;
     this.safelyDetectChanges();
-    this.user = userData;
-    this.safelyDetectChanges();
+    setTimeout(() => {
+      this.user = userData;
+      this.safelyDetectChanges();
+    }, 250 );
   }
 
   /**

--- a/discovery-frontend/src/app/page/page-pivot/page-pivot.component.ts
+++ b/discovery-frontend/src/app/page/page-pivot/page-pivot.component.ts
@@ -701,13 +701,6 @@ export class PagePivotComponent extends AbstractComponent implements OnInit, OnD
    */
   public onChangeFilter($event): void {
 
-    // 필수필터이면 제거 불가능
-    if (this.editingField.field.role === FieldRole.TIMESTAMP && this.editingField.field.type === 'TIMESTAMP') {
-      $event.target ? $event.target.checked = true : $event.currentTarget.checked = true;
-      Alert.warning(this.translateService.instant('msg.board.alert.timestamp.del.error'));
-      return;
-    }
-
     if (this.editingField.field.filtering) {
       $event.target ? $event.target.checked = true : $event.currentTarget.checked = true;
       Alert.warning(this.translateService.instant('msg.board.alert.recomm-filter.del.error'));

--- a/discovery-frontend/src/app/page/page-pivot/pivot-context.component.ts
+++ b/discovery-frontend/src/app/page/page-pivot/pivot-context.component.ts
@@ -93,13 +93,6 @@ export class PivotContextComponent extends AbstractComponent implements OnInit, 
    */
   public onChangeFilter($event): void {
 
-    // 필수필터이면 제거 불가능
-    if (this.editingField.field.role === FieldRole.TIMESTAMP && this.editingField.field.type === 'TIMESTAMP') {
-      $event.target ? $event.target.checked = true : $event.currentTarget.checked = true;
-      Alert.warning(this.translateService.instant('msg.board.alert.timestamp.del.error'));
-      return;
-    }
-
     if (this.editingField.field.filtering) {
       $event.target ? $event.target.checked = true : $event.currentTarget.checked = true;
       Alert.warning(this.translateService.instant('msg.board.alert.recomm-filter.del.error'));

--- a/discovery-frontend/src/app/page/page.component.ts
+++ b/discovery-frontend/src/app/page/page.component.ts
@@ -1896,12 +1896,6 @@ export class PageComponent extends AbstractPopupComponent implements OnInit, OnD
     if (selectedField.useFilter) {
       // 제거
 
-      // 필수필터이면 제거 불가능
-      if (selectedField.role === FieldRole.TIMESTAMP && selectedField.type === 'TIMESTAMP') {
-        Alert.warning(this.translateService.instant('msg.board.alert.timestamp.del.error'));
-        return;
-      }
-
       if (selectedField.filtering) {
         Alert.warning(this.translateService.instant('msg.board.alert.recomm-filter.del.error'));
         return;

--- a/discovery-frontend/src/app/workbook/workbook.component.html
+++ b/discovery-frontend/src/app/workbook/workbook.component.html
@@ -96,7 +96,7 @@
 
             <!-- 데이터 베이스 수 -->
             <div class="ddp-wrap-selectbox" [class.ddp-selected]="isShowDatasourceMenu" *ngIf="datasources">
-              <div class="ddp-data-selectbox" (click)="isShowDatasourceMenu = !isShowDatasourceMenu" >
+              <div class="ddp-data-selectbox" (click)="toggleDatasourceLayer()" >
                 <em class="ddp-icon-database3"></em>
                 {{'msg.board.th.datasource' | translate}}
               </div>

--- a/discovery-frontend/src/app/workbook/workbook.component.ts
+++ b/discovery-frontend/src/app/workbook/workbook.component.ts
@@ -544,6 +544,15 @@ export class WorkbookComponent extends AbstractComponent implements OnInit, OnDe
   } // function - getBoardImage
 
   /**
+   * Toggle datasource layer
+   */
+  public toggleDatasourceLayer() {
+    if( this.datasources && 0 < this.datasources.length ) {
+      this.isShowDatasourceMenu = !this.isShowDatasourceMenu;
+    }
+  } // function - toggleDatasourceLayer
+
+  /**
    * 데이터소스 선택
    * @param dsId
    */

--- a/discovery-frontend/src/assets/css/metatron/component/component.table.css
+++ b/discovery-frontend/src/assets/css/metatron/component/component.table.css
@@ -48,7 +48,7 @@ table.ddp-table-form tbody tr td .ddp-txt-long .ddp-icon-global:before {display:
 
 
 table.ddp-table-form tbody tr td .ddp-txt-long2 {display:inline-block; position:relative;max-width:100%; line-height:21px; height:21px; text-overflow:ellipsis; overflow:hidden; white-space:nowrap; word-wrap:normal; box-sizing:border-box;}
-table.ddp-table-form tbody tr td .ddp-txt-long {display:inline-block; position:relative; max-width:100%; line-height:21px; height:21px; text-overflow:ellipsis; overflow:hidden; white-space:nowrap; word-wrap:normal; box-sizing:border-box; vertical-align:top;}
+table.ddp-table-form tbody tr td .ddp-txt-long {display:inline-block; position:relative; padding-top:1px; margin-top:-2px; margin-bottom:-2px; max-width:100%; line-height:21px; height:21px; text-overflow:ellipsis; overflow:hidden; white-space:nowrap; word-wrap:normal; box-sizing:border-box; vertical-align:top;}
 
 table.ddp-table-form tbody tr td .ddp-txt-long.ddp-global {padding-right:66px;}
 table.ddp-table-form tbody tr td .ddp-txt-long.ddp-global.ddp-new {padding-right:100px;}
@@ -58,6 +58,10 @@ table.ddp-table-form tbody tr td .ddp-txt-long.ddp-global.ddp-en-connection .ddp
 table.ddp-table-form tbody tr td .ddp-txt-long em.ddp-tag-global {position:absolute; top:0; right:0; height:20px; width:60px; padding:2px 2px 3px 2px; color:#666eb2; font-size:11px; text-align:center; border:1px solid #666eb2; border-radius:2px; background:#eff0f7; box-sizing:border-box;}
 
 table.ddp-table-form tbody tr td .ddp-txt-long.ddp-global .ddp-icon-global {display:block;}
+
+table.ddp-table-form tbody tr td .ddp-txt-long .ddp-tag-global.type-tag {float:right; position:relative; margin-top:-1px; right:0; margin-left:5px; width:auto; min-width:60px;}
+table.ddp-table-form tbody tr td .ddp-txt-long .ddp-data-long {display:block; overflow:hidden; white-space:nowrap; text-overflow:ellipsis;}
+
 table.ddp-table-form tr td .ddp-wrap-long .ddp-box-tag {position:relative; top:3px; margin-right:13px;}
 
 

--- a/discovery-frontend/src/assets/css/polaris.v2.layout.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.layout.css
@@ -715,12 +715,12 @@ ul.ddp-list-folder-nav li a:hover {background-color:#e7e7ea}
 .ddp-ui-naviarea:after {display:table; content:'';}
 .ddp-ui-naviarea:after {clear:both;}
 
-.ddp-ui-naviarea .ddp-wrap-naviname {display:inline-block; position:relative; top:4px; float:left; max-width:60%; font-size:16px; color:#4b515b; box-sizing:border-box;}
+.ddp-ui-naviarea .ddp-wrap-naviname {display:inline-block; position:relative; top:5px; float:left; max-width:60%; font-size:16px; color:#4b515b; box-sizing:border-box; line-height:1em;}
 .ddp-ui-naviarea .ddp-wrap-naviname.ddp-full {max-width:100%;}
 .ddp-ui-naviarea .ddp-wrap-naviname .ddp-wrap-popup2 {display:none; position:absolute; top:100%; left:-15px;}
 .ddp-wrap-naviname.ddp-selected .ddp-wrap-popup2 {display:block;}
 .ddp-ui-naviarea .ddp-wrap-naviname .ddp-wrap-popup2.ddp-type {width:245px;}
-.ddp-ui-naviarea .ddp-wrap-naviname span.ddp-data-naviname {display:inline-block; position:relative; width:100%; padding:5px 18px 0px 5px; cursor:pointer; overflow:hidden; white-space:nowrap; text-overflow:ellipsis; word-wrap:normal; box-sizing:border-box; font-family:sans-serif; line-height:1em;}
+.ddp-ui-naviarea .ddp-wrap-naviname span.ddp-data-naviname {display:inline-block; position:relative; width:100%; height:25px; padding:5px 18px 0px 5px; cursor:pointer; overflow:hidden; white-space:nowrap; text-overflow:ellipsis; word-wrap:normal; box-sizing:border-box; font-family:sans-serif; line-height:1em;}
 .ddp-ui-naviarea .ddp-wrap-naviname span.ddp-data-naviname em.ddp-icon-menuview {display:none;}
 .ddp-ui-naviarea .ddp-wrap-naviname span.ddp-data-naviname.ddp-readonly {padding-right:10px; cursor:default;}
 .ddp-ui-naviarea .ddp-wrap-naviname-txt span.ddp-data-naviname  {display:inline-block; position:relative; width:100%; padding:2px 18px 2px 5px; cursor:pointer; overflow:hidden; white-space:nowrap; text-overflow:ellipsis; word-wrap:normal; box-sizing:border-box;}
@@ -731,12 +731,12 @@ ul.ddp-list-folder-nav li a:hover {background-color:#e7e7ea}
 .ddp-ui-naviarea .ddp-wrap-naviname:hover span.ddp-data-naviname.ddp-readonly {background:none;}
 .ddp-ui-naviarea .ddp-wrap-naviname.ddp-type span.ddp-data-naviname {cursor:auto;}
 .ddp-ui-naviarea .ddp-wrap-naviname.ddp-type:hover span.ddp-data-naviname {background:none;}
-.ddp-ui-naviarea input.ddp-input-navi {float:left; padding:3px 5px 2px 5px; width:100%; font-size:16px; border:1px solid #d9dadf; background-color:#d9dadf; box-sizing:border-box; border:none; line-height:1.3em;}
+.ddp-ui-naviarea input.ddp-input-navi {float:left; padding:3px 5px 2px 5px; width:100%; height:25px; font-size:16px; border:1px solid #d9dadf; background-color:#d9dadf; box-sizing:border-box; border:none; line-height:1.3em;}
 .ddp-ui-naviarea input.ddp-input-navi::-webkit-input-placeholder {color:#9ba0ab;}
 .ddp-ui-naviarea input.ddp-input-navi:-ms-input-placeholder {color:#9ba0ab;}
 
 .ddp-ui-naviarea .ddp-box-navi .ddp-wrap-input {display:none; position:relative; top:4px; float:left;}
-.ddp-ui-naviarea .ddp-box-navi.ddp-selected .ddp-wrap-input {display:inline-block; position:relative; top:4px; width:40%; padding-right:23px; box-sizing:border-box; vertical-align: middle;}
+.ddp-ui-naviarea .ddp-box-navi.ddp-selected .ddp-wrap-input {display:inline-block; position:relative; top:5px; width:40%; padding-right:23px; box-sizing:border-box; vertical-align: middle;}
 .ddp-ui-naviarea .ddp-box-navi.ddp-selected.ddp-check-none .ddp-wrap-input {padding-right:0}
 .ddp-ui-naviarea .ddp-box-navi.ddp-selected.ddp-check-none .ddp-wrap-input .ddp-btn-check {display:none;}
 .ddp-ui-naviarea .ddp-box-navi .ddp-wrap-input .ddp-btn-check {display:inline-block; position:absolute; top:0; right:0; height:25px;}
@@ -747,7 +747,7 @@ ul.ddp-list-folder-nav li a:hover {background-color:#e7e7ea}
 .ddp-ui-naviarea .ddp-wrap-naviname:hover span.ddp-data-naviname.ddp-readonly .ddp-icon-edit2 {display:none;}
 .ddp-ui-naviarea .ddp-box-navidet {float:left; position:relative; top:5px; max-width:50%; box-sizing:border-box;}
 .ddp-ui-naviarea .ddp-wrap-navidet {display:inline-block;position:relative;float:left;max-width:100%; white-space: nowrap;box-sizing:border-box;overflow:hidden;}
-.ddp-ui-naviarea .ddp-wrap-navidet span.ddp-data-navidet {display:inline-block;float:left;width:100%;padding:5px;color:#90969f;font-size:12px;cursor:pointer;overflow:hidden;white-space:nowrap;text-overflow:ellipsis;word-wrap:normal;box-sizing:border-box; font-family:sans-serif; letter-spacing:0.4px;}
+.ddp-ui-naviarea .ddp-wrap-navidet span.ddp-data-navidet {display:inline-block;float:left;width:100%; height:25px; padding:5px;color:#90969f;font-size:12px;cursor:pointer;overflow:hidden;white-space:nowrap;text-overflow:ellipsis;word-wrap:normal;box-sizing:border-box; font-family:sans-serif; letter-spacing:0.4px;}
 
 .ddp-ui-naviarea .ddp-wrap-navidet span.ddp-txt-navidet  {display:inline-block; float:left; position:relative; top:3px; width:100%; padding:2px 5px; color:#90969f; font-size:12px; overflow:hidden; white-space:nowrap; text-overflow:ellipsis; word-wrap:normal; box-sizing:border-box;}
 .ddp-ui-naviarea .ddp-wrap-navidet em.ddp-icon-edit2 {display:none;}

--- a/discovery-frontend/src/assets/css/polaris.v2.page.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.page.css
@@ -576,7 +576,7 @@ ul.ddp-list-order li .ddp-data-name .ddp-chart-img {display:inline-block; float:
 .ddp-lnb-dashboard.ddp-close .ddp-wrap-tab2 {display:none;}
 .ddp-lnb-dashboard.ddp-close:hover {z-index:126;}
 .ddp-lnb-dashboard.ddp-close .ddp-ui-toptitle {position:absolute;left:0; }
-.ddp-lnb-dashboard.ddp-close .ddp-btn-folding .ddp-ui-tooltip-info.ddp-down {top:64px; right:inherit; left:100%; margin-left:6px; margin-top:0; width:max-content; white-space:nowrap;;}
+.ddp-lnb-dashboard.ddp-close .ddp-btn-folding .ddp-ui-tooltip-info.ddp-down {position:fixed; top:119px; right:auto; left:30px; margin-top:0; width:max-content; white-space:nowrap;}
 .ddp-lnb-dashboard.ddp-close .ddp-ui-tooltip-info.ddp-down em.ddp-icon-view-top {left:0; transform:rotate(0deg); right:inherit; top:50%; margin-top:-4px;}
 
 .ddp-lnb-dashboard.ddp-close .ddp-btn-folding {width:inherit; height:inherit; top:0; left:0; right:0; bottom:0;}
@@ -5381,7 +5381,11 @@ table.ddp-table-detail table.ddp-table-solid tbody tr td.ddp-nolist {color:#b7b9
 table.ddp-table-detail table.ddp-table-solid tbody tr:hover td.ddp-nolist {background:none;}
 table.ddp-table-detail table.ddp-table-solid tbody tr:hover td {background-color:#f2f1f8;}
 table.ddp-table-solid tbody tr:first-of-type tbody tr td  {border-top:none;}
-table.ddp-table-solid tbody tr td .ddp-txt-long {display:inline-block; position:relative; max-width:100%; line-height:21px; font-size:14px; height:21px; text-overflow:ellipsis; overflow:hidden; white-space:nowrap; word-wrap:normal; box-sizing:border-box;}
+table.ddp-table-solid tbody tr td .ddp-txt-long {display:inline-block; position:relative; padding-top:1px; margin-top:-1px; max-width:100%; line-height:21px; font-size:14px; height:21px; text-overflow:ellipsis; overflow:hidden; white-space:nowrap; word-wrap:normal; box-sizing:border-box;}
+
+table.ddp-table-solid tbody tr td .ddp-txt-long .ddp-data-long {display:block; overflow:hidden; white-space:nowrap; text-overflow:ellipsis;}
+
+table.ddp-table-solid tbody tr td .ddp-txt-long .ddp-tag-global.type-tag {float:right; position:relative; margin-top:-1px; right:0; margin-left:5px; width:auto;}
 table.ddp-table-solid tbody tr td span.ddp-txt-colortype {color:#b7b9c2; font-size:14px;}
 table.ddp-table-solid tbody tr td .ddp-txt-long.ddp-global {padding-right:66px;}
 table.ddp-table-solid tbody tr td .ddp-txt-long.ddp-connection {padding-right:101px;}

--- a/discovery-frontend/src/assets/i18n/en.json
+++ b/discovery-frontend/src/assets/i18n/en.json
@@ -1559,7 +1559,6 @@
   "msg.board.alert.global-filter.edit.error" :"Failed to edit the global filter.",
   "msg.board.alert.update.board.error" : "Error occurred while updating the dashboard",
   "msg.board.ui.fit-to-height.tooltip" : "Min:900 ~ Max:2400",
-  "msg.board.alert.timestamp.del.error" : "Timestamps cannot be deleted.",
   "msg.board.alert.recomm-filter.del.error" : "Recommended filter cannot be deleted.",
   "msg.board.alert.dashboard.update.fail": "There was an error updating the dashboard",
   "msg.board.alert.dashboard.sort.success": "Dashboard order changed",

--- a/discovery-frontend/src/assets/i18n/ko.json
+++ b/discovery-frontend/src/assets/i18n/ko.json
@@ -1557,7 +1557,6 @@
   "msg.board.alert.global-filter.edit.error" :"글로벌 필터 수정에 실패했습니다",
   "msg.board.alert.update.board.error" : "대시보드 업데이트 시에 오류가 발생했습니다",
   "msg.board.ui.fit-to-height.tooltip" : "min:900 ~ max:2400",
-  "msg.board.alert.timestamp.del.error" : "타임스탬프는 삭제할 수 없습니다",
   "msg.board.alert.recomm-filter.del.error" : "추천 필터는 삭제할 수 없습니다",
   "msg.board.alert.dashboard.update.fail": "대시보드 업데이트 시에 오류가 발생했습니다",
   "msg.board.alert.dashboard.sort.success": "대시보드 순서가 변경되었습니다",

--- a/discovery-frontend/src/assets/i18n/zh.json
+++ b/discovery-frontend/src/assets/i18n/zh.json
@@ -1460,7 +1460,6 @@
   "msg.board.alert.global-filter.edit.error": "全局过滤器修改失败",
   "msg.board.alert.update.board.error": "看板更新时发生错误",
   "msg.board.ui.fit-to-height.tooltip": "min:900 ~ max:2400",
-  "msg.board.alert.timestamp.del.error": "不能删除时间戳",
   "msg.board.alert.recomm-filter.del.error": "不能删除推荐过滤器",
   "msg.board.alert.dashboard.update.fail": "看板更新时发生错误",
   "msg.board.alert.dashboard.sort.success": "看板顺序已变更",


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
1. 사진 저장 후 사용자 이미지가 나타나지 않는 현상이 있습니다.
![6](https://user-images.githubusercontent.com/3685833/57082645-18994100-6d32-11e9-8fc5-f264d0a48140.png)

2. 데이터소스 스키마 설정 팝업에서 입력창이 정상적으로 표시되지 않습니다.
![1](https://user-images.githubusercontent.com/3685833/57082639-17681400-6d32-11e9-8005-6e5ebd56736e.png)

3. 데이터소스명과 "open data" 라벨 사이 마진이 넓습니다. 
    administration > workspaces list > detail  ( linked resources >datasource > more popup )
![4](https://user-images.githubusercontent.com/3685833/57082643-1800aa80-6d32-11e9-8087-602ae238ee06.png)

4. 대시보드에서 데이터소스가 없을 때 빈 목록이 나옵니다.
![3](https://user-images.githubusercontent.com/3685833/57082642-1800aa80-6d32-11e9-87e0-d87b51e170ab.png)

5. 대시보드에서 툴팁이 잘립니다.
![2](https://user-images.githubusercontent.com/3685833/57082640-1800aa80-6d32-11e9-823f-7c51db2aed53.png)

6. 대시보드에서 타임스탬프 필터를 삭제할 수 없습니다.
![5](https://user-images.githubusercontent.com/3685833/57082644-1800aa80-6d32-11e9-8ea5-4900862a6845.png)

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 프로필에서 사진 저장 후 사용자 이미지 정상적으로 변경되는지 확인합니다. 
2. 데이터소스 > 상세 > 컬럼 상세 > 컬럼 스키마 설정 팝업에서 입력창이 정상적으로 표시되는지 확인합니다.
3. administration > workspaces list > detail  ( linked resources >datasource > more popup )
     "open data" 라벨이 정상적으로 표시되는지 확인합니다.
4. 대시보드에서 데이터소스가 있을 때만 데이터소스 목록이 표시되는지 확인합니다.
5. 대시보드에서 툴팁이 정상적으로 표시되는지 확인합니다.
6. 대시보드에서 타임스탬프 필터를 삭제할 수 있는지 확인합니다.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
