### PR TITLE
#fn removing mysql dedicated string template in audit stats query.

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/audit/AuditController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/audit/AuditController.java
@@ -214,8 +214,11 @@ public class AuditController {
     LineChartSeriesResponse<DateTime> result = new LineChartSeriesResponse<>(seriesNames);
 
     mapByDate.entrySet().forEach(map -> {
-      DateTime dateTime = new DateTime(map.getKey(), DateTimeZone.UTC)
-              .withTime(0, 0, 0, 0);
+      String yearAndDayOfYear = map.getKey();
+      DateTime dateTime
+          = new DateTime(Integer.parseInt(yearAndDayOfYear.substring(0, 4)), 1, 1, 0, 0, DateTimeZone.UTC)
+                        .plusDays(Integer.parseInt(yearAndDayOfYear.substring(4)) - 1);
+
       Map<Audit.AuditStatus, Long> cntMap = map.getValue();
       result.add(dateTime, cntMap.get(Audit.AuditStatus.SUCCESS), cntMap.get(Audit.AuditStatus.FAIL));
     });

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/audit/AuditRepositoryImpl.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/audit/AuditRepositoryImpl.java
@@ -54,9 +54,12 @@ public class AuditRepositoryImpl extends QueryDslRepositorySupport implements Au
   public List<AuditStatsDto> countStatusByDate(Predicate predicate) {
     NumberPath<Long> aliasDate = Expressions.numberPath(Long.class, "date");
     QAudit qAudit = QAudit.audit;
+    Expression<String> groupDateExpr = qAudit.startTime.year().stringValue()
+                                                       .concat(qAudit.startTime.dayOfYear().stringValue());
 
-    Expression<String> groupDateExpr = Expressions.stringTemplate("DATE_FORMAT({0}, {1})", qAudit.startTime, "%Y-%m-%d");
-    Expression<String> selectDateExpr = Expressions.stringTemplate("DATE_FORMAT({0}, {1})", qAudit.startTime, "%Y-%m-%d").as("date");
+    Expression<String> selectDateExpr = qAudit.startTime.year().stringValue()
+                                                        .concat(qAudit.startTime.dayOfYear().stringValue())
+                                                        .as("date");
 
     return from(qAudit)
             .select(Projections.constructor(AuditStatsDto.class, selectDateExpr, qAudit.status, qAudit.count()))


### PR DESCRIPTION
### Description
removing mysql dedicated string template in audit stats query.
An error occurred in h2 environment.

**Related Issue** : 


### How Has This Been Tested?
1. Data Monitoring > Log Statistics > Daily query success / failure rate
2. see chart without error

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
