### PR TITLE
Change manual link in the LNB

### DIFF
--- a/discovery-frontend/src/app/layout/layout/component/lnb/lnb.component.html
+++ b/discovery-frontend/src/app/layout/layout/component/lnb/lnb.component.html
@@ -285,7 +285,7 @@
         <a (click)="downloadManual()" href="javascript:" class="ddp-btn-box">
           <em class="ddp-icon-manual"></em>{{'msg.lnb.btn.manual' | translate}}
         </a>
-        <a target="_blank" rel="noopener noreferrer" href="https://metatron.app/index.php/documents/" class="ddp-btn-box">
+        <a href="javascript:" class="ddp-btn-box" (click)="popupManual();">
           <em class="ddp-icon-global"></em>{{'msg.lnb.btn.manual.web' | translate}}
         </a>
     </span>

--- a/discovery-frontend/src/app/layout/layout/component/lnb/lnb.component.ts
+++ b/discovery-frontend/src/app/layout/layout/component/lnb/lnb.component.ts
@@ -646,4 +646,14 @@ export class LNBComponent extends AbstractComponent implements OnInit, OnDestroy
     this.isShow=false;
     this.isShowFolderNavi=false;
   } // function - _closeLNB
+
+
+  private popupManual() {
+    const browserLang:string = this.translateService.getBrowserLang();
+    if (browserLang.match(/ko/)) {
+      window.open("https://metatron-app.github.io/metatron-doc-discovery/", "_blank");
+    } else {
+      window.open("https://metatron-app.github.io/metatron-doc-discovery/en", "_blank");
+    }
+  }
 }

--- a/discovery-frontend/src/app/layout/layout/component/lnb/lnb.component.ts
+++ b/discovery-frontend/src/app/layout/layout/component/lnb/lnb.component.ts
@@ -648,7 +648,7 @@ export class LNBComponent extends AbstractComponent implements OnInit, OnDestroy
   } // function - _closeLNB
 
 
-  private popupManual() {
+  public popupManual() {
     const browserLang:string = this.translateService.getBrowserLang();
     if (browserLang.match(/ko/)) {
       window.open("https://metatron-app.github.io/metatron-doc-discovery/", "_blank");


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
We need to change the link URL of the online manual.

"Online" button will link to
(English) https://metatron-app.github.io/metatron-doc-discovery/en/
(Korean) https://metatron-app.github.io/metatron-doc-discovery/

![image](https://user-images.githubusercontent.com/42234141/58142926-e8cfc000-7c83-11e9-887a-c5bdb1837e70.png)


**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
N/A

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Open the LNB
2. Click on the 'Online' button at the bottom of the LNB
3. The online manual opens in a new tab.

#### Need additional checks?
No!

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
