### PR TITLE
#1989 hide geo type column from the filtering list

### DIFF
--- a/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/edit-filter-data-source.component.html
+++ b/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/edit-filter-data-source.component.html
@@ -151,7 +151,7 @@
                   </td>
                   <td>
                     <div class="ddp-wrap-num-checkbox">
-                      <label class="ddp-num-checkbox" (click)="onClickSetColumnFiltering(column); $event.preventDefault()">
+                      <label class="ddp-num-checkbox" (click)="onClickSetColumnFiltering(column); $event.preventDefault()" *ngIf="column.logicalType.indexOf('GEO') == -1">
                         <input type="checkbox" [checked]="isEnableColumnFiltering(column)">
                         <i class="ddp-txt-checkbox">{{column.filteringSeq + 1}}</i>
                       </label>


### PR DESCRIPTION
### Description
Hide geo type column from the filtering list
**Related Issue** : #1989 

### How Has This Been Tested?
1. Generate datasource with geo type.
2. Select the datasource
3. Click Column details
4. Click Edit filters.
5. Check that there is a check box in the recommendation filter.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
