### PR TITLE
fix exceptionhandler to include HttpMessageNotWritableException

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/common/exception/RestExceptionHandler.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/common/exception/RestExceptionHandler.java
@@ -35,6 +35,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -89,7 +90,7 @@ public class RestExceptionHandler extends AbstractExceptionHandler {
    * @param o_O the exception to handle.
    */
   @ExceptionHandler({InvocationTargetException.class, IllegalArgumentException.class, ClassCastException.class,
-      ConversionFailedException.class, NullPointerException.class})
+      ConversionFailedException.class, NullPointerException.class, HttpMessageNotWritableException.class})
   ResponseEntity<ErrorResponse> handleMiscFailures(Exception o_O, WebRequest webRequest) {
 
     return errorResponse(HttpStatus.INTERNAL_SERVER_ERROR, new HttpHeaders(), new UnknownServerException(o_O), webRequest);


### PR DESCRIPTION
### Description
Fix exceptionhandler to include HttpMessageNotWritableException

**Related Issue** : 
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
