### PR TITLE
#1890 enhance presto connection valid check if it is an invalid catalog

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/accessor/PrestoDataAccessor.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/accessor/PrestoDataAccessor.java
@@ -15,11 +15,16 @@
 package app.metatron.discovery.domain.dataconnection.accessor;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 
+import org.apache.commons.lang3.StringUtils;
 import org.pf4j.Extension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,6 +40,48 @@ public class PrestoDataAccessor extends AbstractJdbcDataAccessor {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PrestoDataAccessor.class);
   private static final String TABLE_NAME_COLUMN = "Table";
+  private static final String SHOW_CATALOGS = "SHOW CATALOGS";
+
+  @Override
+  public Map<String, Object> checkConnection() {
+    Map<String, Object> resultMap = Maps.newHashMap();
+    //resultMap.put("connected", true);
+    boolean connected = false;
+
+    Connection conn = null;
+    Statement stmt = null;
+    ResultSet rs = null;
+    try {
+      conn = this.getConnection();
+      stmt = conn.createStatement();
+      stmt.execute(dialect.getTestQuery(connectionInfo));
+
+      // Perform additional catalog validation checks
+      String connectionCatalog = conn.getCatalog();
+      if(StringUtils.isNotEmpty(connectionCatalog)) {
+        List<String> catalogs = this.executeQueryForList(this.getConnection(), SHOW_CATALOGS, (resultSet, i) -> resultSet.getString(1));
+        for(String catalog : catalogs){
+          LOGGER.debug("check catalog : {}", catalog);
+          if(connectionCatalog.equals(catalog)){
+            connected = true;
+            break;
+          }
+        }
+      } else {
+        connected = true;
+      }
+
+      resultMap.put("connected", connected);
+    } catch (Exception e) {
+      LOGGER.warn("Fail to check query : {}", e.getMessage());
+      resultMap.put("connected", false);
+      resultMap.put("message", e.getMessage());
+      return resultMap;
+    } finally {
+      connector.closeConnection(conn, stmt, rs);
+    }
+    return resultMap;
+  }
 
   @Override
   public Map<String, Object> getDatabases(String catalog, String schemaPattern, Integer pageSize, Integer pageNumber) {

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/accessor/PrestoDataAccessor.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/accessor/PrestoDataAccessor.java
@@ -68,7 +68,8 @@ public class PrestoDataAccessor extends AbstractJdbcDataAccessor {
           }
         }
       } else {
-        connected = true;
+        connected = false;
+        resultMap.put("message", "Please set a catalog name.");
       }
 
       resultMap.put("connected", connected);


### PR DESCRIPTION
### Description
For a presto connection, the valid check succeeds even if it is an invalid catalog.
If the catalog is not valid, inform the user that it is invalid.

**Related Issue** : #1890 

### How Has This Been Tested?
1. Generate or modify Presto connection.
2. Type an invalid catalog
3. Validation check -> Notify invalid Connection.
4. Type a valid catalog
5. Validation check -> Success

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
