### PR TITLE
F#2243 show null as missing

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DfSet.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DfSet.java
@@ -16,20 +16,18 @@ package app.metatron.discovery.domain.dataprep.teddy;
 
 import app.metatron.discovery.domain.dataprep.teddy.exceptions.TeddyException;
 import app.metatron.discovery.domain.dataprep.teddy.exceptions.WrongTargetColumnExpressionException;
-import app.metatron.discovery.domain.dataprep.transform.TimestampTemplate;
 import app.metatron.discovery.prep.parser.preparation.RuleVisitorParser;
 import app.metatron.discovery.prep.parser.preparation.rule.Rule;
 import app.metatron.discovery.prep.parser.preparation.rule.Set;
 import app.metatron.discovery.prep.parser.preparation.rule.expr.Expr;
 import app.metatron.discovery.prep.parser.preparation.rule.expr.Expression;
 import app.metatron.discovery.prep.parser.preparation.rule.expr.Identifier;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DfSet extends DataFrame {
   private static Logger LOGGER = LoggerFactory.getLogger(DfSet.class);
@@ -81,33 +79,8 @@ public class DfSet extends DataFrame {
       throw new WrongTargetColumnExpressionException("doSet(): wrong target column expression: " + targetColExpr.toString());
     }
 
-    // add columns
     for (int colno = 0; colno < prevDf.getColCnt(); colno++) {
-      // 변경이 가해진 column은 type이 바뀔 수 있다는 가정 (맞는지는 모르겠으나, backward-compatability를 위해 그렇게 함) --> FIXME: 이제 mismatch가 생겼기 때문에 값에 의해 타입이 바뀌는 일은 없어져야 함
-      if (targetColnos.contains(colno)) {
-        ColumnType columnType = prevDf.decideType(replacedColExprs.get(colno)) == ColumnType.UNKNOWN ? prevDf.getColType(colno) : prevDf.decideType(replacedColExprs.get(colno));
-        String timestampStyle = null;
-
-        //If columnType is timestamp, then set timestamp style.
-        //If there is only one column name in rule-String, then use that columns timestamp style.
-        //Else, use object column's timestamp style.
-        if(columnType == ColumnType.TIMESTAMP){
-          if(prevDf.ruleColumns.size() == 1) {
-            timestampStyle = prevDf.getColTimestampStyleByColName(prevDf.ruleColumns.get(0));
-          } else {
-            timestampStyle = prevDf.getColTimestampStyle(colno);
-          }
-
-          timestampStyle = timestampStyle == null ? TimestampTemplate.DATE_TIME_01.getFormat() : timestampStyle;
-        }
-
-        addColumnWithTimestampStyle(
-                prevDf.getColName(colno),
-                columnType,
-                timestampStyle);
-      } else {
-        addColumn(prevDf.getColName(colno), prevDf.getColDesc(colno));
-      }
+      addColumn(prevDf.getColName(colno), prevDf.getColDesc(colno));
     }
 
     preparedArgs.add(targetColnos);

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/Histogram.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/Histogram.java
@@ -122,17 +122,8 @@ public class Histogram implements Serializable {
       Object obj = rows.get(rowno).get(colno);
 
       // missing, mismatch 처리
-      if (obj == null) {
-        missing++;
-        missingRows.add(rowno);
+      if (checkMismatchMissing(rowno, obj, Map.class)) {
         continue;
-      } else if (!(obj instanceof Map)) {
-        mismatched++;
-        mismatchedRows.add(rowno);
-        continue;
-      } else {
-        matched++;
-        matchedRows.add(rowno);
       }
 
       assert obj instanceof Map : obj;
@@ -182,19 +173,9 @@ public class Histogram implements Serializable {
       Object obj = rows.get(rowno).get(colno);
 
       // missing, mismatch 처리
-      if (obj == null) {
-        missing++;
-        missingRows.add(rowno);
+      if (checkMismatchMissing(rowno, obj, List.class)) {
         continue;
-      } else if (!(obj instanceof List)) {
-        mismatched++;
-        mismatchedRows.add(rowno);
-        continue;
-      } else {
-        matched++;
-        matchedRows.add(rowno);
       }
-      assert obj instanceof List : obj;
 
       for (Object o : (List<Object>) obj) {
         String str = o.toString();
@@ -230,6 +211,22 @@ public class Histogram implements Serializable {
     LOGGER.trace("updateHistArray() end: colno={}", colno);
   }
 
+  private boolean checkMismatchMissing(int rowno, Object obj, Class cls) {
+    if (obj == null || (obj instanceof String && obj.equals(""))) {
+      missing++;
+      missingRows.add(rowno);
+      return true;
+    } else if (!obj.getClass().equals(cls)) {
+      mismatched++;
+      mismatchedRows.add(rowno);
+      return true;
+    }
+
+    matched++;
+    matchedRows.add(rowno);
+    return false;
+  }
+
   private void updateHistString(int colno, List<Row> rows) {
     Map<String, Integer> map = new HashMap();
     Map<String, List<Integer>> mapRownos = new HashMap();
@@ -240,17 +237,8 @@ public class Histogram implements Serializable {
       Object obj = rows.get(rowno).get(colno);
 
       // missing, mismatch 처리
-      if (obj == null) {
-        missing++;
-        missingRows.add(rowno);
+      if (checkMismatchMissing(rowno, obj, String.class)) {
         continue;
-      } else if (!(obj instanceof String)) {
-        mismatched++;
-        mismatchedRows.add(rowno);
-        continue;
-      } else {
-        matched++;
-        matchedRows.add(rowno);
       }
 
       assert obj instanceof String : obj;
@@ -304,17 +292,8 @@ public class Histogram implements Serializable {
       Object obj = rows.get(rowno).get(colno);
 
       // missing, mismatch 처리
-      if (obj == null) {
-        missing++;
-        missingRows.add(rowno);
+      if (checkMismatchMissing(rowno, obj, Boolean.class)) {
         continue;
-      } else if (!(obj instanceof Boolean)) {
-        mismatched++;
-        mismatchedRows.add(rowno);
-        continue;
-      } else {
-        matched++;
-        matchedRows.add(rowno);
       }
 
       assert obj instanceof Boolean : obj;
@@ -349,17 +328,8 @@ public class Histogram implements Serializable {
       Object obj = rows.get(rowno).get(colno);
 
       // missing, mismatch 처리
-      if (obj == null) {
-        missing++;
-        missingRows.add(rowno);
+      if (checkMismatchMissing(rowno, obj, Long.class)) {
         continue;
-      } else if (!(obj instanceof Long)) {
-        mismatched++;
-        mismatchedRows.add(rowno);
-        continue;
-      } else {
-        matched++;
-        matchedRows.add(rowno);
       }
 
       assert obj instanceof Long : obj;
@@ -576,17 +546,8 @@ public class Histogram implements Serializable {
       Object obj = rows.get(rowno).get(colno);
 
       // missing, mismatch 처리
-      if (obj == null) {
-        missing++;
-        missingRows.add(rowno);
+      if (checkMismatchMissing(rowno, obj, DateTime.class)) {
         continue;
-      } else if (!(obj instanceof DateTime)) {
-        mismatched++;
-        mismatchedRows.add(rowno);
-        continue;
-      } else {
-        matched++;
-        matchedRows.add(rowno);
       }
 
       assert obj instanceof DateTime : obj;
@@ -682,17 +643,8 @@ public class Histogram implements Serializable {
       Object obj = rows.get(rowno).get(colno);
 
       // missing, mismatch 처리
-      if (obj == null) {
-        missing++;
-        missingRows.add(rowno);
+      if (checkMismatchMissing(rowno, obj, Double.class)) {
         continue;
-      } else if (!(obj instanceof Double)) {
-        mismatched++;
-        mismatchedRows.add(rowno);
-        continue;
-      } else {
-        matched++;
-        matchedRows.add(rowno);
       }
 
       assert obj instanceof Double : obj;


### PR DESCRIPTION
### Description
Null values will be treated as missing on the Histogram bar.

**Related Issue** : https://github.com/metatron-app/metatron-discovery/issues/2243

### How Has This Been Tested?
1. Import & wrangle [nulltest.csv.txt](https://github.com/metatron-app/metatron-discovery/files/3296160/nulltest.csv.txt)
2. Add set rule ->
  col: Num
  expression: '' (empty string)
  where: `Num`==1
3. See missing (black) in the histogram of Num column. It was missmatched (red) before.

#### Need additional checks?
Yes. Let's use one of testbeds.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional context:
For string type, I'd like to keep showing _(null)_ for null values. (One of the famous data preparation tools works the same way).

_(null)_ might be removed for *non-string types*, later. (It makes the page messy!)
But now, all null values are shown as _(null)_.

