### PR TITLE
#2445 prevents path traversal through csv download api

### DIFF
--- a/discovery-frontend/src/app/workbench/workbench.component.ts
+++ b/discovery-frontend/src/app/workbench/workbench.component.ts
@@ -1731,6 +1731,11 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
       downloadCsvForm.attr('action', CommonConstant.API_CONSTANT.API_URL + `queryeditors/${this.selectedEditorId}/query/download/csv`);
       downloadCsvForm.submit();
       this.intervalDownload = setInterval(() => that.checkQueryStatus(), 1000);
+
+      // 에러처리
+      $('#'+$('#downloadCsvForm').attr('target')).off('load').on('load', function(){
+        Alert.error(JSON.parse($(this).contents().find("body").text()).details);
+      });
     } catch (e) {
       // 재현이 되지 않음.
       console.info('다운로드 에러' + e);

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/QueryEditorController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/QueryEditorController.java
@@ -330,6 +330,7 @@ public class QueryEditorController {
     String csvFilePath = csvPath + File.separator + fileName + "_" + Calendar.getInstance().getTime().getTime() + ".csv";
 
     createCSVFile(query, webSocketId, connectionId, fileName, csvFilePath);
+
     HttpUtils.downloadCSVFile(response, fileName, csvFilePath, "text/csv; charset=utf-8");
   }
 
@@ -419,17 +420,7 @@ public class QueryEditorController {
     String csvFilePath = (String) requestParam.get("csvFilePath");
     String fileName = (String) requestParam.get("fileName");
 
-    if(StringUtils.isEmpty(fileName)){
-      fileName = "noname";
-    }
-
-    String csvBaseDir = workbenchProperties.getTempCSVPath();
-    if(!csvBaseDir.endsWith(File.separator)){
-      csvBaseDir = csvBaseDir + File.separator;
-    }
-    String filePath = csvBaseDir + csvFilePath;
-
-    HttpUtils.downloadCSVFile(response, fileName, filePath, "text/csv");
+    downloadCSV(csvFilePath, fileName, response);
   }
 
   @RequestMapping(path = "/queryeditors/{id}/query/download/csv", method = RequestMethod.POST,
@@ -441,15 +432,28 @@ public class QueryEditorController {
     String csvFilePath = (String) requestBody.get("csvFilePath");
     String fileName = (String) requestBody.get("fileName");
 
+    downloadCSV(csvFilePath, fileName, response);
+  }
+
+  private void downloadCSV(String csvFilePath, String fileName, HttpServletResponse response) throws IOException {
     if(StringUtils.isEmpty(fileName)){
       fileName = "noname";
     }
+
+    Assert.isTrue(!csvFilePath.isEmpty(), "Parameter 'csvFilePath' is empty.");
 
     String csvBaseDir = workbenchProperties.getTempCSVPath();
     if(!csvBaseDir.endsWith(File.separator)){
       csvBaseDir = csvBaseDir + File.separator;
     }
     String filePath = csvBaseDir + csvFilePath;
+
+    File file = new File(filePath);
+    if (file == null || !csvFilePath.equals(file.getName())) {
+      LOGGER.error("csvFilePath : {} : fileName : {}", csvFilePath, file.getName());
+      throw new WorkbenchException(WorkbenchErrorCodes.CSV_FILE_NOT_FOUND, "CSV Download Failed");
+    }
+
     HttpUtils.downloadCSVFile(response, fileName, filePath, "text/csv; charset=utf-8");
   }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/QueryEditorController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/QueryEditorController.java
@@ -449,7 +449,7 @@ public class QueryEditorController {
     String filePath = csvBaseDir + csvFilePath;
 
     File file = new File(filePath);
-    if (file == null || !csvFilePath.equals(file.getName())) {
+    if (!file.exists() || !csvFilePath.equals(file.getName())) {
       LOGGER.error("csvFilePath : {} : fileName : {}", csvFilePath, file.getName());
       throw new WorkbenchException(WorkbenchErrorCodes.CSV_FILE_NOT_FOUND, "CSV Download Failed");
     }


### PR DESCRIPTION
### Description
prevents path traversal through csv download api

**Related Issue** : #2445 
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
1. Call the api with any REST client
Method : POST
URL : /api/queryeditors/test/query/download/csv
Body : {"csvFilePath":"../etc/passwd"}

2. Return 500 error.
{
    "code": "WB0003",
    "message": "CSV Download Failed",
    "details": "WorkbenchException: CSV Download Failed"
}

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
