### PR TITLE
#1850 The user must not move the workbook to a workspace with watcher privileges

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workspace/WorkspaceController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workspace/WorkspaceController.java
@@ -645,7 +645,7 @@ public class WorkspaceController {
     Page<Workspace> results;
     if(CollectionUtils.isEmpty(dataSourceIds) && CollectionUtils.isEmpty(joinedWorkspaceIds)) {
       // dataSourceIds, joinedWorkspaceIds 둘다 0 인 케이스는 질의 불필요
-      results = new PageImpl(Lists.newArrayList());
+      results = new PageImpl(Collections.emptyList(), pageable, 0);
     } else {
       results = workspaceRepository.findAll(
           WorkspacePredicate.searchWorkbookImportAvailable(dataSourceIds, joinedWorkspaceIds, pubType, nameContains), pageable);

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workspace/WorkspaceRepositoryImpl.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workspace/WorkspaceRepositoryImpl.java
@@ -115,7 +115,7 @@ public class WorkspaceRepositoryImpl extends QueryDslRepositorySupport implement
     if(CollectionUtils.isNotEmpty(memberIds)) {
 
       List<String> joinedWorkspaceId = from(member).select(member.workspace.id)
-                                                   .where(member.memberId.in(memberIds)).fetch();
+                                                   .where(member.memberId.in(memberIds), member.role.in("Manager", "Editor")).fetch();
 
       for (String workspaceId : joinedWorkspaceId) {
         SubQueryExpression roleNameExpr = JPAExpressions.selectFrom(member).select(member.role)


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
The user which has watcher privileges must not be able to move the the workbook to a workspace with watcher privileges.

**Related Issue** : #1850 
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. userA have watcher privileges in workspaceA.
2. workspaceA is allowed on the datasources about workbookA 
2. userA try to move workbookA to workspaceA.
3. Check that it is not visible in the workbook list.

#### Need additional checks?
- about all privileges

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
