### PR TITLE
fix column dictionary's name duplicate check

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/ColumnDictionaryController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/ColumnDictionaryController.java
@@ -106,14 +106,17 @@ public class ColumnDictionaryController {
   @RequestMapping(path = "/dictionaries/name/{value}/duplicated", method = RequestMethod.GET)
   public ResponseEntity<?> checkDuplicatedValue(@PathVariable("value") String value) {
 
-    Map<String, Boolean> duplicated = Maps.newHashMap();
-    if (columnDictionaryRepository.exists(ColumnDictionaryPredicate.searchDuplicatedName(value))) {
-      duplicated.put("duplicated", true);
+    Map<String, Boolean> duplicatedResult = Maps.newHashMap();
+    Predicate duplicatedPredicate = ColumnDictionaryPredicate.searchDuplicatedLogicalName(value);
+    Boolean duplicated = columnDictionaryRepository.exists(duplicatedPredicate);
+
+    if (duplicated) {
+      duplicatedResult.put("duplicated", true);
     } else {
-      duplicated.put("duplicated", false);
+      duplicatedResult.put("duplicated", false);
     }
 
-    return ResponseEntity.ok(duplicated);
+    return ResponseEntity.ok(duplicatedResult);
 
   }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/ColumnDictionaryPredicate.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/ColumnDictionaryPredicate.java
@@ -84,4 +84,20 @@ public class ColumnDictionaryPredicate {
     return builder;
   }
 
+  /**
+   * ColumnDictionary Logical 명 중복 조회 조건
+   *
+   * @param logicalName
+   * @return
+   */
+  public static Predicate searchDuplicatedLogicalName(String logicalName) {
+
+    BooleanBuilder builder = new BooleanBuilder();
+    QColumnDictionary dictionary = QColumnDictionary.columnDictionary;
+
+    builder = builder.and(dictionary.logicalName.eq(logicalName));
+
+    return builder;
+  }
+
 }


### PR DESCRIPTION
### Description
fix column dictionary's name duplicate check

**Related Issue** : 

### How Has This Been Tested?
1. create column dictionary (name : abc, recommended name : qwe)
2. change name "abc" to "qwe"
3. click check button for duplicate check
4. Confirms that there are no errors

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
