### PR TITLE
Remove stage connection from filter criteria in data-connection list

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/DataConnectionFilterService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/DataConnectionFilterService.java
@@ -123,6 +123,9 @@ public class DataConnectionFilterService {
     switch(criterionKey){
       case IMPLEMENTOR:
         for(JdbcDialect jdbcDialect : jdbcDialects){
+          if(jdbcDialect.getImplementor().equals("STAGE")){
+            continue;
+          }
           criterion.addFilter(new ListFilter(criterionKey, "implementor", jdbcDialect.getImplementor(), jdbcDialect.getName()));
         }
         break;


### PR DESCRIPTION
### Description
Changed data-connection filter condition to remove stage connection from all registered jdbc implementors.
Because stage connection is a type of connection that user can not create.
![스크린샷 2019-05-20 오전 11 00 42](https://user-images.githubusercontent.com/3770446/58008973-6b436d00-7b28-11e9-853b-c8dda4cf90da.png)


**Related Issue** : integrated test

### How Has This Been Tested?
1. move to Data Storage > Data Connection
2. open DB Type layer.
3. You can see that the stage connection has been deleted.

#### Need additional checks?
NA

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
