### PR TITLE
#2158 Enable ioConfig in the real-time ingestion spec

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/io/KafkaIoConfig.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/io/KafkaIoConfig.java
@@ -132,4 +132,44 @@ public class KafkaIoConfig implements IoConfig {
   public void setTaskDuration(String taskDuration) {
     this.taskDuration = taskDuration;
   }
+
+  public String getStartDelay() {
+    return startDelay;
+  }
+
+  public void setStartDelay(String startDelay) {
+    this.startDelay = startDelay;
+  }
+
+  public String getPeriod() {
+    return period;
+  }
+
+  public void setPeriod(String period) {
+    this.period = period;
+  }
+
+  public Boolean getUseEarliestOffset() {
+    return useEarliestOffset;
+  }
+
+  public void setUseEarliestOffset(Boolean useEarliestOffset) {
+    this.useEarliestOffset = useEarliestOffset;
+  }
+
+  public String getCompletionTimeout() {
+    return completionTimeout;
+  }
+
+  public void setCompletionTimeout(String completionTimeout) {
+    this.completionTimeout = completionTimeout;
+  }
+
+  public String getLateMessageRejectionPeriod() {
+    return lateMessageRejectionPeriod;
+  }
+
+  public void setLateMessageRejectionPeriod(String lateMessageRejectionPeriod) {
+    this.lateMessageRejectionPeriod = lateMessageRejectionPeriod;
+  }
 }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Make IoConfig can be set at real-time ingestion.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#2158 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Create a real time ingestion spec.
2. Add a nested object named "taskOptions" into "ingestion" key.
![image](https://user-images.githubusercontent.com/42234141/58625659-df8ec500-830d-11e9-9f14-37ff1a543453.png)

3. Post a datasource
4. Check your ingestion spec that ioConfig is set.
![image](https://user-images.githubusercontent.com/42234141/58625535-9dfe1a00-830d-11e9-8a9c-dca456f8465e.png)



#### Need additional checks?
No


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
