### PR TITLE
Fix metadata change column error

### DIFF
--- a/discovery-frontend/src/app/domain/meta-data-management/metadata-column.ts
+++ b/discovery-frontend/src/app/domain/meta-data-management/metadata-column.ts
@@ -47,6 +47,10 @@ export class MetadataColumn {
   // Value to be used only on View
   ////////////////////////////////////////////////////////////////////////////
 
+  public static isRoleIsTimestamp(metadataColumn: MetadataColumn) {
+    return metadataColumn.role === Type.Role.TIMESTAMP
+  }
+
   public static isTypeIsTimestamp(metadataColumn: MetadataColumn) {
     return metadataColumn.type === Type.Logical.TIMESTAMP
   }

--- a/discovery-frontend/src/app/meta-data-management/detail/component/column-schema/column-schema.component.html
+++ b/discovery-frontend/src/app/meta-data-management/detail/component/column-schema/column-schema.component.html
@@ -397,7 +397,7 @@
             <!-- //select -->
           </div>
           <div class="ddp-ui-info"
-               [hidden]="isTypeIsTimestamp(column) === false"
+               [hidden]="isShowInformationIcon(column) === false"
                [class.ddp-selected]="column.format?.isShowTimestampValidPopup">
             <!-- TODO 추후 데이터소스 연결시 error2에 있는 hasMetadataColumnInDatasource container와 template 제거 -->
             <ng-container *ngIf="hasMetadataColumnInDatasource(); else none">
@@ -415,7 +415,7 @@
             </ng-template>
             <!-- format layer -->
             <datetime-valid-popup
-              [hidden]="isTypeIsTimestamp(column) === false"
+              [hidden]="isShowInformationIcon(column) === false"
               [fieldFormat]="column?.format"
               [fieldDataList]="fieldDataList"
               [fieldName]="column.physicalName"

--- a/discovery-frontend/src/app/meta-data-management/detail/component/column-schema/column-schema.component.html
+++ b/discovery-frontend/src/app/meta-data-management/detail/component/column-schema/column-schema.component.html
@@ -319,9 +319,8 @@
             (clickOutside)="column['typeListFl'] = false;">
           <div class="ddp-wrap-type-option">
             <!-- select -->
-            <div #logicalType
+            <div #logicalType class="ddp-ui-selected-option"
                  [class.ddp-selected]="column['typeListFl']"
-                 [ngClass]="['ddp-ui-selected-option']"
                  (click)="onShowLogicalTypeList(column, logicalType, logicalTypeList)">
                 <span class="ddp-link-text ddp-txt-icon">
                   <em [ngClass]="[getFieldTypeIconClass(column.type)]"></em>
@@ -332,7 +331,7 @@
                   </span>
                 </span>
               <!--suppress JSUnusedGlobalSymbols -->
-              <div class="ddp-wrap-popup2 ddp-scroll-none" [ngClass]="['ddp-types']"
+              <div class="ddp-wrap-popup2 ddp-types ddp-scroll-none"
                    #logicalTypeList>
                 <ul class="ddp-list-popup">
                   <li [class.ddp-selected]="isSelectedColumnLogicalType(column, LOGICAL.STRING)">
@@ -396,25 +395,24 @@
               <!-- //popup -->
             </div>
             <!-- //select -->
-            <div class="ddp-ui-info"
-                 [hidden]="isTypeIsTimestamp(column) === false"
-                 [class.ddp-selected]="column.format?.isShowTimestampValidPopup">
-              <!-- TODO 추후 데이터소스 연결시 error2에 있는 hasMetadataColumnInDatasource container와 template 제거 -->
-              <ng-container *ngIf="hasMetadataColumnInDatasource(); else none">
-                <em [class.ddp-icon-sinfo2]="isValidInformationIcon(column)"
-                    [class.ddp-icon-error2]="isInvalidInformationIcon(column)"
-                    [ngClass]="[TIMESTAMP_VALID_PUPOP_ELEMENT]"
-                    (click)="onClickInfoIcon(column, index)">
-                </em>
-              </ng-container>
-              <ng-template #none>
-                <em class="ddp-icon-sinfo2"
-                    [ngClass]="[TIMESTAMP_VALID_PUPOP_ELEMENT]"
-                    (click)="onClickInfoIcon(column, index)">
-                </em>
-              </ng-template>
-
-            </div>
+          </div>
+          <div class="ddp-ui-info"
+               [hidden]="isTypeIsTimestamp(column) === false"
+               [class.ddp-selected]="column.format?.isShowTimestampValidPopup">
+            <!-- TODO 추후 데이터소스 연결시 error2에 있는 hasMetadataColumnInDatasource container와 template 제거 -->
+            <ng-container *ngIf="hasMetadataColumnInDatasource(); else none">
+              <em [class.ddp-icon-sinfo2]="isValidInformationIcon(column)"
+                  [class.ddp-icon-error2]="isInvalidInformationIcon(column)"
+                  [ngClass]="[TIMESTAMP_VALID_PUPOP_ELEMENT]"
+                  (click)="onClickInfoIcon(column, index)">
+              </em>
+            </ng-container>
+            <ng-template #none>
+              <em class="ddp-icon-sinfo2"
+                  [ngClass]="[TIMESTAMP_VALID_PUPOP_ELEMENT]"
+                  (click)="onClickInfoIcon(column, index)">
+              </em>
+            </ng-template>
             <!-- format layer -->
             <datetime-valid-popup
               [hidden]="isTypeIsTimestamp(column) === false"

--- a/discovery-frontend/src/app/meta-data-management/detail/component/column-schema/column-schema.component.ts
+++ b/discovery-frontend/src/app/meta-data-management/detail/component/column-schema/column-schema.component.ts
@@ -456,8 +456,8 @@ export class ColumnSchemaComponent extends AbstractComponent implements OnInit, 
       && this.isTimestampColumn(metadataColumn) === false;
   }
 
-  public isTypeIsTimestamp(metadataColumn: MetadataColumn) {
-    return MetadataColumn.isTypeIsTimestamp(metadataColumn);
+  public isShowInformationIcon(metadataColumn: MetadataColumn) {
+    return MetadataColumn.isTypeIsTimestamp(metadataColumn) && !MetadataColumn.isRoleIsTimestamp(metadataColumn);
   }
 
   public isTimestampColumn(metadataColumn: MetadataColumn) {
@@ -846,7 +846,7 @@ export class ColumnSchemaComponent extends AbstractComponent implements OnInit, 
       .then((result) => {
         // 변경된 컬럼의 사전정보로 logicalType, Format, CodeTable, Description 적용
         this._selectedColumn.type = result.logicalType || null;
-        this._selectedColumn.format = result.format || new FieldFormat();
+        this._selectedColumn.format = result.format || null;
         this._selectedColumn.description = result.description || null;
 
         // 이름이 사용자에 의해 변경되지 않았다면 컬럼 사전의 이름을 name으로 지정함

--- a/discovery-frontend/src/assets/css/polaris.v2.page.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.page.css
@@ -7761,8 +7761,7 @@ table.ddp-table-type3.ddp-popup tr td {padding:10px 10px 11px 10px;}
 
 .ddp-data-details.ddp-ui-preview-contents .ddp-table-form {white-space:nowrap;}
 .ddp-data-details.ddp-ui-preview-contents table tr th {border-bottom:1px solid #e9e9ec;}
-.ddp-data-details.ddp-ui-preview-contents .ddp-ui-selected-option.ddp-selected .ddp-wrap-popup2 {left:inherit; right:0px; width:140px;}
-
+.ddp-data-details.ddp-ui-preview-contents .ddp-ui-selected-option.ddp-selected .ddp-wrap-popup2 {left:inherit; right:0px; width:140px; z-index:20;}
 
 
 .ddp-ui-preview-contents table.ddp-table-form.ddp-table-details tbody tr:nth-child(odd):hover td {background-color:#fafafa;}

--- a/discovery-frontend/src/assets/css/polaris.v2.page.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.page.css
@@ -7169,8 +7169,9 @@ table.ddp-table-type2 tr td.ddp-info.ddp-selected,
 table.ddp-table-type2 tr td.ddp-info:hover {padding:12px 29px 13px 9px;}
 table.ddp-table-type2 tr td.ddp-info:hover {background-color:#f1f1f3 !important; border:1px solid #f1f1f3;cursor:pointer; }
 table.ddp-table-type2 tr td.ddp-info .ddp-ui-info {position:absolute; top:50%; right:9px; margin-top:-7px; cursor:pointer; font-size:0px;}
+table.ddp-table-type2 tr td.ddp-info.ddp-selected .ddp-ui-info,
+table.ddp-table-type2 tr td.ddp-info:hover .ddp-ui-info {right:8px;}
 table.ddp-table-type2 tr td.ddp-info .ddp-ui-info .ddp-icon-error2 {position:relative; top:0;}
-table.ddp-table-type2 tr td.ddp-info:hover .ddp-ui-info .ddp-icon-error2 {right:-1px;}
 table.ddp-table-type2 tr td.ddp-info .ddp-ui-info.ddp-selected .ddp-box-layout4.type-time {display:block; z-index:20;}
 table.ddp-table-type2 tr td.ddp-info .ddp-ui-info .ddp-box-layout4.type-time {display:none; width:330px; position:absolute; top:100%; right:-30px; margin-top:5px;}
 table.ddp-table-type2 tr td.ddp-info .ddp-ui-info.ddp-selected .ddp-icon-sinfo2 {background-position:-28px -30px; }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
메타데이터 컬럼의 타입 변경시 TIMSTAMP 타입이 아닌 경우 format이 남아있던 현상 수정
메타데이터 컬럼의 role이 TIMESTAMP인 경우 format을 변경할 수 있는 아이콘이 나오는 현상 수정 (데이터소스와 동일)
disable 된 컬럼 위에 컬럼 타입 목록이 열려있는경우 해당 위치의 타입을 클릭할 수 없던 현상 수정

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
통합테스트

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 메타데이터 > 컬럼 Dictionary를 type을 TIMESTAMP가 아닌 타입으로 생성 (format이 없는타입)
2. format 정보가 있는 메타데이터 상세화면
3. format 정보가 있는 컬럼에 1에서 생성한 컬럼 Dictionary를 import
4. 수정 완료후 조회시 에러가 발생하지 않는것 확인
5. role이 타임스탬프인 컬럼에서 format을 변경 할 수 있는 아이콘이 출력되지 않는지 확인

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
- 기존에 format이 있는 컬럼에 컬럼 Dictionary를 import 한 경우 에러가 발생할 때 아래와 같은 조치로 해결할 수 있습니다.
1. 해당 컬럼의 컬럼 Dictionary를 재설정(또는 해제후 재설정)
2. 해당 컬럼의 컬럼 Dictionary를 해제후 다른 타입으로 변경

- 추후 별도의 이슈를 통해 수정이 필요
메타데이터 > column dictionary를 생성시에 timestamp 타입으로 생성하는 경우 format이 있음
이렇게 생성한 column dictionary를 메타데이터에서 불러올경우 format validation없이 해당 포맷이 덮어 씌워지게 됨
(현재는 logical column name을 제외한 값은 변경이 불가능하도록 되어있음)
추후 format을 변경또는 validation할수 있는것을 활성화 필요