### PR TITLE
#2396 Performance issues when viewing a list of shared workspaces

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/user/group/GroupMember.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/user/group/GroupMember.java
@@ -34,7 +34,9 @@ import static com.fasterxml.jackson.annotation.JsonProperty.Access.WRITE_ONLY;
  * Created by kyungtaak on 2016. 1. 5..
  */
 @Entity
-@Table(name = "user_group_member")
+@Table(name = "user_group_member", indexes = {
+    @Index(name = "i_user_member_id", columnList = "member_id")
+})
 public class GroupMember implements MetatronDomain<Long> {
 
   @Id

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/user/group/GroupRepository.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/user/group/GroupRepository.java
@@ -15,10 +15,13 @@
 package app.metatron.discovery.domain.user.group;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.querydsl.QueryDslPredicateExecutor;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 import app.metatron.discovery.domain.context.ContextDomainRepository;
+
+import java.util.List;
 
 /**
  * Created by kyungtaak on 2016. 1. 7..
@@ -31,4 +34,7 @@ public interface GroupRepository extends JpaRepository<Group, String>,
   Group findByName(String name);
 
   Group findByPredefinedAndDefaultGroup(Boolean predefined, Boolean defaultGroup);
+
+  @Query("select g from Group g join g.members m where m.memberId = ?1")
+  List<Group> findJoinedGroups(String memberId);
 }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/user/group/GroupService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/user/group/GroupService.java
@@ -94,7 +94,7 @@ public class GroupService {
    */
   public List<Group> getJoinedGroups(String username) {
 
-    Iterable<Group> groups = groupRepository.findAll(GroupPredicate.searchGroupByMemberId(username));
+    Iterable<Group> groups = groupRepository.findJoinedGroups(username);
 
     return Lists.newArrayList(groups);
   }


### PR DESCRIPTION
### Description
느림 현상 원인은 아래 Hibernate가 생성한 쿼리를 공유 워크스페이스 하나에 한번씩 실행(SKT 환경에서 2초 정도 소요)하면서 발생
```sql
-- app.metatron.discovery.domain.user.group.GroupService#getJoinedGroups
-- Iterable<Group> groups = groupRepository.findAll(GroupPredicate.searchGroupByMemberId(username));

    select
        group0_.id as id1_65_,
        group0_.created_by as created_2_65_,
        group0_.created_time as created_3_65_,
        group0_.modified_by as modified4_65_,
        group0_.modified_time as modified5_65_,
        group0_.version as version6_65_,
        group0_.group_contexts as group_co7_65_,
        group0_.group_default as group_de8_65_,
        group0_.group_desc as group_de9_65_,
        group0_.group_member_count as group_m10_65_,
        group0_.group_name as group_n11_65_,
        group0_.group_predefined as group_p12_65_,
        group0_.group_read_only as group_r13_65_ 
    from
        user_group group0_ 
    where
        exists (
            select
                1 
            from
                user_group_member members1_ 
            where
                group0_.id=members1_.group_id 
                and members1_.member_id=?
        )
```
아래 처럼 성능 개선
1. 쿼리 튜닝
위의 쿼리를 아래 처럼 변경 
```sql
select
        group0_.id as id1_65_,
        group0_.created_by as created_2_65_,
        group0_.created_time as created_3_65_,
        group0_.modified_by as modified4_65_,
        group0_.modified_time as modified5_65_,
        group0_.version as version6_65_,
        group0_.group_contexts as group_co7_65_,
        group0_.group_default as group_de8_65_,
        group0_.group_desc as group_de9_65_,
        group0_.group_member_count as group_m10_65_,
        group0_.group_name as group_n11_65_,
        group0_.group_predefined as group_p12_65_,
        group0_.group_read_only as group_r13_65_ 
    from
        user_group group0_ 
    inner join
        user_group_member members1_ 
            on group0_.id=members1_.group_id 
    where
        members1_.member_id=?
```
2. DB 테이블 INDEX 추가
```java
// app.metatron.discovery.domain.user.group.GroupMember
@Entity
@Table(name = "user_group_member", indexes = {
    @Index(name = "i_user_member_id", columnList = "member_id")
})
public class GroupMember implements MetatronDomain<Long> {
```
**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#2396 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
기존 공유 워크스페이스 목록이 정상적으로 보여지는 것을 확인하고 SKT 환경에 적용 시 속도 개선 확인

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
