### PR TITLE
#2242 metadata col dictionary timestamp validation

### DIFF
--- a/discovery-frontend/src/app/meta-data-management/detail/component/column-schema/column-schema.component.html
+++ b/discovery-frontend/src/app/meta-data-management/detail/component/column-schema/column-schema.component.html
@@ -294,7 +294,7 @@
                  [ngModel]="column.name"
                  (ngModelChange)="column.name = $event; column.nameChangeFl = true; column.replaceFl = true">
         </td>
-        <td>
+        <td [ngClass]="{'ddp-disabled': isGeoType(column.type)}">
           <div class="ddp-select-search ddp-hover-tooltip">
             <a href="javascript:"
                class="ddp-ui-search2"

--- a/discovery-frontend/src/app/meta-data-management/detail/component/column-schema/column-schema.component.html
+++ b/discovery-frontend/src/app/meta-data-management/detail/component/column-schema/column-schema.component.html
@@ -499,14 +499,11 @@
         </td>
         <td [ngClass]="['ddp-input-form']"
             #metadataColumnSchemaDescriptionTds
-            [class.ddp-padding-none]="!isSelectedMetadataColumnInColumnDictionaryDefined(column)"
-            [class.ddp-disabled]="isSelectedMetadataColumnInColumnDictionaryDefined(column)"
             (click)="focusMetadataColumnSchemaDescriptionInput(index, column)">
           <input type="text"
                  class="ddp-txt-input"
                  #metadataColumnSchemaDescriptionInputs
                  (blur)="blurMetadataColumnSchemaDescriptionInput(index)"
-                 [readOnly]="isSelectedMetadataColumnInColumnDictionaryDefined(column)"
                  [ngModel]="column.description"
                  (ngModelChange)="column.description = $event; column.replaceFl = true">
         </td>

--- a/discovery-frontend/src/app/meta-data-management/detail/component/column-schema/column-schema.component.ts
+++ b/discovery-frontend/src/app/meta-data-management/detail/component/column-schema/column-schema.component.ts
@@ -12,15 +12,21 @@
  * limitations under the License.
  */
 
-import {Component, ElementRef, EventEmitter, Injector, Input, OnDestroy, OnInit, Output, QueryList, Renderer, ViewChildren} from '@angular/core';
-import {AbstractComponent} from '../../../../common/component/abstract.component';
 import {
-  ConnectionType,
-  Datasource,
-  FieldFormat,
-  FieldFormatType,
-  FieldRole, LogicalType
-} from '../../../../domain/datasource/datasource';
+  Component,
+  ElementRef,
+  EventEmitter,
+  Injector,
+  Input,
+  OnDestroy,
+  OnInit,
+  Output,
+  QueryList,
+  Renderer,
+  ViewChildren
+} from '@angular/core';
+import {AbstractComponent} from '../../../../common/component/abstract.component';
+import {ConnectionType, Datasource, FieldFormat, FieldFormatType} from '../../../../domain/datasource/datasource';
 import * as _ from 'lodash';
 import {MetadataService} from '../../../metadata/service/metadata.service';
 import {MetadataModelService} from '../../../metadata/service/metadata.model.service';
@@ -183,13 +189,20 @@ export class ColumnSchemaComponent extends AbstractComponent implements OnInit, 
     super.ngOnDestroy();
   }
 
-  public onClickInfoIcon(metadataColumn: MetadataColumn, index: number): void {
+  public onClickInfoIcon(metadataColumn: MetadataColumn, index: number, isFromDictionary: boolean = false): void {
     if (MetadataColumn.isTypeIsTimestamp(metadataColumn)) {
       if (metadataColumn[ 'typeListFl' ]) {
         metadataColumn[ 'typeListFl' ] = false;
       }
       metadataColumn.checked = true;
-      this._datetimePopupComponentList.toArray()[ index ].init();
+
+      if (isFromDictionary) {
+        // 열리는 순간 바로 validation을 해야한다.
+        this._datetimePopupComponentList.toArray()[index].initFromDictionary();
+      } else {
+        this._datetimePopupComponentList.toArray()[ index ].init();
+      }
+
     }
   }
 
@@ -329,8 +342,29 @@ export class ColumnSchemaComponent extends AbstractComponent implements OnInit, 
     this._selectedColumn.replaceFl = true;
     // 현재 선택한 컬럼의 사전 변경
     this._selectedColumn.dictionary = columnDictionary;
-    // 컬럼 사전이 있다면 해당 컬럼 사전의 상세정보 조회
-    columnDictionary && this._getDetailColumnDictionary(columnDictionary.id);
+
+    // 컬럼 딕셔너리 삭제시
+    if (columnDictionary === null) {
+      // logical column name 초기화
+      this._selectedColumn.name = this._selectedColumn.physicalName;
+
+      // type string으로 초기화
+      this._selectedColumn.type = Type.Logical.STRING;
+      this._selectedColumn.format = null;
+
+      // code table 삭제
+      if (!_.isNil(this._selectedColumn.codeTable)) {
+        delete this._selectedColumn.codeTable
+      }
+
+      // description 초기화
+      this._selectedColumn.description = '';
+
+    } else {
+      // 컬럼 사전이 있다면 해당 컬럼 사전의 상세정보 조회
+      this._getDetailColumnDictionary(columnDictionary.id);
+    }
+
   }
 
   /**
@@ -847,9 +881,16 @@ export class ColumnSchemaComponent extends AbstractComponent implements OnInit, 
     this.loadingShow();
     this._columnDictionaryService.getColumnDictionaryDetail(dictionaryId)
       .then((result) => {
-        // 변경된 컬럼의 사전정보로 logicalType, Format, CodeTable, Description 적용
-        this._selectedColumn.type = result.logicalType || null;
-        this._selectedColumn.format = result.format || null;
+
+        // 데이터소스 타입 메타데이터이고 && 컬럼의 role이 timestamp라면 ? 컬럼 딕셔너리를 추가했을때
+        // 타입과 포멧이 변경되면 안됨. stay as timestamp
+        console.info('selected type ==>', this._selectedColumn);
+        if (!(this._selectedColumn.role === Type.Role.TIMESTAMP && this.isMetadataSourceTypeIsEngine())) {
+          // 변경된 컬럼의 사전정보로 logicalType, Format, CodeTable, Description 적용
+          this._selectedColumn.type = result.logicalType || null;
+          this._selectedColumn.format = result.format || null;
+        }
+
         this._selectedColumn.description = result.description || null;
 
         // 이름이 사용자에 의해 변경되지 않았다면 컬럼 사전의 이름을 name으로 지정함
@@ -861,6 +902,19 @@ export class ColumnSchemaComponent extends AbstractComponent implements OnInit, 
           this._removeCodeTableForSelectedColumn();
           this.loadingHide();
         }
+
+        // 딕셔너리 타입이 타임스템프인경우 벨리데이션 전이기 떄문에 팝업 오픈 + 빨강 아이콘
+        if (result.logicalType === Type.Logical.TIMESTAMP) {
+
+          const idx = this.getColumns().findIndex((item) => {
+            return item.id === this._selectedColumn.id
+          });
+
+          this.safelyDetectChanges();
+          this.onClickInfoIcon(this._selectedColumn, idx, true);
+
+        }
+
       })
       .catch(error => this.commonExceptionHandler(error));
   }

--- a/discovery-frontend/src/app/meta-data-management/detail/component/column-schema/column-schema.component.ts
+++ b/discovery-frontend/src/app/meta-data-management/detail/component/column-schema/column-schema.component.ts
@@ -348,9 +348,16 @@ export class ColumnSchemaComponent extends AbstractComponent implements OnInit, 
       // logical column name 초기화
       this._selectedColumn.name = this._selectedColumn.physicalName;
 
-      // type string으로 초기화
-      this._selectedColumn.type = Type.Logical.STRING;
-      this._selectedColumn.format = null;
+      // # 2242
+      // role이 타입스템프 타입에 딕셔너리를 적용할 경우 type과 format 이 적용되지 않기 때문에..
+      // 딕셔너리를 해제해도 string으로 초기화 하지 않음
+      if (this._selectedColumn.role !== Type.Role.TIMESTAMP) {
+        // type string으로 초기화
+        this._selectedColumn.type = Type.Logical.STRING;
+        this._selectedColumn.format = null;
+
+      }
+
 
       // code table 삭제
       if (!_.isNil(this._selectedColumn.codeTable)) {
@@ -359,6 +366,12 @@ export class ColumnSchemaComponent extends AbstractComponent implements OnInit, 
 
       // description 초기화
       this._selectedColumn.description = '';
+
+
+      // check validation
+      this.setIsExistErrorInFieldListFlag();
+
+
 
     } else {
       // 컬럼 사전이 있다면 해당 컬럼 사전의 상세정보 조회

--- a/discovery-frontend/src/app/meta-data-management/detail/component/column-schema/column-schema.component.ts
+++ b/discovery-frontend/src/app/meta-data-management/detail/component/column-schema/column-schema.component.ts
@@ -426,6 +426,12 @@ export class ColumnSchemaComponent extends AbstractComponent implements OnInit, 
    */
   public onClickSearchDictionary(metadataColumn: MetadataColumn): void {
     event.stopImmediatePropagation();
+
+
+    // GEO타입 딕셔너리 수정 불가 : #2242
+    if (this.isGeoType(metadataColumn.type)) {
+      return;
+    }
     this._saveCurrentlySelectedColumn(metadataColumn);
     this._chooseDictionaryEvent.emit({ name: 'CREATE', dictionary: metadataColumn.dictionary }); // 컬럼 사전 선택 컴포넌트
   }
@@ -484,6 +490,15 @@ export class ColumnSchemaComponent extends AbstractComponent implements OnInit, 
     if (this.hasMetadataColumnInDatasource()) {
       this.isSaveInvalid = this.columnList.some(field =>  field.role !== Type.Role.TIMESTAMP && (field.type === Type.Logical.TIMESTAMP && !field.format.isValidFormat));
     }
+  }
+
+  /**
+   * Return true if column is geo type
+   * @param type
+   */
+  public isGeoType(type: Type.Logical): boolean {
+    const types = ['GEO_LINE', 'GEO_POINT','GEO_POLYGON'];
+    return -1 < types.indexOf(type)
   }
 
   public isLogicalTypesLayerActivation(metadataColumn: MetadataColumn) {

--- a/discovery-frontend/src/app/shared/datasource-metadata/component/datetime-valid-popup.component.ts
+++ b/discovery-frontend/src/app/shared/datasource-metadata/component/datetime-valid-popup.component.ts
@@ -119,6 +119,40 @@ export class DatetimeValidPopupComponent extends AbstractComponent {
     this.changedFieldFormat.emit(this.fieldFormat);
   }
 
+
+  public initFromDictionary(): void {
+    // field format
+    if (isNullOrUndefined(this.fieldFormat.formatInitialize)) {
+      this.fieldFormat = FieldFormat.of(this.fieldFormat);
+    }
+    // set value list
+    if (isNullOrUndefined(this._valueList)) {
+      this._valueList = this._dateList ? this._dateList.reduce((acc, data) => {
+        if (!isNullOrUndefined(data[this.name])) {
+          acc.push(data[this.name]);
+        }
+        return acc;
+      }, []) : [];
+    }
+    // if init format
+    if (StringUtil.isEmpty(this.fieldFormat.format) && this.fieldFormat.type === FieldFormatType.DATE_TIME) {
+      // if not exist default format
+      if (isNullOrUndefined(this.defaultFormat)) {
+        this._checkFormatValidation(true);
+      } else { // if exist default format
+        this.fieldFormat.format = this.defaultFormat;
+        this.fieldFormat.isValidFormat = true;
+      }
+    } else if (StringUtil.isNotEmpty(this.fieldFormat.format) && this.fieldFormat.type === FieldFormatType.DATE_TIME) {
+      this._checkFormatValidation();
+    } else if (this.fieldFormat.type === FieldFormatType.UNIX_TIME) {
+      this.fieldFormat.isValidFormat = true;
+    }
+    // open
+    this.fieldFormat.isShowTimestampValidPopup = true;
+    this.changedFieldFormat.emit(this.fieldFormat);
+  }
+
   /**
    * Cancel
    */

--- a/discovery-frontend/src/assets/css/metatron/component/component.table.css
+++ b/discovery-frontend/src/assets/css/metatron/component/component.table.css
@@ -173,6 +173,7 @@ table.ddp-table-type2 tbody tr td .ddp-input-form:hover:before {position:absolut
 table.ddp-table-type2 tbody tr td.ddp-selected .ddp-input-form:hover:before {display:none;}
 
 table.ddp-table-type2 tbody tr td.ddp-disabled > div {opacity:0.3;}
+table.ddp-table-type2 tbody tr td.ddp-disabled > div.ddp-ui-info {opacity:1; cursor:pointer; z-index:20}
 table.ddp-table-type2 tbody tr td.ddp-input-form {cursor:pointer;}
 table.ddp-table-type2 tbody tr td.ddp-input-form:hover {background-color:#f1f1f3 !important;}
 table.ddp-table-type2 tbody tr td.ddp-input-form input.ddp-txt-input {display:block; position:relative; width:100%; height:100%; border:none; background:none; font-size:13px; box-sizing:border-box; z-index:10; cursor:pointer;}

--- a/discovery-frontend/src/assets/css/polaris.v2.page.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.page.css
@@ -7192,7 +7192,7 @@ table.ddp-table-type2 tr td.ddp-info .ddp-ui-info {position:absolute; top:50%; r
 table.ddp-table-type2 tr td.ddp-info.ddp-selected .ddp-ui-info,
 table.ddp-table-type2 tr td.ddp-info:hover .ddp-ui-info {right:8px;}
 table.ddp-table-type2 tr td.ddp-info .ddp-ui-info .ddp-icon-error2 {position:relative; top:0;}
-table.ddp-table-type2 tr td.ddp-info .ddp-ui-info.ddp-selected .ddp-box-layout4.type-time {display:block; z-index:20;}
+table.ddp-table-type2 tr td.ddp-info .ddp-ui-info.ddp-selected .ddp-box-layout4.type-time {display:block; z-index:23;}
 table.ddp-table-type2 tr td.ddp-info .ddp-ui-info .ddp-box-layout4.type-time {display:none; width:330px; position:absolute; top:100%; right:-30px; margin-top:5px;}
 table.ddp-table-type2 tr td.ddp-info .ddp-ui-info.ddp-selected .ddp-icon-sinfo2 {background-position:-28px -30px; }
 .ddp-box-layout4.type-time .ddp-wrap-edit3 + .ddp-wrap-edit3{margin-top:20px;}
@@ -7812,7 +7812,9 @@ table.ddp-table-type3.ddp-popup tr td {padding:10px 10px 11px 10px;}
 /*.ddp-ui-preview-contents table.ddp-table-form.ddp-table-details tbody tr td.ddp-selected:after {display:inline-block; position:absolute; top:0; right:0; bottom:0; left:0; border:1px solid #9ca2cc; content:'';}*/
 .ddp-ui-preview-contents table.ddp-table-form.ddp-table-details tbody tr td.ddp-selected {border:1px solid #9ca2cc; padding:12px 9px 13px 9px}
 .ddp-ui-preview-contents table.ddp-table-form.ddp-table-details tbody tr td.ddp-selected.ddp-info {padding-right:29px;}
+.ddp-ui-preview-contents table.ddp-table-form.ddp-table-details tbody tr td.ddp-info.ddp-disabled {cursor:initial !important;}
 .ddp-ui-preview-contents table.ddp-table-type2 tbody tr td.ddp-selected .ddp-input-form input.ddp-txt-input {display:inline-block; position:absolute; top:0; right:0; bottom:0; left:0; padding:12px 9px 13px 9px; content:'';}
+
 
 
 .ddp-ui-preview-contents .ddp-data-details {margin-top:-46px; height:100%; padding-top:46px; box-sizing:border-box;}

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/source/MetaSourceService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/source/MetaSourceService.java
@@ -17,16 +17,20 @@ package app.metatron.discovery.domain.mdm.source;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 import app.metatron.discovery.domain.dataconnection.DataConnectionRepository;
+import app.metatron.discovery.domain.datasource.DataSource;
+import app.metatron.discovery.domain.datasource.DataSourceProjections;
 import app.metatron.discovery.domain.datasource.DataSourceRepository;
 import app.metatron.discovery.domain.mdm.Metadata;
 import app.metatron.discovery.domain.mdm.MetadataController;
 import app.metatron.discovery.domain.workbook.DashboardRepository;
+import app.metatron.discovery.util.ProjectionUtils;
 
 @Component
 @Transactional(readOnly = true)
@@ -46,6 +50,9 @@ public class MetaSourceService {
   @Autowired
   DashboardRepository dashboardRepository;
 
+  @Autowired
+  ProjectionFactory projectionFactory;
+
   public List<MetadataSource> findMetadataSourcesBySourceId(String type, String sourceId) {
     return null;
   }
@@ -58,14 +65,16 @@ public class MetaSourceService {
    * @return
    */
   public Object getSourcesBySourceId(Metadata.SourceType type, String sourceId) {
-
+    Object source = null;
     switch (type) {
       case ENGINE:
-        return dataSourceRepository.findOne(sourceId);
+        DataSource dataSource = dataSourceRepository.findOne(sourceId);
+        return ProjectionUtils.toResource(projectionFactory, DataSourceProjections.ForDetailProjection.class, dataSource);
       case JDBC:
-        return dataConnectionRepository.findOne(sourceId);
+        source = dataConnectionRepository.findOne(sourceId);
+        break;
     }
 
-    return null;
+    return source;
   }
 }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
테스트 목록 기획서 참고해주세요.
![image](https://user-images.githubusercontent.com/42233517/60152307-f0522e00-981a-11e9-8112-b567075f2686.png)

1. Can't modify column dictionary when column is geo type
2. When removing Dictionary, initialise logical name, type, code table, description
3. Description is always editable whether you add a column dictionary or not
4. If you add a timestamp type column dictionary, you can modify the format
5. If metadata type is datasource and column role is timestamp,
type and format should not be changed when adding a column dictionary. It stays as timestamp

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#2242 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Ran locally

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
