### PR TITLE
#2242 fix proxy casting error with MetadataSource

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/source/MetaSourceService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/source/MetaSourceService.java
@@ -65,6 +65,23 @@ public class MetaSourceService {
    * @return
    */
   public Object getSourcesBySourceId(Metadata.SourceType type, String sourceId) {
+    switch (type) {
+      case ENGINE:
+        return dataSourceRepository.findOne(sourceId);
+      case JDBC:
+        return dataConnectionRepository.findOne(sourceId);
+    }
+    return null;
+  }
+
+  /**
+   * Gets sources by source id with projection.
+   *
+   * @param type     the type
+   * @param sourceId the source id
+   * @return the sources by source id with projection
+   */
+  public Object getSourcesBySourceIdWithProjection(Metadata.SourceType type, String sourceId) {
     Object source = null;
     switch (type) {
       case ENGINE:
@@ -74,7 +91,6 @@ public class MetaSourceService {
         source = dataConnectionRepository.findOne(sourceId);
         break;
     }
-
     return source;
   }
 }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/source/MetadataSourceProjections.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/source/MetadataSourceProjections.java
@@ -47,7 +47,7 @@ public class MetadataSourceProjections extends BaseProjections {
 
     //String getSourceId();
 
-    @Value("#{@metaSourceService.getSourcesBySourceId(target.type, target.sourceId)}")
+    @Value("#{@metaSourceService.getSourcesBySourceIdWithProjection(target.type, target.sourceId)}")
     Object getSource();
 
     String getSchema();


### PR DESCRIPTION
### Description
An error occurs when casting a resource object through projection.

**Related Issue** : #2242

### How Has This Been Tested?
1. create linked datasource.
2. go to created datasource's metadata.
3. click column tab
4. see column without error

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
