### PR TITLE
Fix datasource and connection ui error

### DIFF
--- a/discovery-frontend/src/app/common/component/input/input.component.html
+++ b/discovery-frontend/src/app/common/component/input/input.component.html
@@ -18,6 +18,7 @@
          (keyup)="keyupHandler($event)" (focus)="focusHandler()" (blur)="blurHandler()"
          (mousedown)="$event.stopPropagation()" (mousemove)="$event.stopPropagation()"
          class="{{inputClass}} {{optionalClass}}" type="text" >
+  <a href="javascript:" class="ddp-btn-delete" *ngIf="isEnableDelete && isNotEmptyInput()" (click)="clearValue()" [style.display]="isNotEmptyInput() ? 'block' : 'none'"></a>
 </ng-container>
 
 <ng-container *ngIf="'apply' === compType" >

--- a/discovery-frontend/src/app/common/component/input/input.component.ts
+++ b/discovery-frontend/src/app/common/component/input/input.component.ts
@@ -65,6 +65,7 @@ export class InputComponent implements OnInit, OnDestroy {
   @Input() public isTrim: boolean = true;        // 공백 제거 여부
 
   @Input() public showClear: boolean = true;    // Clear 버튼 표시 여부 ( 현재는 search 에서만 표시 )
+  @Input() public isEnableDelete: boolean;    // Clear 버튼 표시 여부 ( default input 용 )
 
   @Input() public inputClass: string = ''; // Input Element 클래스
 

--- a/discovery-frontend/src/app/data-storage/component/criterion/criterion.component.ts
+++ b/discovery-frontend/src/app/data-storage/component/criterion/criterion.component.ts
@@ -85,6 +85,8 @@ export class CriterionComponent extends AbstractComponent {
     // if exist search params
     if (Object.keys(searchParams).length > 0) {
       this.queryParams = _.cloneDeep(searchParams);
+    } else {
+      this.queryParams = {};
     }
     // if exist criterion list
     if (!_.isNil(this.queryParams[Criteria.KEY_EXTENSIONS])) {

--- a/discovery-frontend/src/app/data-storage/data-connection/data-connection.component.html
+++ b/discovery-frontend/src/app/data-storage/data-connection/data-connection.component.html
@@ -37,6 +37,7 @@
         <div class="ddp-form-filter-search">
           <component-input
             [autoFocus]="false"
+            [isEnableDelete]="true"
             [value]="searchKeyword"
             [placeHolder]="'msg.storage.ph.connection.search' | translate"
             (changeValue)="onChangedSearchKeyword($event)">
@@ -60,7 +61,11 @@
       <a href="javascript:" class=" ddp-btn-pop ddp-bg-black" (click)="onClickCreateConnection()"><em class="ddp-icon-add2"></em>{{'msg.comm.btn.new' | translate}}</a>
     </div>
     <!-- //create connection -->
-    <table class="ddp-table-form ddp-table-type3">
+    <div class="ddp-data-source-none" *ngIf="isEmptyList(); else existList">
+      {{'msg.comm.ui.no.rslt' | translate}}
+    </div>
+    <ng-template #existList>
+      <table class="ddp-table-form ddp-table-type3">
       <colgroup>
         <col width="*">
         <col width="12%">
@@ -105,9 +110,10 @@
       </tr>
       </tbody>
     </table>
-    <!-- Pagination -->
-    <component-pagination [info]="pageResult" (changePageData)="changePage($event)"></component-pagination>
-    <!-- // Pagination -->
+      <!-- Pagination -->
+      <component-pagination [info]="pageResult" (changePageData)="changePage($event)"></component-pagination>
+      <!-- // Pagination -->
+    </ng-template>
   </div>
 </div>
 <!-- 커넥션 생성 팝업 -->

--- a/discovery-frontend/src/app/data-storage/data-connection/data-connection.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-connection/data-connection.component.ts
@@ -27,6 +27,8 @@ import {Criteria} from "../../domain/datasource/criteria";
 import {ActivatedRoute} from "@angular/router";
 import {Alert} from "../../common/util/alert.util";
 import {isNullOrUndefined} from "util";
+import * as _ from 'lodash';
+import {StorageService} from "../service/storage.service";
 
 @Component({
   selector: 'app-data-connection',
@@ -48,9 +50,6 @@ export class DataConnectionComponent extends AbstractComponent implements OnInit
   @ViewChild(DeleteModalComponent)
   private deleteModalComponent: DeleteModalComponent;
 
-  // 커넥션 생성 step
-  public connectionStep: string;
-
   // connection list
   public connectionList: Dataconnection[] = [];
 
@@ -62,6 +61,7 @@ export class DataConnectionComponent extends AbstractComponent implements OnInit
 
   // Constructor
   constructor(private dataconnectionService: DataconnectionService,
+              private storageService: StorageService,
               private activatedRoute: ActivatedRoute,
               protected elementRef: ElementRef,
               protected injector: Injector) {
@@ -86,6 +86,10 @@ export class DataConnectionComponent extends AbstractComponent implements OnInit
           // if exist search param in URL
           if (isExistSearchParams) {
             paramKeys.forEach((key) => {
+              // #1539 call by metadata create step
+              if (key === 'isCreateMode') {
+                this.onClickCreateConnection();
+              }
               if (key === 'size') {
                 this.page.size = params['size'];
               } else if (key === 'page') {
@@ -100,17 +104,20 @@ export class DataConnectionComponent extends AbstractComponent implements OnInit
                 searchParams[key] = params[key].split(',');
               }
             });
+            // TODO 추후 criterion component로 이동
+            delete searchParams['pseudoParam'];
+            // init criterion search param
+            this.criterionComponent.initSearchParams(searchParams);
           }
-
-          // TODO 추후 criterion component로 이동
-          delete searchParams['pseudoParam'];
-          // init criterion search param
-          this.criterionComponent.initSearchParams(searchParams);
           // set connection list
           this._setConnectionList();
         }));
       })
       .catch(reason => this.commonExceptionHandler(reason));
+  }
+
+  isEmptyList(): boolean {
+    return this.connectionList.length === 0;
   }
 
   /**
@@ -240,29 +247,11 @@ export class DataConnectionComponent extends AbstractComponent implements OnInit
    * @returns {string}
    */
   public getConnectionImplementorLabel(implementor: ImplementorType): string {
-    switch (implementor) {
-      case ImplementorType.MYSQL:
-        return 'MySQL';
-      case ImplementorType.ORACLE:
-        return 'Oracle';
-      case ImplementorType.TIBERO:
-        return 'Tibero';
-      case ImplementorType.HIVE:
-        return 'Hive';
-      case ImplementorType.POSTGRESQL:
-        return 'PostgreSQL';
-      case ImplementorType.PRESTO:
-        return 'Presto';
-      case ImplementorType.MSSQL:
-        return 'MsSQL';
-      case ImplementorType.DRUID:
-        return 'Druid';
-      case ImplementorType.STAGE:
-        return 'StagingDB';
-      case ImplementorType.FILE:
-        return 'File';
-      default:
-        return implementor.toString();
+    const jdbc = this.storageService.findConnectionType(implementor);
+    if (_.isNil(jdbc)) {
+      return implementor.toString();
+    } else {
+      return jdbc.name;
     }
   }
 
@@ -345,6 +334,10 @@ export class DataConnectionComponent extends AbstractComponent implements OnInit
     // if search keyword not empty
     if (StringUtil.isNotEmpty(this.searchKeyword)) {
       params['containsText'] = this.searchKeyword.trim();
+    }
+    // remove isCreateMode property
+    if (!_.isNil(params['isCreateMode'])) {
+      delete params['isCreateMode'];
     }
     return params;
   }

--- a/discovery-frontend/src/app/data-storage/data-source-list/data-source-list.component.html
+++ b/discovery-frontend/src/app/data-storage/data-source-list/data-source-list.component.html
@@ -38,6 +38,7 @@
         <div class="ddp-form-filter-search">
           <component-input
             [autoFocus]="false"
+            [isEnableDelete]="true"
             [value]="searchKeyword"
             [placeHolder]="'msg.storage.ph.source.search' | translate"
             (changeValue)="onChangedSearchKeyword($event)">
@@ -61,71 +62,72 @@
       <a href="javascript:" class=" ddp-btn-pop ddp-bg-black" (click)="changeMode('create-data-source')"><em class="ddp-icon-add2"></em>{{'msg.comm.btn.new' | translate}}</a>
     </div>
     <!-- //create datasource -->
-    <table class="ddp-table-form ddp-table-type3">
-      <colgroup>
-        <col width="*">
-        <col width="10%">
-        <col width="13%">
-        <col width="7%">
-        <col width="20%">
-      </colgroup>
-      <thead>
-      <tr>
-        <th>
-          {{'msg.comm.th.ds' | translate}}
-        </th>
-        <th>
-          {{'msg.storage.th.data_type' | translate}}
-        </th>
-        <th>
-          {{'msg.storage.th.ingestion_type' | translate}}
-        </th>
-        <th>
-          {{'msg.storage.th.status' | translate}}
-        </th>
-        <th class="ddp-cursor" (click)="sortDatasourceList('createdTime')">
-          {{'msg.comm.th.created' | translate}}
-          <em class="ddp-icon-array-asc2" *ngIf="selectedContentSort.key === 'createdTime' && selectedContentSort.sort === 'asc'"></em>
-          <em class="ddp-icon-array-des2" *ngIf="selectedContentSort.key === 'createdTime' && selectedContentSort.sort === 'desc'"></em>
-        </th>
-      </tr>
-      </thead>
-      <tbody>
-      <tr *ngFor="let datasource of datasourceList" (click)="onClickDatasource(datasource.id)">
-        <td>
-          <div class="ddp-txt-long" [class.ddp-global]="datasource.published">
-            {{datasource.name}}
-            <em class="ddp-icon-info3" *ngIf="datasource.fieldsMatched === false"></em>
-            <span class="ddp-txt-colortype" *ngIf="datasource.description">-{{datasource.description}}</span>
-            <em class="ddp-tag-global" *ngIf="datasource.published">{{'msg.comm.ui.list.ds.opendata' | translate}}</em>
-          </div>
-        </td>
-        <td>
-          {{getDataTypeChange(datasource.srcType)}}
-        </td>
-        <td>
-          {{(datasource.connType.toString() == 'ENGINE' ? 'msg.storage.ui.list.ingested.data':'msg.storage.ui.list.linked.data') | translate}}
-        </td>
-        <td>
-          <span class="{{getSourceStatusIcon(datasource.status)}}">{{getSourceStatusLabel(datasource.status)}}</span>
-        </td>
-        <td class="ddp-data-last">
-          {{datasource.createdTime | mdate: 'YYYY-MM-DD HH:mm'}}  <em class="ddp-icon-by">{{'msg.storage.ui.by' | translate}}</em>{{datasource.createdBy.fullName}}
-          <div class="ddp-btn-control">
-            <em class="ddp-icon-control-cut" (click)="onClickRemoveDatasource(datasource); $event.stopPropagation()"></em>
-          </div>
-        </td>
-      </tr>
-      </tbody>
-    </table>
-    <!-- no result -->
-<!--    <div class="ddp-data-source-none" *ngIf="datasourceList.length === 0; else yesCt">-->
-<!--      데이터가 없습니다-->
-<!--    </div>-->
+    <div class="ddp-data-source-none" *ngIf="isEmptyList(); else existList">
+      {{'msg.comm.ui.no.rslt' | translate}}
+    </div>
     <!-- //no result -->
-    <!-- Pagination -->
-    <component-pagination [info]="pageResult" (changePageData)="changePage($event)"></component-pagination>
-    <!-- // Pagination -->
+    <ng-template #existList>
+      <table class="ddp-table-form ddp-table-type3">
+        <colgroup>
+          <col width="*">
+          <col width="10%">
+          <col width="13%">
+          <col width="7%">
+          <col width="20%">
+        </colgroup>
+        <thead>
+        <tr>
+          <th>
+            {{'msg.comm.th.ds' | translate}}
+          </th>
+          <th>
+            {{'msg.storage.th.data_type' | translate}}
+          </th>
+          <th>
+            {{'msg.storage.th.ingestion_type' | translate}}
+          </th>
+          <th>
+            {{'msg.storage.th.status' | translate}}
+          </th>
+          <th class="ddp-cursor" (click)="sortDatasourceList('createdTime')">
+            {{'msg.comm.th.created' | translate}}
+            <em class="ddp-icon-array-asc2" *ngIf="selectedContentSort.key === 'createdTime' && selectedContentSort.sort === 'asc'"></em>
+            <em class="ddp-icon-array-des2" *ngIf="selectedContentSort.key === 'createdTime' && selectedContentSort.sort === 'desc'"></em>
+          </th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr *ngFor="let datasource of datasourceList" (click)="onClickDatasource(datasource.id)">
+          <td>
+            <div class="ddp-txt-long" [class.ddp-global]="datasource.published">
+              {{datasource.name}}
+              <em class="ddp-icon-info3" *ngIf="datasource.fieldsMatched === false"></em>
+              <span class="ddp-txt-colortype" *ngIf="datasource.description">-{{datasource.description}}</span>
+              <em class="ddp-tag-global" *ngIf="datasource.published">{{'msg.comm.ui.list.ds.opendata' | translate}}</em>
+            </div>
+          </td>
+          <td>
+            {{getDataTypeChange(datasource.srcType)}}
+          </td>
+          <td>
+            {{(datasource.connType.toString() == 'ENGINE' ? 'msg.storage.ui.list.ingested.data':'msg.storage.ui.list.linked.data') | translate}}
+          </td>
+          <td>
+            <span class="{{getSourceStatusIcon(datasource.status)}}">{{getSourceStatusLabel(datasource.status)}}</span>
+          </td>
+          <td class="ddp-data-last">
+            {{datasource.createdTime | mdate: 'YYYY-MM-DD HH:mm'}}  <em class="ddp-icon-by">{{'msg.storage.ui.by' | translate}}</em>{{datasource.createdBy.fullName}}
+            <div class="ddp-btn-control">
+              <em class="ddp-icon-control-cut" (click)="onClickRemoveDatasource(datasource); $event.stopPropagation()"></em>
+            </div>
+          </td>
+        </tr>
+        </tbody>
+      </table>
+      <!-- Pagination -->
+      <component-pagination [info]="pageResult" (changePageData)="changePage($event)"></component-pagination>
+      <!-- // Pagination -->
+    </ng-template>
   </div>
 </div>
 <!-- 데이터소스 생성 -->

--- a/discovery-frontend/src/app/data-storage/data-source-list/data-source-list.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/data-source-list.component.ts
@@ -92,16 +92,20 @@ export class DataSourceListComponent extends AbstractComponent {
                 searchParams[key] = params[key].split(',');
               }
             });
+            // TODO 추후 criterion component로 이동
+            delete searchParams['pseudoParam'];
+            // init criterion search param
+            this.criterionComponent.initSearchParams(searchParams);
           }
-          // TODO 추후 criterion component로 이동
-          delete searchParams['pseudoParam'];
-          // init criterion search param
-          this.criterionComponent.initSearchParams(searchParams);
           // set datasource list
           this._setDatasourceList();
         }));
       })
       .catch(error => this.commonExceptionHandler(error));
+  }
+
+  isEmptyList(): boolean {
+    return this.datasourceList.length === 0;
   }
 
   /**

--- a/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/column-detail-data-source/edit-config-schema.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/column-detail-data-source/edit-config-schema.component.ts
@@ -314,7 +314,7 @@ export class EditConfigSchemaComponent extends AbstractComponent {
       // 만약 기존 타입이 GEO 또는 TIMESTAMP 타입이라면
       if (prevLogicalType ===  LogicalType.GEO_POINT || prevLogicalType === LogicalType.GEO_POLYGON || prevLogicalType === LogicalType.GEO_LINE || prevLogicalType === LogicalType.TIMESTAMP) {
         // remove format
-        delete targetField.format;
+        targetField.format = null;
         this.setIsExistErrorInFieldListFlag();
       }
       // 변경될 타입이 GEO 타입이라면

--- a/discovery-frontend/src/assets/css/metatron/component/component.filtering.list.css
+++ b/discovery-frontend/src/assets/css/metatron/component/component.filtering.list.css
@@ -45,9 +45,11 @@
 
 
 .ddp-wrap-top-filtering .ddp-filter-search {}
-.ddp-wrap-top-filtering .ddp-filter-search .ddp-form-filter-search {float:left; position:relative; padding-left:10px; width:195px; box-sizing:border-box;}
-.ddp-wrap-top-filtering .ddp-filter-search .ddp-form-filter-search input {display:block; padding:18px 10px; width:100%; font-size:13px; box-sizing:border-box; background:none; border:none;}
+.ddp-wrap-top-filtering .ddp-filter-search .ddp-form-filter-search {float:left; position:relative; padding-left:25px; padding-right:20px; margin-right:10px; width:195px; box-sizing:border-box;}
+.ddp-wrap-top-filtering .ddp-filter-search .ddp-form-filter-search input {display:block; padding:18px 0; width:100%; font-size:13px; box-sizing:border-box; background:none; border:none;}
 .ddp-wrap-top-filtering .ddp-filter-search .ddp-form-filter-search:before {display:inline-block; position:absolute; top:50%; left:0; margin-top:-7px; width:14px; height:14px; background:url(../../../images/icon_search.png) no-repeat; background-position:-15px -12px; content:'';}
+.ddp-wrap-top-filtering .ddp-filter-search .ddp-btn-delete {display:none; position:absolute; top:50%; right:0; margin-top:-7px; width:14px; height:14px; background:url(../../../images/btn_sclose.png) no-repeat; background-position:left -131px;}
+.ddp-wrap-top-filtering .ddp-filter-search .ddp-type-search { width:195px;float:left;}
 .ddp-wrap-top-filtering .ddp-filter-search .ddp-btn-selection {float:left; margin:10px 0 0 0;}
 .ddp-filter-option {padding:18px 0 11px 0; text-align:right;}
 .ddp-filter-option .ddp-btn-pop {padding:8px 9px;}


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
- 데이터소스, 커넥션 목록에서 defaultFilters가 존재하는경우 변경된 필터가 제대로 유지되지 않던 현상 수정
![스크린샷 2019-06-11 오후 6 00 58](https://user-images.githubusercontent.com/42233627/59258415-e228dd00-8c72-11e9-9dc6-ac6be785a30d.png)

- MSSQL인 경우 커넥션 목록에서 제대로 표기되지 않던 현상 수정
![스크린샷 2019-06-11 오후 5 58 22](https://user-images.githubusercontent.com/42233627/59258305-af7ee480-8c72-11e9-8da8-d04f1fd2d4b1.png)

- 데이터소스, 커넥션 목록에서 목록이 없는경우 template 추가
![스크린샷 2019-06-11 오후 5 58 04](https://user-images.githubusercontent.com/42233627/59258314-b4439880-8c72-11e9-8974-059bf63927b6.png)

- 데이터소스, 커넥션 목록에서 검색어를 입력하는경우 x 버튼이 뜨도록 수정
![스크린샷 2019-06-11 오후 5 57 57](https://user-images.githubusercontent.com/42233627/59258320-b73e8900-8c72-11e9-8e5e-4d2c8befa55f.png)

- 데이터소스 > 상세화면 > edit schema 화면에서 기존 타임스탬프 타입을 변경 하는 경우 format값을 null을 보내도록 수정
![스크린샷 2019-06-11 오후 5 58 45](https://user-images.githubusercontent.com/42233627/59258323-b9a0e300-8c72-11e9-8165-8f196fa1ad74.png)

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
통합테스트

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 데이터소스, 커넥션 목록에서 defaultFilters가 존재하는경우 변경된 필터가 제대로 유지되는지 확인
2. 커넥션 > MSSQL인 경우 목록에서 제대로 표기되는지 확인 
3. 데이터소스, 커넥션 목록에서 목록이 없는경우 결과가 없다는 안내가 dataset과 같게 표기되는지 확인
4. 데이터소스, 커넥션 목록에서 검색어 입력시 x 버튼이 뜨는지 확인
5. 데이터소스 > 상세화면 > edit schema 화면에서 기존 타임스탬프인 컬럼의 타입을 변경하는 경우 params에 format: null이 제대로 넘어가는지 확인

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
