### PR TITLE
#fn fill all fields of DataConnection class while dataset creation

### DIFF
--- a/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-db-query.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-db-query.component.ts
@@ -713,7 +713,9 @@ export class CreateDatasetDbQueryComponent extends AbstractPopupComponent implem
         this.datasetJdbc.dataconnection.connection.catalog = connectionInfo.catalog;
       }
 
-      if (this.datasetJdbc.dataconnection.connection.implementor === 'TIBERO' && !connectionInfo.url) {
+      if ( (this.datasetJdbc.dataconnection.connection.implementor === 'TIBERO' || this.datasetJdbc.dataconnection.connection.implementor === 'ORACLE')
+            && !connectionInfo.url) {
+
         this.datasetJdbc.dataconnection.connection.sid = connectionInfo.sid;
       }
 


### PR DESCRIPTION
### Description
There is a missing field while creating a dataset of Oracle connection.
so dataset creation was failed

**Related Issue** : None


### How Has This Been Tested?
If you can create a dataset of Oracle connection with no error, it is OK

#### Need additional checks?
make sure that you are using an extension for oracle connection

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
