### PR TITLE
#2152 fix transfer workspace to user whose name contains dot

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workspace/WorkspaceController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workspace/WorkspaceController.java
@@ -799,7 +799,7 @@ public class WorkspaceController {
     return ResponseEntity.noContent().build();
   }
 
-  @RequestMapping(path = "/workspaces/{id}/delegate/{owner}", method = RequestMethod.POST)
+  @RequestMapping(path = "/workspaces/{id}/delegate/{owner:.+}", method = RequestMethod.POST)
   public ResponseEntity<?> delegateWorkspace(@PathVariable("id") String workspaceId,
                                              @PathVariable("owner") String owner) {
 


### PR DESCRIPTION
### Description
Cannot transfer workspace to user whose name contains dot

**Related Issue** : #2152 


### How Has This Been Tested?
1. Make a shared workspace.
2. Add an user whose name contains dot to a workspace member.
3. Change owner to the user.

#### Need additional checks?
User delete and transfer to the user

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
