### PR TITLE
#2045 Users should be able to search for hidden value in filter widget

### DIFF
--- a/discovery-frontend/src/app/dashboard/filters/component/filter-multi-select/filter-multi-select.component.html
+++ b/discovery-frontend/src/app/dashboard/filters/component/filter-multi-select/filter-multi-select.component.html
@@ -14,17 +14,23 @@
 
 <!-- //Drop down -->
 <div class="ddp-list-part ddp-type">
+  <a  (click)="candidateFromSearchText()" class="ddp-btn-line"
+      [ngStyle]="(viewType === 'widget' && '' !== searchText && isShowSelectList) ?  {'display': 'block'} : {'display': 'none'}">
+    {{'msg.comm.ui.search-all' | translate}}
+  </a>
   <!-- selectbox -->
   <!-- 클릭시 ddp-selecte 추가 -->
   <div class="ddp-wrap-drop-search" #ddpOffSet
-       [ngClass]="{'ddp-selected' : isShowSelectList && isShowSelectListForOutSide, 'ddp-offset' : viewType === 'widget'}">
+       [ngClass]="{'ddp-selected' : isShowSelectList && isShowSelectListForOutSide, 'ddp-offset' : viewType === 'widget'}"
+       [ngStyle]="(viewType === 'widget' && '' !== searchText) ? {'overflow': 'hidden'} : {}" (click)="setViewListPosition()">
     <div class="ddp-type-selectbox2"  (click)="toggleSelectList()">
       <span class="ddp-txt-selectbox ddp-result">{{viewText}}</span>
     </div>
 
     <!-- drop search -->
     <div class="ddp-ui-drop-search" [ngClass]="{'ddp-drop' : viewType === 'widget'}">
-      <input type="text" class="ddp-input-search" placeholder="Search" [(ngModel)]="searchText" [disabled]="isMockup" >
+      <input type="text" class="ddp-input-search" placeholder="Search" [(ngModel)]="searchText" [disabled]="isMockup"
+             (keyup)="setViewListPosition()">
       <ul class="ddp-list-selectbox2"
           infinite-scroll
           [scrollWindow]="false"
@@ -49,7 +55,7 @@
                      [disabled]="isMockup" (change)="selected(item, $event)"
                      [checked]="isSelectedItem(item)">
               <i class="ddp-icon-checkbox ddp-dark"></i>
-              <span class="ddp-txt-checkbox">{{item[viewKey]}}</span>
+              <span class="ddp-txt-checkbox" [ngStyle]="item.isTemporary ? {'color': '#8fb66a'} : {}">{{item[viewKey]}}</span>
             </label>
           </a>
         </li>

--- a/discovery-frontend/src/app/dashboard/filters/component/filter-select/filter-select.component.html
+++ b/discovery-frontend/src/app/dashboard/filters/component/filter-select/filter-select.component.html
@@ -14,17 +14,23 @@
 
 <!-- //Drop down -->
 <div class="ddp-list-part ddp-type">
+  <a (click)="candidateFromSearchText()" class="ddp-btn-line"
+     [ngStyle]="(viewType === 'widget' && '' !== searchText && isShowSelectList) ?  {'display': 'block'} : {'display': 'none'}">
+    {{'msg.comm.ui.search-all' | translate}}
+  </a>
   <!-- selectbox -->
   <!-- 클릭시 ddp-selecte 추가 -->
   <div class="ddp-wrap-drop-search" #ddpOffSet
-       [ngClass]="{'ddp-selected' : isShowSelectList && isShowSelectListForOutSide, 'ddp-offset' : viewType === 'widget'}">
-    <div class="ddp-type-selectbox2"  (click)="toggleSelectList()">
+       [ngClass]="{'ddp-selected' : isShowSelectList && isShowSelectListForOutSide, 'ddp-offset' : viewType === 'widget'}"
+       [ngStyle]="(viewType === 'widget' && '' !== searchText) ? {'overflow': 'hidden'} : {}" (click)="setViewListPosition()">
+    <div class="ddp-type-selectbox2" (click)="toggleSelectList()">
       <span class="ddp-txt-selectbox ddp-result">{{selectedItem == null ? unselectedMessage :  isStringArray ? selectedItem : selectedItem[viewKey] }}</span>
     </div>
 
     <!-- drop search -->
     <div class="ddp-ui-drop-search" [ngClass]="{'ddp-drop' : viewType === 'widget'}">
-      <input type="text" class="ddp-input-search" placeholder="Search" [(ngModel)]="searchText" [disabled]="isMockup" >
+      <input type="text" class="ddp-input-search" placeholder="Search" [(ngModel)]="searchText" [disabled]="isMockup"
+             (keyup)="setViewListPosition()">
       <ul class="ddp-list-selectbox2"
           infinite-scroll
           [scrollWindow]="false"
@@ -35,7 +41,7 @@
           <a href="javascript:"  draggable="false" (click)="selectAllItem();">{{'msg.comm.ui.list.all'|translate}}</a>
         </li>
         <li *ngFor="let item of array | baseFilter:['name', searchText]">
-          <a href="javascript:" (click)="selectCandidateItem(item);">{{isStringArray ? item : item[viewKey]}}</a>
+          <a href="javascript:" (click)="selectCandidateItem(item);" [ngStyle]="item.isTemporary ? {'color': '#8fb66a'} : {}">{{isStringArray ? item : item[viewKey]}}</a>
         </li>
       </ul>
     </div>

--- a/discovery-frontend/src/app/dashboard/filters/inclusion-filter/inclusion-filter-panel.component.html
+++ b/discovery-frontend/src/app/dashboard/filters/inclusion-filter/inclusion-filter-panel.component.html
@@ -149,6 +149,7 @@
         <!-- //popup -->
       </div>
     </div>
+    <div class="search-all-message">{{searchAllMessage}}</div>
     <!-- // 검색 영여 -->
     <!-- 목록 영역 -->
     <ul class="ddp-list-checktype ddp-list-padd" *ngIf="isMultiSelector" >

--- a/discovery-frontend/src/app/dashboard/filters/inclusion-filter/inclusion-filter-panel.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/inclusion-filter/inclusion-filter-panel.component.ts
@@ -80,6 +80,8 @@ export class InclusionFilterPanelComponent extends AbstractFilterPanelComponent 
   public isSearchFocus: boolean = false;          // 검색바 포커스 여부
   public isOverCandidateWarning: boolean = false;  // Candidate Limit 을 넘겼는지 여부
 
+  public searchAllMessage = '';
+
   @Input('filter')
   public originalFilter: InclusionFilter;
 
@@ -318,6 +320,11 @@ export class InclusionFilterPanelComponent extends AbstractFilterPanelComponent 
    * @param {boolean} isInitial
    */
   public setCandidatePage(page: number, isInitial: boolean = false) {
+    if(this.searchText === '') {
+      this.searchAllMessage = '';
+    } else {
+      this.searchAllMessage = this.translateService.instant('msg.board.filter.ui.search-all');
+    }
 
     if (isInitial) {
       this.pageCandidateList = [];
@@ -501,6 +508,12 @@ export class InclusionFilterPanelComponent extends AbstractFilterPanelComponent 
 
         // 위젯 화면 표시
         this.isShowFilter = true;
+
+        if(result == null || result.length == 0) {
+          this.searchAllMessage = this.translateService.instant('msg.board.filter.ui.search-all.nodata');
+        } else {
+          this.searchAllMessage = '';
+        }
 
         this.loadingHide();
       }).catch((error) => {

--- a/discovery-frontend/src/app/dashboard/widgets/filter-widget/filter-widget.component.html
+++ b/discovery-frontend/src/app/dashboard/widgets/filter-widget/filter-widget.component.html
@@ -47,6 +47,8 @@
                                      [selectedArray]="selectedItems"
                                      [viewKey]="'name'"
                                      [mockup]="isEditMode"
+                                     [filter]="filter"
+                                     [dashboard]="dashboard"
                                      (onSelected)="onSelectInclude($event)"
                                      (changeDisplayOptions)="toggleOptionsSelectComp($event)">
       </component-filter-multi-select>
@@ -58,6 +60,8 @@
                                [selectedItem]="selectedItems ? selectedItems[0] : null"
                                [viewKey]="'name'"
                                [mockup]="isEditMode"
+                               [filter]="filter"
+                               [dashboard]="dashboard"
                                (onSelected)="onSelectInclude($event)"
                                (onCheckAll)="checkAllInclude()"
                                (changeDisplayOptions)="toggleOptionsSelectComp($event)">

--- a/discovery-frontend/src/app/domain/workbook/configurations/filter/inclusion-filter.ts
+++ b/discovery-frontend/src/app/domain/workbook/configurations/filter/inclusion-filter.ts
@@ -69,6 +69,7 @@ export class Candidate {
   public count: number;
   public isDefinedValue: boolean = false;
   public isShow: boolean = false;   // Whether icon is displayed
+  public isTemporary: boolean = false;
 }
 
 export enum InclusionSortBy {

--- a/discovery-frontend/src/assets/css/polaris.v2.page.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.page.css
@@ -1237,6 +1237,7 @@ ul.ddp-list-text li a .ddp-data-info span {display:block; color:#4b515b; font-si
 .ddp-area-boardside .ddp-ui-down-title2 {min-height:50px; margin:0 -10px 0 -17px; padding:0 10px 0 17px;cursor:move;}
 .ddp-area-boardside .ddp-box-down .ddp-wrap-divide {padding-top:0px;}
 .ddp-area-boardside .ddp-contents-divide.ddp-type {margin-top:-10px;}
+.ddp-area-boardside .ddp-contents-divide.ddp-type .search-all-message {color:#b7b9c2;}
 .ddp-area-boardside .ddp-ui-down-title2 .ddp-ui-buttons {position:relative; top:17px; float:right; background:none;}
 .ddp-area-boardside .ddp-ui-down-title2 .ddp-wrap-morebutton {display:inline-block;}
 .ddp-area-boardside .ddp-ui-down-title2 .ddp-ui-buttons .ddp-wrap-datalock,.ddp-area-boardside .ddp-ui-down-title2 .ddp-ui-buttons .ddp-wrap-datarecommend,
@@ -3757,6 +3758,7 @@ em[class*="ddp-bg-chart-"] {display:inline-block; position:absolute; top:50%; le
 .ddp-list-part .ddp-label-checkbox.ddp-check-full span.ddp-txt-checkbox {font-size:12px;}
 .ddp-list-part2 .ddp-label-checkbox.ddp-check-full span.ddp-txt-checkbox {font-size:12px;}
 .ddp-list-part .ddp-label-radio.ddp-check-full span.ddp-txt-radio {font-size:12px;}
+.ddp-list-part .ddp-btn-line {display:none; float:right; margin-left:4px; cursor: pointer;}
 .ddp-list-part2 .ddp-label-radio.ddp-check-full span.ddp-txt-radio {font-size:12px;}
 .ddp-wrap-option-checkbox {padding:3px 0;}
 .ddp-wrap-option-checkbox .ddp-label-type {line-height:29px; color:#d0d1d8;}

--- a/discovery-frontend/src/assets/i18n/en.json
+++ b/discovery-frontend/src/assets/i18n/en.json
@@ -1517,6 +1517,8 @@
   "msg.board.filter.ui.condition.less.than.des" : "is below",
   "msg.board.filter.ui.condition.equal.greater.than.des" : "is above or equal to",
   "msg.board.filter.ui.condition.equal.less.than.des" : "is below or equal to",
+  "msg.board.filter.ui.search-all" : "Search all to see more results",
+  "msg.board.filter.ui.search-all.nodata" : "No results found",
   "msg.board.filter.title.chart-filter" : "Chart filter",
   "msg.board.filter.title.global-filter" : "Global filter",
   "msg.board.filter.btn.ingest" : "Ingest",

--- a/discovery-frontend/src/assets/i18n/ko.json
+++ b/discovery-frontend/src/assets/i18n/ko.json
@@ -1515,6 +1515,8 @@
   "msg.board.filter.ui.condition.less.than.des" : "아래에 있음",
   "msg.board.filter.ui.condition.equal.greater.than.des" : "is above or equal to",
   "msg.board.filter.ui.condition.equal.less.than.des" : "is below or equal to",
+  "msg.board.filter.ui.search-all" : "전체 데이터에서 검색하면 더 많은 검색 결과를 확인할 수 있습니다",
+  "msg.board.filter.ui.search-all.nodata" : "검색결과가 없습니다",
   "msg.board.filter.title.chart-filter" : "차트 필터",
   "msg.board.filter.title.global-filter" : "글로벌 필터",
   "msg.board.filter.btn.ingest" : "수집",


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
* 대시보드 필터(단건, 다건)에 나타나지 않던 값을 추가로 사용자가 직접 검색하여 사용할 수 있도록 하였습니다.
* 대시보드 편집 > 필터 Search all 검색시 문구를 추가 하였습니다.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#2045 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
#### 대시 보드 조회 화면
1. 내장된 Sales 데이터소스를 사용하여 City 차원값을 사용하여 필터를 만들고 대시보드에 추가하였습니다.
2. 대시보드 필터 검색창에 사용자가 문자를 입력하는 경우 '전체 검색' 버튼이 노출되는 것을 확인했습니다.
![image](https://user-images.githubusercontent.com/16472109/58310391-7d335180-7e41-11e9-8c19-73af18b7677f.png)
2. 'York'을 입력하고 '전체 검색'을 누르면 일치하는 값이 필터에 추가되는 것을 확인했습니다.
![image](https://user-images.githubusercontent.com/16472109/58310506-bf5c9300-7e41-11e9-9c17-857e675b5368.png)

#### 대시 보드 편집 화면
1. 검색창에 사용자가 문자를 입력하는 경우 안내 문구가 노출되는 것을 확인했습니다.
![image](https://user-images.githubusercontent.com/16472109/58310591-ef0b9b00-7e41-11e9-8b98-2a7b260a9c76.png)
2. 검색결과가 없는 경우 안내 문구가 노출되는 것을 확인했습니다.
![image](https://user-images.githubusercontent.com/16472109/58310670-237f5700-7e42-11e9-88a8-3ea5361dc620.png)

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
