### PR TITLE
#1920 Fix edit field name and css in datasource create step

### DIFF
--- a/discovery-frontend/src/app/data-storage/component/schema-configure/schema-configure-field.component.ts
+++ b/discovery-frontend/src/app/data-storage/component/schema-configure/schema-configure-field.component.ts
@@ -574,6 +574,10 @@ export class SchemaConfigureFieldComponent extends AbstractComponent {
       field.isInvalidName = true;
       return false;
     }
+    // is same prev name
+    else if (Field.isNameEqualEditName(field)) {
+      return true;
+    }
     // check column name length
     else if (!Field.isEnableFieldEditNameLength(field)) {
       field.invalidNameMessage = this.translateService.instant('msg.storage.ui.file.result.FV004');

--- a/discovery-frontend/src/app/domain/datasource/datasource.ts
+++ b/discovery-frontend/src/app/domain/datasource/datasource.ts
@@ -260,6 +260,11 @@ export class Field {
     return StringUtil.isEmpty(field.editName);
   }
 
+  public static isNameEqualEditName(field: Field): boolean {
+    return field.name === field.editName.trim();
+  }
+
+
   public static isDisableFieldEditNameCharacter(field: Field): boolean {
     return (/^[!@#$%^*+=()~`\{\}\[\]\-\_\;\:\'\"\,\.\/\?\<\>\|\&\\]+$/gi).test(field.editName) || (/[\s\r\n]/gi).test(field.editName);
   }

--- a/discovery-frontend/src/assets/css/polaris.v2.page.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.page.css
@@ -7312,7 +7312,6 @@ table.ddp-table-view tbody tr.ddp-selected td {padding:2px 10px 3px 10px; border
 table.ddp-table-view tbody tr.ddp-selected td:first-of-type {padding-left:9px; border-left:1px solid #666eb2;}
 table.ddp-table-view tbody tr.ddp-selected td:last-of-type {padding-right:9px; border-right:1px solid #666eb2;}
 
-
 table.ddp-table-view tbody tr.ddp-selected td .ddp-icon-view {display:block; }
 table.ddp-table-form tbody tr.ddp-disabled em.ddp-icon-view {display:none;}
 table.ddp-table-form tbody tr.ddp-disabled .ddp-ui-checkbox {display:none;}
@@ -7322,6 +7321,9 @@ table.ddp-table-form tbody tr.ddp-disabled:nth-child(even) td {background-color:
 
 table.ddp-table-form tbody tr.ddp-disabled:nth-child(odd) td:first-of-type {border-left:1px solid #fafafa;}
 table.ddp-table-form tbody tr.ddp-disabled:nth-child(odd) td:last-of-type {border-right:1px solid #fafafa;}
+
+table.ddp-table-form tbody tr.ddp-disabled.ddp-selected:nth-child(odd) td:first-of-type {border-left:1px solid #666eb2;}
+table.ddp-table-form tbody tr.ddp-disabled.ddp-selected:nth-child(odd) td:last-of-type {border-right:1px solid #666eb2;}
 
 .ddp-box-viewtable .ddp-ui-gridbody.ddp-action {bottom:103px;}
 .ddp-box-schema.ddp-box-full .ddp-wrap-fleft{width:100%;}

--- a/discovery-frontend/src/assets/css/polaris.v2.page.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.page.css
@@ -7461,7 +7461,7 @@ ul.ddp-list-value li.ddp-total {color:#b7b9c2;}
 .ddp-box-action .ddp-ui-checkaction .ddp-type-selectbox {width:180px;}
 .ddp-box-action a.ddp-btn-line {position:absolute; top:9px; right:9px;}
 
-.ddp-box-viewtable.ddp-selected .ddp-box-action.ddp-type {display:block;}
+.ddp-box-viewtable.ddp-selected .ddp-box-action.ddp-type {display:block; z-index:10;}
 .ddp-box-action.ddp-type {display:none; height:45px;}
 .ddp-box-action.ddp-type .ddp-box-button {clear:both; padding:17px 0 13px 0;text-align:center;}
 .ddp-box-action.ddp-type .ddp-box-button [class*="ddp-btn-"] {position:relative; top:0; right:0; margin:0 2px; vertical-align:middle;}


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
schema configure 단계에서 컬럼 편집을 누르고 수정없이 확인을 누르는 경우 invalid에러가 나는 현상 수정
선택된 컬럼이 삭제되었을때 selected 표시가 깨지는현상 수정
컬럼을 선택후 delete layer popup이 뜰때 undo 아이콘이 popup 위에 뜨는 현상 수정

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#1920 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
schema configure 에서

1. 컬럼편집을 누르고 수정없이 확인을 눌렀을 경우 invalid error가 발생하지 않은채 편집이 닫히는것 확인
2. 선택된 컬럼에서 우측 detail 에서 삭제버튼을 클릭할 경우, selected 표시가 깨지지 않는것 확인
3. undo 아이콘이 하나라도 있을때(삭제된 컬럼이 하나라도 존재하는경우), 다른 컬럼을 체크후 나타나는 하단의 layer에서 delete를 클릭해나오는 layer popup위에 undo 아이콘이 뜨지 않는것 확인

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
