### PR TITLE
Add Tooltips to the Workbench Tab

### DIFF
--- a/discovery-frontend/src/app/workbench/workbench.component.html
+++ b/discovery-frontend/src/app/workbench/workbench.component.html
@@ -226,7 +226,7 @@
                   <li *ngFor="let item of getFilteringList(textList, editorListObj)"
                       (click)="tabChangeHandler(findIndexInList(textList, item), false, item )"
                       [ngClass]="{'ddp-selected': item['selected'],'ddp-edit': item['editorMode']}">
-                    <div class="ddp-data-tab">
+                    <div class="ddp-data-tab" [title]="item['name']">
                       {{item['name']}}
                       <!-- more -->
                       <div class="ddp-wrap-morebutton">


### PR DESCRIPTION
### Description
A very small modification has been made to show the tooltip on the "workbench" tab.

**Related Issue** : N/A
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
Make sure that the tooltip is visible when you hover your mouse over the tab in the workbench.

#### Need additional checks?
N/A

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
![스크린샷 2019-08-01 오후 5 48 17](https://user-images.githubusercontent.com/41019113/62279422-09d33f00-b485-11e9-8aa3-3c3ab6dda2b5.png)
