### PR TITLE
#2168 DataSource for webSocket is not existed

### DIFF
--- a/discovery-frontend/src/app/workbench/workbench.component.ts
+++ b/discovery-frontend/src/app/workbench/workbench.component.ts
@@ -1311,6 +1311,11 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
       .catch((error) => {
         this.isExecutingQuery = false;
         this.loadingBar.hide();
+
+        if(error.code && error.code === "WB0002") {
+          this.stomp.initAndConnect();
+        }
+
         if (!isUndefined(error.details) && this._executeSqlReconnectCnt <= 5) {
           this.webSocketCheck(() => {
             this.setExecuteSql(param);
@@ -1406,6 +1411,11 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
       .catch((error) => {
         this.isExecutingQuery = false;
         this.loadingBar.hide();
+
+        if(error.code && error.code === "WB0002") {
+          this.stomp.initAndConnect();
+        }
+
         if (!isUndefined(error.details) && this._executeSqlReconnectCnt <= 5) {
           this.webSocketCheck(() => {
             this.retryQuery(item);


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
서버 재 시작으로 워크벤치에서 웹 소켓 아이디로 연결된 데이터소스 커넥션이 존재하지 않는 경우 사용자가에게 알림으로 표시하고 페이지를 새로고침하여 새로운 웹 소켓 아이디에 데이터소스 커넥션을 생성하도록 수정하였습니다.

사용자에게 알림 메시지와 처리 방식은 AbstractComponent.checkAndConnectWebSocket 를 참고하여 구현 하였습니다.
![image](https://user-images.githubusercontent.com/16472109/58856377-7b894980-86dd-11e9-8484-7b2c80633337.png)

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#2168 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
* 워크벤치에서 진입한 상태에서 대기 후 메타트론 서버를 재시작 후 쿼리를 다시 실행 하였을 때 알림 메시지와 페이지가 새로고침 되고 쿼리가 정상적으로 실행 되는 것을 테스트 하였습니다.
* 위와 동일한 상황에서 워크벤치 쿼리 "Retry"를 테스트 하였습니다.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
