### PR TITLE
#1539 Fix css in metadata create step

### DIFF
--- a/discovery-frontend/src/app/meta-data-management/metadata/create-metadata/component/metadata-control-complete.component.html
+++ b/discovery-frontend/src/app/meta-data-management/metadata/create-metadata/component/metadata-control-complete.component.html
@@ -11,45 +11,47 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<div class="ddp-ui-sheet-list ddp-flex-column">
-  <table class="ddp-table-sheet">
-    <colgroup>
-      <col width="250px">
-      <col width="330px">
-      <col width="*">
-    </colgroup>
-    <thead>
-    <tr>
-      <th>{{'msg.metadata.th.create.table' | translate}}</th>
-      <th>{{'msg.metadata.th.create.name' | translate}}</th>
-      <th>{{'msg.metadata.th.create.description' | translate}}</th>
-    </tr>
-    </thead>
-    <tbody>
-    <tr *ngFor="let metadata of metadataList">
-      <td>
-        {{metadata.table}}
-      </td>
-      <td>
-        <div class="ddp-sheet-form">
-          <input type="text" class="ddp-input-typebasic" placeholder="{{metadata.table}}" [ngModel]="metadata.name" (ngModelChange)="onChangeMetadataName(metadata, $event)">
-          <span class="ddp-data-error" *ngIf="isErrorMetadataName(metadata)"> {{metadata.errorMessage}}</span>
-        </div>
-      </td>
-      <td>
-        <div class="ddp-sheet-form">
-          <div class="ddp-textarea-resize">
+<div class="ddp-sheet-table type-info">
+  <div class="ddp-ui-sheet-list ">
+    <table class="ddp-table-sheet">
+      <colgroup>
+        <col width="250px">
+        <col width="330px">
+        <col width="*">
+      </colgroup>
+      <thead>
+      <tr>
+        <th>{{'msg.metadata.th.create.table' | translate}}</th>
+        <th>{{'msg.metadata.th.create.name' | translate}}</th>
+        <th>{{'msg.metadata.th.create.description' | translate}}</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr *ngFor="let metadata of metadataList">
+        <td>
+          {{metadata.table}}
+        </td>
+        <td>
+          <div class="ddp-sheet-form">
+            <input type="text" class="ddp-input-typebasic" placeholder="{{metadata.table}}" [ngModel]="metadata.name" (ngModelChange)="onChangeMetadataName(metadata, $event)">
+            <span class="ddp-data-error" *ngIf="isErrorMetadataName(metadata)"> {{metadata.errorMessage}}</span>
+          </div>
+        </td>
+        <td>
+          <div class="ddp-sheet-form">
+            <div class="ddp-textarea-resize">
           <textarea  placeholder="{{'msg.metadata.ph.create.description' | translate}}" #descriptionElement
                      [ngModel]="metadata.description" (ngModelChange)="onChangeMetadataDescription(metadata, $event)" (keyup)="changeDescriptionHeight(descriptionElement)">
           </textarea>
+            </div>
+            <!--                <span class="ddp-data-error"> Invalid Connect</span>-->
           </div>
-          <!--                <span class="ddp-data-error"> Invalid Connect</span>-->
-        </div>
 
-      </td>
-    </tr>
-    </tbody>
-  </table>
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </div>
 </div>
 <div class="ddp-box-synch type-error" *ngIf="!isEmptyMetadataList() && isErrorInMetadataList()">
   <div class="ddp-txt-synch">

--- a/discovery-frontend/src/app/meta-data-management/metadata/create-metadata/component/schema-select-box.component.ts
+++ b/discovery-frontend/src/app/meta-data-management/metadata/create-metadata/component/schema-select-box.component.ts
@@ -14,7 +14,15 @@
  */
 
 import {AbstractComponent} from "../../../../common/component/abstract.component";
-import {Component, ElementRef, EventEmitter, HostListener, Injector, Input, Output} from "@angular/core";
+import {
+  Component,
+  ElementRef,
+  EventEmitter,
+  HostListener,
+  Injector,
+  Input,
+  Output,
+} from "@angular/core";
 import * as _ from 'lodash';
 import {StringUtil} from "../../../../common/util/string.util";
 import {CommonUtil} from "../../../../common/util/common.util";
@@ -28,6 +36,7 @@ export class SchemaSelectBoxComponent extends AbstractComponent {
   @Input() readonly isDisableSelect: boolean;
   @Input() readonly isEnableWindowResizeAutoClose: boolean;
   @Input() readonly isEnableSearch: boolean;
+  @Input() readonly isEnableAutoShowList: boolean;
 
   @Input() readonly schemaList: string[];
   @Input() selectedSchema: string;
@@ -54,6 +63,12 @@ export class SchemaSelectBoxComponent extends AbstractComponent {
     super.ngOnInit();
     this.pageResult.number = 0;
     this.pageResult.size = 20;
+  }
+
+  ngAfterViewInit() {
+    if (this.isEnableAutoShowList && this.isEmptySelectedSchema()) {
+      setTimeout(() => { this.isShowList = true})
+    }
   }
 
   /**

--- a/discovery-frontend/src/app/meta-data-management/metadata/create-metadata/create-metadata-db-complete.component.html
+++ b/discovery-frontend/src/app/meta-data-management/metadata/create-metadata/create-metadata-db-complete.component.html
@@ -24,7 +24,7 @@
     </div>
   </div>
   <div class="ddp-type-contents-in ddp-sheet-resize">
-    <div class="ddp-box-popupcontents ddp-wrap-file-create ddp-flex">
+    <div class="ddp-box-popupcontents type-metadata">
       <div class="ddp-wrap-boxtype ddp-flex-column">
         <table class="ddp-wrap-boxdata">
           <colgroup>

--- a/discovery-frontend/src/app/meta-data-management/metadata/create-metadata/create-metadata-db-select.component.html
+++ b/discovery-frontend/src/app/meta-data-management/metadata/create-metadata/create-metadata-db-select.component.html
@@ -50,7 +50,7 @@
         <!-- edit -->
         <div class="ddp-wrap-edit3 ddp-type">
           <label class="ddp-label-type ddp-bold ">
-            스키마 선택
+            {{'msg.metadata.ui.select.schema' | translate}}
           </label>
           <!-- edit option -->
           <div class="ddp-ui-edit-option">

--- a/discovery-frontend/src/app/meta-data-management/metadata/create-metadata/create-metadata-db-select.component.html
+++ b/discovery-frontend/src/app/meta-data-management/metadata/create-metadata/create-metadata-db-select.component.html
@@ -91,7 +91,7 @@
   <div class="ddp-ui-buttons">
     <a href="javascript:" class="ddp-btn-type-popup" (click)="changeToPrevStep()">{{'msg.comm.btn.previous' | translate}}</a>
     <!-- disabled 시 ddp-disabled 추가 -->
-    <a href="javascript:" class="ddp-btn-type-popup ddp-bg-black" (click)="changeToNextStep()">{{'msg.comm.btn.next' | translate}}</a>
+    <a href="javascript:" class="ddp-btn-type-popup ddp-bg-black" [class.ddp-disabled]="!isEnableNext()" (click)="changeToNextStep()">{{'msg.comm.btn.next' | translate}}</a>
   </div>
   <!-- //buttons -->
 

--- a/discovery-frontend/src/app/meta-data-management/metadata/create-metadata/create-metadata-db-select.component.html
+++ b/discovery-frontend/src/app/meta-data-management/metadata/create-metadata/create-metadata-db-select.component.html
@@ -59,6 +59,7 @@
               <schema-select-box [schemaList]="schemaList"
                                  [selectedSchema]="selectedSchema"
                                  [isEnableWindowResizeAutoClose]="true"
+                                 [isEnableAutoShowList]="true"
                                  (changedSchema)="onChangeSelectedSchema($event)"></schema-select-box>
             </div>
           </div>

--- a/discovery-frontend/src/app/meta-data-management/metadata/create-metadata/create-metadata-db-select.component.ts
+++ b/discovery-frontend/src/app/meta-data-management/metadata/create-metadata/create-metadata-db-select.component.ts
@@ -102,7 +102,7 @@ export class CreateMetadataDbSelectComponent extends AbstractComponent {
   }
 
   changeToNextStep(): void {
-    if (this._isEnableNext()) {
+    if (this.isEnableNext()) {
       if (this.createData.isNotEmptySchemaInfo() && this._isChangedSchema()) {
         this.createData.removeCompleteInfo();
       }
@@ -111,16 +111,16 @@ export class CreateMetadataDbSelectComponent extends AbstractComponent {
     }
   }
 
-  private _isChangedSchema(): boolean {
-    return this.createData.schemaInfo.selectedSchema !== this.selectedSchema;
-  }
-
-  private _isEnableNext() {
+  isEnableNext(): boolean {
     return !_.isNil(this.selectedSchema) && !_.isNil(this._tableListComponent) && !this._tableListComponent.isEmptyCheckedTableList();
   }
 
   isEmptyTableList(): boolean {
     return _.isNil(this.tableList) || this.tableList.length === 0;
+  }
+
+  private _isChangedSchema(): boolean {
+    return this.createData.schemaInfo.selectedSchema !== this.selectedSchema;
   }
 
   /**

--- a/discovery-frontend/src/app/meta-data-management/metadata/create-metadata/create-metadata-staging-complete.component.html
+++ b/discovery-frontend/src/app/meta-data-management/metadata/create-metadata/create-metadata-staging-complete.component.html
@@ -24,7 +24,7 @@
     </div>
   </div>
   <div class="ddp-type-contents-in ddp-sheet-resize">
-    <div class="ddp-box-popupcontents ddp-wrap-file-create ddp-flex">
+    <div class="ddp-box-popupcontents type-metadata">
       <div class="ddp-wrap-boxtype ddp-flex-column">
         <table class="ddp-wrap-boxdata">
           <colgroup>

--- a/discovery-frontend/src/app/meta-data-management/metadata/create-metadata/create-metadata-staging-select.component.html
+++ b/discovery-frontend/src/app/meta-data-management/metadata/create-metadata/create-metadata-staging-select.component.html
@@ -50,7 +50,7 @@
         <!-- edit -->
         <div class="ddp-wrap-edit3 ddp-type">
           <label class="ddp-label-type ddp-bold ">
-            스키마 선택
+            {{'msg.metadata.ui.select.schema' | translate}}
           </label>
           <!-- edit option -->
           <div class="ddp-ui-edit-option">

--- a/discovery-frontend/src/app/meta-data-management/metadata/create-metadata/create-metadata-staging-select.component.html
+++ b/discovery-frontend/src/app/meta-data-management/metadata/create-metadata/create-metadata-staging-select.component.html
@@ -91,7 +91,7 @@
   <div class="ddp-ui-buttons">
     <a href="javascript:" class="ddp-btn-type-popup" (click)="onCancel()">{{'msg.comm.btn.cancl' | translate}}</a>
     <!-- disabled 시 ddp-disabled 추가 -->
-    <a href="javascript:" class="ddp-btn-type-popup ddp-bg-black" (click)="changeToNextStep()">{{'msg.comm.btn.next' | translate}}</a>
+    <a href="javascript:" class="ddp-btn-type-popup ddp-bg-black" [class.ddp-disabled]="!isEnableNext()" (click)="changeToNextStep()">{{'msg.comm.btn.next' | translate}}</a>
   </div>
   <!-- //buttons -->
 

--- a/discovery-frontend/src/app/meta-data-management/metadata/create-metadata/create-metadata-staging-select.component.html
+++ b/discovery-frontend/src/app/meta-data-management/metadata/create-metadata/create-metadata-staging-select.component.html
@@ -59,6 +59,7 @@
               <schema-select-box [schemaList]="schemaList"
                                  [selectedSchema]="selectedSchema"
                                  [isEnableWindowResizeAutoClose]="true"
+                                 [isEnableAutoShowList]="true"
                                  (changedSchema)="onChangeSelectedSchema($event)"></schema-select-box>
             </div>
           </div>

--- a/discovery-frontend/src/app/meta-data-management/metadata/create-metadata/create-metadata-staging-select.component.ts
+++ b/discovery-frontend/src/app/meta-data-management/metadata/create-metadata/create-metadata-staging-select.component.ts
@@ -96,7 +96,7 @@ export class CreateMetadataStagingSelectComponent extends AbstractComponent {
   }
 
   changeToNextStep(): void {
-    if (this._isEnableNext()) {
+    if (this.isEnableNext()) {
       if (this.createData.isNotEmptySchemaInfo() && this._isChangedSchema()) {
         this.createData.removeCompleteInfo();
       }
@@ -105,16 +105,16 @@ export class CreateMetadataStagingSelectComponent extends AbstractComponent {
     }
   }
 
-  private _isChangedSchema(): boolean {
-    return this.createData.schemaInfo.selectedSchema !== this.selectedSchema;
-  }
-
-  private _isEnableNext() {
+  isEnableNext(): boolean {
     return !_.isNil(this.selectedSchema) && !_.isNil(this._tableListComponent) && !this._tableListComponent.isEmptyCheckedTableList();
   }
 
   isEmptyTableList(): boolean {
     return _.isNil(this.tableList) || this.tableList.length === 0;
+  }
+
+  private _isChangedSchema(): boolean {
+    return this.createData.schemaInfo.selectedSchema !== this.selectedSchema;
   }
 
   /**

--- a/discovery-frontend/src/app/meta-data-management/metadata/metadata.component.html
+++ b/discovery-frontend/src/app/meta-data-management/metadata/metadata.component.html
@@ -87,8 +87,8 @@
       <col width="*">
       <col width="150px">
       <col width="150px">
-      <col width="300px">
-      <col width="300px">
+      <col width="200px">
+      <col width="250px">
     </colgroup>
     <thead>
     <tr>

--- a/discovery-frontend/src/assets/css/polaris.v2.page.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.page.css
@@ -5896,6 +5896,9 @@ table.ddp-table-union tr td .ddp-data-dropped strong {color:#666eb2; font-weight
 
 .ddp-box-upload {height:70px; padding:0 140px 0 29px; margin-bottom:5px; background-color:#f6f6f7;}
 .ddp-wrap-file-create {width:880px;}
+.popup-prep-create-complete .type-metadata .ddp-wrap-boxtype  {height:auto; min-height:160px; max-height:160px; margin-bottom:0px; }
+.popup-prep-create-complete .type-metadata .ddp-sheet-table {margin-top:-192px; padding-top:202px; padding-bottom:10px; height:100%; box-sizing:border-box;}
+.popup-prep-create-complete .type-metadata .ddp-sheet-table.type-info {margin-top:-223px; padding-top:233px;}
 .ddp-box-popupcontents.ddp-flex {display:flex;flex-direction: column;}
 .ddp-box-popupcontents.ddp-flex .ddp-flex-column { margin-bottom:10px;}
 .ddp-box-popupcontents.ddp-flex .ddp-wrap-boxtype.ddp-flex-column {height:auto; min-height:auto; max-height:auto; overflow-y:inherit}

--- a/discovery-frontend/src/assets/i18n/en.json
+++ b/discovery-frontend/src/assets/i18n/en.json
@@ -3911,6 +3911,7 @@
   "msg.metadata.ui.no.db.list" : "No DB connection",
   "msg.metadata.ui.no.col.dic" : "No column dictionary",
   "msg.metadata.ui.no.code.table" : "No code table",
+  "msg.metadata.ui.select.schema" : "Select schema",
   "msg.metadata.ui.title" : "Metadata",
   "msg.metadata.ui.codetable.title" : "Code Table",
   "msg.metadata.ui.dictionary.title" : "Column Dictionary",

--- a/discovery-frontend/src/assets/i18n/ko.json
+++ b/discovery-frontend/src/assets/i18n/ko.json
@@ -3912,6 +3912,7 @@
   "msg.metadata.ui.no.db.list" : "DB 커넥션이 없습니다",
   "msg.metadata.ui.no.col.dic" : "컬럼 사전이 없습니다",
   "msg.metadata.ui.no.code.table" : "코드 테이블이 없습니다",
+  "msg.metadata.ui.select.schema" : "스키마 선택",
   "msg.metadata.ui.title" : "메타 데이터",
   "msg.metadata.ui.codetable.title" : "코드 테이블",
   "msg.metadata.ui.dictionary.title" : "용어 사전",

--- a/discovery-frontend/src/assets/i18n/zh.json
+++ b/discovery-frontend/src/assets/i18n/zh.json
@@ -2971,6 +2971,7 @@
   "msg.metadata.ui.no.db.list" : "No DB connection",
   "msg.metadata.ui.no.col.dic" : "No column dictionary",
   "msg.metadata.ui.no.code.table" : "No code table",
+  "msg.metadata.ui.select.schema" : "Select schema",
   "msg.metadata.ui.title": "元数据",
   "msg.metadata.ui.codetable.title": "代码表",
   "msg.metadata.ui.dictionary.title": "列字典",


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
메타데이터 생성시 테이블 선택을 하지않은 경우 '다음' 버튼이 비활성화 되도록 수정
저해상도의 환경에서 메타데이터 목록을 볼때 name의 width가 사리지지 않도록 수정

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#1539 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 메타데이터 생성 >  테이블 선택 단계에서 테이블을 선택하지 않을 경우 하단의 '다음' 버튼이 비활성화 되는지 확인
2. 저해상도 환경에서 메타데이터 목록 화면을 볼 때, name이 사라지지 않는지 확인 
(고해상도에서 브라우저 창의 가로폭을 줄여서 확인)

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
