### PR TITLE
#1925 Fix combobox in create datasource schema step

### DIFF
--- a/discovery-frontend/src/app/data-storage/component/schema-config/schema-config-action-bar.component.ts
+++ b/discovery-frontend/src/app/data-storage/component/schema-config/schema-config-action-bar.component.ts
@@ -13,7 +13,17 @@
  * limitations under the License.
  */
 import { AbstractComponent } from '../../../common/component/abstract.component';
-import { Component, ElementRef, EventEmitter, Injector, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  EventEmitter,
+  HostListener,
+  Injector,
+  Input,
+  OnChanges,
+  Output,
+  SimpleChanges
+} from '@angular/core';
 import { Field, FieldRole, LogicalType } from '../../../domain/datasource/datasource';
 
 @Component({
@@ -178,6 +188,32 @@ export class SchemaConfigActionBarComponent extends AbstractComponent {
 
   ngOnDestroy() {
     super.ngOnDestroy();
+  }
+
+
+  /**
+   * Window resize
+   * @param event
+   */
+  @HostListener('window:resize', ['$event'])
+  protected onResize(event) {
+    // #1925
+    this.closeSelectBoxes();
+  }
+
+  /**
+   * Close select box
+   */
+  public closeSelectBoxes(): void {
+    if (this.actionTypeListShowFlag === true) {
+      this.actionTypeListShowFlag = false;
+    }
+    if (this.roleTypeListShowFlag === true) {
+      this.roleTypeListShowFlag = false;
+    }
+    if (this.logicalTypeListShowFlag === true) {
+      this.logicalTypeListShowFlag = false;
+    }
   }
 
   /**

--- a/discovery-frontend/src/app/data-storage/component/schema-config/schema-config-detail.component.html
+++ b/discovery-frontend/src/app/data-storage/component/schema-config/schema-config-detail.component.html
@@ -30,7 +30,7 @@
       <!-- //value -->
 
       <!-- setting -->
-      <div class="ddp-wrap-value-setting">
+      <div class="ddp-wrap-value-setting" (scroll)="closeSelectBoxes()">
         <div class="ddp-ui-value-setting">
           <div class="ddp-ui-title">
             {{'msg.storage.ui.setting' | translate}}
@@ -67,17 +67,15 @@
               <div class="ddp-ui-option-in">
                 <!-- seletbox -->
                 <!-- 선택시 ddp-selected 추가 -->
-                <div class="ddp-type-selectbox"
-                     [class.ddp-disabled]="isDisabledTypeChangeInField(selectedField)"
-                     [class.ddp-selected]="logicalTypeListShowFlag"
-                     (click)="onChangeLogicalTypeListShowFlag()" (clickOutside)="logicalTypeListShowFlag = false">
+                <div class="ddp-type-selectbox" [class.ddp-disabled]="isDisabledTypeChangeInField(selectedField)" [class.ddp-selected]="logicalTypeListShowFlag"
+                     (click)="onChangeLogicalTypeListShowFlag($event)" (clickOutside)="logicalTypeListShowFlag = false" #logicalElement>
                   <span class="ddp-txt-selectbox">
                       <span class="ddp-type-txt">
                           <em class="{{getLogicalTypeIconClass(selectedField)}}"></em>
                         {{getSelectedFieldLogicalTypeLabel(selectedField)}}
                       </span>
                   </span>
-                  <div class="ddp-wrap-popup2 ddp-types">
+                  <div class="ddp-wrap-popup2 ddp-types" #logicalPopupElement>
                     <ul class="ddp-list-popup">
                       <!-- ddp-selected -->
                       <li *ngFor="let type of logicalTypeList" [class.ddp-selected]="selectedField.logicalType === type.value"
@@ -107,6 +105,7 @@
                 <storage-filter-select-box [filterList]="geoCoordinateList"
                                            [isOnlyStringList]="true"
                                            [isDisableList]="!selectedField.derived && !selectedField.format.isValidFormat"
+                                           [isEnableFloating]="true"
                                            [selectedFilter]="selectedField.format.originalSrsName"
                                            (changedFilter)="onChangeGeoCoordinateInField(selectedField, $event)">
                 </storage-filter-select-box>
@@ -245,11 +244,12 @@
                     클릭할때 : ddp-selected 추가
                     결과 보여질때 : ddp-result 추가
                 -->
-                <div class="ddp-type-selectbox ddp-type-search-select ddp-result" [class.ddp-selected]="isShowTimezoneList" (click)="onChangeTimezoneSelectBoxShowFlag($event)" (clickOutside)="isShowTimezoneList = false">
+                <div class="ddp-type-selectbox ddp-type-search-select ddp-result" [class.ddp-selected]="isShowTimezoneList"
+                     (click)="onChangeTimezoneSelectBoxShowFlag($event)" (clickOutside)="isShowTimezoneList = false" #timezoneElement>
                   <!-- 선택시 자동 input display:block; -->
                   <input type="text" class="ddp-input-selectbox" placeholder="{{'msg.storage.ph.search.timezone' | translate}}" [ngModel]="searchTimezoneKeyword" (ngModelChange)="onChangeSearchTimezoneKeyword($event)">
                   <span class="ddp-txt-selectbox">{{getSelectedTimezoneLabel(selectedField.format)}}</span>
-                  <div class="ddp-wrap-popup2">
+                  <div class="ddp-wrap-popup2" #timezonePopupElement>
                     <ul class="ddp-list-popup ddp-focus-hover">
                       <li *ngIf="filteredTimezoneList && filteredTimezoneList.length === 0">
                         <span class="ddp-noresult">{{'msg.comm.ui.no.rslt' | translate}}</span>

--- a/discovery-frontend/src/app/data-storage/component/schema-config/schema-config-detail.component.ts
+++ b/discovery-frontend/src/app/data-storage/component/schema-config/schema-config-detail.component.ts
@@ -42,6 +42,7 @@ import {TimeZoneObject, TimezoneService} from "../../service/timezone.service";
 import {SchemaConfigDataPreviewComponent} from "./schema-config-data-preview.component";
 import {isNullOrUndefined} from "util";
 import {FieldConfigService} from "../../service/field-config.service";
+import {StorageFilterSelectBoxComponent} from "../../data-source-list/component/storage-filter-select-box.component";
 
 declare let moment: any;
 
@@ -197,6 +198,17 @@ export class SchemaConfigDetailComponent extends AbstractComponent implements On
   @ViewChild(SchemaConfigDataPreviewComponent)
   private _previewComponent: SchemaConfigDataPreviewComponent;
 
+  @ViewChild('logicalElement')
+  private readonly LOGICAL_ELEMENT: ElementRef;
+  @ViewChild('logicalPopupElement')
+  private readonly LOGICAL_POPUP_ELEMENT: ElementRef;
+  @ViewChild('timezoneElement')
+  private readonly TIMEZONE_ELEMENT: ElementRef;
+  @ViewChild('timezonePopupElement')
+  private readonly TIMEZONE_POPUP_ELEMENT: ElementRef;
+  @ViewChild(StorageFilterSelectBoxComponent)
+  private readonly _geoCoordinateComponent: StorageFilterSelectBoxComponent;
+
   // 생성자
   constructor(private _datasourceService: DatasourceService,
               private _timezoneService: TimezoneService,
@@ -228,6 +240,23 @@ export class SchemaConfigDetailComponent extends AbstractComponent implements On
       this.searchTimezoneKeyword = undefined;
       // set searched timezone list
       this._setSearchedTimezoneList(this.searchTimezoneKeyword);
+    }
+  }
+
+  /**
+   * Close select box
+   */
+  public closeSelectBoxes() {
+    // if open logical type list
+    if (this.logicalTypeListShowFlag) {
+      this.logicalTypeListShowFlag = false;
+    }
+    // if open timezone list
+    if (this.isShowTimezoneList) {
+      this.isShowTimezoneList = false;
+    }
+    if (this._geoCoordinateComponent && this._geoCoordinateComponent.isListShow) {
+      this._geoCoordinateComponent.isListShow = false;
     }
   }
 
@@ -521,12 +550,41 @@ export class SchemaConfigDetailComponent extends AbstractComponent implements On
 
   /**
    * Logical type list show flag change event
+   * @param {MouseEvent} event
    */
-  public onChangeLogicalTypeListShowFlag(): void {
+  public onChangeLogicalTypeListShowFlag(event: MouseEvent): void {
     // if enable type change
     if (!this.isDisabledTypeChangeInField(this.selectedField)) {
       // change logical type list show / hide flag
       this.logicalTypeListShowFlag = !this.logicalTypeListShowFlag;
+      // if open show flag
+      if (this.logicalTypeListShowFlag) {
+        $(this.LOGICAL_POPUP_ELEMENT.nativeElement).css({
+          'position' : 'fixed',
+          'top': $(event.currentTarget).offset().top + 35,
+          'left' : $(event.currentTarget).offset().left,
+          'width' : $(event.currentTarget).outerWidth()
+        });
+      }
+    }
+  }
+
+  /**
+   * Change timezone selectbox show flag
+   * @param {MouseEvent} event
+   */
+  public onChangeTimezoneSelectBoxShowFlag(event: MouseEvent): void {
+    if ($(event.target).hasClass('ddp-type-selectbox ddp-type-search-select') || $(event.target).hasClass('ddp-txt-selectbox')) {
+      this.isShowTimezoneList = !this.isShowTimezoneList;
+      // if open show flag
+      if (this.isShowTimezoneList) {
+        $(this.TIMEZONE_POPUP_ELEMENT.nativeElement).css({
+          'position' : 'fixed',
+          'top': $(event.currentTarget).offset().top + 35,
+          'left' : $(event.currentTarget).offset().left,
+          'width' : $(event.currentTarget).outerWidth()
+        });
+      }
     }
   }
 
@@ -755,16 +813,6 @@ export class SchemaConfigDetailComponent extends AbstractComponent implements On
     this.searchTimezoneKeyword = searchKeyword;
     // set searched timezone list
     this._setSearchedTimezoneList(this.searchTimezoneKeyword);
-  }
-
-  /**
-   * Change timezone selectbox show flag
-   * @param {MouseEvent} event
-   */
-  public onChangeTimezoneSelectBoxShowFlag(event: MouseEvent): void {
-    if ($(event.target).hasClass('ddp-type-selectbox ddp-type-search-select') || $(event.target).hasClass('ddp-txt-selectbox')) {
-      this.isShowTimezoneList = !this.isShowTimezoneList
-    }
   }
 
   /**

--- a/discovery-frontend/src/app/data-storage/component/schema-config/schema-config-detail.component.ts
+++ b/discovery-frontend/src/app/data-storage/component/schema-config/schema-config-detail.component.ts
@@ -17,7 +17,7 @@ import {AbstractComponent} from '../../../common/component/abstract.component';
 import {
   Component,
   ElementRef,
-  EventEmitter,
+  EventEmitter, HostListener,
   Injector,
   Input,
   OnChanges,
@@ -244,18 +244,29 @@ export class SchemaConfigDetailComponent extends AbstractComponent implements On
   }
 
   /**
+   * Window resize
+   * @param event
+   */
+  @HostListener('window:resize', ['$event'])
+  protected onResize(event) {
+    // #1925
+    this.closeSelectBoxes();
+  }
+
+
+  /**
    * Close select box
    */
   public closeSelectBoxes() {
     // if open logical type list
-    if (this.logicalTypeListShowFlag) {
+    if (this.logicalTypeListShowFlag === true) {
       this.logicalTypeListShowFlag = false;
     }
     // if open timezone list
-    if (this.isShowTimezoneList) {
+    if (this.isShowTimezoneList === true) {
       this.isShowTimezoneList = false;
     }
-    if (this._geoCoordinateComponent && this._geoCoordinateComponent.isListShow) {
+    if (this._geoCoordinateComponent && this._geoCoordinateComponent.isListShow === true) {
       this._geoCoordinateComponent.isListShow = false;
     }
   }

--- a/discovery-frontend/src/app/data-storage/component/schema-config/schema-config.component.ts
+++ b/discovery-frontend/src/app/data-storage/component/schema-config/schema-config.component.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import {Component, ElementRef, EventEmitter, Injector, Input, Output, ViewChild} from '@angular/core';
+import {Component, ElementRef, EventEmitter, HostListener, Injector, Input, Output, ViewChild} from '@angular/core';
 import {
   ConnectionType,
   DatasourceInfo,
@@ -119,6 +119,25 @@ export class SchemaConfigComponent extends AbstractComponent {
     // if action bar open
     if (this.getCheckedFieldList().length !== 0) {
       this._actionBarComponent.init(this.getCheckedFieldList(), this.selectedTimestampField, this.selectedTimestampType, this.selectedAction);
+    }
+  }
+
+  /**
+   * Window resize
+   * @param event
+   */
+  @HostListener('window:resize', ['$event'])
+  protected onResize(event) {
+    // #1925
+    this.closeSelectBoxes();
+  }
+
+  /**
+   * Close select box
+   */
+  public closeSelectBoxes(): void {
+    if (this.logicalTypeFilterListShowFlag === true) {
+      this.logicalTypeFilterListShowFlag = false;
     }
   }
 

--- a/discovery-frontend/src/app/data-storage/data-source-list/component/add-column.component.html
+++ b/discovery-frontend/src/app/data-storage/data-source-list/component/add-column.component.html
@@ -62,7 +62,7 @@
         <!-- latitude column -->
         <div class="ddp-col-6 ddp-form-error">
           <!-- select box -->
-          <column-select-box
+          <column-select-box #latitude_select
             [columnList]="latitudeColumnList"
             [selectedColumn]="selectedLatitudeColumn"
             [placeholder]="'msg.storage.ui.latitude.column' | translate"
@@ -75,7 +75,7 @@
         <!-- longitude column -->
         <div class="ddp-col-6 ddp-form-error">
           <!-- select box -->
-          <column-select-box
+          <column-select-box #longitude_select
             [columnList]="longitudeColumnList"
             [selectedColumn]="selectedLongitudeColumn"
             [placeholder]="'msg.storage.ui.longitude.column' | translate"

--- a/discovery-frontend/src/app/data-storage/data-source-list/component/add-column.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/component/add-column.component.ts
@@ -13,17 +13,24 @@
  * limitations under the License.
  */
 
-import { Component, ElementRef, EventEmitter, Injector, Input, Output } from '@angular/core';
+import {Component, ElementRef, EventEmitter, HostListener, Injector, Input, Output, ViewChild} from '@angular/core';
 import { StringUtil } from '../../../common/util/string.util';
 import * as _ from 'lodash';
 import { AbstractComponent } from '../../../common/component/abstract.component';
 import { FieldRole, IngestionRuleType, LogicalType } from '../../../domain/datasource/datasource';
+import {ColumnSelectBoxComponent} from "./column-select-box.component";
 
 @Component({
   selector: 'add-column-component',
   templateUrl: './add-column.component.html'
 })
 export class AddColumnComponent extends AbstractComponent {
+
+  @ViewChild('latitude_select')
+  private readonly _latitudeSelectComponent: ColumnSelectBoxComponent;
+
+  @ViewChild('longitude_select')
+  private readonly _longitudeSelectComponent: ColumnSelectBoxComponent;
 
   // column list
   private _columnList: any;
@@ -87,6 +94,33 @@ export class AddColumnComponent extends AbstractComponent {
    */
   public ngOnDestroy() {
     super.ngOnDestroy();
+  }
+
+
+  /**
+   * Window resize
+   * @param event
+   */
+  @HostListener('window:resize', ['$event'])
+  protected onResize(event) {
+    // #1925
+    this.closeSelectBoxes();
+  }
+
+  /**
+   * Close select box
+   */
+  public closeSelectBoxes(): void {
+    if (this.isMethodTypeListShow === true) {
+      this.isMethodTypeListShow = false;
+    }
+    if (this.selectedMethodType.value !== 'user_defined') {
+      if (this._latitudeSelectComponent && this._latitudeSelectComponent.isListShow === true) {
+        this._latitudeSelectComponent.isListShow = false;
+      } else if (this._longitudeSelectComponent && this._longitudeSelectComponent.isListShow === true) {
+        this._longitudeSelectComponent.isListShow = false;
+      }
+    }
   }
 
 

--- a/discovery-frontend/src/app/data-storage/data-source-list/component/storage-filter-select-box.component.html
+++ b/discovery-frontend/src/app/data-storage/data-source-list/component/storage-filter-select-box.component.html
@@ -12,7 +12,7 @@
   ~ limitations under the License.
   -->
 
-<div class="ddp-type-selectbox" [class.ddp-selected]="isListShow" [class.ddp-disabled]="isDisableList" (click)="onChangeListShow()" >
+<div class="ddp-type-selectbox" [class.ddp-selected]="isListShow" [class.ddp-disabled]="isDisableList" (click)="onChangeListShow($event)" #wrapElement>
   <span class="ddp-txt-selectbox" *ngIf="!isEnableIcon">{{isOnlyStringList ? selectedFilter : selectedFilter.label}}</span>
   <span class="ddp-txt-selectbox" *ngIf="isEnableIcon">
     <span class="ddp-type-txt">
@@ -20,14 +20,14 @@
       {{selectedFilter.label}}
     </span>
   </span>
-  <ul class="ddp-list-selectbox ddp-selectdown" *ngIf="!isEnableIcon">
+  <ul class="ddp-list-selectbox ddp-selectdown" *ngIf="!isEnableIcon" #listElement>
     <li *ngFor="let filter of filterList">
       <a href="javascript:" (click)="onChangedFilter(filter)">
         {{isOnlyStringList ? filter : filter.label}}
       </a>
     </li>
   </ul>
-  <div class="ddp-wrap-popup2 ddp-types" *ngIf="isEnableIcon">
+  <div class="ddp-wrap-popup2 ddp-types" *ngIf="isEnableIcon" #listElement>
     <ul class="ddp-list-popup">
       <li [class.ddp-selected]="selectedFilter.value === filter.value" *ngFor="let filter of filterList">
         <a href="javascript:" (click)="onChangedFilter(filter)">

--- a/discovery-frontend/src/app/data-storage/data-source-list/component/storage-filter-select-box.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/component/storage-filter-select-box.component.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import {Component, ElementRef, EventEmitter, Injector, Input, Output} from "@angular/core";
+import {Component, ElementRef, EventEmitter, Injector, Input, Output, ViewChild} from "@angular/core";
 import {AbstractComponent} from "../../../common/component/abstract.component";
 
 @Component({
@@ -26,13 +26,18 @@ import {AbstractComponent} from "../../../common/component/abstract.component";
 export class StorageFilterSelectBoxComponent extends AbstractComponent {
 
   @Output('changedFilter')
-  private readonly _changedFilter: EventEmitter<any> = new EventEmitter();
+  private readonly _changedFilter = new EventEmitter();
+
+  @ViewChild('wrapElement')
+  private readonly WRAP_ELEMENT: ElementRef;
+  @ViewChild('listElement')
+  private readonly LIST_ELEMENT: ElementRef;
 
   /**
    * Only {label: string, value: any} array
    */
   @Input()
-  public readonly filterList: any;
+  public readonly filterList;
 
   @Input()
   public readonly isEnableIcon: boolean;
@@ -42,6 +47,9 @@ export class StorageFilterSelectBoxComponent extends AbstractComponent {
 
   @Input()
   public readonly isOnlyStringList: boolean;
+
+  @Input()
+  public readonly isEnableFloating: boolean;
 
   @Input()
   public selectedFilter: any;
@@ -57,7 +65,7 @@ export class StorageFilterSelectBoxComponent extends AbstractComponent {
 
   /**
    * 컴포넌트 내부  host 클릭이벤트 처리
-   * @param event
+   * @param {MouseEvent} event
    */
   public onClickHost(event: MouseEvent) {
     // 현재 element 내부에서 생긴 이벤트가 아닌경우 hide 처리
@@ -71,7 +79,7 @@ export class StorageFilterSelectBoxComponent extends AbstractComponent {
    * Change filter
    * @param filter
    */
-  public onChangedFilter(filter: any): void {
+  public onChangedFilter(filter): void {
     // change filter
     this.selectedFilter = filter;
     // event emit
@@ -80,10 +88,20 @@ export class StorageFilterSelectBoxComponent extends AbstractComponent {
 
   /**
    * Change list show
+   * @param {MouseEvent} event
    */
-  public onChangeListShow(): void {
+  public onChangeListShow(event: MouseEvent): void {
     if (!this.isDisableList) {
-      this.isListShow = !this.isListShow
+      this.isListShow = !this.isListShow;
+      // if open list and is enable floating option
+      if (this.isListShow && this.isEnableFloating) {
+        $(this.LIST_ELEMENT.nativeElement).css({
+          'position' : 'fixed',
+          'top': $(event.currentTarget).offset().top + 35,
+          'left' : $(event.currentTarget).offset().left,
+          'width' : $(event.currentTarget).outerWidth()
+        });
+      }
     }
   }
 }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
데이터소스 생성 > schema 설정 화면 > 컬럼 상세화면의 셀렉트박스 목록이 낮은 해상도에서 잘리는 현상 수정
적용 셀렉트박스 : 타임존 셀렉트박스, 타입 셀렉트박스, 좌표계 셀렉트박스
(적용과 동시에 셀렉트박스가 열려있는경우 스크롤 이벤트가 발생했을때 닫히는 것 추가 - 선택한 컬럼의 설정부분)

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#1925 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 데이터 소스 생성 > schema 설정 화면
2. 컬럼 선택후 우측 패널에서 타임존, 타입, 좌표계 셀렉트박스를 클릭
3. 셀렉트박스가 우측 패널 위에 floating된 상태로 보이는지 확인
4. 셀렉트박스가 열려있는 상태에서 우측 패널 스크롤 이벤트 발생시 셀렉트박스가 닫히는지 확인

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
