### PR TITLE
#2144 Explicit GC in snapshot when polaris.dataprep.etl.explicitGC=true

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepProperties.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepProperties.java
@@ -17,6 +17,7 @@ package app.metatron.discovery.domain.dataprep;
 import app.metatron.discovery.domain.dataprep.exceptions.PrepErrorCodes;
 import app.metatron.discovery.domain.dataprep.exceptions.PrepException;
 import app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey;
+import app.metatron.discovery.domain.workspace.Book;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
@@ -49,6 +50,7 @@ public class PrepProperties {
   public static final String ETL_LIMIT_ROWS       = "polaris.dataprep.etl.limitRows";
   public static final String ETL_JAR              = "polaris.dataprep.etl.jar";
   public static final String ETL_JVM_OPTIONS      = "polaris.dataprep.etl.jvmOptions";
+  public static final String ETL_EXPLICIT_GC      = "polaris.dataprep.etl.explicitGC";
 
   public static String dirDataprep = "dataprep";
   public static String dirPreview = "previews";
@@ -117,6 +119,7 @@ public class PrepProperties {
   public Integer getEtlLimitRows()       { return etl.getLimitRows(); }
   public String  getEtlJar()             { return etl.getJar(); }
   public String  getEtlJvmOptions()      { return etl.getJvmOptions(); }
+  public Boolean getEtlExplicitGC()      { return etl.getExplicitGC(); }
 
   // wrapper functions
   public boolean isHDFSConfigured()      { return (hadoopConfDir != null && stagingBaseDir != null); }
@@ -133,6 +136,7 @@ public class PrepProperties {
     map.put(ETL_TIMEOUT,         getEtlTimeout());
     map.put(ETL_LIMIT_ROWS,      getEtlLimitRows());
     map.put(ETL_JVM_OPTIONS,     getEtlJvmOptions());
+    map.put(ETL_EXPLICIT_GC,     getEtlExplicitGC());
 
     return map;
   }
@@ -217,6 +221,7 @@ public class PrepProperties {
     public Integer limitRows;
     public String jar;
     public String jvmOptions;
+    public Boolean explicitGC;
 
     public EtlInfo() {
     }
@@ -256,6 +261,13 @@ public class PrepProperties {
       return jvmOptions;
     }
 
+    public Boolean getExplicitGC() {
+      if (explicitGC == null) {
+        explicitGC = false;
+      }
+      return explicitGC;
+    }
+
     public void setCores(Integer cores) {
       this.cores = cores;
     }
@@ -276,10 +288,14 @@ public class PrepProperties {
       this.jvmOptions = jvmOptions;
     }
 
+    public void setExplicitGC(Boolean explicitGC) {
+      this.explicitGC = explicitGC;
+    }
+
     @Override
     public String toString() {
-      return String.format("EtlInfo{cores=%d timeout=%d jar=%s jvmOptions=%s}",
-                                    cores, timeout, jar, jvmOptions);
+      return String.format("EtlInfo{cores=%d timeout=%d jar=%s jvmOptions=%s explicitGC=%b}",
+                                    cores, timeout, jar, jvmOptions, explicitGC);
     }
   }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/etl/TeddyExecutor.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/etl/TeddyExecutor.java
@@ -117,6 +117,7 @@ import app.metatron.discovery.prep.parser.preparation.RuleVisitorParser;
 import app.metatron.discovery.prep.parser.preparation.rule.Rule;
 
 import static app.metatron.discovery.domain.dataprep.PrepProperties.ETL_CORES;
+import static app.metatron.discovery.domain.dataprep.PrepProperties.ETL_EXPLICIT_GC;
 import static app.metatron.discovery.domain.dataprep.PrepProperties.ETL_LIMIT_ROWS;
 import static app.metatron.discovery.domain.dataprep.PrepProperties.ETL_TIMEOUT;
 import static app.metatron.discovery.domain.dataprep.PrepProperties.HADOOP_CONF_DIR;
@@ -150,6 +151,7 @@ public class TeddyExecutor {
     public Integer timeout;
     public Integer cores;
     public Integer limitRows;
+    public Boolean explicitGC;
     public final Integer CANCEL_INTERVAL = 1000;
 
     String oauth_token;
@@ -179,6 +181,7 @@ public class TeddyExecutor {
         cores         = (Integer) prepPropertiesInfo.get(ETL_CORES);
         timeout       = (Integer) prepPropertiesInfo.get(ETL_TIMEOUT);
         limitRows     = (Integer) prepPropertiesInfo.get(ETL_LIMIT_ROWS);
+        explicitGC    = (Boolean) prepPropertiesInfo.get(ETL_EXPLICIT_GC);
 
         if (hadoopConfDir != null) {
             hadoopConf = PrepUtil.getHadoopConf(hadoopConfDir);
@@ -545,6 +548,10 @@ public class TeddyExecutor {
             LOGGER.debug("applyRuleStrings(): end: ruleString={}", ruleString);
             cache.put(masterFullDsId, newDf);
             updateSnapshot("ruleCntDone", String.valueOf(incrRuleCntDone(ssId)), ssId);
+
+            if (explicitGC) {
+                System.gc();
+            }
         }
 
         LOGGER.trace("applyRuleStrings(): end");


### PR DESCRIPTION
### Description
When polaris.dataprep.etl.explicitGC is true, GC occurs explicitly on every transform in snapshot generation.

**Related Issue** : https://github.com/metatron-app/metatron-discovery/issues/2144

### How Has This Been Tested?
Run locally, with -verbose:gc JVM option

#### Need additional checks?
No.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
