### PR TITLE
#2214 permission schema deleted and set default permission schema

### DIFF
--- a/discovery-frontend/src/app/admin/workspace-management/component/workspace-permission-schemas/detail-permission-schema.component.ts
+++ b/discovery-frontend/src/app/admin/workspace-management/component/workspace-permission-schemas/detail-permission-schema.component.ts
@@ -12,21 +12,21 @@
  * limitations under the License.
  */
 
-import { Component, ElementRef, Injector, OnDestroy, OnInit, ViewChild } from '@angular/core';
-import { AbstractComponent } from '../../../../common/component/abstract.component';
-import { ActivatedRoute } from '@angular/router';
-import { PermissionService } from '../../../../user/service/permission.service';
-import { RoleSet } from '../../../../domain/user/role/roleSet';
-import { Alert } from '../../../../common/util/alert.util';
-import { Modal } from '../../../../common/domain/modal';
-import { Location } from "@angular/common";
-import { ConfirmModalComponent } from '../../../../common/component/modal/confirm/confirm.component';
-import { isUndefined } from 'util';
-import { CommonUtil } from '../../../../common/util/common.util';
-import { PermissionSchemaSetComponent } from '../../../../workspace/component/permission/permission-schema-set.component';
+import {Component, ElementRef, Injector, OnDestroy, OnInit, ViewChild} from '@angular/core';
+import {AbstractComponent} from '../../../../common/component/abstract.component';
+import {ActivatedRoute} from '@angular/router';
+import {PermissionService} from '../../../../user/service/permission.service';
+import {RoleSet} from '../../../../domain/user/role/roleSet';
+import {Alert} from '../../../../common/util/alert.util';
+import {Modal} from '../../../../common/domain/modal';
+import {Location} from "@angular/common";
+import {ConfirmModalComponent} from '../../../../common/component/modal/confirm/confirm.component';
+import {isUndefined} from 'util';
+import {CommonUtil} from '../../../../common/util/common.util';
+import {PermissionSchemaSetComponent} from '../../../../workspace/component/permission/permission-schema-set.component';
 import * as _ from 'lodash';
-import { Page } from '../../../../domain/common/page';
-import { Workspace } from '../../../../domain/workspace/workspace';
+import {Page} from '../../../../domain/common/page';
+import {Workspace} from '../../../../domain/workspace/workspace';
 
 @Component({
   selector: 'app-detail-permission-schema',
@@ -398,7 +398,7 @@ export class DetailPermissionSchemaComponent extends AbstractComponent implement
         const wsList = result['_embedded']['workspaces'];
         if( 1 === pageSize ) {
           this.firstWorkspace = wsList[0];
-          this.totalWsCnt = ( 0 < result['page']['totalElements'] ) ? result['page']['totalElements'] - 1 : 0;
+          this.totalWsCnt = ( 0 < result['page']['totalElements'] ) ? result['page']['totalElements'] : 0;
         } else {
           if( 1 < wsList.length ) {
             wsList.shift(0);

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/user/role/RoleSet.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/user/role/RoleSet.java
@@ -85,7 +85,7 @@ import app.metatron.discovery.domain.workspace.Workspace;
 //  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
   Integer linkedWorkspaces = 0;
 
-  @ManyToMany(cascade = {CascadeType.MERGE, CascadeType.PERSIST})
+  @ManyToMany(cascade = {CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.REMOVE})
   @JoinTable(name = "role_set_workspace",
       joinColumns = @JoinColumn(name = "rs_id", referencedColumnName = "id"),
       inverseJoinColumns = @JoinColumn(name = "ws_id", referencedColumnName = "id"))

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/user/role/RoleSet.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/user/role/RoleSet.java
@@ -85,7 +85,7 @@ import app.metatron.discovery.domain.workspace.Workspace;
 //  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
   Integer linkedWorkspaces = 0;
 
-  @ManyToMany(cascade = {CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.REMOVE})
+  @ManyToMany(fetch = FetchType.EAGER, cascade = {CascadeType.MERGE, CascadeType.PERSIST})
   @JoinTable(name = "role_set_workspace",
       joinColumns = @JoinColumn(name = "rs_id", referencedColumnName = "id"),
       inverseJoinColumns = @JoinColumn(name = "ws_id", referencedColumnName = "id"))

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/user/role/RoleSet.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/user/role/RoleSet.java
@@ -85,7 +85,7 @@ import app.metatron.discovery.domain.workspace.Workspace;
 //  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
   Integer linkedWorkspaces = 0;
 
-  @ManyToMany(fetch = FetchType.EAGER, cascade = {CascadeType.MERGE, CascadeType.PERSIST})
+  @ManyToMany(cascade = {CascadeType.MERGE, CascadeType.PERSIST})
   @JoinTable(name = "role_set_workspace",
       joinColumns = @JoinColumn(name = "rs_id", referencedColumnName = "id"),
       inverseJoinColumns = @JoinColumn(name = "ws_id", referencedColumnName = "id"))

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/user/role/RoleSetEventHandler.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/user/role/RoleSetEventHandler.java
@@ -17,6 +17,7 @@ package app.metatron.discovery.domain.user.role;
 import com.google.common.collect.Lists;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.hibernate.Hibernate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -96,6 +97,7 @@ public class RoleSetEventHandler {
 //  @PreAuthorize("hasAnyAuthority('PERM_SYSTEM_WRITE_USER') " +
 //          "or hasPermission(#roleSet, 'PERM_WORKSPACE_WRITE_MEMBER')")
   public void handleBeforeDelete(RoleSet roleSet) {
+    Hibernate.initialize(roleSet);
   }
 
   @HandleAfterDelete
@@ -123,7 +125,6 @@ public class RoleSetEventHandler {
         }
       }
     }
-
   }
 
   @HandleBeforeLinkDelete

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/user/role/RoleSetEventHandler.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/user/role/RoleSetEventHandler.java
@@ -108,6 +108,7 @@ public class RoleSetEventHandler {
       Set<Workspace> linkedWorkspaces = roleSet.getWorkspaces();
       List<String> workspaceIds = Lists.newArrayList();
       for (Workspace workspace : linkedWorkspaces) {
+        LOGGER.debug("UPDATED: Set linked workspace({}) to default permission schema", workspace.getId());
         defaultRoleSetWorkspaces.add(workspace);
         workspaceIds.add(workspace.getId());
       }
@@ -117,6 +118,7 @@ public class RoleSetEventHandler {
 
       if (CollectionUtils.isNotEmpty(roleSet.getRoleNames())) {
         for (String deletedRoleName : roleSet.getRoleNames()) {
+          LOGGER.debug("UPDATED: Set linked workspace({}) in roleset({}) to {}", workspaceIds, deletedRoleName, defaultRoleSet.getDefaultRole().getName());
           workspaceMemberRepository.updateMultiMemberRoleInWorkspaces(workspaceIds, deletedRoleName, defaultRoleSet.getDefaultRole().getName());
         }
       }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/user/role/RoleSetEventHandler.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/user/role/RoleSetEventHandler.java
@@ -97,7 +97,7 @@ public class RoleSetEventHandler {
 //  @PreAuthorize("hasAnyAuthority('PERM_SYSTEM_WRITE_USER') " +
 //          "or hasPermission(#roleSet, 'PERM_WORKSPACE_WRITE_MEMBER')")
   public void handleBeforeDelete(RoleSet roleSet) {
-    Hibernate.initialize(roleSet);
+    Hibernate.initialize(roleSet.getWorkspaces());
   }
 
   @HandleAfterDelete

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/user/role/RoleSetEventHandler.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/user/role/RoleSetEventHandler.java
@@ -14,10 +14,13 @@
 
 package app.metatron.discovery.domain.user.role;
 
+import com.google.common.collect.Lists;
+
 import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.rest.core.annotation.HandleAfterDelete;
 import org.springframework.data.rest.core.annotation.HandleBeforeCreate;
 import org.springframework.data.rest.core.annotation.HandleBeforeDelete;
 import org.springframework.data.rest.core.annotation.HandleBeforeLinkDelete;
@@ -25,7 +28,12 @@ import org.springframework.data.rest.core.annotation.HandleBeforeLinkSave;
 import org.springframework.data.rest.core.annotation.HandleBeforeSave;
 import org.springframework.data.rest.core.annotation.RepositoryEventHandler;
 
+import java.util.List;
+import java.util.Set;
+
 import app.metatron.discovery.domain.workspace.Workspace;
+import app.metatron.discovery.domain.workspace.WorkspaceMemberRepository;
+import app.metatron.discovery.domain.workspace.WorkspaceRepository;
 
 /**
  * Created by kyungtaak on 2016. 5. 14..
@@ -37,6 +45,15 @@ public class RoleSetEventHandler {
 
   @Autowired
   RoleSetService roleSetService;
+
+  @Autowired
+  RoleSetRepository roleSetRepository;
+
+  @Autowired
+  WorkspaceRepository workspaceRepository;
+
+  @Autowired
+  WorkspaceMemberRepository workspaceMemberRepository;
 
   @HandleBeforeCreate
 //  @PreAuthorize("hasAnyAuthority('PERM_SYSTEM_WRITE_USER') " +
@@ -79,6 +96,32 @@ public class RoleSetEventHandler {
 //  @PreAuthorize("hasAnyAuthority('PERM_SYSTEM_WRITE_USER') " +
 //          "or hasPermission(#roleSet, 'PERM_WORKSPACE_WRITE_MEMBER')")
   public void handleBeforeDelete(RoleSet roleSet) {
+  }
+
+  @HandleAfterDelete
+  public void handleAfterDelete(RoleSet roleSet) {
+    // 연결된 워크스페이스 기본 퍼미션 스키마로 변경, Member의 Role도 defaultRole로 변경
+    if (roleSet.getScope() == RoleSet.RoleSetScope.PUBLIC &&
+        roleSet.getLinkedWorkspaces() > 0) {
+      RoleSet defaultRoleSet = roleSetService.getDefaultRoleSet();
+      Set<Workspace> defaultRoleSetWorkspaces = defaultRoleSet.getWorkspaces();
+      Set<Workspace> linkedWorkspaces = roleSet.getWorkspaces();
+      List<String> workspaceIds = Lists.newArrayList();
+      for (Workspace workspace : linkedWorkspaces) {
+        defaultRoleSetWorkspaces.add(workspace);
+        workspaceIds.add(workspace.getId());
+      }
+      defaultRoleSet.setWorkspaces(defaultRoleSetWorkspaces);
+      defaultRoleSet.setLinkedWorkspaces(defaultRoleSet.getWorkspaces().size());
+      roleSetRepository.saveAndFlush(defaultRoleSet);
+
+      if (CollectionUtils.isNotEmpty(roleSet.getRoleNames())) {
+        for (String deletedRoleName : roleSet.getRoleNames()) {
+          workspaceMemberRepository.updateMultiMemberRoleInWorkspaces(workspaceIds, deletedRoleName, defaultRoleSet.getDefaultRole().getName());
+        }
+      }
+    }
+
   }
 
   @HandleBeforeLinkDelete


### PR DESCRIPTION
### Description
If a permission schema deleted, linked workspaces to the schema is setted to the default permission schema.

**Related Issue** : #2214 
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
1. Create a shared workspace.
2. Create a new permission schema.
3. Set the permission schema to the workspace.
4. Delete the permission schema.
5. Check the workspace to see if it is set to the default permission schema.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
