### PR TITLE
HibernateProxy object unproxy in WorkbenchProjections

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/WorkbenchProjections.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/WorkbenchProjections.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Component;
 import java.util.Set;
 
 import app.metatron.discovery.common.BaseProjections;
+import app.metatron.discovery.domain.dataconnection.DataConnectionProjections;
 import app.metatron.discovery.domain.user.UserProfile;
 import app.metatron.discovery.domain.workspace.WorkspaceProjections;
 
@@ -72,11 +73,11 @@ public class WorkbenchProjections extends BaseProjections{
 
     String getGlobalVar();
 
+    @Value("#{T(app.metatron.discovery.util.HibernateUtils).unproxy(target.workspace)}")
     WorkspaceProjections.HeaderViewProjection getWorkspace();
 
-    @Value("#{target.dataConnection.getDataConnectionProjection(@projectionFactory, T(app.metatron.discovery.domain.dataconnection.DataConnectionProjections$defaultProjection))}")
-    Object getDataConnection();
-    //DataConnectionProjections.defaultProjection getDataConnection();
+    @Value("#{T(app.metatron.discovery.util.HibernateUtils).unproxy(target.dataConnection)}")
+    DataConnectionProjections.defaultProjection getDataConnection();
 
     Set<QueryEditor> getQueryEditors();
 


### PR DESCRIPTION
### Description
HibernateProxy object unproxy in WorkbenchProjections.
Proxy object error due to hibernate version up.
To solve this problem, HibernateProxy Object unproxy.

**Related Issue** : 

### How Has This Been Tested?
1. create workbench
2. go into workbench withour error.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
