### PR TITLE
Fix snapshot loading and add name title

### DIFF
--- a/discovery-frontend/src/app/data-preparation/data-snapshot/data-snapshot.component.ts
+++ b/discovery-frontend/src/app/data-preparation/data-snapshot/data-snapshot.component.ts
@@ -90,6 +90,8 @@ export class DataSnapshotComponent extends AbstractComponent implements OnInit, 
 
     // Init
     super.ngOnInit();
+    // loading hide
+    this.loadingHide();
 
     this._initView();
 

--- a/discovery-frontend/src/app/workspace/workspace.component.html
+++ b/discovery-frontend/src/app/workspace/workspace.component.html
@@ -313,7 +313,7 @@
         <!-- //top -->
         <!-- box contents -->
         <div class="ddp-ui-box-contents">
-          <span class="ddp-data-name" [ngClass]="{'ddp-data-line2' : book.type != 'notebook'}">{{book.name}}</span>
+          <span class="ddp-data-name" [ngClass]="{'ddp-data-line2' : book.type != 'notebook'}" [title]="book.name">{{book.name}}</span>
           <span class="ddp-data-date">{{'msg.comm.ui.list.last' | translate}} <span class="ddp-data-ago">{{book.modifiedTime | amTimeAgo}}</span></span>
         </div>
         <!-- //box contents -->
@@ -462,7 +462,7 @@
 
           <!-- Name -->
           <div class="ddp-wrap-name">
-            <span class="ddp-data-name" [class.ddp-data-new]="book.createdTime | moment: 'isNew'">
+            <span class="ddp-data-name" [class.ddp-data-new]="book.createdTime | moment: 'isNew'" [title]="book.name">
               {{book.name}}
               <em class="ddp-icon-new" *ngIf="book.createdTime | moment: 'isNew'">{{'msg.common.ui.new' | translate}}</em>
             </span>

--- a/discovery-frontend/src/assets/css/polaris.v2.page.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.page.css
@@ -2414,11 +2414,14 @@ em.ddp-icon-control-cut .ddp-ui-tooltip-info.ddp-down em.ddp-icon-view-top {righ
 .ddp-box-block .ddp-ui-box-contents span.ddp-data-name {display:block; font-size:18px; color:#545b65; font-weight:bold;  overflow:hidden; text-overflow:ellipsis; word-wrap:normal; white-space:nowrap;}
 
 .ddp-box-block .ddp-ui-box-contents span.ddp-data-name.ddp-data-line2 {max-height:44px; white-space:normal; overflow: hidden;
-	text-overflow: ellipsis;
-	display: -webkit-box;
-	-webkit-line-clamp: 2; /* 라인수 */
-	-webkit-box-orient: vertical;
-	word-wrap:normal;}
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2; /* 라인수 */
+  /* autoprefixer: off */
+  -webkit-box-orient: vertical;
+  /* autoprefixer: on */
+  word-wrap:break-word;}
 .ddp-box-block .ddp-ui-box-contents span.ddp-data-date {display:block; padding:7px 0 0 0; font-size:12px; color:#c5c6cd; }
 .ddp-box-block .ddp-ui-box-contents span.ddp-data-date span.ddp-data-ago {color:#4c515a;}
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
- 워크스페이스 화면에서 이름이 긴 workbook, workbench 등 에 대해 말줄임 표시가 나타나지 않는 현상 수정
- lnb에서 데이터스냅샷 접근시 로딩이 사라지지 않는 현상 수정

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
통합테스트

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 개인 워크스페이스 화면 진입
2. 이름이 긴 이름의 book에 말줄임 표시가 표시되는지 확인 (커서를 올렸을 경우 tooltip이 표시되는지 확인)
3. LNB에서 '데이터스냅샷'을 클릭시 데이터스냅샷 화면에서 로딩이 사라지는지 확인

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
