### PR TITLE
F#2232 back button action on dataflow details

### DIFF
--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-dataflow-rule-2.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-dataflow-rule-2.component.ts
@@ -48,6 +48,7 @@ import {DataflowModelService} from "../../../service/dataflow.model.service";
 import {ActivatedRoute} from "@angular/router";
 import {CommonConstant} from "../../../../../common/constant/common.constant";
 import {Observable} from "rxjs";
+import {Subscription} from "rxjs/Subscription";
 
 declare let Split;
 
@@ -162,6 +163,8 @@ export class EditDataflowRule2Component extends AbstractPopupComponent implement
   // tell if union is updating or just adding
   public isUpdate: boolean = false;
 
+  public isForward: boolean; // location.forward
+
 
   // Histogram
   public charts: any = [];
@@ -251,6 +254,17 @@ export class EditDataflowRule2Component extends AbstractPopupComponent implement
 
     // Init
     super.ngOnInit();
+
+    this.subscriptions.push(
+      <Subscription>this.location.subscribe((popState) => {
+        if( this.isForward !== true ) {
+          this.isForward = true;
+          this.location.forward();
+        } else {
+          this.isForward = false;
+        }
+      })
+    );
 
     // 데이터소스 생성완료시 사용
     this.subscriptions.push(

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/dataflow-detail2.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/dataflow-detail2.component.ts
@@ -32,6 +32,7 @@ import {PreparationAlert} from "../../util/preparation-alert.util";
 import {Modal} from "../../../common/domain/modal";
 import {DatasetInfoPopupComponent} from "./component/dataset-info-popup/dataset-info-popup.component";
 import {PreparationCommonUtil} from "../../util/preparation-common.util";
+import {Subscription} from "rxjs/Subscription";
 
 declare let echarts: any;
 
@@ -142,6 +143,8 @@ export class DataflowDetail2Component extends AbstractPopupComponent {
 
   public cloneFlag: boolean = false;
 
+  public isForward: boolean; // location.forward
+
   public step: string;
   public longUpdatePopupType: string = '';
 
@@ -176,6 +179,17 @@ export class DataflowDetail2Component extends AbstractPopupComponent {
     super.ngOnInit();
 
     // navigation back check
+    this.subscriptions.push(
+      <Subscription>this.location.subscribe((popState) => {
+        if( this.isForward !== true ) {
+          this.isForward = true;
+          this.location.forward();
+        } else {
+          this.isForward = false;
+        }
+      })
+    );
+
     this.step = '';
 
     this._initialiseValues();
@@ -232,7 +246,7 @@ export class DataflowDetail2Component extends AbstractPopupComponent {
    * 뒤로가기
    * */
   public close() {
-    this._location.back();
+    this.router.navigate(['/management/datapreparation/dataflow']);
   }
 
   // 다른 데이터 플로우로 이동


### PR DESCRIPTION
### Description
For the convenience of editing, the operation of the history back is limited
However, we changed the history back to route to the details of dataflow because a path that can not escape from the edit screen occurred

**Related Issue** : 
[#2232](https://github.com/metatron-app/metatron-discovery/issues/2232)

### How Has This Been Tested?
1. go to a page of the rule editing
2. go to a page of the diagram of the dataflow
3. press back button or go back to previous page 

If you are on the page of the dataflow list. It works. 

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
