### PR TITLE
fix the custom field name of a chart can not be a reserved word

### DIFF
--- a/discovery-frontend/src/app/dashboard/component/custom-field/custom-field.component.html
+++ b/discovery-frontend/src/app/dashboard/component/custom-field/custom-field.component.html
@@ -31,6 +31,9 @@
       <div class="ddp-ui-info-det" *ngIf="isCalFuncSuccess === 'S' && (columnName == null ||  columnName.trim() === '')">
         <em class="ddp-icon-error-info"></em> {{'msg.board.custom.ui.column.empty' | translate}}
       </div>
+      <div class="ddp-ui-info-det" *ngIf="isCalFuncSuccess === 'S' && isReservedFieldName(columnName)">
+        <em class="ddp-icon-error-info"></em> {{'msg.board.custom.ui.column.reserved' | translate}}
+      </div>
     </div>
     <!-- //title -->
     <div class="ddp-ui-popup-contents">

--- a/discovery-frontend/src/app/dashboard/component/custom-field/custom-field.component.html
+++ b/discovery-frontend/src/app/dashboard/component/custom-field/custom-field.component.html
@@ -21,7 +21,7 @@
 
       <div class="ddp-ui-pop-buttons">
         <a href="javascript:" class="ddp-btn-pop" (click)="close.emit()">{{'msg.comm.btn.cancl' | translate}}</a>
-        <a href="javascript:" class="ddp-btn-pop ddp-bg-black" [ngClass]="{'ddp-disabled' : !(isCalFuncSuccess === 'S' && (columnName != null &&  columnName.trim() !== ''))}" (click)="done()">{{'msg.comm.btn.done' | translate}}</a>
+        <a href="javascript:" class="ddp-btn-pop ddp-bg-black" [ngClass]="{'ddp-disabled' : !(isCalFuncSuccess === 'S' && (columnName != null &&  columnName.trim() !== '' && !isReservedFieldName(columnName)))}" (click)="done()">{{'msg.comm.btn.done' | translate}}</a>
       </div>
 
       <!-- det -->

--- a/discovery-frontend/src/app/dashboard/component/custom-field/custom-field.component.ts
+++ b/discovery-frontend/src/app/dashboard/component/custom-field/custom-field.component.ts
@@ -463,7 +463,7 @@ export class CustomFieldComponent extends AbstractComponent implements OnInit, O
   public done() {
 
     // callFuncSuccess가 아닐때 columnName이 없을때 return
-    if ('S' !== this.isCalFuncSuccess || !this.columnName || '' == this.columnName.trim()) {
+    if ('S' !== this.isCalFuncSuccess || !this.columnName || '' == this.columnName.trim() || this.isReservedFieldName(this.columnName)) {
       return;
     }
 

--- a/discovery-frontend/src/app/dashboard/component/custom-field/custom-field.component.ts
+++ b/discovery-frontend/src/app/dashboard/component/custom-field/custom-field.component.ts
@@ -14,22 +14,29 @@
 
 import * as _ from 'lodash';
 import {
-  AfterViewInit, Component, ElementRef, EventEmitter, Injector, Input, OnDestroy,
-  OnInit, Output,
+  AfterViewInit,
+  Component,
+  ElementRef,
+  EventEmitter,
+  Injector,
+  Input,
+  OnDestroy,
+  OnInit,
+  Output,
   ViewChild
 } from '@angular/core';
-import { DashboardService } from '../../service/dashboard.service';
-import { CommonCode } from '../../../domain/code/common-code';
+import {DashboardService} from '../../service/dashboard.service';
+import {CommonCode} from '../../../domain/code/common-code';
 import {ConnectionType, Field, FieldRole} from '../../../domain/datasource/datasource';
-import { AbstractComponent } from '../../../common/component/abstract.component';
-import { Alert } from '../../../common/util/alert.util';
-import { BoardDataSource } from '../../../domain/dashboard/dashboard';
-import { StringUtil } from '../../../common/util/string.util';
-import { ConfirmModalComponent } from '../../../common/component/modal/confirm/confirm.component';
-import { Modal } from '../../../common/domain/modal';
-import { CustomField } from '../../../domain/workbook/configurations/field/custom-field';
-import { DashboardUtil } from '../../util/dashboard.util';
-import { isNullOrUndefined } from "util";
+import {AbstractComponent} from '../../../common/component/abstract.component';
+import {Alert} from '../../../common/util/alert.util';
+import {BoardDataSource} from '../../../domain/dashboard/dashboard';
+import {StringUtil} from '../../../common/util/string.util';
+import {ConfirmModalComponent} from '../../../common/component/modal/confirm/confirm.component';
+import {Modal} from '../../../common/domain/modal';
+import {CustomField} from '../../../domain/workbook/configurations/field/custom-field';
+import {DashboardUtil} from '../../util/dashboard.util';
+import {isNullOrUndefined} from "util";
 
 declare let $: any;
 
@@ -658,6 +665,14 @@ export class CustomFieldComponent extends AbstractComponent implements OnInit, O
       return logicalType
     }
 
+  }
+
+  public isReservedFieldName(name: string): boolean {
+    if (name === 'count' || name === '__time' || name === 'timestamp') {
+      return true;
+    } else {
+      return false;
+    }
   }
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/discovery-frontend/src/assets/i18n/en.json
+++ b/discovery-frontend/src/assets/i18n/en.json
@@ -1467,6 +1467,7 @@
   "msg.board.ui.use.filter" : "filter is in use. Please disable it and try again.",
   "msg.board.ui.not.delete.custom" : "Can not delete custom fields",
   "msg.board.custom.ui.column.empty" : "Please fill in column name",
+  "msg.board.custom.ui.column.reserved" : "This column name can not be a reserved word(count, __time, timestamp)",
   "msg.board.custom.ui.val.un.check" : "Please proceed to validate the condition",
   "msg.board.custom.th.title" : "Custom column",
   "msg.board.custom.th.role" : "Role",

--- a/discovery-frontend/src/assets/i18n/ko.json
+++ b/discovery-frontend/src/assets/i18n/ko.json
@@ -1465,6 +1465,7 @@
   "msg.board.ui.use.filter" : "필터에서 사용중입니다. 사용 해제 후 다시 시도해 주세요.",
   "msg.board.ui.not.delete.custom" : "사용자 정의 필드 삭제 불가",
   "msg.board.custom.ui.column.empty" : "컬럼을 입력해주세요",
+  "msg.board.custom.ui.column.reserved" : "예약어를 사용할 수 없습니다.(count, __time, timestamp)",
   "msg.board.custom.ui.val.un.check" : "조건식을 검증해주세요.",
   "msg.board.custom.th.title" : "사용자 컬럼",
   "msg.board.custom.th.role" : "역할",

--- a/discovery-frontend/src/assets/i18n/zh.json
+++ b/discovery-frontend/src/assets/i18n/zh.json
@@ -1367,6 +1367,7 @@
   "msg.board.ui.use.filter": "过滤器正在使用中，请解除使用后再次尝试",
   "msg.board.ui.not.delete.custom": "不可删除用户定义字段",
   "msg.board.custom.ui.column.empty": "请输入列",
+  "msg.board.custom.ui.column.reserved" : "此列名称不能是保留字。(count, __time, timestamp)",
   "msg.board.custom.ui.val.un.check": "请验证条件",
   "msg.board.custom.th.title": "用户列",
   "msg.board.custom.th.role": "作用",


### PR DESCRIPTION
### Description
the custom field name of a chart can not be a reserved word

**Related Issue** : 
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Go to a workbook.
2. Create a chart with a custom field
3. Set the column name to count, __time, timestamp.
4. See the error message.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
