### PR TITLE
Fixed metatron.sh script upstart mode

### DIFF
--- a/discovery-distribution/bin/metatron.sh
+++ b/discovery-distribution/bin/metatron.sh
@@ -27,6 +27,9 @@ while [ $# -gt 0 ]; do
     start)
       MODE="start"
       ;;
+    foreground)
+      MODE="foreground"
+      ;;
     stop)
       MODE="stop"
       ;;
@@ -138,13 +141,13 @@ function check_if_process_is_alive() {
   fi
 }
 
-function upstart() {
+function foreground() {
 
   initialize_default_directories
 
-  echo "METATRON_CLASSPATH: ${METATRON_CLASSPATH_OVERRIDES}:${CLASSPATH}" >> "${METATRON_OUTFILE}"
+  echo "METATRON_CLASSPATH: ${METATRON_CLASSPATH_OVERRIDES}:${CLASSPATH}"
 
-  $METATRON_RUNNER $JAVA_OPTS -cp "${METATRON_CLASSPATH_OVERRIDES}:${CLASSPATH}" $METATRON_MAIN $METATRON_OPTION >> "${METATRON_OUTFILE}"
+  $METATRON_RUNNER $JAVA_OPTS -cp "${METATRON_CLASSPATH_OVERRIDES}:${CLASSPATH}" $METATRON_MAIN $METATRON_OPTION
 }
 
 function start() {
@@ -230,8 +233,8 @@ case "${MODE}" in
   stop)
     stop
     ;;
-  upstart)
-    upstart
+  foreground)
+    foreground
     ;;
   reload)
     stop


### PR DESCRIPTION
### Description

The upstart mode couldn't be used because there was no logic to extract the flag from the arguments passed to the script.

The upstart mode starts the application in foreground mode which is useful if you use a service manager which manages the lifecycle of the process. I renamed the upstart mode to foreground since it basically just starts the application in the foreground. This mode is also used by other service managers like systemd or Solaris / Illumos SMF.

I have also removed the piping of stdout to log file from the forgeround mode. When using systems like systemd, SMF, etc. these manage the output of the processes they manage. For example in case of systemd by displaying it via journalctl and SMF does this similar.

**Related Issue** : 

#2206

### How Has This Been Tested?

Metatron could be sucesfully started with `/opt/metatron/discovery/bin/metatron.sh --config=/etc/metatron/discovery foreground`.

#### Need additional checks?

### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Normally the `upstart` argument rename to `foreground` would be a breaking change. However considering it has been broken since the initial check-in (as far as I can tell) I don't think this is a breaking change.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes. 

