### PR TITLE
fix advance setting folding in reingestion popup

### DIFF
--- a/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/file-create-component/file-preview/file-preview.component.html
+++ b/discovery-frontend/src/app/data-storage/data-source-list/create-data-source/file-create-component/file-preview/file-preview.component.html
@@ -209,7 +209,7 @@
           <!-- 클릭시 ddp-selected 추가 -->
           <div class="ddp-wrap-advance" [class.ddp-selected]="advanceSetting">
 
-            <a href="javascript:" class="ddp-txt-setting" (click)="advanceSetting = true">{{'msg.storage.th.advanced.setting' | translate}}</a>
+            <a href="javascript:" class="ddp-txt-setting" (click)="advanceSetting = !advanceSetting">{{'msg.storage.th.advanced.setting' | translate}}</a>
             <div class="ddp-wrap-boxtype">
 
               <table class="ddp-wrap-boxdata">


### PR DESCRIPTION
### Description
fix advance setting folding in re-ingestion popup

**Related Issue** : 
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
Re-ingest a datasource with a file.
Fold advance setting in re-ingestion popup

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
