### PR TITLE
Fix custom field filter and filter widget errors

### DIFF
--- a/discovery-frontend/src/app/dashboard/update-dashboard.component.ts
+++ b/discovery-frontend/src/app/dashboard/update-dashboard.component.ts
@@ -1260,14 +1260,21 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
    * @param {Filter} filter
    */
   public configureFilter(filter: Filter) {
-    this.updateFilter(filter, true);
+    if( DashboardUtil.isNewFilter( this.dashboard, filter ) ) {
+      this.addFilter( filter, () => {
+        this.updateFilter(filter, true);
+      });
+    } else {
+      this.updateFilter(filter, true);
+    }
   } // function - configureFilter
 
   /**
    * 단일 필터 추가
    * @param {Filter} filter
+   * @param {Function} callback
    */
-  public addFilter(filter: Filter) {
+  public addFilter(filter: Filter, callback?:Function) {
     if (!filter.ui.widgetId) {
       this.showBoardLoading();
       const newFilterWidget: FilterWidget = new FilterWidget(filter, this.dashboard);
@@ -1278,6 +1285,15 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
 
         // 글로벌 필터 업데이트
         this.dashboard = DashboardUtil.addBoardFilter(this.dashboard, filter);
+
+        ( callback ) && ( callback() );
+
+        this.safelyDetectChanges();
+
+        // Layout 업데이트
+        this.renderLayout();
+
+        this.dashboard.updateId = CommonUtil.getUUID();
 
         this.hideBoardLoading();
       });

--- a/discovery-frontend/src/app/dashboard/util/dashboard.util.ts
+++ b/discovery-frontend/src/app/dashboard/util/dashboard.util.ts
@@ -676,6 +676,15 @@ export class DashboardUtil {
   } // function - addBoardFilter
 
   /**
+   * 신규 필터 여부
+   * @param board
+   * @param filter
+   */
+  public static isNewFilter(board: Dashboard, filter: Filter):boolean {
+    return -1 === board.configuration.filters.findIndex(item => item.dataSource === filter.dataSource && item.field === filter.field);
+  } // function - isNewFilter
+
+  /**
    * 글로벌 필터 갱신
    * @param {Dashboard} board
    * @param {Filter} filter

--- a/discovery-frontend/src/assets/i18n/en.json
+++ b/discovery-frontend/src/assets/i18n/en.json
@@ -1570,6 +1570,7 @@
   "msg.board.alert.global-filter.edit.error" :"Failed to edit the global filter.",
   "msg.board.alert.update.board.error" : "Error occurred while updating the dashboard",
   "msg.board.ui.fit-to-height.tooltip" : "Min:900 ~ Max:2400",
+  "msg.board.alert.global-filter.del.error" : "Global filter cannot be deleted.",
   "msg.board.alert.recomm-filter.del.error" : "Recommended filter cannot be deleted.",
   "msg.board.alert.dashboard.update.fail": "There was an error updating the dashboard",
   "msg.board.alert.dashboard.sort.success": "Dashboard order changed",

--- a/discovery-frontend/src/assets/i18n/ko.json
+++ b/discovery-frontend/src/assets/i18n/ko.json
@@ -1568,6 +1568,7 @@
   "msg.board.alert.global-filter.edit.error" :"글로벌 필터 수정에 실패했습니다",
   "msg.board.alert.update.board.error" : "대시보드 업데이트 시에 오류가 발생했습니다",
   "msg.board.ui.fit-to-height.tooltip" : "min:900 ~ max:2400",
+  "msg.board.alert.global-filter.del.error" : "글로벌 필터는 삭제할 수 없습니다",
   "msg.board.alert.recomm-filter.del.error" : "추천 필터는 삭제할 수 없습니다",
   "msg.board.alert.dashboard.update.fail": "대시보드 업데이트 시에 오류가 발생했습니다",
   "msg.board.alert.dashboard.sort.success": "대시보드 순서가 변경되었습니다",

--- a/discovery-frontend/src/assets/i18n/zh.json
+++ b/discovery-frontend/src/assets/i18n/zh.json
@@ -1464,6 +1464,7 @@
   "msg.board.alert.global-filter.edit.error": "全局过滤器修改失败",
   "msg.board.alert.update.board.error": "看板更新时发生错误",
   "msg.board.ui.fit-to-height.tooltip": "min:900 ~ max:2400",
+  "msg.board.alert.global-filter.del.error": "不能删除推荐过滤器",
   "msg.board.alert.recomm-filter.del.error": "不能删除推荐过滤器",
   "msg.board.alert.dashboard.update.fail": "看板更新时发生错误",
   "msg.board.alert.dashboard.sort.success": "看板顺序已变更",


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
1. 사용자 정의 필드에 대해 필터가 동작하지 않습니다. 
![image (1)](https://user-images.githubusercontent.com/3685833/59274026-6c356d80-8c94-11e9-956c-b3c6b19f818a.png)

2. 초기 대시보드 생성 후, 대시보드 내 위젯이 없는 상태에서, 필터를 위젯으로 처음 추가 시 위젯으로 등록되지 않음
![2019-06-11_11-27-14-1](https://user-images.githubusercontent.com/3685833/59274022-68a1e680-8c94-11e9-83be-e28bbaa02f4f.gif)

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 처음 대시보드를 생성하고, 필터만 생성한 후에 위젯으로 배치되는지 확인합니다.
2. 차트 편집 화면에서 사용자 정의 필드를 만들고 필터로 추가되는지 확인합니다.

#### Need additional checks?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
