### PR TITLE
Disable next and previous button in paging component

### DIFF
--- a/discovery-frontend/src/app/common/component/pagination/pagination.component.html
+++ b/discovery-frontend/src/app/common/component/pagination/pagination.component.html
@@ -15,7 +15,7 @@
 <div class="ddp-box-page">
   <!-- num -->
   <div class="ddp-page-num">
-    <a (click)="prevPagination()" href="javascript:" class="ddp-btn-prev"></a>
+    <a (click)="prevPagination()" href="javascript:" class="ddp-btn-prev" [ngClass]="{'ddp-disabled':range[0] === 0}" ></a>
     <a *ngFor="let item of range"
        (click)="changePage(item)"
        [ngClass]="{'ddp-selected' : item === info.number }"

--- a/discovery-frontend/src/app/common/component/pagination/pagination.component.html
+++ b/discovery-frontend/src/app/common/component/pagination/pagination.component.html
@@ -15,14 +15,22 @@
 <div class="ddp-box-page">
   <!-- num -->
   <div class="ddp-page-num">
-    <a (click)="prevPagination()" href="javascript:" class="ddp-btn-prev" [ngClass]="{'ddp-disabled':range[0] === 0}" ></a>
+    <a (click)="prevPagination()"
+       href="javascript:"
+       class="ddp-btn-prev"
+       [ngClass]="{'ddp-disabled':range[0] === 0}">
+    </a>
     <a *ngFor="let item of range"
        (click)="changePage(item)"
        [ngClass]="{'ddp-selected' : item === info.number }"
        href="javascript:" class="ddp-selected">
       {{item + 1}}
     </a>
-    <a (click)="nextPagination()" href="javascript:" class="ddp-btn-next"></a>
+    <a (click)="nextPagination()"
+       href="javascript:"
+       class="ddp-btn-next"
+       [ngClass]="{'ddp-disabled':range[range.length-1]+1 === info.totalPages}">
+    </a>
   </div>
   <!-- // num -->
   <!-- setting -->

--- a/discovery-frontend/src/app/common/component/pagination/pagination.component.ts
+++ b/discovery-frontend/src/app/common/component/pagination/pagination.component.ts
@@ -130,6 +130,14 @@ export class PaginationComponent extends AbstractComponent implements OnInit, On
     this._setRange(startPage);
   } // function - nextPagination
 
+
+  public openChangePageComboBox() {
+    if (this.info.totalElements <= this.info.size) {
+      return;
+    }
+
+    this.isOpenOpts = !this.isOpenOpts;
+  }
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Private Method
    |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/

--- a/discovery-frontend/src/assets/css/metatron/component/component.page.css
+++ b/discovery-frontend/src/assets/css/metatron/component/component.page.css
@@ -42,6 +42,8 @@
 .ddp-box-page .ddp-page-num a.ddp-btn-next {margin-left:12px; transform:rotate(180deg);}
 .ddp-box-page .ddp-page-num a.ddp-btn-prev:before,
 .ddp-box-page .ddp-page-num a.ddp-btn-next:before{display:Inline-block; position:absolute; top:50%; left:50%; margin:-4px 0 0 -2px; width:4px; height:7px; background:url(../../../images/btn_page2.png) no-repeat; background-position:-8px -29px; content:'';}
+.ddp-box-page .ddp-page-num a.ddp-btn-prev.ddp-disabled,
+.ddp-box-page .ddp-page-num a.ddp-btn-next.ddp-disabled {opacity:0.3; cursor:no-drop;}
 .ddp-box-page .ddp-page-num a.ddp-page-skip:before {display:inline-block; position:absolute; top:50%; left:50%; margin:-2px 0 0 -8px; width:16px; height:4px; background:url(../../../images/icon_page_skip.png) no-repeat; content:'';}
 .ddp-box-page .ddp-page-num a.ddp-selected {background-color:#f6f6f7; font-weight:bold;}
 .ddp-box-page .ddp-page-setting {float:right; padding:6px 0;}


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Disable next or previous button when there is no next or previous pages

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
No  issue

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Button is disabled when next, previous page does not exist
![image](https://user-images.githubusercontent.com/42233517/58142900-ce95e200-7c83-11e9-9853-48cf2e44f5f9.png)


#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
