### PR TITLE
#2217 Enhance error message on wrong row number in header rule

### DIFF
--- a/discovery-frontend/src/assets/i18n/en.json
+++ b/discovery-frontend/src/assets/i18n/en.json
@@ -792,7 +792,7 @@
   "msg.dp.alert.no.snapshot" : "Snapshot does not exist",
   "msg.dp.alert.unsupported.imported.dataset" : "Unsupported imported dataset type",
   "msg.dp.alert.no.flow.info" : "No dataflow information",
-  "msg.dp.alert.no.row.data" : " data does not exist",
+  "msg.dp.alert.no.row.data" : "Wrong row number",
   "msg.dp.alert.out.of.range": "Value out of range",
   "msg.dp.alert.please.sel.ds": "Please select dataset",
   "msg.dp.alert.redo.fail": "REDO failed",

--- a/discovery-frontend/src/assets/i18n/ko.json
+++ b/discovery-frontend/src/assets/i18n/ko.json
@@ -791,7 +791,7 @@
   "msg.dp.alert.no.snapshot" : "Snapshot이 존재하지 않습니다",
   "msg.dp.alert.unsupported.imported.dataset" : "지원하지 않는 형식의 imported dataset입니다",
   "msg.dp.alert.no.flow.info" : "데이터플로우 정보가 없습니다",
-  "msg.dp.alert.no.row.data" : " 데이터가 없습니다",
+  "msg.dp.alert.no.row.data" : "행 번호가 잘못되었습니다",
   "msg.dp.alert.out.of.range":"범위를 벗어난 값입니다",
   "msg.dp.alert.please.sel.ds": "데이터 셋을 선택해 주세요",
   "msg.dp.alert.redo.fail" : "REDO 적용에 실패하였습니다",

--- a/discovery-frontend/src/assets/i18n/zh.json
+++ b/discovery-frontend/src/assets/i18n/zh.json
@@ -766,7 +766,7 @@
   "msg.dp.alert.no.snapshot" : "不存在Snapshot",
   "msg.dp.alert.unsupported.imported.dataset" : "不支持的导入数据集类型",
   "msg.dp.alert.no.flow.info": "无数据流信息",
-  "msg.dp.alert.no.row.data": "无数据",
+  "msg.dp.alert.no.row.data": "行号错误",
   "msg.dp.alert.out.of.range": "超出范围的值",
   "msg.dp.alert.please.sel.ds": "请选择数据集",
   "msg.dp.alert.redo.fail": "REDO适用失败",

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DfHeader.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DfHeader.java
@@ -37,8 +37,8 @@ public class DfHeader extends DataFrame {
     Header header = (Header) rule;
 
     int targetRowno = header.getRownum().intValue() - 1;
-    if (targetRowno < 0) {
-      throw new NoRowException("DfHeader.prepare(): rownum should be >= 1: rownum=" + (targetRowno + 1));
+    if (targetRowno < 0 || targetRowno >= prevDf.rows.size()) {
+      throw new NoRowException("DfHeader.prepare(): row number should be >= 1 and < row_count: rowno=" + (targetRowno + 1));
     }
 
     int i = 1;


### PR DESCRIPTION
### Description
When use a wrong row number in header rule, a better error message will be shown.
The error message in the same situation was an unknown error.
Now it's "Wrong row number" or "행 번호가 잘못되었습니다" or "行号错误".

**Related Issue** : https://github.com/metatron-app/metatron-discovery/issues/2217

### How Has This Been Tested?
Run locally.

#### Need additional checks?
Yes. In English, Korean and Chinese (simplified)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
