### PR TITLE
#2250 change hibernate connection properties

### DIFF
--- a/discovery-server/src/main/resources/application.yaml
+++ b/discovery-server/src/main/resources/application.yaml
@@ -314,6 +314,8 @@ spring:
           auto: update
         dialect: org.hibernate.dialect.MySQL5InnoDBDialect
         naming_strategy: org.hibernate.cfg.ImprovedNamingStrategy
+        connection:
+          release_mode: after_transaction
 
 ---
 spring:

--- a/discovery-server/src/main/resources/logback-console.xml
+++ b/discovery-server/src/main/resources/logback-console.xml
@@ -33,6 +33,9 @@
     <!-- show hibernate sql -->
     <logger name="org.hibernate.SQL" level="info"/>
 
+    <!-- hide warn HibernateJpaDialect, because release_mode : after_transaction -->
+    <logger name="org.springframework.orm.jpa.vendor" level="error"/>
+
     <!-- show bound hibernate parameters with trace -->
     <logger name="org.hibernate.type" level="info"/>
 


### PR DESCRIPTION
### Description
Currently, the release_mode of the hibernate connection is on_close (default), which keeps the connection until the hibernate session is closed.
There is a risk of error if it does not match db timeout setting.
Also, resources are wasted due to connection.
So we need to change it to after_transaction to release it at the end of the transaction.

**Related Issue** : #2250 


### How Has This Been Tested?
NA

#### Need additional checks?
NA

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
