### PR TITLE
#1309 fix displaying array type of column on presto connection

### DIFF
--- a/discovery-server/pom.xml
+++ b/discovery-server/pom.xml
@@ -1068,6 +1068,13 @@
         </dependency>
         <!-- Kurbernetes (E) -->
 
+        <dependency>
+            <groupId>com.mockrunner</groupId>
+            <artifactId>mockrunner-jdbc</artifactId>
+            <version>2.0.1</version>
+            <scope>test</scope>
+        </dependency>
+
 
         <!-- SAML -->
         <dependency>

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcCSVWriter.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcCSVWriter.java
@@ -14,8 +14,6 @@
 
 package app.metatron.discovery.domain.datasource.connection.jdbc;
 
-import com.facebook.presto.jdbc.PrestoArray;
-
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -160,11 +158,7 @@ public class JdbcCSVWriter extends CsvResultSetWriter implements ICsvResultSetWr
       // thrown before writing occurs
       objects.clear();
       for( int columnIndex = 1; columnIndex <= numberOfColumns; columnIndex++ ) {
-        if(resultSet.getObject(columnIndex) instanceof PrestoArray) {
-          objects.add(resultSet.getString(columnIndex));
-        } else {
-          objects.add(resultSet.getObject(columnIndex));
-        }
+        objects.add(resultSet.getString(columnIndex));
       }
       super.writeRow(objects);
     }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcCSVWriter.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcCSVWriter.java
@@ -14,6 +14,8 @@
 
 package app.metatron.discovery.domain.datasource.connection.jdbc;
 
+import com.facebook.presto.jdbc.PrestoArray;
+
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -158,7 +160,11 @@ public class JdbcCSVWriter extends CsvResultSetWriter implements ICsvResultSetWr
       // thrown before writing occurs
       objects.clear();
       for( int columnIndex = 1; columnIndex <= numberOfColumns; columnIndex++ ) {
-        objects.add(resultSet.getObject(columnIndex));
+        if(resultSet.getObject(columnIndex) instanceof PrestoArray) {
+          objects.add(resultSet.getString(columnIndex));
+        } else {
+          objects.add(resultSet.getObject(columnIndex));
+        }
       }
       super.writeRow(objects);
     }

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcCSVWriterTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcCSVWriterTest.java
@@ -14,8 +14,13 @@
 
 package app.metatron.discovery.domain.datasource.connection.jdbc;
 
+import com.mockrunner.mock.jdbc.MockResultSet;
+
+import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mock;
 import org.supercsv.prefs.CsvPreference;
+import org.supercsv.util.Util;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -24,9 +29,12 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
 import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 
 import app.metatron.discovery.domain.dataconnection.DataConnection;
@@ -130,5 +138,28 @@ public class JdbcCSVWriterTest {
 
     pw.close();
     System.out.println("done!");
+  }
+
+  @Test
+  public void getStringFromResultSetTest() throws SQLException {
+    MockResultSet resultSet = new MockResultSet("mock_rs");
+
+    List<Object> objects = new LinkedList<Object>();
+    List<Object> strings = new LinkedList<Object>();
+
+    resultSet.addColumn("string", new String[]{"a","b","c"});
+    resultSet.addColumn("int", new Integer[]{1, 2, 3});
+
+    while( resultSet.next() ) {
+      objects.clear();
+      strings.clear();
+      for( int columnIndex = 1; columnIndex < 3; columnIndex++ ) {
+        objects.add(resultSet.getObject(columnIndex));
+        strings.add(resultSet.getString(columnIndex));
+      }
+      Assert.assertArrayEquals("The two arrays are identical.", Util.objectListToStringArray(objects), Util.objectListToStringArray(strings));
+    }
+
+
   }
 }


### PR DESCRIPTION
### Description
When querying presto on the workbench,
If the query column has an array type, the column value is not displayed and the package name is output.

**Related Issue** : #1309 


### How Has This Been Tested?
Query presto on the workbench which has an array type.
Check the column value is displayed, not the package name.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
