### PR TITLE
#2179 Conditional register the StorageProperties bean

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/DataConnectionController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/DataConnectionController.java
@@ -104,7 +104,7 @@ public class DataConnectionController {
   @Autowired
   MetadataSourceRepository metadataSourceRepository;
   
-  @Autowired
+  @Autowired(required = false)
   StorageProperties storageProperties;
 
   @Autowired
@@ -195,11 +195,7 @@ public class DataConnectionController {
   @RequestMapping(value = "/connections/query/hive/databases", method = RequestMethod.POST)
   public @ResponseBody ResponseEntity<?> queryForListOfHiveDatabases(Pageable pageable) {
 
-    StorageProperties.StageDBConnection stageDBConnection = storageProperties.getStagedb();
-
-    if(stageDBConnection == null){
-      throw new ResourceNotFoundException("StorageProperties.StageDBConnection");
-    }
+    StorageProperties.StageDBConnection stageDBConnection = getStageDBConnection(storageProperties);
 
     DataConnection hiveConnection = stageDBConnection.getJdbcDataConnection();
 
@@ -224,11 +220,7 @@ public class DataConnectionController {
     //유효성 체크
     SearchParamValidator.checkNull(checkRequest.getDatabase(), "database");
 
-    StorageProperties.StageDBConnection stageDBConnection = storageProperties.getStagedb();
-
-    if(stageDBConnection == null){
-      throw new ResourceNotFoundException("StorageProperties.StageDBConnection");
-    }
+    StorageProperties.StageDBConnection stageDBConnection = getStageDBConnection(storageProperties);
 
     DataConnection hiveConnection = stageDBConnection.getJdbcDataConnection();
 
@@ -263,11 +255,7 @@ public class DataConnectionController {
     SearchParamValidator.checkNull(checkRequest.getQuery(), "query");
     SearchParamValidator.checkNull(checkRequest.getDatabase(), "database");
 
-    StorageProperties.StageDBConnection stageDBConnection = storageProperties.getStagedb();
-
-    if(stageDBConnection == null){
-      throw new ResourceNotFoundException("StorageProperties.StageDBConnection");
-    }
+    StorageProperties.StageDBConnection stageDBConnection = getStageDBConnection(storageProperties);
 
     DataConnection hiveConnection = stageDBConnection.getJdbcDataConnection();
 
@@ -548,11 +536,7 @@ public class DataConnectionController {
     //유효성 체크
     SearchParamValidator.checkNull(checkRequest.getDatabase(), "database");
 
-    StorageProperties.StageDBConnection stageDBConnection = storageProperties.getStagedb();
-
-    if(stageDBConnection == null){
-      throw new ResourceNotFoundException("StorageProperties.StageDBConnection");
-    }
+    StorageProperties.StageDBConnection stageDBConnection = getStageDBConnection(storageProperties);
 
     DataConnection hiveConnection = stageDBConnection.getJdbcDataConnection();
 
@@ -565,6 +549,14 @@ public class DataConnectionController {
     Map<String, Object> returnMap = Maps.newHashMap();
     returnMap.put("tables", filteredTableNameList);
     return ResponseEntity.ok(returnMap);
+  }
+
+  private static StorageProperties.StageDBConnection getStageDBConnection(StorageProperties storageProperties) {
+    if (storageProperties == null || storageProperties.getStagedb() == null) {
+      throw new ResourceNotFoundException("StorageProperties.StageDBConnection");
+    }
+
+    return storageProperties.getStagedb();
   }
 
   public List<String> filterTableForMdm(List<String> tableNameList,
@@ -610,19 +602,13 @@ public class DataConnectionController {
   @Deprecated
   @RequestMapping(value = "/connections/query/hive/strict", method = RequestMethod.GET)
   public @ResponseBody ResponseEntity<?> strictModeForHiveIngestion() {
-    StorageProperties.StageDBConnection stageDBConnection = storageProperties.getStagedb();
-    if(stageDBConnection == null){
-      throw new ResourceNotFoundException("StorageProperties.StageDBConnection");
-    }
+    StorageProperties.StageDBConnection stageDBConnection = getStageDBConnection(storageProperties);
     return ResponseEntity.ok(stageDBConnection.isStrictMode());
   }
 
   @RequestMapping(value = "/connections/query/hive/partitions/enable", method = RequestMethod.GET)
   public @ResponseBody ResponseEntity<?> enablePartitionForHiveIngestion() {
-    StorageProperties.StageDBConnection stageDBConnection = storageProperties.getStagedb();
-    if(stageDBConnection == null){
-      throw new ResourceNotFoundException("StorageProperties.StageDBConnection");
-    }
+    StorageProperties.StageDBConnection stageDBConnection = getStageDBConnection(storageProperties);
     return ResponseEntity.ok(stageDBConnection.getMetastore().includeJdbc());
   }
 
@@ -634,11 +620,7 @@ public class DataConnectionController {
     SearchParamValidator.checkNull(checkRequest.getQuery(), "query");
     SearchParamValidator.checkNull(checkRequest.getDatabase(), "database");
 
-    StorageProperties.StageDBConnection stageDBConnection = storageProperties.getStagedb();
-
-    if(stageDBConnection == null){
-      throw new ResourceNotFoundException("StorageProperties.StageDBConnection");
-    }
+    StorageProperties.StageDBConnection stageDBConnection = getStageDBConnection(storageProperties);
 
     //when strict mode, requires hive metastore connection info
     if(stageDBConnection.isStrictMode()){
@@ -668,11 +650,7 @@ public class DataConnectionController {
     SearchParamValidator.checkNull(checkRequest.getDatabase(), "database");
     SearchParamValidator.checkNull(checkRequest.getPartitions(), "partitions");
 
-    StorageProperties.StageDBConnection stageDBConnection = storageProperties.getStagedb();
-
-    if(stageDBConnection == null){
-      throw new ResourceNotFoundException("StorageProperties.StageDBConnection");
-    }
+    StorageProperties.StageDBConnection stageDBConnection = getStageDBConnection(storageProperties);
 
     //when strict mode, requires hive metastore connection info
     //if(stageDBConnection.isStrictMode()){

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetFileService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetFileService.java
@@ -102,7 +102,7 @@ public class PrepDatasetFileService {
     @Autowired(required = false)
     PrepProperties prepProperties;
 
-    @Autowired
+    @Autowired(required = false)
     StorageProperties storageProperties;
 
     @Autowired

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetStagingDbService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetStagingDbService.java
@@ -16,6 +16,7 @@ package app.metatron.discovery.domain.dataprep;
 
 import static app.metatron.discovery.domain.dataprep.entity.PrDataset.RS_TYPE.QUERY;
 
+import app.metatron.discovery.common.exception.ResourceNotFoundException;
 import app.metatron.discovery.domain.dataconnection.DataConnection;
 import app.metatron.discovery.domain.dataconnection.DataConnectionHelper;
 import app.metatron.discovery.domain.dataconnection.DataConnectionRepository;
@@ -72,7 +73,7 @@ public class PrepDatasetStagingDbService {
     @Autowired(required = false)
     PrepProperties prepProperties;
 
-    @Autowired
+    @Autowired(required = false)
     StorageProperties storageProperties;
 
     @Autowired
@@ -227,6 +228,8 @@ public class PrepDatasetStagingDbService {
             List<Field> fields = Lists.newArrayList();
             List<Map<String, String>> headers = Lists.newArrayList();
 
+            validateStorageProperties(storageProperties);
+
             StageDBConnection stageDB = storageProperties.getStagedb();
             DataConnection stageDataConnection = new DataConnection();
             stageDataConnection.setHostname(    stageDB.getHostname());
@@ -320,6 +323,12 @@ public class PrepDatasetStagingDbService {
         return responseMap;
     }
 
+    private static void validateStorageProperties(StorageProperties storageProperties) {
+        if (storageProperties == null || storageProperties.getStagedb() == null) {
+            throw new ResourceNotFoundException("Stage DB information required.");
+        }
+    }
+
     // FIXME: connectUrl에 명시된 server에 hiveserver2가 돌고 있어야 한다.
     public DataFrame getPreviewStagedbForDataFrame(String queryStmt, String dbName, String tblName, String size) throws SQLException {
 
@@ -331,6 +340,8 @@ public class PrepDatasetStagingDbService {
             if(dbName==null || dbName.isEmpty()) {
                 dbName = "default";
             }
+
+            validateStorageProperties(storageProperties);
 
             StageDBConnection stageDB = storageProperties.getStagedb();
             DataConnection stageDataConnection = new DataConnection();
@@ -448,6 +459,8 @@ public class PrepDatasetStagingDbService {
             } else {
                 sql = "SELECT * FROM " + tblName + " LIMIT " + size;
             }
+
+            validateStorageProperties(storageProperties);
 
             StageDBConnection stageDB = storageProperties.getStagedb();
             DataConnection stageDataConnection = new DataConnection();
@@ -575,6 +588,8 @@ public class PrepDatasetStagingDbService {
 
     public void writeSnapshot(ServletOutputStream outputStream, String dbName, String sql, String fileType) throws PrepException {
         try {
+            validateStorageProperties(storageProperties);
+
             StageDBConnection stageDB = storageProperties.getStagedb();
             DataConnection stageDataConnection = new DataConnection();
             stageDataConnection.setHostname(    stageDB.getHostname());
@@ -619,6 +634,8 @@ public class PrepDatasetStagingDbService {
 
     public void dropHiveSnapshotTable(String sql) throws PrepException {
         try {
+            validateStorageProperties(storageProperties);
+
             StageDBConnection stageDB = storageProperties.getStagedb();
             DataConnection stageDataConnection = new DataConnection();
             stageDataConnection.setHostname(    stageDB.getHostname());

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/service/PrDatasetController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/service/PrDatasetController.java
@@ -98,7 +98,7 @@ public class PrDatasetController {
     @Autowired
     PrepProperties prepProperties;
 
-    @Autowired
+    @Autowired(required = false)
     StorageProperties storageProperties;
 
     @Value("${spring.http.multipart.max-file-size}")
@@ -464,12 +464,10 @@ public class PrDatasetController {
             if(prepProperties.getLocalBaseDir() != null) {
                 storageTypes.add(PrDataset.STORAGE_TYPE.LOCAL);
             }
-            StorageProperties.StageDBConnection stageDBConnection = storageProperties.getStagedb();
-            if(prepProperties.getStagingBaseDir() != null && storageProperties.getStagedb()!=null ) {
+            if(storageProperties != null && prepProperties.getStagingBaseDir() != null && storageProperties.getStagedb() != null ) {
                 storageTypes.add(PrDataset.STORAGE_TYPE.HDFS);
             }
-            StorageProperties.S3Connection s3Connection = storageProperties.getS3();
-            if(storageProperties.getS3()!=null ) {
+            if(storageProperties != null && storageProperties.getS3() != null) {
                 storageTypes.add(PrDataset.STORAGE_TYPE.S3);
             }
             response.put("storage_types", storageTypes);

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
@@ -157,7 +157,7 @@ public class PrepTransformService {
   @Autowired(required = false)
   PrepProperties prepProperties;
 
-  @Autowired
+  @Autowired(required = false)
   StorageProperties storageProperties;
 
   @Value("${server.port:8180}")
@@ -210,8 +210,9 @@ public class PrepTransformService {
     }
 
     Map<String, Object> mapEveryForEtl = prepProperties.getEveryForEtl();
-    StageDBConnection stageDB = storageProperties.getStagedb();
-    if(stageDB!=null) { // if the value is null, that means storage.stagedb is not in a yaml. NOT using STAGING_DB
+
+    if(storageProperties != null && storageProperties.getStagedb() != null) { // if the value is null, that means storage.stagedb is not in a yaml. NOT using STAGING_DB
+      StageDBConnection stageDB = storageProperties.getStagedb();
       mapEveryForEtl.put(STAGEDB_HOSTNAME, stageDB.getHostname());
       mapEveryForEtl.put(STAGEDB_PORT, stageDB.getPort());
       mapEveryForEtl.put(STAGEDB_USERNAME, stageDB.getUsername());

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/TeddyImpl.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/TeddyImpl.java
@@ -57,6 +57,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepErrorCodes.PREP_TEDDY_ERROR_CODE;
+
 @Component
 public class TeddyImpl {
   private static Logger LOGGER = LoggerFactory.getLogger(TeddyImpl.class);
@@ -72,7 +74,7 @@ public class TeddyImpl {
   @Autowired
   PrepProperties prepProperties;
 
-  @Autowired
+  @Autowired(required = false)
   StorageProperties storageProperties;
 
   public void checkNonAlphaNumericalColNames(String dsId) throws IllegalColumnNameForHiveException {
@@ -309,7 +311,7 @@ public class TeddyImpl {
       stmt = conn.createStatement();
     } catch (SQLException e) {
       e.printStackTrace();
-      throw PrepException.create(PrepErrorCodes.PREP_TEDDY_ERROR_CODE, e);
+      throw PrepException.create(PREP_TEDDY_ERROR_CODE, e);
     }
 
     DataFrame df = new DataFrame(dsName);   // join, union등에서 dataset 이름을 제공하기위해 dsName 추가
@@ -318,10 +320,10 @@ public class TeddyImpl {
       df.setByJDBC(stmt, sql, prepProperties.getSamplingLimitRows());
     } catch (JdbcTypeNotSupportedException e) {
       LOGGER.error("loadHiveDataset(): JdbcTypeNotSupportedException occurred", e);
-      throw PrepException.create(PrepErrorCodes.PREP_TEDDY_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_TEDDY_NOT_SUPPORTED_TYPE);
+      throw PrepException.create(PREP_TEDDY_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_TEDDY_NOT_SUPPORTED_TYPE);
     } catch (JdbcQueryFailedException e) {
       LOGGER.error("loadHiveDataset(): JdbcQueryFailedException occurred", e);
-      throw PrepException.create(PrepErrorCodes.PREP_TEDDY_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_TEDDY_QUERY_FAILED);
+      throw PrepException.create(PREP_TEDDY_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_TEDDY_QUERY_FAILED);
     }
 
     return createStage0(dsId, df);
@@ -346,10 +348,10 @@ public class TeddyImpl {
       df.setByJDBC(stmt, sql, prepProperties.getSamplingLimitRows());
     } catch (JdbcTypeNotSupportedException e) {
       LOGGER.error("loadContentsByImportedJdbc(): JdbcTypeNotSupportedException occurred", e);
-      throw PrepException.create(PrepErrorCodes.PREP_TEDDY_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_TEDDY_NOT_SUPPORTED_TYPE);
+      throw PrepException.create(PREP_TEDDY_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_TEDDY_NOT_SUPPORTED_TYPE);
     } catch (JdbcQueryFailedException e) {
       LOGGER.error("loadContentsByImportedJdbc(): JdbcQueryFailedException occurred", e);
-      throw PrepException.create(PrepErrorCodes.PREP_TEDDY_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_TEDDY_QUERY_FAILED);
+      throw PrepException.create(PREP_TEDDY_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_TEDDY_QUERY_FAILED);
     }
 
     return createStage0(dsId, df);

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourceService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourceService.java
@@ -114,7 +114,7 @@ public class DataSourceService {
   @Autowired
   DataSourceProperties dataSourceProperties;
 
-  @Autowired
+  @Autowired(required = false)
   StorageProperties storageProperties;
 
   /**
@@ -416,8 +416,7 @@ public class DataSourceService {
             DataSource.SourceType.SNAPSHOT
         };
 
-        boolean supportStageDB = storageProperties.getStagedb() != null;
-        if(supportStageDB){
+        if(storageProperties != null && storageProperties.getStagedb() != null){
           srcTypes = ArrayUtils.add(srcTypes, 2, DataSource.SourceType.HIVE);
         }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/ingestion/job/IngestionJobRunner.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/ingestion/job/IngestionJobRunner.java
@@ -94,7 +94,7 @@ public class IngestionJobRunner {
   @Autowired
   private EngineProperties engineProperties;
 
-  @Autowired
+  @Autowired(required = false)
   private StorageProperties storageProperties;
 
   @Autowired

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/MetadataEventHandler.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/MetadataEventHandler.java
@@ -62,7 +62,7 @@ public class MetadataEventHandler {
   @Autowired
   EngineProperties engineProperties;
 
-  @Autowired
+  @Autowired(required = false)
   StorageProperties storageProperties;
 
   @HandleBeforeCreate
@@ -180,11 +180,10 @@ public class MetadataEventHandler {
       String schema = metadataSource.getSchema();
       String tableName = metadataSource.getTable();
 
-      StorageProperties.StageDBConnection stageDBConnection = storageProperties.getStagedb();
-
-      if (stageDBConnection == null) {
-        throw new IllegalArgumentException("Staging Hive DB info. required.");
+      if(storageProperties == null || storageProperties.getStagedb() == null) {
+        throw new IllegalArgumentException("Staging database information required.");
       }
+      StorageProperties.StageDBConnection stageDBConnection = storageProperties.getStagedb();
 
       DataConnection hiveConnection = new DataConnection();
       hiveConnection.setUrl(stageDBConnection.getUrl());

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/storage/StorageController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/storage/StorageController.java
@@ -28,7 +28,7 @@ public class StorageController {
 
   private static Logger LOGGER = LoggerFactory.getLogger(StorageController.class);
 
-  @Autowired
+  @Autowired(required = false)
   StorageProperties storageProperties;
 
   @RequestMapping(value = "/storage/{storageType}", method = RequestMethod.GET)
@@ -36,10 +36,11 @@ public class StorageController {
 
     switch (storageType){
       case STAGEDB:
-        StorageProperties.StageDBConnection stageDBConnection = storageProperties.getStagedb();
-        if(stageDBConnection == null){
+        if(storageProperties == null || storageProperties.getStagedb() == null) {
           return ResponseEntity.noContent().build();
         }
+        StorageProperties.StageDBConnection stageDBConnection = storageProperties.getStagedb();
+
         return ResponseEntity.ok(stageDBConnection);
       default:
         throw new IllegalArgumentException("Not supported type " + storageType);

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/storage/StorageProperties.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/storage/StorageProperties.java
@@ -48,18 +48,7 @@ public class StorageProperties {
 
   @PostConstruct
   public void init() {
-
-//    if(stagedb == null) {
-//      this.stagedb = new StageDBConnection();
-//      stagedb.setHostname("localhost");
-//      stagedb.setPort(10000);
-//      stagedb.setUsername("hive");
-//      stagedb.setPassword("hive");
-//      MetaStoreProperties metaStoreProperties = new MetaStoreProperties();
-//      metaStoreProperties.setUri("thrift://localhost:9083");
-//      stagedb.setMetastore(metaStoreProperties);
-//    }
-    // 설정 하위 호환을 위하여 처리
+    // For the Backwards compatibility.
     if(stagedb.getMetastore() == null) {
       stagedb.setMetastore(new MetaStoreProperties(stagedb.getMetastoreUri(),
                                                    stagedb.getMetastoreHost(),

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/storage/StorageProperties.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/storage/StorageProperties.java
@@ -15,6 +15,7 @@
 package app.metatron.discovery.domain.storage;
 
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
@@ -31,6 +32,7 @@ import app.metatron.discovery.domain.dataconnection.dialect.HiveDialect;
 
 @Component
 @ConfigurationProperties(prefix = "polaris.storage")
+@ConditionalOnProperty(value = "polaris.storage")
 public class StorageProperties {
 
   public enum StorageType{
@@ -46,6 +48,17 @@ public class StorageProperties {
 
   @PostConstruct
   public void init() {
+
+//    if(stagedb == null) {
+//      this.stagedb = new StageDBConnection();
+//      stagedb.setHostname("localhost");
+//      stagedb.setPort(10000);
+//      stagedb.setUsername("hive");
+//      stagedb.setPassword("hive");
+//      MetaStoreProperties metaStoreProperties = new MetaStoreProperties();
+//      metaStoreProperties.setUri("thrift://localhost:9083");
+//      stagedb.setMetastore(metaStoreProperties);
+//    }
     // 설정 하위 호환을 위하여 처리
     if(stagedb.getMetastore() == null) {
       stagedb.setMetastore(new MetaStoreProperties(stagedb.getMetastoreUri(),


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Make runnable without the staging db configuration.

Related properties key is
- polaris.storage

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#2179 


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Delete polaris.storage properties in your 'application.yaml'
2. Run Metatron Discovery
3. Run normally

#### Need additional checks?
Changed the condition of the classes that autowiring the StorageProperties.
(Especially in the data preparation and data connection)
Please check related logic @joohokim1 @ufoscw  😄 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
**It is configured in the 'local' profile, so a user who not using the 'local' profile can run.**