### PR TITLE
Error when deleting last item in the list 

### DIFF
--- a/discovery-frontend/src/app/admin/user-management/component/group/detail-group/detail-user-management-groups.component.ts
+++ b/discovery-frontend/src/app/admin/user-management/component/group/detail-group/detail-user-management-groups.component.ts
@@ -141,8 +141,9 @@ export class DetailUserManagementGroupsComponent extends AbstractUserManagementC
         this.loadingHide();
         // 기존에 저장된 라우트 삭제
         this.cookieService.delete('PREV_ROUTER_URL');
+
         // 그룹 관리 목록으로 돌아가기
-        this.router.navigate(['/admin/user/groups']);
+        this._location.back();
       })
       .catch((error) => {
         // alert

--- a/discovery-frontend/src/app/admin/user-management/component/group/update-group/update-user-management-groups.component.html
+++ b/discovery-frontend/src/app/admin/user-management/component/group/update-group/update-user-management-groups.component.html
@@ -12,7 +12,7 @@
   ~ limitations under the License.
   -->
 
-<div class="ddp-layout-popuptype" style="display:;" *ngIf="modalShowFl">
+<div class="ddp-layout-popuptype" *ngIf="modalShowFl">
   <em class="ddp-bg-popup"></em>
   <div class="ddp-ui-popup">
     <!-- title -->

--- a/discovery-frontend/src/app/admin/user-management/component/group/user-management-groups.component.ts
+++ b/discovery-frontend/src/app/admin/user-management/component/group/user-management-groups.component.ts
@@ -394,6 +394,15 @@ export class UserManagementGroupsComponent extends AbstractUserManagementCompone
     this.groupsService.getGroupList(params)
       .then((result) => {
 
+        // 현재 페이지에 아이템이 없다면 전 페이지를 불러온다
+        if (this.page.page > 0 &&
+          isNullOrUndefined(result['_embedded']) ||
+          (!isNullOrUndefined(result['_embedded']) && result['_embedded'].groups.length === 0))
+        {
+          this.page.page = result.page.number - 1;
+          this._getGroupList();
+        }
+
         // 검색 파라메터 정보 저장
         this._searchParams = params;
 

--- a/discovery-frontend/src/app/admin/user-management/component/members/detail-member/detail-user-management-members.component.ts
+++ b/discovery-frontend/src/app/admin/user-management/component/members/detail-member/detail-user-management-members.component.ts
@@ -378,7 +378,7 @@ export class DetailUserManagementMembersComponent extends AbstractUserManagement
       // 기존에 저장된 라우트 삭제
       this.cookieService.delete('PREV_ROUTER_URL');
       // 사용자 관리 목록으로 돌아가기
-      this.router.navigate(['/admin/user/members']);
+      this._location.back();
     }).catch((error) => {
       // alert
       Alert.error(error);

--- a/discovery-frontend/src/app/admin/user-management/component/members/user-management-members.component.ts
+++ b/discovery-frontend/src/app/admin/user-management/component/members/user-management-members.component.ts
@@ -448,7 +448,7 @@ export class UserManagementMembersComponent extends AbstractUserManagementCompon
           this.page.page = this.page.page - 1;
         }
         // 재조회
-        this.reloadPage();
+        this.reloadPage(false);
       })
       .catch((error)=> {
         // alert
@@ -475,7 +475,7 @@ export class UserManagementMembersComponent extends AbstractUserManagementCompon
           ? this.translateService.instant('msg.mem.alert.change.usr.status.inactive.success', {value: userName})
           : this.translateService.instant('msg.mem.alert.change.usr.status.active.success', {value: userName}));
         // 재조회
-        this.reloadPage();
+        this.reloadPage(false);
       })
       .catch((error) => {
         // alert
@@ -529,6 +529,15 @@ export class UserManagementMembersComponent extends AbstractUserManagementCompon
     const params = this._getMemberParams();
     this.membersService.getRequestedUser(params)
       .then((result) => {
+
+        // 현재 페이지에 아이템이 없다면 전 페이지를 불러온다
+        if (this.page.page > 0 &&
+          isNullOrUndefined(result['_embedded']) ||
+          (!isNullOrUndefined(result['_embedded']) && result['_embedded'].users.length === 0))
+        {
+          this.page.page = result.page.number - 1;
+          this._getMemberList();
+        }
 
         // 검색 파라메터 정보 저장
         this._searchParams = params;

--- a/discovery-frontend/src/app/admin/workspace-management/component/workspace-permission-schemas/permission-schemas.component.ts
+++ b/discovery-frontend/src/app/admin/workspace-management/component/workspace-permission-schemas/permission-schemas.component.ts
@@ -448,6 +448,14 @@ export class PermissionSchemasComponent extends AbstractComponent implements OnI
     this.permissionService.getRolesets(params)
       .then((result) => {
 
+        if (this.page.page > 0 &&
+          isNullOrUndefined(result['_embedded']) ||
+          (!isNullOrUndefined(result['_embedded']) && result['_embedded'].roleSets.length === 0))
+        {
+          this.page.page = result.page.number - 1;
+          this._getRoleSetList();
+        }
+
         // 검색 파라메터 정보 저장
         this._searchParams = params;
 
@@ -461,7 +469,12 @@ export class PermissionSchemasComponent extends AbstractComponent implements OnI
         // 로딩 hide
         this.loadingHide();
       })
-      .catch(error => this.commonExceptionHandler(error));
+      .catch((error) => {
+
+          this.loadingHide();
+          this.commonExceptionHandler(error)
+        }
+      );
   } // function - _getRoleSetList
 
   /**

--- a/discovery-frontend/src/app/admin/workspace-management/component/workspaces/shared-workspaces.component.ts
+++ b/discovery-frontend/src/app/admin/workspace-management/component/workspaces/shared-workspaces.component.ts
@@ -508,8 +508,13 @@ export class SharedWorkspacesComponent extends AbstractComponent {
       .then(() => {
         // alert
         Alert.success(this.translateService.instant('msg.spaces.shared.alert.delete'));
+
+        if (this.page.page > 0 && this._workspaceList.length === 1) {
+          this.page.page -= 1;
+        }
+
         // 페이지 새로고침
-        this.reloadPage();
+        this.reloadPage(false);
       })
       .catch((error) => {
         // alert
@@ -566,6 +571,15 @@ export class SharedWorkspacesComponent extends AbstractComponent {
 
     this.workspaceService.getWorkspaceByAdmin(params)
       .then((result) => {
+
+        if (this.page.page > 0 &&
+          isNullOrUndefined(result['_embedded']) ||
+          (!isNullOrUndefined(result['_embedded']) && result['_embedded'].workspaces.length === 0))
+        {
+          this.page.page = result.page.number - 1;
+          this._getWorkspaceListInServer();
+        }
+
         // 검색 파라메터 정보 저장
         this._searchParams = params;
         // 페이지 객체

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow.component.ts
@@ -228,6 +228,15 @@ export class DataflowComponent extends AbstractComponent implements OnInit, OnDe
 
     this.dataflowService.getDataflowList(params).then((data) => {
 
+      // 현재 페이지에 아이템이 없다면 전 페이지를 불러온다
+      if (this.page.page > 0 &&
+        isNullOrUndefined(data['_embedded']) ||
+        (!isNullOrUndefined(data['_embedded']) && data['_embedded'].preparationdataflows.length === 0))
+      {
+        this.page.page = data['page'].number - 1;
+        this.getDataflows();
+      }
+
       this._searchParams = params;
 
       this.pageResult = data['page'];

--- a/discovery-frontend/src/app/data-preparation/dataset/dataset.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataset/dataset.component.ts
@@ -178,6 +178,15 @@ export class DatasetComponent extends AbstractComponent implements OnInit {
     this.datasetService.getDatasets(params)
       .then((data) => {
 
+        // 현재 페이지에 아이템이 없다면 전 페이지를 불러온다
+        if (this.page.page > 0 &&
+          isNullOrUndefined(data['_embedded']) ||
+          (!isNullOrUndefined(data['_embedded']) && data['_embedded'].preparationdatasets.length === 0))
+        {
+          this.page.page = data['page'].number - 1;
+          this.getDatasets();
+        }
+
         this._searchParams = params;
 
         this.pageResult = data['page'];

--- a/discovery-frontend/src/app/data-storage/data-connection/data-connection.component.html
+++ b/discovery-frontend/src/app/data-storage/data-connection/data-connection.component.html
@@ -111,8 +111,8 @@
   </div>
 </div>
 <!-- 커넥션 생성 팝업 -->
-<app-create-connection (createdConnection)="reloadPage(true)"></app-create-connection>
+<app-create-connection (createdConnection)="reloadPage()"></app-create-connection>
 <!-- 커넥션 상세 팝업 -->
-<app-update-connection (updatedConnection)="reloadPage(true)"></app-update-connection>
+<app-update-connection (updatedConnection)="reloadPage(false)"></app-update-connection>
 <!-- 삭제 모달 -->
 <app-delete-modal (deleteConfirm)="removeConnection($event)"></app-delete-modal>

--- a/discovery-frontend/src/app/data-storage/data-connection/data-connection.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-connection/data-connection.component.ts
@@ -26,6 +26,7 @@ import {CriterionComponent} from "../component/criterion/criterion.component";
 import {Criteria} from "../../domain/datasource/criteria";
 import {ActivatedRoute} from "@angular/router";
 import {Alert} from "../../common/util/alert.util";
+import {isNullOrUndefined} from "util";
 
 @Component({
   selector: 'app-data-connection',
@@ -302,6 +303,16 @@ export class DataConnectionComponent extends AbstractComponent implements OnInit
     // get connection list
     this.dataconnectionService.getConnectionList(this.page.page, this.page.size, this.selectedContentSort.key + ',' + this.selectedContentSort.sort, this._getConnectionParams())
       .then((result) => {
+
+        // 현재 페이지에 아이템이 없다면 전 페이지를 불러온다.
+        if (this.page.page > 0 &&
+          isNullOrUndefined(result['_embedded']) ||
+          (!isNullOrUndefined(result['_embedded']) && result['_embedded'].connections.length === 0))
+        {
+          this.page.page = result.page.number - 1;
+          this._setConnectionList();
+        }
+
         // set page result
         this.pageResult = result['page'];
         // set connection list

--- a/discovery-frontend/src/app/data-storage/data-source-list/data-source-list.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/data-source-list.component.ts
@@ -23,6 +23,7 @@ import { StringUtil } from '../../common/util/string.util';
 import {ActivatedRoute} from "@angular/router";
 import {CriterionComponent} from "../component/criterion/criterion.component";
 import {Criteria} from "../../domain/datasource/criteria";
+import {isNullOrUndefined} from "util";
 
 @Component({
   selector: 'app-data-source',
@@ -326,6 +327,16 @@ export class DataSourceListComponent extends AbstractComponent {
     // 데이터 소스 조회 요청
     this.datasourceService.getDatasourceList(this.page.page, this.page.size, this.selectedContentSort.key + ',' + this.selectedContentSort.sort, this._getDatasourceParams())
       .then((result) => {
+
+        // 현재 페이지에 아이템이 없다면 전 페이지를 불러온다.
+        if (this.page.page > 0 &&
+          isNullOrUndefined(result['_embedded']) ||
+          (!isNullOrUndefined(result['_embedded']) && result['_embedded'].datasources.length === 0))
+        {
+          this.page.page = result.page.number - 1;
+          this._setDatasourceList();
+        }
+
         // set page result
         this.pageResult = result['page'];
         // set datasource list

--- a/discovery-frontend/src/app/meta-data-management/code-table/code-table.component.ts
+++ b/discovery-frontend/src/app/meta-data-management/code-table/code-table.component.ts
@@ -384,6 +384,15 @@ export class CodeTableComponent extends AbstractComponent implements OnInit, OnD
 
     this._codeTableService.getCodeTableList(params).then((result) => {
 
+      // 현재 페이지에 아이템이 없다면 전 페이지를 불러온다.
+      if (this.page.page > 0 &&
+        isNullOrUndefined(result['_embedded']) ||
+        (!isNullOrUndefined(result['_embedded']) && result['_embedded'].codetables.length === 0))
+      {
+        this.page.page = result.page.number - 1;
+        this._getCodeTableList();
+      }
+
       this._searchParams = params;
 
       this.pageResult = result.page;

--- a/discovery-frontend/src/app/meta-data-management/column-dictionary/column-dictionary.component.ts
+++ b/discovery-frontend/src/app/meta-data-management/column-dictionary/column-dictionary.component.ts
@@ -388,6 +388,15 @@ export class ColumnDictionaryComponent extends AbstractComponent implements OnIn
 
     this._columnDictionaryService.getColumnDictionaryList(params).then((result) => {
 
+      // 현재 페이지에 아이템이 없다면 전 페이지를 불러온다.
+      if (this.page.page > 0 &&
+        isNullOrUndefined(result['_embedded']) ||
+        (!isNullOrUndefined(result['_embedded']) && result['_embedded'].dictionaries.length === 0))
+      {
+        this.page.page = result.page.number - 1;
+        this._getColumnDictionaryList();
+      }
+
       this._searchParams = params;
 
       this.pageResult = result.page;


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Show previous page when there is no item left in the list

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
No issue

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

- Users > member, group
- Prep > Dataset, dataflow
- Workspaces > permission schema, workspaces
- Data storage > Datasource, data connection
- Metadata > Code table, column dictionary

현재 리스트에 아이템이 하나만 있게 만들고(현재 페이지가 1번 페이지가 아닌상태) 상세 화면으로 들어가서 아이템을 삭제합니다.
리스트로 돌아갔을 때 보고 있던 페이지가 아닌 전 페이지로 랜딩 하면 OK

Make sure there is only one item in the list and it is not the first page !
Go into the detail screen and delete the item.
When you return to the list paging number should be : page you were looking at minus 1


#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
