### PR TITLE
Fixed a problem where the create widget button was hidden

### DIFF
--- a/discovery-frontend/src/app/dashboard/widgets/filter-widget/filter-widget.component.html
+++ b/discovery-frontend/src/app/dashboard/widgets/filter-widget/filter-widget.component.html
@@ -12,7 +12,7 @@
   ~ limitations under the License.
   -->
 
-<div class="ddp-box-widget" >
+<div class="ddp-box-widget" (mouseleave)="mouseoutWidget()">
   <!-- Top Control -->
   <div *ngIf="isAuthMgmtViewMode" class="ddp-top-control ddp-clear"
        [ngStyle]="{'margin-right': isVisibleScrollbar ? '20px' : '' }">

--- a/discovery-frontend/src/app/dashboard/widgets/filter-widget/filter-widget.component.ts
+++ b/discovery-frontend/src/app/dashboard/widgets/filter-widget/filter-widget.component.ts
@@ -229,6 +229,24 @@ export class FilterWidgetComponent extends AbstractWidgetComponent implements On
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Public Method
    |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
+  /**
+   * 마우스가 벗어남
+   */
+  public mouseoutWidget() {
+
+    if (this.filterSelectComponent && this.filterSelectComponent.isShowSelectList ) {
+      this.filterSelectComponent.isShowSelectList = false;
+      this.safelyDetectChanges();
+      this.toggleOptionsSelectComp(false);
+    }
+
+    if (this.filterMultiSelectComponent && this.filterMultiSelectComponent.isShowSelectList) {
+      this.filterMultiSelectComponent.isShowSelectList = false;
+      this.safelyDetectChanges();
+      this.toggleOptionsSelectComp(false);
+    }
+
+  } // function - mouseoutWidget
 
   /**
    * 위젯 설정 변경
@@ -361,7 +379,7 @@ export class FilterWidgetComponent extends AbstractWidgetComponent implements On
       filter.valueList.push(item.name);
     } else if (filter.selector === InclusionSelectorType.MULTI_LIST) {
       // 멀티 리스트
-      if (-1 === filter.valueList.indexOf( item.name ) ) {
+      if (-1 === filter.valueList.indexOf(item.name)) {
         filter.valueList.push(item.name);
       } else {
         const idx = filter.valueList.indexOf(item.name);


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
대시보드 열람 화면에서 위젯 생성 버튼이 위젯에 숨겨지는 문제가 있습니다.
![image](https://user-images.githubusercontent.com/3685833/59236182-f3042f00-8c2f-11e9-8c35-2d3cc2aff769.png)


**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 셀렉트박스 형태의 필터 위젯이 우측 상단에 위치한 대시보드를 생성합니다.
2.대시보드 열람화면에서 필터의 셀렉트박스를 펼친 후 우측 상단의 위젯 생성 버튼으로 마우스를 위치합니다.
3. 필터 위젯의 셀렉트 박스가 닫히고 위젯 생성 버튼이 정상적으로 표시되는지 확인합니다.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
