### PR TITLE
#2299 disable rollup mode in case of including geo type column

### DIFF
--- a/discovery-frontend/proxy.conf.js
+++ b/discovery-frontend/proxy.conf.js
@@ -2,7 +2,8 @@ const PROXY_CONFIG = [
   {
     context: [
       "/api",
-      "/oauth"
+      "/oauth",
+      "/extensions"
     ],
     target: "http://localhost:8180",
     secure: false

--- a/discovery-frontend/src/app/data-storage/data-source-list/component/ingestion-setting.component.html
+++ b/discovery-frontend/src/app/data-storage/data-source-list/component/ingestion-setting.component.html
@@ -541,7 +541,7 @@
         <!-- edit option -->
         <div class="ddp-ui-edit-option">
           <label class="ddp-label-radio" *ngFor="let type of rollUpTypeList" (change)="onChangeRollUpType(type)">
-            <input type="radio" [checked]="selectedRollUpType.value === type.value" [disabled]="isReinjestion">
+            <input type="radio" [checked]="selectedRollUpType.value === type.value" [disabled]="isReinjestion || includGeoType">
             <i class="ddp-icon-radio"></i>
             <span class="ddp-txt-radio">{{type.label}}</span>
           </label>

--- a/discovery-frontend/src/app/data-storage/data-source-list/component/ingestion-setting.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/component/ingestion-setting.component.ts
@@ -648,6 +648,14 @@ export class IngestionSettingComponent extends AbstractComponent {
     return StringUtil.isNotEmpty(this._sourceData.datasourceId);
   }
 
+  public get includGeoType() : boolean {
+    if (Array.isArray(this._sourceData.schemaData.fieldList)) {
+      let fieldList:Array<Field> = this._sourceData.schemaData.fieldList;
+      return fieldList.filter(field => Field.isGeoType(field)).length > 0;
+    }
+    return false;
+  }
+
   /**
    * ui init
    * @private


### PR DESCRIPTION
### Description
Disable the rollup mode radio button in case of including geo type column

**Related Issue** : #2299 
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Create a datasource with the geo type column at least one.
2. See the rollup mode radio button which is disabled in the ingestion setting page.
3. Create a datasource without the geo type column.
4. See the rollup mode radio button which is able to choose in the ingestion setting page.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
