### PR TITLE
#fn fix display update user on workbench

### DIFF
--- a/discovery-frontend/src/app/workbench/workbench.component.html
+++ b/discovery-frontend/src/app/workbench/workbench.component.html
@@ -15,6 +15,9 @@
 <div class="ddp-wrap-naviarea ddp-naviarea2 ddp-clear" *ngIf="mainViewShow">
 
   <div class="ddp-ui-navidata ddp-type">
+    <span class="ddp-data-time" *ngIf="workbench.modifiedBy"
+          [innerHTML]="'msg.common.ui.updated.emphasis.name' | translate : {modifiedTime : workbench.modifiedTime | mdate:'YYYY-MM-DD HH:mm', fullName :workbench.modifiedBy.fullName } ">
+        </span>
 
     <!-- 버튼 -->
     <div class="ddp-ui-work-buttons" (click)="showOption()" (clickOutside)="isWorkbenchOptionShow = false">
@@ -34,7 +37,6 @@
           </ul>
           <!-- date -->
           <div class="ddp-ui-date">
-            <span class="ddp-data-date" *ngIf="workbench.modifiedBy">{{'msg.common.ui.updated' | translate : { modifiedTime : workbench.modifiedTime | mdate : 'YYYY-MM-DD HH:mm', fullName :workbench.modifiedBy.fullName } }}</span>
             <span class="ddp-data-date">{{'msg.common.ui.created' | translate : { createdTime : workbench.createdTime | mdate : 'YYYY-MM-DD HH:mm', fullName :workbench.createdBy.fullName } }}</span>
           </div>
           <!-- //date -->


### PR DESCRIPTION
### Description
fix display update user on workbench

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
1. Go to workbench
2. Check displaying update information
![image](https://user-images.githubusercontent.com/45194478/59257797-9e81a380-8c71-11e9-80a3-e9229411d4f9.png)



#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
