### PR TITLE
Fix chart filter css and message

### DIFF
--- a/discovery-frontend/src/app/dashboard/filters/time-filter/time-filter-panel.component.html
+++ b/discovery-frontend/src/app/dashboard/filters/time-filter/time-filter-panel.component.html
@@ -105,15 +105,15 @@
 <!-- // 상단 영역 -->
 
 <!-- 내용 영역 -->
-<div *ngIf="isShowFilter" class="ddp-contents-divide">
+<div *ngIf="isShowFilter" class="ddp-contents-divide" style="margin-top:20px;">
   <!-- 연속 형식 - None Granularity -->
   <div *ngIf="!isDiscontinuousFilter && isContinuousByAll" class="ddp-ui-divide">
     <!-- 탭 영역 -->
     <div class="ddp-toggle">
       <ul class="ddp-list-buttons ddp-tab3" >
-        <li (click)="setTimeAllFilter()" [class.ddp-selected]="isAllType">All time</li>
-        <li (click)="setTimeRelativeFilter()" [class.ddp-selected]="isRelativeType">Relative</li>
-        <li (click)="setTimeRangeFilter()" [class.ddp-selected]="isRangeType">Specific</li>
+        <li (click)="setTimeAllFilter()" [class.ddp-selected]="isAllType" style="font-size: 11px;">All time</li>
+        <li (click)="setTimeRelativeFilter()" [class.ddp-selected]="isRelativeType" style="font-size: 11px;">Relative</li>
+        <li (click)="setTimeRangeFilter()" [class.ddp-selected]="isRangeType" style="font-size: 11px;">Specific</li>
       </ul>
     </div>
     <!-- // 탭 영역 -->

--- a/discovery-frontend/src/assets/css/polaris.v2.page.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.page.css
@@ -1559,7 +1559,7 @@ ul.ddp-list-text li a .ddp-data-info span {display:block; color:#4b515b; font-si
 .ddp-add-filter ul.ddp-list-filter li .ddp-btn-edit:hover {background-position-x:-52px;}
 
 .ddp-filter1 {position:relative; height:100%; padding:60px 0 0 0; box-sizing:border-box;}
-
+.ddp-filter1 .ddp-dropdown-filter {margin-bottom:0;}
 .ddp-filter1 .ddp-wrap-setting {padding:8px 25px; width:100%;background-color:#f6f6f7; overflow:hidden; box-sizing:border-box;}
 .ddp-filter1 .ddp-wrap-setting .ddp-wrap-edit .ddp-label-type {padding-right:15px; letter-spacing:-1px;}
 .ddp-filter1 .ddp-wrap-setting .ddp-wrap-edit .ddp-ui-edit-option .ddp-type-selectbox {width:148px; background-color:#fff;}

--- a/discovery-frontend/src/assets/css/polaris.v2.page.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.page.css
@@ -1413,7 +1413,7 @@ ul.ddp-list-text li a .ddp-data-info span {display:block; color:#4b515b; font-si
 
 .ddp-area-boardside .ddp-ui-divide .ddp-none-bar.ddp-select-bar:hover,
 .ddp-dropdown-filter.ddp-selected .ddp-none-bar.ddp-select-bar {background-color:#dfe0e4;}
-.ddp-dropdown-filter {position:relative;}
+.ddp-dropdown-filter {position:relative; margin-bottom:-20px;}
 .ddp-dropdown-filter.ddp-selected .ddp-select-bar .ddp-icon-view {transform:rotate(180deg);}
 .ddp-dropdown-filter .ddp-wrap-popup2 {display:none; width:238px;position:absolute; top:100%; left:-14px; padding:6px 0;}
 .ddp-dropdown-filter .ddp-wrap-popup2 .ddp-label-type {padding:10px 12px 3px 12px; color:#b7b9c2; font-size:12px;}

--- a/discovery-frontend/src/assets/i18n/en.json
+++ b/discovery-frontend/src/assets/i18n/en.json
@@ -3612,7 +3612,7 @@
   "msg.page.format.custom.symbol.position": "Custom Symbol Position",
   "msg.page.format.custom.symbol.position.front": "Front",
   "msg.page.format.custom.symbol.position.back": "Back",
-  "msg.page.format.numeric.alias": "CuNumber Abbreviations",
+  "msg.page.format.numeric.alias": "Number Abbreviations",
   "msg.page.format.numeric.alias.none": "None",
   "msg.page.format.numeric.alias.auto": "Automation",
   "msg.page.format.numeric.alias.kilo": "Kilo",


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
- 차트 필터에서 보더와 헤더사이의 여백 제거
- 차트 number format에서 CuNumber라고 되있는 문구를 Number로 수정 (영문일떄만 발생)

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
통합테스트

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 대시보드 > 차트 > 차트 편집
2. 차트 생성을 클릭한 후
3. 우측 메뉴에서 filter를 추가하고 여백이 생기는지 확인
3-1. 우측 메뉴에서 Number format을 선택하고 Number Abbreviation 문구가 CuNumber Abbreviation로 표기되지 않는것 확인

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
