### PR TITLE
fix dataconnection unpublishing checkbox

### DIFF
--- a/discovery-frontend/src/app/data-storage/data-connection/update-connection.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-connection/update-connection.component.ts
@@ -12,16 +12,14 @@
  * limitations under the License.
  */
 
-import {
-  Component, ElementRef, EventEmitter, Injector, Output, ViewChild
-} from '@angular/core';
-import { DataconnectionService } from '../../dataconnection/service/dataconnection.service';
-import { DeleteModalComponent } from '../../common/component/modal/delete/delete.component';
-import { SetWorkspacePublishedComponent } from '../component/set-workspace-published/set-workspace-published.component';
-import { CommonUtil } from '../../common/util/common.util';
-import { StringUtil } from '../../common/util/string.util';
+import {Component, ElementRef, EventEmitter, Injector, Output, ViewChild} from '@angular/core';
+import {DataconnectionService} from '../../dataconnection/service/dataconnection.service';
+import {DeleteModalComponent} from '../../common/component/modal/delete/delete.component';
+import {SetWorkspacePublishedComponent} from '../component/set-workspace-published/set-workspace-published.component';
+import {CommonUtil} from '../../common/util/common.util';
+import {StringUtil} from '../../common/util/string.util';
 import {AuthenticationType, Dataconnection} from '../../domain/dataconnection/dataconnection';
-import {ConnectionComponent, ConnectionValid} from "../component/connection/connection.component";
+import {ConnectionComponent} from "../component/connection/connection.component";
 import {AbstractComponent} from "../../common/component/abstract.component";
 import {Alert} from "../../common/util/alert.util";
 import {Modal} from "../../common/domain/modal";
@@ -309,8 +307,9 @@ export class UpdateConnectionComponent extends AbstractComponent {
     // update connection
     this.connectionService.updateConnection(this._connectionId, {published: !this.originConnectionData.published})
       .then((result) => {
-        this.originConnectionData.published = this.published = result.published;
-        this.originConnectionData.modifiedTime = this.published = result.modifiedTime;
+        this.originConnectionData.published = result.published;
+        this.originConnectionData.modifiedTime = result.modifiedTime;
+        this.published = result.published;
         // alert
         result['published']
           ? Alert.success(this.translateService.instant('msg.storage.alert.dconn-public.success'))


### PR DESCRIPTION
### Description
When you do not allow all workspaces to use a dataconnection, the checkbox does not change.

**Related Issue** : 
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Create a dataconnection.
2. Uncheck the checkbox which is allowing all workspaces.
3. See the checkbox.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
