### PR TITLE
#2303 fix default dataconnection icon of extensions

### DIFF
--- a/discovery-frontend/src/app/workbench/workbench.component.ts
+++ b/discovery-frontend/src/app/workbench/workbench.component.ts
@@ -2300,6 +2300,8 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
             workbenchId: this.workbenchId,
             webSocketId: CommonConstant.websocketId
           };
+        } else if(data['connected'] === false){
+          Alert.error(data['message']);
         }
 
         if ('CONNECT' == data.command) {

--- a/discovery-frontend/src/app/workspace/workspace.component.ts
+++ b/discovery-frontend/src/app/workspace/workspace.component.ts
@@ -15,7 +15,12 @@
 import {Component, ElementRef, Injector, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {AbstractComponent} from '../common/component/abstract.component';
 import {CreateWorkbookComponent} from '../workbook/component/create-workbook/create-workbook.component';
-import {CountByBookType, PermissionChecker, PublicType, Workspace} from '../domain/workspace/workspace';
+import {
+  CountByBookType,
+  PermissionChecker,
+  PublicType,
+  Workspace
+} from '../domain/workspace/workspace';
 import {WorkspaceService} from './service/workspace.service';
 import {ActivatedRoute} from '@angular/router';
 import {Book} from '../domain/workspace/book';
@@ -300,9 +305,9 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
       this._connTypeList = StorageService.connectionTypeList;
     }
     const connType = this.getConnType(book);
-    return this.getConnImplementorGrayImgUrl(
-      connType,
-      this._connTypeList.find(item => item.implementor === connType).iconResource3
+    return this.getConnImplementorGrayImgUrl(connType,
+      isNullOrUndefined(this._connTypeList.find(item => item.implementor === connType)) ?
+        null : this._connTypeList.find(item => item.implementor === connType).iconResource3
     );
   } // function - getWorkbenchConnTypeIcon
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcConnectionService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcConnectionService.java
@@ -1100,25 +1100,34 @@ public class JdbcConnectionService {
   }
 
   public boolean isSupportSaveAsHiveTable(DataConnection jdbcDataConnection){
-    JdbcDialect dialect = DataConnectionHelper.lookupDialect(jdbcDataConnection);
-    if(dialect instanceof HiveDialect){
-      return HiveDialect.isSupportSaveAsHiveTable(jdbcDataConnection);
+    try{
+      JdbcDialect dialect = DataConnectionHelper.lookupDialect(jdbcDataConnection);
+      if(dialect instanceof HiveDialect){
+        return HiveDialect.isSupportSaveAsHiveTable(jdbcDataConnection);
+      }
+    } catch (JdbcDataConnectionException e){
+      LOGGER.error("cannot get isSupportSaveAsHiveTable for {}", jdbcDataConnection.getImplementor(), e);
     }
     return false;
   }
 
   public Object getConnectionInformation(DataConnection jdbcDataConnection){
-    JdbcDialect dialect = DataConnectionHelper.lookupDialect(jdbcDataConnection);
-
     Map<String, Object> extensionInfo = new HashMap<>();
-    extensionInfo.put("name", dialect.getName());
-    extensionInfo.put("implementor", dialect.getImplementor());
-    extensionInfo.put("scope", dialect.getScope());
-    extensionInfo.put("inputSpec", dialect.getInputSpec());
-    extensionInfo.put("iconResource1", dialect.getIconResource1());
-    extensionInfo.put("iconResource2", dialect.getIconResource2());
-    extensionInfo.put("iconResource3", dialect.getIconResource3());
-    extensionInfo.put("iconResource4", dialect.getIconResource4());
+    extensionInfo.put("implementor", jdbcDataConnection.getImplementor());
+
+    try{
+      JdbcDialect dialect = DataConnectionHelper.lookupDialect(jdbcDataConnection);
+      extensionInfo.put("name", dialect.getName());
+      extensionInfo.put("scope", dialect.getScope());
+      extensionInfo.put("inputSpec", dialect.getInputSpec());
+      extensionInfo.put("iconResource1", dialect.getIconResource1());
+      extensionInfo.put("iconResource2", dialect.getIconResource2());
+      extensionInfo.put("iconResource3", dialect.getIconResource3());
+      extensionInfo.put("iconResource4", dialect.getIconResource4());
+    } catch (JdbcDataConnectionException e){
+      LOGGER.error("cannot get ConnectionInformation for {}", jdbcDataConnection.getImplementor(), e);
+    }
+
     return extensionInfo;
   }
 


### PR DESCRIPTION
### Description
fix default dataconnection icon of extensions

**Related Issue** : #2303 
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
1. create oracle connection and workbench.
2. remove oracle extension and restart discovery.
3. see default dataconnection icon.
![image](https://user-images.githubusercontent.com/45194478/60504490-ae365a00-9cfc-11e9-9475-4d067148d776.png)

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
