### PR TITLE
#fn show histogram correctly for oracle number datatype

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/ColumnType.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/ColumnType.java
@@ -15,6 +15,7 @@
 package app.metatron.discovery.domain.dataprep.teddy;
 
 import app.metatron.discovery.domain.dataprep.teddy.exceptions.UnknownTypeException;
+import java.math.BigDecimal;
 import org.joda.time.DateTime;
 
 import java.math.BigInteger;
@@ -75,6 +76,9 @@ public enum ColumnType {
     }
     else if (obj instanceof BigInteger) {
       return Long.valueOf(((BigInteger) obj).longValue());
+    }
+    else if (obj instanceof BigDecimal) {
+      return Long.valueOf(((BigDecimal) obj).longValue());
     }
     else if (obj instanceof Float) {
       return Double.valueOf(((Float) obj).doubleValue());


### PR DESCRIPTION
### Description
When get a dataframe from an Oracle table, the BigDecimal object is used as the numeric type
However, when I draw the histogram, We missed it because we did not recognize the object type

**Related Issue** : None


### How Has This Been Tested?
1. create a dataset of database with an oracle data connection
2. edit rules of the W.dataset
3. check numeric fields
If the fields have a correct histogram, the problem was solved.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
