### PR TITLE
#fn represent selected cols when the col-name is enclosed in quotation marks

### DIFF
--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-settype.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-settype.component.ts
@@ -374,7 +374,12 @@ export class EditRuleSettypeComponent extends EditRuleComponent implements OnIni
 
     // COLUMN
     let arrFields:string[] = data.jsonRuleString.col;
-    this.selectedFields = arrFields.map( item => this.fields.find( orgItem => orgItem.name === item ) ).filter(field => !!field);
+    this.selectedFields = arrFields.map( item => {
+      if(item.length>2 && item.startsWith('`') && item.endsWith('`')) {
+        item = item.substring(1,item.length-1);
+      }
+      return this.fields.find( orgItem => orgItem.name === item );
+    } ).filter(field => !!field);
 
     // TYPE
     this.selectedType = data.jsonRuleString.type.toLowerCase();


### PR DESCRIPTION
### Description
While auto-typing is working,
The JsonRuleString of Set-Type rule can have column name is enclosed in "`"

**Related Issue** : None

### How Has This Been Tested?
1. create a dataset of number type fields -> auto-typing is working
2. create a dataflow and make a wrangled dataset 
3. click edit button of the set-type rule in rule tab. 
4. make sure the column names of the select box is checked

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
