### PR TITLE
#1969 Custom color settings in map charts are initialized when changing other filter conditions

### DIFF
--- a/discovery-frontend/src/app/common/component/chart/type/map-chart/map-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/map-chart/map-chart.component.ts
@@ -2492,6 +2492,7 @@ export class MapChartComponent extends BaseChart implements AfterViewInit {
 
       // Option panel change cancel, not current shelf change
       if (!this.drawByType || String(this.drawByType) == "" || (EventType.CHANGE_PIVOT == this.drawByType && uiOption.layerNum != index)
+        || EventType.FILTER == this.drawByType
         || isNullOrUndefined(field)) {
         continue;
       }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
맵뷰에서 필터 적용시 커스텀 컬러가 초기화 되는 오류를 수정 했습니다.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#1969 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
* 내장된 Sales 데이터소스를 사용하여 맵뷰를 만들고 #1969 에 재현 경로에 따라 테스트 하였고 커스텀 컬러가 유지 되는 것을 화인 했습니다.

#### Need additional checks?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
