### PR TITLE
#fn apply result object converter to CsvWriter

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcConnectionService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcConnectionService.java
@@ -405,6 +405,7 @@ public class JdbcConnectionService {
     JdbcCSVWriter jdbcCSVWriter = null;
     try {
       jdbcCSVWriter = new JdbcCSVWriter(new FileWriter(tempFileName), CsvPreference.STANDARD_PREFERENCE);
+      jdbcCSVWriter.setJdbcDialect(jdbcDialect);
       jdbcCSVWriter.setConnection(connection);
       jdbcCSVWriter.setQuery(queryString);
       jdbcCSVWriter.setFileName(tempFileName);
@@ -642,6 +643,7 @@ public class JdbcConnectionService {
     Preconditions.checkNotNull(realConnection, "connection info. required.");
 
     JdbcAccessor jdbcDataAccessor = DataConnectionHelper.getAccessor(realConnection);
+    JdbcDialect jdbcDialect = jdbcDataAccessor.getDialect();
     Connection connection = jdbcDataAccessor.getConnection(ingestionInfo.getDatabase(), true);
 
     // Max time 이 없는 경우 고려
@@ -664,6 +666,7 @@ public class JdbcConnectionService {
     JdbcCSVWriter jdbcCSVWriter = null;
     try {
       jdbcCSVWriter = new JdbcCSVWriter(new FileWriter(tempFileName), CsvPreference.STANDARD_PREFERENCE);
+      jdbcCSVWriter.setJdbcDialect(jdbcDialect);
       jdbcCSVWriter.setConnection(connection);
       jdbcCSVWriter.setQuery(queryString);
       jdbcCSVWriter.setFetchSize(fetchSize);
@@ -762,12 +765,12 @@ public class JdbcConnectionService {
     JdbcUtils.closeConnection(connection);
   }
 
-  public int writeResultSetToCSV(ResultSet resultSet, String tempCsvFilePath, List<String> headers) throws SQLException {
+  public int writeResultSetToCSV(JdbcDialect jdbcDialect, ResultSet resultSet, String tempCsvFilePath, List<String> headers) throws SQLException {
     JdbcCSVWriter jdbcCSVWriter = null;
     int rowNumber = 0;
     try {
       jdbcCSVWriter = new JdbcCSVWriter(new FileWriter(tempCsvFilePath), CsvPreference.STANDARD_PREFERENCE);
-
+      jdbcCSVWriter.setJdbcDialect(jdbcDialect);
       //write header from list if exist
       if (headers != null && !headers.isEmpty()) {
         jdbcCSVWriter.setWithHeader(false);

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/QueryEditorController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/QueryEditorController.java
@@ -46,12 +46,15 @@ import app.metatron.discovery.common.exception.ResourceNotFoundException;
 import app.metatron.discovery.domain.audit.Audit;
 import app.metatron.discovery.domain.audit.AuditRepository;
 import app.metatron.discovery.domain.dataconnection.DataConnection;
+import app.metatron.discovery.domain.dataconnection.DataConnectionHelper;
 import app.metatron.discovery.domain.dataconnection.DataConnectionRepository;
 import app.metatron.discovery.domain.datasource.Field;
 import app.metatron.discovery.domain.datasource.connection.jdbc.JdbcCSVWriter;
 import app.metatron.discovery.domain.datasource.connection.jdbc.JdbcConnectionService;
 import app.metatron.discovery.domain.workbench.util.WorkbenchDataSource;
 import app.metatron.discovery.domain.workbench.util.WorkbenchDataSourceManager;
+import app.metatron.discovery.extension.dataconnection.jdbc.accessor.JdbcAccessor;
+import app.metatron.discovery.extension.dataconnection.jdbc.dialect.JdbcDialect;
 import app.metatron.discovery.util.HibernateUtils;
 import app.metatron.discovery.util.HttpUtils;
 
@@ -334,6 +337,9 @@ public class QueryEditorController {
                         String connectionId, String fileName, String csvFilePath) throws IOException{
     //Hibernate Proxy Initialize
     DataConnection dataConnection = dataConnectionRepository.findOne(connectionId);
+    JdbcAccessor jdbcDataAccessor = DataConnectionHelper.getAccessor(dataConnection);
+    JdbcDialect jdbcDialect = jdbcDataAccessor.getDialect();
+
     if(dataConnection == null){
       throw new ResourceNotFoundException("DataConnection(" + connectionId + ")");
     }
@@ -346,6 +352,7 @@ public class QueryEditorController {
     dataSourceInfo.setQueryStatus(QueryStatus.RUNNING);
     try{
       JdbcCSVWriter jdbcCSVWriter = new JdbcCSVWriter(new FileWriter(csvFilePath), CsvPreference.STANDARD_PREFERENCE);
+      jdbcCSVWriter.setJdbcDialect(jdbcDialect);
       jdbcCSVWriter.setConnection(dataSourceInfo.getPrimaryConnection());
       jdbcCSVWriter.setFetchSize(5000);
       jdbcCSVWriter.setMaxRow(1000000);


### PR DESCRIPTION
### Description
In the process of creating the DataSource, the method used to process the ResultSet in the API used differs from the method used to process the ResultSet in the CsvWriter.
Modified CsvWriter's processing method to be same as other API

**Related Issue** : 

### How Has This Been Tested?
1. create datasource from oracle database
2. select schema : SCOTT
3. select table : EMP
4. choose segment granularity : MONTH
5. create datasource without error

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
