### PR TITLE
 fix error that not working selection filter when use prediction

### DIFF
--- a/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
+++ b/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
@@ -978,8 +978,8 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
   public showDownloadLayer(event: MouseEvent) {
     event.preventDefault();
     event.stopPropagation();
-    if( ConnectionType.LINK === ConnectionType[this.widget.configuration.dataSource.connType] ) {
-      this._dataDownComp.openGridDown(event, this._dataGridComp );
+    if (ConnectionType.LINK === ConnectionType[this.widget.configuration.dataSource.connType]) {
+      this._dataDownComp.openGridDown(event, this._dataGridComp);
     } else {
       this._dataDownComp.openWidgetDown(event, this.widget.id, this.isOriginDown);
     }
@@ -1072,7 +1072,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
       }
     };
 
-    if( ConnectionType.LINK === ConnectionType[this.widget.configuration.dataSource.connType] ) {
+    if (ConnectionType.LINK === ConnectionType[this.widget.configuration.dataSource.connType]) {
       const boardConf: BoardConfiguration = this.widget.dashBoard.configuration;
       const query: SearchQueryRequest
         = this.datasourceService.makeQuery(
@@ -1528,7 +1528,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
         // line차트이면서 columns 데이터가 있는경우
         if (this.chartType === 'line' && this.resultData.data.columns && this.resultData.data.columns.length > 0) {
           // 고급분석 예측선 API 호출
-          this.getAnalysis();
+          this.getAnalysis(cloneQuery);
         } else {
           this.chart.resultData = this.resultData;
           this.isSetChartData = true;
@@ -1703,18 +1703,20 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
 
   /**
    * 고급분석 예측선 API 호출
+   * @param query
    */
-  private getAnalysis(): void {
+  private getAnalysis(query: SearchQueryRequest): void {
     if (this.isAnalysisPredictionEnabled()) {
       Promise
         .resolve()
         .then(() => {
           if (this.isAnalysisPredictionEnabled()) {
-            this.analysisPredictionService.getAnalysisPredictionLineFromDashBoard(this.widgetConfiguration, this.widget, this.chart, this.resultData)
-              .catch((error) => {
-                this._showError(error);
-                this.updateComplete();
-              });
+            this.analysisPredictionService.getAnalysisPredictionLineFromDashBoard(
+              this.widgetConfiguration, this.widget, this.chart, this.resultData, query.filters
+            ).catch((error) => {
+              this._showError(error);
+              this.updateComplete();
+            });
           } else {
             this.predictionLineDisabled();
           }
@@ -1735,9 +1737,9 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
       for (const widgetDatasource of this.widget.configuration.dataSource.dataSources) {
         for (const dashboardDatasource of this.inputWidget.dashBoard.dataSources) {
           if (widgetDatasource.id == dashboardDatasource.id) {
-            if (!dashboardDatasource.valid){
+            if (!dashboardDatasource.valid) {
               valid = false;
-              if(invalidDatasourceName != '') {
+              if (invalidDatasourceName != '') {
                 invalidDatasourceName += ', '
               }
               invalidDatasourceName += dashboardDatasource.name;
@@ -1757,7 +1759,10 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
     }
 
     if (!valid) {
-      this._showError({code: 'GB0000', details: this.translateService.instant('msg.board.error.deny-datasource', {datasource : invalidDatasourceName})});
+      this._showError({
+        code: 'GB0000',
+        details: this.translateService.instant('msg.board.error.deny-datasource', {datasource: invalidDatasourceName})
+      });
     }
   }
 

--- a/discovery-frontend/src/app/page/component/analysis/service/analysis.prediction.service.ts
+++ b/discovery-frontend/src/app/page/component/analysis/service/analysis.prediction.service.ts
@@ -20,6 +20,7 @@ import * as _ from 'lodash';
 import {PageWidget, PageWidgetConfiguration} from '../../../../domain/dashboard/widget/page-widget';
 import {UIOption} from '../../../../common/component/chart/option/ui-option';
 import {CommonUtil} from "../../../../common/util/common.util";
+import {Filter} from "../../../../domain/workbook/configurations/filter/filter";
 
 @Injectable()
 export class AnalysisPredictionService extends AbstractService implements OnInit {
@@ -150,9 +151,12 @@ export class AnalysisPredictionService extends AbstractService implements OnInit
   public getAnalysisPredictionLineFromDashBoard(widgetConfiguration: PageWidgetConfiguration,
                                                 widget: PageWidget,
                                                 chart: any,
-                                                resultData?: { data: any; config: SearchQueryRequest; uiOption: UIOption }): Promise<any> {
+                                                resultData: { data: any; config: SearchQueryRequest; uiOption: UIOption },
+                                                filters?:Filter[] ): Promise<any> {
 
-    return this.getAnalysis(this.createGetAnalysisParameter(widgetConfiguration, widget))
+    const analysisParam:Analysis = this.createGetAnalysisParameter(widgetConfiguration, widget);
+    analysisParam.filters = filters;
+    return this.getAnalysis(analysisParam)
       .then((result) => {
         this.createPredictionLineSeriesList(result, widgetConfiguration);
         return result;

--- a/discovery-frontend/src/app/workspace/workspace.component.html
+++ b/discovery-frontend/src/app/workspace/workspace.component.html
@@ -141,7 +141,7 @@
     <div class="ddp-ui-space-nav">
       <div (click)="topFolder()" class="ddp-data-nav">
         <em class="ddp-icon-space" ></em>
-        {{workspaceName}}
+        <span>{{workspaceName}}</span>
         <!-- 폴더 생성 -->
         <a *ngIf="!folder.hierarchies && permissionChecker && permissionChecker.isManageWsFolder()" (click)="createFolder()"
            draggable="false" href="javascript:" class="ddp-btn-folderplus" ></a>

--- a/discovery-frontend/src/assets/css/polaris.v2.page.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.page.css
@@ -2478,13 +2478,12 @@ em.ddp-icon-control-cut .ddp-ui-tooltip-info.ddp-down em.ddp-icon-view-top {righ
 .ddp-ui-space-option .ddp-ui-option-right { position:absolute; top:5px; right:0;}
 .ddp-ui-space-option .ddp-ui-space-nav {padding:20px 0 0 0;}
 .ddp-ui-space-option .ddp-ui-space-nav .ddp-data-nav {display:inline-block; min-height:25px; max-width:15%; position:relative; padding-left:19px; margin-right:4px; cursor: pointer; white-space:nowrap; text-overflow:ellipsis; overflow:hidden; word-wrap:normal;}
-.ddp-ui-space-option .ddp-ui-space-nav .ddp-data-nav:hover {text-decoration: underline;}
 .ddp-ui-space-option .ddp-ui-space-nav .ddp-data-nav:after {display:inline-block; content:''; position:absolute; top:50%; left:0; width:4px; height:7px; margin-top:-4px; background:url(../images/icon_dataview.png) no-repeat; background-position:-5px -19px;}
 .ddp-ui-space-option .ddp-ui-space-nav .ddp-data-nav:first-of-type {padding-left:0; max-width:15%; white-space:nowrap; text-overflow:ellipsis; overflow:hidden; word-wrap:normal; line-height:23px;}
 .ddp-ui-space-option .ddp-ui-space-nav .ddp-data-nav:first-of-type:after {display:none;}
 .ddp-ui-space-option .ddp-ui-space-nav .ddp-data-nav em.ddp-icon-space {display:inline-block; position:relative; top:-1px; width:14px; height:14px; margin-right:8px; background:url(../images/icon_workspace.png) no-repeat; vertical-align: middle;}
 .ddp-ui-space-option .ddp-ui-space-nav .ddp-data-nav span.ddp-data-namefolder {display:inline-block; position:relative; color:#35393f; font-size:13px; line-height:2em; cursor:pointer;}
-.ddp-ui-space-option .ddp-ui-space-nav .ddp-data-nav span.ddp-data-namefolder:hover {text-decoration: underline;}
+.ddp-ui-space-option .ddp-ui-space-nav .ddp-data-nav span:hover {text-decoration: underline;}
 .ddp-ui-space-option .ddp-ui-space-nav a.ddp-btn-folderplus {display:inline-block; position:relative; top:6px; width:16px; height:15px; background:url(../images/icon_buttons.png) no-repeat; background-position:left -198px; vertical-align: top;}
 .ddp-ui-space-option .ddp-ui-space-nav a.ddp-btn-folderplus:hover {background-position:-17px -198px;}
 .ddp-ui-space-option .ddp-ui-option-right .ddp-form-search {float:left; margin:10px 15px 0 0;}


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
1. 라인차트 예측선 활성화시 선택필터 동작하지 않음
2. 워크스페이스 내 폴더 생성을 hover하려고 하면 폴더경로 하이어라키가 활성화가 됨
![image (1)](https://user-images.githubusercontent.com/3685833/60556942-7e2f9b00-9d7e-11e9-8c6a-b00c399b866d.png)

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 워크스페이스 폴더 생성 아이콘에 마우스를 위치했을 때 좌측 하이어라키 경로에 밑줄이 생성되지 않는지 확인합니다.
2. 대시보드에서 셀렉션 필터를 적용했을 때 예측선이 적용된 차트에 필터가 적용되는지 확인합니다.

#### Need additional checks?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
