### PR TITLE
#2227 add ref to user defined field

### DIFF
--- a/discovery-frontend/src/app/common/component/chart/type/line-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/line-chart.component.ts
@@ -1008,7 +1008,7 @@ export class LineChartComponent extends BaseChart implements OnInit, AfterViewIn
     }
 
     // userCodes가 있는경우 codes대신 userCodes를 설정한다
-    if((<UIChartColorBySeries>this.uiOption.color).mapping) list = _.cloneDeep((<UIChartColorBySeries>this.uiOption.color).mapping);
+    // if((<UIChartColorBySeries>this.uiOption.color).mapping) list = _.cloneDeep((<UIChartColorBySeries>this.uiOption.color).mapping);
 
     // subType이 value가 아닌경우visualMap 존재한다면 삭제
     if (this.uiOption.color.type !== ChartColorType.MEASURE) delete this.chartOption.visualMap;
@@ -1024,22 +1024,35 @@ export class LineChartComponent extends BaseChart implements OnInit, AfterViewIn
         .map((obj) => {
           // 시리즈명을 delimiter 로 분리, 현재 시리즈의 측정값 필드명 추출, 라인차트의 dimension때에는 name을 그대로 가져오기
           const aggName = _.last(_.split(obj.name, CHART_STRING_DELIMITER));
-          // 측정값 필드명의 인덱스
-          const fieldIdx = _.indexOf(this.fieldInfo.aggs, aggName);
-          // 측정값 필드명의 인덱스에 맵핑되는 컬러인덱스
-          const colorIdx = fieldIdx >= list.length ? fieldIdx % list.length : fieldIdx;
+          const mappingInfo = (<UIChartColorBySeries>this.uiOption.color).mapping;
           // 기존 스타일이 존재 하지 않을 경우 기본스타일 생성 후 적용
           if (_.isUndefined(obj.itemStyle)) obj.itemStyle = optGen.ItemStyle.auto();
-          // 현재 시리즈에 컬러 적용
-          // border 가 존재한다면 border 에 컬러 적용
-          if (!_.isUndefined(obj.itemStyle.normal.borderWidth) && obj.itemStyle.normal.borderWidth > 0) {
-            obj.itemStyle.normal.borderColor = list[colorIdx];
-            delete obj.itemStyle.normal.color;
+
+          if( mappingInfo && mappingInfo[aggName] ) {
+            // 현재 시리즈에 컬러 적용 - border 가 존재한다면 border 에 컬러 적용
+            if (!_.isUndefined(obj.itemStyle.normal.borderWidth) && obj.itemStyle.normal.borderWidth > 0) {
+              obj.itemStyle.normal.borderColor = mappingInfo[aggName];
+              delete obj.itemStyle.normal.color;
+            } else {
+              obj.itemStyle.normal.color = mappingInfo[aggName];
+            }
+            // 텍스트로 구성되는 차트일 경우
+            if (!_.isUndefined(obj.textStyle)) obj.textStyle.normal.color = mappingInfo[aggName];
           } else {
-            obj.itemStyle.normal.color = list[parameterIdx];
+            // 측정값 필드명의 인덱스
+            const fieldIdx = _.indexOf(this.fieldInfo.aggs, aggName);
+            // 측정값 필드명의 인덱스에 맵핑되는 컬러인덱스
+            const colorIdx = fieldIdx >= list.length ? fieldIdx % list.length : fieldIdx;
+            // 현재 시리즈에 컬러 적용 - border 가 존재한다면 border 에 컬러 적용
+            if (!_.isUndefined(obj.itemStyle.normal.borderWidth) && obj.itemStyle.normal.borderWidth > 0) {
+              obj.itemStyle.normal.borderColor = list[colorIdx];
+              delete obj.itemStyle.normal.color;
+            } else {
+              obj.itemStyle.normal.color = list[parameterIdx];
+            }
+            // 텍스트로 구성되는 차트일 경우
+            if (!_.isUndefined(obj.textStyle)) obj.textStyle.normal.color = list[colorIdx];
           }
-          // 텍스트로 구성되는 차트일 경우
-          if (!_.isUndefined(obj.textStyle)) obj.textStyle.normal.color = list[colorIdx];
         });
     });
 
@@ -1106,6 +1119,11 @@ export class LineChartComponent extends BaseChart implements OnInit, AfterViewIn
       case ChartColorType.DIMENSION: {
 
         this.chartOption = this.convertLineColorByDimension();
+        if (!this.isAnalysisPredictionLineEmpty()) {
+          this.chartOption = this.exceptPredictionLineColorBySeries();
+          this.chartOption = this.predictionLineLineStyleColorBySeries();
+          this.chartOption = this.predictionLineAreaStyleColorBySeries();
+        }
         break;
       }
       case ChartColorType.MEASURE: {

--- a/discovery-frontend/src/app/page/component/analysis/prediction/analysis-prediction.component.html
+++ b/discovery-frontend/src/app/page/component/analysis/prediction/analysis-prediction.component.html
@@ -327,8 +327,10 @@
 
                 <!-- checkbox -->
                 <label class="ddp-label-checkbox ddp-type3">
-                    <input type="checkbox" [checked]="data.isSelectedForecast"
-                           [(ngModel)]="data.isSelectedForecast">
+                  <input type="checkbox"
+                         [(ngModel)]="data.isSelectedForecast" [checked]="data.isSelectedForecast"
+                         [disabled]="data.isSelectedForecast && !data.isSelectedConfidence"
+                         (change)="changeUseForecast()">
                     <i class="ddp-icon-checkbox"></i>
 
                     <!-- label : Forecast -->
@@ -373,8 +375,9 @@
                 <label *ngIf="data.isPredictionLineActive"
                        class="ddp-label-checkbox ddp-type3">
                     <input type="checkbox"
-                           [checked]="data.isSelectedConfidence"
-                           [(ngModel)]="data.isSelectedConfidence">
+                           [checked]="data.isSelectedConfidence" [(ngModel)]="data.isSelectedConfidence"
+                           [disabled]="data.isSelectedConfidence && !data.isSelectedForecast"
+                           (change)="changeUseConfidence()">
                     <i class="ddp-icon-checkbox"></i>
 
                     <!-- label : Confidence -->

--- a/discovery-frontend/src/app/page/component/analysis/prediction/analysis-prediction.component.ts
+++ b/discovery-frontend/src/app/page/component/analysis/prediction/analysis-prediction.component.ts
@@ -760,10 +760,17 @@ export class AnalysisPredictionComponent extends AbstractComponent implements On
           .forEach((agg) => {
             const hyperParameter = new HyperParameter();
 
-            // alias가 있는경우
-            if (agg.alias) hyperParameter.field = agg.alias;
-            // alias가 없는경우
-            else hyperParameter.field = `${agg.aggregationType + '(' + agg.name + ')'}`;
+            if (agg.alias) {
+              // alias가 있는경우
+              hyperParameter.field = agg.alias;
+            } else {
+              // alias가 없는경우
+              if( agg.ref ) {
+                hyperParameter.field = `${agg.aggregationType + '(' + agg.ref + '.' + agg.name + ')'}`;
+              } else {
+                hyperParameter.field = `${agg.aggregationType + '(' + agg.name + ')'}`;
+              }
+            }
 
             hyperParameter.alpha = resultData[`${hyperParameter.field}.params`][0];
             hyperParameter.beta = resultData[`${hyperParameter.field}.params`][1];
@@ -792,10 +799,18 @@ export class AnalysisPredictionComponent extends AbstractComponent implements On
 
           // alias 설정
           let alias: string;
-          // alias가 있는경우
-          if (agg.alias) alias = agg.alias;
-          // alias가 없는경우
-          else alias = `${agg.aggregationType + '(' + agg.name + ')'}`;
+          if (agg.alias) {
+            // alias가 있는경우
+            alias = agg.alias;
+          }
+          else {
+            // alias가 없는경우
+            if( agg.ref ) {
+              alias = `${agg.aggregationType + '(' + agg.ref + '.' + agg.name + ')'}`;
+            } else {
+              alias = `${agg.aggregationType + '(' + agg.name + ')'}`;
+            }
+          }
 
           const parameter = this.data.analysis.analysis.forecast.parameters
             .filter((param) => {
@@ -1621,10 +1636,18 @@ export class AnalysisPredictionComponent extends AbstractComponent implements On
       .forEach((agg) => {
         const hyperParameter = new HyperParameter();
 
-        // alias가 있는경우
-        if (agg.alias) hyperParameter.field = agg.alias;
-        // alias가 없는경우
-        else hyperParameter.field = `${agg.aggregationType + '(' + agg.name + ')'}`;
+        if (agg.alias) {
+          // alias가 있는경우
+          hyperParameter.field = agg.alias;
+        }
+        else {
+          // alias가 없는경우
+          if( agg.ref ) {
+            hyperParameter.field = `${agg.aggregationType + '(' + agg.ref + '.' + agg.name + ')'}`;
+          } else {
+            hyperParameter.field = `${agg.aggregationType + '(' + agg.name + ')'}`;
+          }
+        }
 
         // 고급분석 제외
         analysisInAnalysis.forecast.parameters.push(_.cloneDeep(hyperParameter));

--- a/discovery-frontend/src/app/page/component/analysis/prediction/analysis-prediction.component.ts
+++ b/discovery-frontend/src/app/page/component/analysis/prediction/analysis-prediction.component.ts
@@ -1354,6 +1354,21 @@ export class AnalysisPredictionComponent extends AbstractComponent implements On
       });
   }
 
+  /**
+   * 예측선 사용 여부
+   */
+  public changeUseForecast() {
+    if( this.data.isSelectedForecast ) {
+      this.data.analysis.analysis.forecast.style.lineType = 'SOLID';
+      this.data.analysis.analysis.forecast.style.lineThickness = 2.0;
+      this.predictionLineForecastDataChangeNotification();
+    } else {
+      this.data.analysis.analysis.forecast.style.lineType = 'SOLID';
+      this.data.analysis.analysis.forecast.style.lineThickness = 0;
+      this.predictionLineForecastDataChangeNotification();
+    }
+  } // function - changeUseForecast
+
   // -------------------------------------------------------------------------------------------------------------------
   // Confidence 관련
   // -------------------------------------------------------------------------------------------------------------------
@@ -1417,6 +1432,13 @@ export class AnalysisPredictionComponent extends AbstractComponent implements On
     // 예측선 Confidence 데이터 변경 알림
     this.predictionLineConfidenceDataChangeNotification();
   } // function - setConfidenceTransparency
+
+  /**
+   * 투명도 사용 여부 변경
+   */
+  public changeUseConfidence() {
+    this.setConfidenceTransparency( this.data.isSelectedConfidence ? 10 : 0 );
+  } // function - changeUseConfidence
 
   // -------------------------------------------------------------------------------------------------------------------
   // 셀렉트 박스 콜백 관련


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
An error occurs when you place a measure that declares a user-defined field on the shelf and activates the prediction line.

**Related Issue** : #2227 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Go to 'New Dashboard' linked with "Sales"
2. Click on 'New Chart'
3. Create a user-defined field with measure role named "test_field"
    : Set the expression to "Sales + 1"
4. Put on the shelf: Orderdate (month) on column area, "test_field" on aggregation area.
5. Click on "Analysis" tab > Predict line and enable "Activation"

#### Need additional checks?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
