### PR TITLE
fix the original name of reserved fields when loading a temporary datasource

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/engine/EngineLoadService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/engine/EngineLoadService.java
@@ -165,6 +165,8 @@ public class EngineLoadService {
                                             .anyMatch(legacyField -> legacyField.getName().equals(compareField));
           }
           field.setName(newFieldName);
+          // #1920 Change buildspec column to originalname
+          field.setOriginalName(newFieldName);
         }
       }
     }


### PR DESCRIPTION

### Description
fix the original name of reserved fields when loading a temporary datasource

**Related Issue** : 
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
1. Create a data connection with druid
2. Create a workbench with the datasource
3. Execute a query and chart preview

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
