### PR TITLE
#fn changed the query to retrieve table information

### DIFF
--- a/discovery-extensions/oracle-connection/src/main/java/app/metatron/discovery/OracleConnectionExtension.java
+++ b/discovery-extensions/oracle-connection/src/main/java/app/metatron/discovery/OracleConnectionExtension.java
@@ -291,15 +291,14 @@ public class OracleConnectionExtension extends Plugin {
     @Override
     public String getTableDescQuery(JdbcConnectInformation connectInfo, String catalog, String schema, String table) {
       StringBuilder builder = new StringBuilder();
-      builder.append(" SELECT S.OWNER, S.SEGMENT_NAME, S.BYTES / 1024 KB, S.BYTES/1024/1024 MB, T.NUM_ROWS ");
-      builder.append(" FROM DBA_SEGMENTS S ");
-      builder.append("   INNER JOIN ALL_TABLES T ON S.SEGMENT_NAME = T.TABLE_NAME ");
+      builder.append(" SELECT * ");
+      builder.append(" FROM ALL_TABLES T ");
       builder.append(" WHERE 1=1 ");
       if(StringUtils.isNotEmpty(schema)){
-        builder.append(" AND S.OWNER = UPPER('" + schema + "') ");
+        builder.append(" AND T.OWNER = UPPER('" + schema + "') ");
       }
       if(StringUtils.isNotEmpty(table)){
-        builder.append(" AND S.SEGMENT_NAME = UPPER('" + table + "') ");
+        builder.append(" AND T.TABLE_NAME = UPPER('" + table + "') ");
       }
       return builder.toString();
     }


### PR DESCRIPTION
### Description
When retrieving additional information from an Oracle table, the query was modified because of a permissions problem.

**Related Issue** : 


### How Has This Been Tested?
1. create oracle workbench
2. open scheam browser
3. see information tab without error

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
