### PR TITLE
#1902 Fix Gradient Settings Maximum

### DIFF
--- a/discovery-frontend/src/assets/css/polaris.v2.component.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.component.css
@@ -639,7 +639,7 @@ ul.ddp-list-typebasic.ddp-view li.ddp-selected a .ddp-icon-plus {display:block;}
 .cp-default {display:none !important;}
 
 #gradX2 {padding:10px 0 20px 0; text-align:center;}
-#gradX2 .gradx {display:inline-block; width:220px; border:none; padding:0; background:none; cursor:none;}
+#gradX2 .gradx {display:inline-block; width:223px!important; border:none; padding:0; background:none; cursor:none;}
 #gradX2 .gradx_container {padding:0; margin:0; border:none; background:none; }
 #gradX2 .gradx_panel {width:220px; height:29px; cursor:default;}
 #gradX2 .gradx_start_sliders {position:relative; height:0px; margin-top:0px; margin-left:-2px;background:none; box-shadow:none; border:none; cursor:default;}


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
The drag and drop of the maximum value of the gradient color is malfunctioning.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#1902 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Chart > Color > Measure > Custom Color Setting > Gradient
1. 차트 생성 화면으로 진입합니다.
2. 임의의 차트를 그립니다.
3. 색상 설정 옵션을 열고 Measure를 선택한 후에 custom color setting을 활성화 합니다.
4. 색상 설정 방식을 gradient로 변경하고 gradient tool에서 슬라이더를 중간으로 옮겼다가 끝으로 옮깁니다.
5. 슬라이더가 정상적으로 끝에 위치하는지 확인합니다.
#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
