### PR TITLE
Add format placeholder in column dictionary detail

### DIFF
--- a/discovery-frontend/src/app/meta-data-management/column-dictionary/detail-column-dictionary/detail-column-dictionary.component.html
+++ b/discovery-frontend/src/app/meta-data-management/column-dictionary/detail-column-dictionary/detail-column-dictionary.component.html
@@ -157,9 +157,7 @@
             <!-- 클릭시 ddp-selected 추가 -->
             <div class="ddp-txt-edit" [class.ddp-selected]="shortNameEditFl" (clickOutside)="shortNameEditFl = false">
               <!-- data -->
-              <span class="ddp-data-name"
-                    [class.ddp-data-none]="!columnDictionary.suggestionShortName"
-                    (click)="onChangeShortNameMode()">
+              <span class="ddp-data-name" [class.ddp-data-none]="!columnDictionary.suggestionShortName" (click)="onChangeShortNameMode()">
               {{ columnDictionary.suggestionShortName && columnDictionary.suggestionShortName.length > 0 ? columnDictionary.suggestionShortName : 'msg.metadata.ui.codetable.detail.used.column.dictionary.no.name' | translate }}
               <em class="ddp-icon-edit2"></em>
             </span>
@@ -362,8 +360,8 @@
                    [class.ddp-selected]="timeFormatEditFl"
                    (clickOutside)="timeFormatEditFl = false">
                 <!-- data -->
-                <span class="ddp-data-name" (click)="onChangeTimeFormatMode()">
-              {{(columnDictionary.format && columnDictionary.format.hasOwnProperty('format')) ? columnDictionary.format.format : columnDictionary.format}}
+                <span class="ddp-data-name" [class.ddp-data-none]="isEmptyDictionaryFormat()" (click)="onChangeTimeFormatMode()">
+              {{isEmptyDictionaryFormat() ? ('msg.metadata.ui.codetable.detail.used.column.dictionary.no.format'| translate) : columnDictionary.format.format}}
                   <em class="ddp-icon-edit2"></em>
             </span>
                 <!-- //data -->

--- a/discovery-frontend/src/app/meta-data-management/column-dictionary/detail-column-dictionary/detail-column-dictionary.component.ts
+++ b/discovery-frontend/src/app/meta-data-management/column-dictionary/detail-column-dictionary/detail-column-dictionary.component.ts
@@ -28,6 +28,7 @@ import * as _ from 'lodash';
 import {LinkedMetadataComponent} from '../../component/linked-metadata-columns/linked-metadata.component';
 import {LinkedMetaDataColumn} from '../../../domain/meta-data-management/metadata-column';
 import {Location} from '@angular/common';
+import {StringUtil} from "../../../common/util/string.util";
 
 @Component({
   selector: 'app-detail-column-dictionary',
@@ -184,6 +185,10 @@ export class DetailColumnDictionaryComponent extends AbstractComponent implement
    */
   public isSelectedLogicalType(type: any): boolean {
     return this.columnDictionary.logicalType === type;
+  }
+
+  public isEmptyDictionaryFormat(): boolean {
+    return _.isNil(this.columnDictionary.format) || StringUtil.isEmpty(this.columnDictionary.format.format);
   }
 
   /**

--- a/discovery-frontend/src/assets/i18n/en.json
+++ b/discovery-frontend/src/assets/i18n/en.json
@@ -3973,6 +3973,7 @@
   "msg.metadata.ui.codetable.detail.used.column.dictionary.no.name" : "No name",
   "msg.metadata.ui.codetable.detail.used.column.dictionary.no.description" : "No description",
   "msg.metadata.ui.codetable.detail.used.column.dictionary.no.code.table" : "No code table",
+  "msg.metadata.ui.codetable.detail.used.column.dictionary.no.format" : "No format",
   "msg.metadata.ui.codetable.detail.restore.btn" : "Restore",
   "msg.metadata.ui.codetable.detail.code.table.save.btn" : "Save code table",
   "msg.metadata.ui.codetable.choose.code.table.title" : "Choose a code table",

--- a/discovery-frontend/src/assets/i18n/ko.json
+++ b/discovery-frontend/src/assets/i18n/ko.json
@@ -3974,6 +3974,7 @@
   "msg.metadata.ui.codetable.detail.used.column.dictionary.no.name" : "이름이 없습니다",
   "msg.metadata.ui.codetable.detail.used.column.dictionary.no.description" : "설명이 없습니다",
   "msg.metadata.ui.codetable.detail.used.column.dictionary.no.code.table" : "코드 테이블이 없습니다",
+  "msg.metadata.ui.codetable.detail.used.column.dictionary.no.format" : "포맷이 없습니다",
   "msg.metadata.ui.codetable.detail.restore.btn" : "되돌리기",
   "msg.metadata.ui.codetable.detail.code.table.save.btn" : "코드 테이블 저장",
   "msg.metadata.ui.codetable.choose.code.table.title" : "코드 테이블을 선택해 주세요",


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
컬럼 딕셔너리가 TIMESTAMP 타입이고 format이 없거나 비어있는경우 아래와 같은 placeholder가 보이도록 수정
![스크린샷 2019-07-03 오전 9 31 22](https://user-images.githubusercontent.com/42233627/60555005-5982f580-9d75-11e9-8f8d-486a19107d27.png)


**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
통합테스트


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 메타데이터 > 컬럼 딕셔너리 > 컬럼 딕셔너리 생성
2. 타입을 TIMESTAMP로 지정하고 format을 입력하지 않고 생성
3. 2에서 생성한 컬럼 딕셔너리 상세화면으로 이동
4. format부분이 placeholder가 표기되는지 확인

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
