### PR TITLE
Fix dictionary import error in metadata column schema

### DIFF
--- a/discovery-frontend/src/app/meta-data-management/detail/component/column-schema/column-schema.component.ts
+++ b/discovery-frontend/src/app/meta-data-management/detail/component/column-schema/column-schema.component.ts
@@ -197,6 +197,11 @@ export class ColumnSchemaComponent extends AbstractComponent implements OnInit, 
       metadataColumn.checked = true;
 
       if (isFromDictionary) {
+        // if not exist format in column, initial format
+        if (_.isNil(metadataColumn.format)) {
+          metadataColumn.format = new FieldFormat();
+          this.safelyDetectChanges();
+        }
         // 열리는 순간 바로 validation을 해야한다.
         this._datetimePopupComponentList.toArray()[index].initFromDictionary();
       } else {


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
메타데이터 상세화면 > 컬럼 스키마에서
TIMESTAMP타입이고 format이 없는 컬럼 딕셔너리를 import하는 경우 error가 발생하는 현상 수정

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
통합테스트

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 메타데이터 > 컬럼 딕셔너리 > 컬럼 딕셔너리 생성
2. TIMESTAMP로 타입 지정후 format을 입력하지 않고 생성
3. 또는 이미 생성된 컬럼 딕셔너리 상세화면 > 타입을 TIMESTAMP로 바꾸고 format을 입력하지 않음
4. 메타데이터 상세화면 > 컬럼 스키마 화면으로 이동
5. 2 또는 3에서 생성, 수정된 컬럼 딕셔너리를 import
6. 에러가 발생하지 않는 것 확인

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
