### PR TITLE
#2472 hidden the button for main node

### DIFF
--- a/discovery-frontend/src/app/meta-data-management/detail/component/lineage-view/lineage-detail.component.html
+++ b/discovery-frontend/src/app/meta-data-management/detail/component/lineage-view/lineage-detail.component.html
@@ -33,10 +33,10 @@
 
   <div class="ddp-ui-databuttons ddp-type">
     <div class="ddp-databuttons ddp-clear">
-      <div class="ddp-col-6">
+      <div [ngClass]="(selectedNode.metadataId!==mainMetadataId)?'ddp-col-6':'ddp-col-12'">
         <a href="javscript:" class="ddp-btn-line ddp-full">View column lineage</a>
       </div>
-      <div class="ddp-col-6">
+      <div *ngIf="selectedNode.metadataId!==mainMetadataId" class="ddp-col-6">
         <a (click)="gotoLineage();" href="javscript:" class="ddp-btn-solid ddp-bg-black ddp-full">Go to Metadata</a>
       </div>
     </div>

--- a/discovery-frontend/src/app/meta-data-management/detail/component/lineage-view/lineage-detail.component.html
+++ b/discovery-frontend/src/app/meta-data-management/detail/component/lineage-view/lineage-detail.component.html
@@ -33,10 +33,12 @@
 
   <div class="ddp-ui-databuttons ddp-type">
     <div class="ddp-databuttons ddp-clear">
+      <!-- next step
       <div [ngClass]="(selectedNode.metadataId!==mainMetadataId)?'ddp-col-6':'ddp-col-12'">
         <a href="javscript:" class="ddp-btn-line ddp-full">View column lineage</a>
       </div>
-      <div *ngIf="selectedNode.metadataId!==mainMetadataId" class="ddp-col-6">
+      -->
+      <div *ngIf="selectedNode.metadataId!==mainMetadataId" class="ddp-col-12">
         <a (click)="gotoLineage();" href="javscript:" class="ddp-btn-solid ddp-bg-black ddp-full">Go to Metadata</a>
       </div>
     </div>

--- a/discovery-frontend/src/app/meta-data-management/detail/component/lineage-view/lineage-detail.component.ts
+++ b/discovery-frontend/src/app/meta-data-management/detail/component/lineage-view/lineage-detail.component.ts
@@ -56,6 +56,8 @@ export class LineageDetailComponent extends AbstractComponent implements OnInit,
 
   public emptyGrid : boolean = false;
 
+  public mainMetadataId: string = null;
+
   @Input()
   public selectedNode: any;
 
@@ -89,6 +91,8 @@ export class LineageDetailComponent extends AbstractComponent implements OnInit,
   public ngOnInit() {
     // Init
     super.ngOnInit();
+
+    this.mainMetadataId = this.metaDataModelService.getMetadata().id;
 
     this.emptyGrid = false;
 


### PR DESCRIPTION
### Description
when loading, main node will be selected
if main node is selected, 'go to metadata' button will not be shown

**Related Issue** : 
[#2472 ](https://github.com/metatron-app/metatron-discovery/issues/2472)

### How Has This Been Tested?
1. go to lineage diagram page
2. check them
 1) is main node selected? 
 2) on the details of main node, is there a button labeled 'go to metadata'?

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
