### PR TITLE
#2176 fix infinite loop when list is empty

### DIFF
--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow.component.ts
@@ -12,15 +12,23 @@
  * limitations under the License.
  */
 
-import { Component, ElementRef, OnInit, Injector, ViewChild, OnDestroy, HostListener } from '@angular/core';
-import { AbstractComponent } from '../../common/component/abstract.component';
-import { DataflowService } from './service/dataflow.service';
-import { PrDataflow } from '../../domain/data-preparation/pr-dataflow';
-import { Modal } from '../../common/domain/modal';
-import { DeleteModalComponent } from '../../common/component/modal/delete/delete.component';
-import { Alert } from '../../common/util/alert.util';
-import { MomentDatePipe } from '../../common/pipe/moment.date.pipe';
-import { CreateDataflowNameDescComponent } from './create-dataflow-name-desc.component';
+import {
+  Component,
+  ElementRef,
+  HostListener,
+  Injector,
+  OnDestroy,
+  OnInit,
+  ViewChild
+} from '@angular/core';
+import {AbstractComponent} from '../../common/component/abstract.component';
+import {DataflowService} from './service/dataflow.service';
+import {PrDataflow} from '../../domain/data-preparation/pr-dataflow';
+import {Modal} from '../../common/domain/modal';
+import {DeleteModalComponent} from '../../common/component/modal/delete/delete.component';
+import {Alert} from '../../common/util/alert.util';
+import {MomentDatePipe} from '../../common/pipe/moment.date.pipe';
+import {CreateDataflowNameDescComponent} from './create-dataflow-name-desc.component';
 import {isNullOrUndefined} from "util";
 import {StringUtil} from "../../common/util/string.util";
 import {ActivatedRoute} from "@angular/router";
@@ -230,8 +238,8 @@ export class DataflowComponent extends AbstractComponent implements OnInit, OnDe
 
       // 현재 페이지에 아이템이 없다면 전 페이지를 불러온다
       if (this.page.page > 0 &&
-        isNullOrUndefined(data['_embedded']) ||
-        (!isNullOrUndefined(data['_embedded']) && data['_embedded'].preparationdataflows.length === 0))
+        (isNullOrUndefined(data['_embedded']) ||
+          (!isNullOrUndefined(data['_embedded']) && data['_embedded'].preparationdatasets.length === 0)))
       {
         this.page.page = data['page'].number - 1;
         this.getDataflows();

--- a/discovery-frontend/src/app/data-preparation/dataset/dataset.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataset/dataset.component.ts
@@ -180,8 +180,8 @@ export class DatasetComponent extends AbstractComponent implements OnInit {
 
         // 현재 페이지에 아이템이 없다면 전 페이지를 불러온다
         if (this.page.page > 0 &&
-          isNullOrUndefined(data['_embedded']) ||
-          (!isNullOrUndefined(data['_embedded']) && data['_embedded'].preparationdatasets.length === 0))
+          (isNullOrUndefined(data['_embedded']) ||
+          (!isNullOrUndefined(data['_embedded']) && data['_embedded'].preparationdatasets.length === 0)))
         {
           this.page.page = data['page'].number - 1;
           this.getDatasets();


### PR DESCRIPTION
### Description
When the list of dataset, dataflow is empty, an infinite loop occurs.

**Related Issue** : #2176 
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Make the list of dataset, dataflow empty.
2. Go to the list.
3. An infinite loop does not occur.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
