### PR TITLE
recovery original style sheets

### DIFF
--- a/discovery-frontend/src/assets/css/metatron/component/component.tag.css
+++ b/discovery-frontend/src/assets/css/metatron/component/component.tag.css
@@ -37,11 +37,9 @@
 .ddp-box-tag-value.ddp-datasource,
 .ddp-box-tag-value.ddp-hive,
 .ddp-box-tag-value.ddp-stagingdb {display:inline-block; min-width:61px; padding:0 3px; text-align:center; font-size:10px;}
-.ddp-box-tag-value.ddp-etc,
 .ddp-box-tag-value.ddp-datasource {border:1px solid #50549a; color:#50549a;}
 .ddp-box-tag-value.ddp-hive {border:1px solid #f6a300; color:#f6a300;}
 .ddp-box-tag-value.ddp-stagingdb {border:1px solid #17a5ae; color:#17a5ae;}
-.ddp-box-tag-value.ddp-etc {border:1px solid #50549a; color:#50549a;}
 
 .ddp-box-power {display:inline-block; padding:2px 4px 1px 4px; width:60px; border-radius:2px; color:#fff; font-size:10px; text-align:center; box-sizing:border-box; white-space:nowrap; text-overflow:ellipsis; overflow:hidden; word-wrap:normal;}
 .ddp-box-power.ddp-watcher {background-color:#b7b9c2;}

--- a/discovery-frontend/src/assets/css/metatron/polaris.metatron.page.css
+++ b/discovery-frontend/src/assets/css/metatron/polaris.metatron.page.css
@@ -1,8 +1,24 @@
+/*
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @charset "utf-8";
 
 /****************************************************************************
    Page
 *************************************************************************/
+
 /* 01_워크스페이스_01목록 */
 @import url('page/metatron.page.01Workspace.css');
 
@@ -12,18 +28,13 @@
 @import url('page/metatron.page.02Workbook_Dashboard.css');
 /* 02_워크북_03차트_03main */
 @import url('page/metatron.page.02Workbook_Chart.css');
-
+/* 05_매니지먼트_00데이터저장소_00목록_01데이터소스 */
+@import url('page/metatron.page.05Management_datasourceList.css');
 /* 05_매니지먼트_00데이터저장소_02데이터소스상세 */
 @import url('page/metatron.page.05Management_datasourceDetail.css');
 
-/* 05_매니지먼트_00메타데이터 */
-@import url('page/metatron.page.05Management_metadata.css');
-
 /* 99_데이터프리퍼레이션_01데이터플로우_03룰2 */
 @import url('page/metatron.page.99Preperation_dataflow_rule.css');
-
-/* 05.06_DataMonitoring_01overview */
-@import url('page/metatron.page.05.06DataMonitoring.css');
 
 /****************************************************************************
    Popup
@@ -34,8 +45,6 @@
 @import url('popup/metatron.popup.02Workbook_ChartMap.css');
 /* 02_워크북_02대시보드_05데이터보기(데이터그리드,컬럼)_popup */
 @import url('popup/metatron.popup.02Workbook_Dashboard_dataview.css');
-/* 02_워크북_02대시보드_01추가_03조인옵션_popup */
-@import url('popup/metatron.popup.02Workbook_Dashboard_join.css');
 /* 02대시보드_01멀티데이터소스 */
 @import url('popup/metatron.popup.02Dashboard_multidata.css');
 
@@ -51,22 +60,13 @@
     99_데이터프리퍼레이션_02데이터셋_02파일업로드2
 */
 @import url('popup/metatron.popup.99Preperation_dataset.css');
-/*
-   99_데이터프리퍼레이션_01데이터플로우_04조인_popup
-*/
-@import url('popup/metatron.popup.99Preperation_dataflow.css');
 
 
-/* 05_06DataMonitoring_01overview_01DruidInfo_popup */
-@import url('popup/metatron.popup.05.06DataMonitoring.css');
+@import url('popup/metatron.popup.99Preparation_dataflow.css');
 
 
-
-
-
-
-
-
+/* 02_워크북_02대시보드_01추가_03조인옵션_popup */
+@import url('popup/metatron.popup.02Workbook_Dashboard_join.css');
 
 
 

--- a/discovery-frontend/src/assets/css/polaris.v2.component.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.component.css
@@ -1,4 +1,126 @@
+/*
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @charset "utf-8";
+
+/**************************************************************
+	라벨 인풋 폼 (사용자필드)
+**************************************************************/
+
+.ddp-pop-select.ddp-selected .ddp-pop-fix {display:block !important;}
+
+
+.ddp-wrap-edit2.ddp-inline {float:left; width:100%;}
+.ddp-wrap-edit2.ddp-inline .ddp-label-type {float:left; width:117px;}
+.ddp-wrap-edit2.ddp-inline .ddp-inline {display:block;}
+
+.ddp-form-label2 label.ddp-label-type {display:inline-block; padding-right:15px; color:#b7b9c2; font-size:14px; vertical-align:middle;}
+.ddp-form-label2 .ddp-wrap-dropdown {display:inline-block; vertical-align:middle;}
+
+.ddp-wrap-edit3 {display:table; width:100%; table-layout:fixed; min-height:30px;}
+.ddp-wrap-edit3.ddp-error .ddp-ui-error{display:inline-block;}
+.ddp-wrap-edit3 .ddp-ui-error {display:none; position:relative; top:-2px; margin-left:5px; color:#eb5f58; font-size:12px; white-space:nowrap;}
+
+.ddp-wrap-edit3 .ddp-ui-label-name {display:block; width:100%; margin-bottom:14px; color:#b7b9c2; font-size:13px;  vertical-align:middle;}
+.ddp-wrap-edit3 label.ddp-label-type {display:table-cell; width: 131px; padding:8px 0;color:#b7b9c2;font-size:13px;vertical-align:top;}
+.ddp-table-detail.ddp-setting .ddp-wrap-edit3 label.ddp-label-type {width:195px;}
+.ddp-box-detail.ddp-label-size .ddp-wrap-edit3 label.ddp-label-type {width:150px;}
+.ddp-wrap-edit3 label.ddp-label-type.ddp-text-right {padding-right:15px;}
+
+.ddp-wrap-edit3 .ddp-ui-sub-edit {margin-top:4px;}
+.ddp-wrap-edit3 label.ddp-label-subtype {width:121px; float:left; padding-left:20px; color:#4c515a; font-size:14px; box-sizing:border-box; vertical-align: middle; line-height:30px;}
+
+.ddp-wrap-edit3 .ddp-ui-edit-suboption {overflow:hidden;}
+.ddp-wrap-edit3 .ddp-ui-edit-option .ddp-wrap-list-detail {padding:6px 0 8px 0;}
+.ddp-wrap-edit3 .ddp-ui-edit-option .ddp-list-detail + .ddp-list-detail {display:block; padding-top:7px;}
+
+.ddp-wrap-edit3 .ddp-ui-edit-option span.ddp-detail {display:inline-block; padding:7px 0; font-size:13px;}
+.ddp-wrap-edit3 .ddp-ui-edit-option span.ddp-detail em.ddp-by {color:#b7bac1;}
+.ddp-wrap-edit3 .ddp-ui-edit-option {display:table-cell; position:relative;min-height:30px; vertical-align:middle; box-sizing:border-box;}
+.ddp-wrap-edit3 .ddp-ui-edit-option .ddp-input-apply {display:inline-block; width:200px;}
+.ddp-wrap-edit3 .ddp-ui-edit-option .ddp-ui-buttons {margin-top:8px;}
+.ddp-wrap-edit3 .ddp-ui-edit-option .ddp-input-typebasic.ddp-input-size {display:inline-block; width:170px;}
+.ddp-wrap-edit3 .ddp-ui-edit-option .ddp-ui-option-in {display:inline-block; width:100%;}
+.ddp-wrap-edit3 .ddp-ui-edit-option .ddp-label-radio {display:inline-block; position:relative; margin-right:20px; vertical-align: top;}
+.ddp-wrap-edit3 .ddp-ui-edit-option.ddp-middle .ddp-label-radio {vertical-align: middle;}
+.ddp-wrap-edit3 .ddp-ui-edit-option.ddp-middle .ddp-wrap-radio {float:left;}
+.ddp-wrap-edit3 .ddp-ui-edit-option.ddp-middle .ddp-wrap-hidden {display:block; padding-left:20px; overflow:hidden;}
+.ddp-wrap-edit3 .ddp-ui-edit-option.ddp-middle .ddp-ui-calen.ddp-inline {vertical-align:middle;}
+.ddp-wrap-edit3 .ddp-ui-edit-option .ddp-label-radio:last-of-type {margin-right:0;}
+
+.ddp-wrap-edit3 .ddp-ui-edit-option .ddp-ui-option-sub {position:relative; top:5px; margin-top:20px;}
+.ddp-wrap-edit3 .ddp-ui-edit-option .ddp-ui-option-sub:first-of-type {margin-top:0;}
+.ddp-wrap-edit3 .ddp-ui-edit-option .ddp-ui-option-sub label.ddp-ui-label-name {margin-bottom:8px; color:#4c515a; font-size:13px; font-weight:normal;}
+
+.ddp-wrap-edit3 .ddp-ui-edit-option.ddp-type {position:relative; padding-bottom:20px;}
+.ddp-wrap-edit3 .ddp-ui-edit-option.ddp-type.ddp-btn-multy {padding-right:107px;}
+.ddp-wrap-edit3 .ddp-ui-edit-option.ddp-type.ddp-btn-multy .ddp-btn-gray {position:absolute; top:0; right:0; width:100px; padding:7px; text-align:center; box-sizing:border-box;}
+.ddp-wrap-edit3 .ddp-ui-edit-option .ddp-data-error {position:absolute; bottom:4px; left:0; color:#e70000; font-size:12px; font-style:italic;}
+.ddp-wrap-edit3 .ddp-ui-edit-option .ddp-data-error:before {display:inline-block; width:13px; height:13px; vertical-align:middle; background:url(../images/icon_info.png) no-repeat; background-position:-28px top; content:'';}
+
+.ddp-wrap-edit3 .ddp-ui-edit-option .ddp-box-slider {padding:6px 0 0 0;}
+.ddp-wrap-edit3 .ddp-ui-edit-option .ddp-box-slider .ddp-checkbox-slide.ddp-checkbox-automatic2 {padding-left:30px; margin-bottom:10px}
+
+
+.ddp-wrap-edit3 .ddp-ui-edit-option.ddp-type .ddp-type-multy {margin-bottom:-20px; }
+.ddp-wrap-edit3 .ddp-ui-edit-option.ddp-type .ddp-type-multy [class*="ddp-col-"] {position:relative; padding-bottom:20px;}
+
+.ddp-wrap-edit3 .ddp-ui-edit-option .ddp-textarea {display:block; padding:5px 10px; width:100%; border:1px solid #d0d1d9; border-radius:2px; box-sizing:border-box;}
+.ddp-wrap-edit3.ddp-type .ddp-label-type {position:relative; color:#4c515a; font-size:14px;}
+.ddp-wrap-edit3.ddp-type .ddp-label-type.ddp-bold {font-weight:bold; font-size:13px;}
+.ddp-wrap-edit3.ddp-type .ddp-label-type.ddp-normal {padding-top:0; width:170px; font-weight:normal;}
+.ddp-wrap-edit3.ddp-type .ddp-label-type a.ddp-link-edit2 {position:absolute; top:25px; left:0; bottom:inherit;}
+.ddp-wrap-edit3.ddp-type .ddp-type-selectbox {display:inline-block;width:168px; box-sizing:border-box;}
+
+.ddp-wrap-edit3.ddp-type .ddp-type-selectbox.ddp-flow {width:289px}
+.ddp-wrap-edit3.ddp-type .ddp-type-multy .ddp-type-selectbox {width:100%;}
+.ddp-wrap-edit3.ddp-type .ddp-type-multy {margin:0 -3px;}
+.ddp-wrap-edit3.ddp-type .ddp-type-multy [class*="ddp-col-6"] {position:relative; padding:0 3px;}
+.ddp-wrap-edit3.ddp-type .ddp-label-type.ddp-size {width:180px; font-size:14px;}
+.ddp-wrap-edit3.ddp-type .ddp-wrap-hover-info {display:inline-block; position:relative; cursor:pointer;}
+.ddp-wrap-edit3.ddp-type .ddp-wrap-hover-info .ddp-icon-info3 {display:inline-block; position:relative; top:-1px; width:11px; height:11px; background:url(../images/icon_que.png) no-repeat; background-position:left -12px;}
+.ddp-wrap-edit3.ddp-type .ddp-wrap-hover-info .ddp-box-layout4 {display:none; position:absolute; width:320px;}
+.ddp-wrap-edit3.ddp-type .ddp-wrap-hover-info:hover .ddp-box-layout4 {display:block;}
+
+.ddp-box-popup3 .ddp-wrap-edit3.ddp-type .ddp-type-selectbox{display:block;}
+.ddp-box-popup3 .ddp-wrap-edit3.ddp-error .ddp-ui-error {margin-left:0; position:absolute; top:inherit; bottom:-20px;}
+
+.ddp-wrap-edit3.ddp-type.ddp-block .ddp-type-selectbox  {width:100%; box-sizing:border-box;}
+.ddp-wrap-edit3 .ddp-ui-label-name .ddp-wrap-hover-info {display:inline-block; margin-left:5px;  position:relative; vertical-align: middle; cursor:pointer;}
+.ddp-wrap-edit3 .ddp-ui-label-name .ddp-wrap-hover-info:hover {z-index:50;}
+.ddp-ui-label-name .ddp-wrap-hover-info em.ddp-icon-info3 {display:inline-block; position:relative; top:-1px; width:11px; height:11px; background:url(../images/icon_que.png) no-repeat; background-position:left -12px;}
+
+.ddp-ui-label-name .ddp-wrap-hover-info .ddp-box-layout4 {display:none; position:absolute; top:-15px; left:20px; width:240px;}
+.ddp-wrap-edit3 .ddp-wrap-hover-info .ddp-box-layout4 .ddp-data-det {padding:18px 20px; color:#90969f; font-weight:normal; font-size:12px; line-height:18px;}
+.ddp-wrap-edit3 .ddp-wrap-hover-info .ddp-box-layout4 .ddp-data-title + .ddp-data-det {padding-top:0;}
+.ddp-wrap-edit3 .ddp-ui-label-name .ddp-wrap-hover-info .ddp-box-layout4 .ddp-data-det .ddp-txt-tip {padding:18px 0 0 0; color:#35393f; font-size:12px;}
+
+.ddp-wrap-edit3 .ddp-form-edit {position:relative; padding-left:80px;}
+.ddp-wrap-edit3 .ddp-form-edit .ddp-label-sub {position:absolute; top:8px; left:0; width:80px; padding-right:6px; text-align:right; color:#90969f; font-size:13px; box-sizing:border-box;}
+
+.ddp-ui-label-name .ddp-wrap-hover-info.ddp-type .ddp-box-layout4 {display:none;}
+.ddp-ui-label-name .ddp-wrap-hover-info.ddp-type:hover .ddp-box-layout4 {display:block;}
+
+.ddp-info-inline .ddp-wrap-hover-info {display:inline-block; position:relative; vertical-align: middle; cursor: pointer;}
+.ddp-info-inline .ddp-wrap-hover-info em.ddp-icon-info3,
+.ddp-info-inline .ddp-wrap-hover-info em.ddp-icon-info3 {display:inline-block; position:relative; top:-1px; width:11px; height:11px; background:url(../images/icon_que.png) no-repeat; background-position:left -12px;}
+.ddp-info-inline .ddp-wrap-hover-info .ddp-box-layout4 {display:none; position:absolute; top:-40px; left:20px; width:240px;}
+.ddp-info-inline .ddp-wrap-hover-info .ddp-box-layout4.ddp-bottom {top:inherit; bottom:-30px;}
+.ddp-info-inline .ddp-wrap-hover-info .ddp-box-layout4 .ddp-data-det {padding:18px 20px; color:#90969f; font-weight:normal; font-size:12px; line-height:18px;}
+.ddp-info-inline .ddp-wrap-hover-info .ddp-box-layout4 .ddp-data-title + .ddp-data-det {padding-top:0;}
+.ddp-info-inline .ddp-wrap-hover-info:hover .ddp-box-layout4 {display:block;}
 
 
 /**************************************************************
@@ -24,20 +146,6 @@ ul.ddp-list-typebasic.ddp-view li.ddp-selected a {background-color:#f6f6f7;}
 ul.ddp-list-typebasic.ddp-view li.ddp-selected a .ddp-btn-view {display:block; background-color:#dbdce1;}
 ul.ddp-list-typebasic.ddp-view li.ddp-selected a .ddp-icon-plus {display:block;}
 
-.ddp-view-formula.type-view ul.ddp-list-typebasic.ddp-view li a {padding-right:20px;}
-.ddp-view-formula.type-view ul.ddp-list-typebasic.ddp-view li a .ddp-icon-plus {right:10px;}
-
-.ddp-ui-typebasic .ddp-ui-dropdown span.ddp-list-name {position:relative; padding-left:25px; background-color:#f6f6f7; cursor:pointer;}
-.ddp-ui-typebasic .ddp-ui-dropdown span.ddp-list-name:before {display:inline-block; position:absolute; top:50%; left:10px; margin-top:-4px; width:4px; height:7px; background:url(../images/icon_dataview.png) no-repeat; background-position:0 -110px; content:'';}
-.ddp-ui-typebasic .ddp-ui-dropdown.ddp-selected span.ddp-list-name:before {width:7px; height:4px; margin-top:-2px;background-position-y:-118px;}
-.ddp-ui-typebasic .ddp-ui-dropdown .ddp-list-typebasic {display:none;}
-.ddp-ui-typebasic .ddp-ui-dropdown.ddp-selected .ddp-list-typebasic {display:block;}
-.ddp-ui-typebasic .ddp-ui-dropdown ul.ddp-list-typebasic.ddp-view {padding-left:20px;}
-.ddp-ui-typebasic .ddp-ui-dropdown ul.ddp-list-typebasic.ddp-view li a {cursor: default;padding-left:5px;}
-.ddp-ui-typebasic .ddp-ui-dropdown ul.ddp-list-typebasic.ddp-view li a:hover {background-color:#f2f1f8;}
-.ddp-ui-typebasic .ddp-ui-dropdown ul.ddp-list-typebasic.ddp-view li.ddp-selected a {background-color:#9ca2cc; color:#fff;}
-.ddp-ui-typebasic .ddp-ui-dropdown ul.ddp-list-typebasic.ddp-view li.ddp-selected a .ddp-icon-plus {background-position-x:-16px;}
-
 /**************************************************************
 	대시보드 열람 dropdown slider
 **************************************************************/
@@ -61,9 +169,11 @@ ul.ddp-list-typebasic.ddp-view li.ddp-selected a .ddp-icon-plus {display:block;}
 .ddp-box-board-filter.ddp-calen .ddp-type-selectbox.ddp-type-filter .ddp-list-selectbox li a {font-size:12px; white-space:nowrap; text-overflow:ellipsis; overflow:hidden; word-wrap:normal;}
 .ddp-type-selectbox.ddp-type-filter .ddp-list-selectbox li a:hover {background:#fff;}
 
+
 /***************************************************************************
 	대시보드 편집 오른쪽 메뉴 filter info
 *************************************************************************/
+
 .ddp-ui-info.ddp-info-error {display:inline-block; position:relative; vertical-align:middle;}
 .ddp-ui-info.ddp-info-error .ddp-box-layout4 {display:none; position:absolute; left:-30px; top:100%; margin-top:6px;}
 .ddp-ui-info.ddp-info-error:hover .ddp-box-layout4 {display:block; white-space:normal;}
@@ -85,7 +195,6 @@ ul.ddp-list-typebasic.ddp-view li.ddp-selected a .ddp-icon-plus {display:block;}
 	slider
 **************************************************************/
 .ddp-ui-slider-type {margin:0 -5px;}
-.ddp-ui-slider-type .irs-bar-edge {height:3px; background-color:#90969f; bottom:0; top:inherit;}
 .ddp-ui-slider-type .irs {height:inherit;}
 .ddp-ui-slider-type .irs .irs {padding-top:25px; height:inherit;}
 .ddp-ui-slider-type .irs-from {display:none !important;}
@@ -103,16 +212,14 @@ ul.ddp-list-typebasic.ddp-view li.ddp-selected a .ddp-icon-plus {display:block;}
 /*.ddp-ui-slider-type .ddp-bar:nth-child(5) {left:83.333333%;}*/
 
 .irs-line {top:0; height:3px; cursor: pointer; overflow:inherit;}
-.ddp-slider-bg .irs-bar-edge {bottom:0; height:9px; border-radius:9px 0 0 9px; background-color:#c1cef1}
 .irs-slider,
 .irs-bar {bottom:0; top:inherit; cursor: pointer; z-index:15;}
 .irs-line-left,
 .irs-line-mid,
 .irs-line-right {top:0;}
-.irs-line-left {left:0;}
-.irs-line-right {right:0;}
+.irs-line-left {left:5px;}
+.irs-line-right {right:5px;}
 .irs-slider {display:inline-block; position:absolute; width:9px; height:9px; background-color:#4b515b; border-radius:45%; content:'';}
-
 .irs-slider.from,
 .irs-slider.to,
 .irs-slider.single {margin:0; bottom:-3px; z-index:15;}
@@ -195,16 +302,6 @@ ul.ddp-list-typebasic.ddp-view li.ddp-selected a .ddp-icon-plus {display:block;}
 
 .ddp-ui-info-popup {position:fixed; left:0; right:0; background-color:#526169; text-align:center; z-index:20}
 .ddp-ui-info-popup span.ddp-ui-create-det {display:inline-block; padding:16px 0 16px 0; color:#fff; font-size:14px;}
-
-/**************************************************************
-	bar per
-**************************************************************/
-.ddp-ui-bar-per {display:inline-block;position:relative; width:200px; height:12px; background-color:#e7e7e9; border-radius:1px;}
-.ddp-ui-bar-per .ddp-ui-bar {position:absolute; top:0; left:0; bottom:0; background-color:#4b525b; cursor:pointer;}
-.ddp-ui-bar-per .ddp-ui-bar:hover .ddp-ui-tooltip-info {display:block;}
-.ddp-ui-bar-per .ddp-ui-bar .ddp-ui-tooltip-info {display:none; position:absolute; left:50%; top:100%; margin:8px 0 0 -29px; width:57px; text-align:center; box-sizing:border-box; }
-.ddp-ui-bar-per .ddp-bar-line {position:absolute;top:0; bottom:0; border-left:1px solid #dc494f;}
-.ddp-wrap-bar-per .ddp-data-bar {display:inline-block; position:relative; top:-2px;padding-left:20px; color:#4b515b; font-size:13px}
 
 /**************************************************************
 	대시보드 편집
@@ -369,15 +466,11 @@ ul.ddp-list-typebasic.ddp-view li.ddp-selected a .ddp-icon-plus {display:block;}
     padding: 2px 5px;
     box-sizing:border-box;
 }
-.node-content-wrapper em.ddp-box-type {position:relative; float:left; width:28px; height:28px; border-radius:2px; border:1px solid red;}
-.node-content-wrapper em.ddp-box-type.type-dimension {border:1px solid #439fe5;}
-.node-content-wrapper em.ddp-box-type.type-measure {border:1px solid #5fd7a5;}
-.node-content-wrapper em.ddp-box-type em[class*="ddp-icon-"] {position:absolute; top:50%; left:50%;}
 .node-content-wrapper em[class*="ddp-img-chart"] {float:left; vertical-align: middle;}
-.node-content-wrapper span {display:block; padding:6px 0 6px 12px; color:#4b515b; font-size:13px; white-space:nowrap; text-overflow:ellipsis; overflow:hidden; word-wrap:normal;}
+.node-content-wrapper span {display:block; padding:6px 0 6px 12px; overflow:hidden; color:#4b515b; font-size:13px; white-space:nowrap; text-overflow:ellipsis; overflow:hidden; word-wrap:normal;}
 .node-content-wrapper em.ddp-data-num {float:left; position:relative; width:48px; height:28px; line-height:28px; text-align:center; content:'';}
-.node-content-wrapper em.ddp-data-num .node-wrapper {display: -webkit-box;display: -ms-flexbox;display: flex; -webkit-box-align: start; -ms-flex-align: start; align-items: flex-start;}
-
+.node-content-wrapper em.ddp-data-num
+.node-wrapper {display: -webkit-box;display: -ms-flexbox;display: flex; -webkit-box-align: start; -ms-flex-align: start; align-items: flex-start;}
 .tree-children .node-content-wrapper {margin-left:28px;}
 .tree-children .node-content-wrapper em.ddp-data-num {width:20px;}
 .tree-children .node-content-wrapper em.ddp-data-num:before {display:inline-block; position:absolute; top:-10px; right:0;width:13px; height:23px; background:url(../images/icon_depth.png) no-repeat; content:'';}
@@ -389,13 +482,14 @@ ul.ddp-list-typebasic.ddp-view li.ddp-selected a .ddp-icon-plus {display:block;}
 **************************************************************/
 .slick-header-menuicon {display:inline-block; width:17px; height:17px; margin-right:5px; text-align:center; border-radius:50%; border:1px solid #727ab7;}
 .slick-header-menuicon:before {display:inline-block; font-size:9px; color:#727ab7; line-height:17px;}
-.slick-header-menuicon.type-rn:before {content:'Rn';}
+.slick-header-menuicon.type-rn:before {content:'Rn';  }
 .slick-header-menuicon.type-dp:before {content:'Dp';}
 .slick-header-menuicon.type-st:before {content:'St';}
 .slick-header-menuicon.type-so:before {content:'So';}
 .slick-header-menuicon.type-mv:before {content:'Mv';}
 .slick-headerrow::-webkit-scrollbar {display: none;}
 .slick-header::-webkit-scrollbar {display: none;}
+
 /**************************************************************
     공통
 **************************************************************/
@@ -483,7 +577,7 @@ ul.ddp-list-typebasic.ddp-view li.ddp-selected a .ddp-icon-plus {display:block;}
 .sp-container button.sp-choose {width:100%; max-height:300px; padding:10px 0; background:#fff; color:#90969f; font-size:14px; font-weight:normal; text-shadow:none;}
 .sp-container button.sp-choose:hover {color:#4b515b; border:1px solid #4b515b;}
 .sp-container button.sp-choose:active {box-shadow:none;}
-.sp-container {position:fixed !important;padding:20px;
+.sp-container {position:fixed !important;padding:20px; background-color:#fff;
     border-radius:3px; border:none; background-color:#fff;
     -moz-box-shadow: 0 1px 3px 1px rgba(82,97,105,.3); /* drop shadow */
     -webkit-box-shadow: 0 1px 3px 1px rgba(82,97,105,.3); /* drop shadow */
@@ -525,6 +619,9 @@ ul.ddp-list-typebasic.ddp-view li.ddp-selected a .ddp-icon-plus {display:block;}
 .ddp-box-color .sp-replacer.sp-active:before {display:block; position:absolute; top:0; right:0; bottom:0; left:0; border:2px solid #000; content:''; z-index:1;}
 .ddp-box-color .sp-replacer.sp-active:after {display:block; position:absolute; top:2px; left:2px; right:2px; bottom:2px; border:1px solid #fff; content:'';}
 .sp-replacer .sp-dd {display:none;}
+
+
+
 
 /**************************************************************
   Date Picker
@@ -618,6 +715,7 @@ ul.ddp-list-typebasic.ddp-view li.ddp-selected a .ddp-icon-plus {display:block;}
 /**************************************************************
   meta-grid
 **************************************************************/
+
 .slick-column-name > span {display:inline-block; max-width:100%; padding-left:20px; text-align:left; font-weight:bold; font-size:12px; box-sizing:border-box;}
 .meta-grid-type .slick-headerrow .slick-data {padding:2px 10px 3px 10px; text-align:left; color:#9499c2; background-color:#f9fafd;font-size:12px; white-space:nowrap; text-overflow:ellipsis; overflow:hidden; word-wrap:normal; border-right:1px solid #ebebed}
 .meta-grid-type .slick-viewport {top:50px !important;}
@@ -627,11 +725,10 @@ ul.ddp-list-typebasic.ddp-view li.ddp-selected a .ddp-icon-plus {display:block;}
 
 .meta-grid .slick-column-name {line-height:initial;}
 
-.meta-grid .slick-column-det {display:block; color:#90969f; font-size:11px; font-weight:normal; text-align:left; white-space:nowrap; text-overflow:ellipsis; overflow:hidden;}
+.meta-grid .slick-column-det {display:block; color:#90969f; font-size:12px; font-weight:normal; text-align:left; white-space:nowrap; text-overflow:ellipsis; overflow:hidden;}
 .meta-grid .slick-viewport {top:45px !important;}
 .meta-grid .slick-header-columns {overflow:initial !important;}
 .meta-grid .slick-header-column.ui-state-default {padding:7px 20px 8px 9px !important;}
-
 /**************************************************************
   split
 **************************************************************/
@@ -649,15 +746,11 @@ ul.ddp-list-typebasic.ddp-view li.ddp-selected a .ddp-icon-plus {display:block;}
 .ddp-box-synch + .ddp-box-synch {margin-top:4px;}
 .ddp-box-synch .ddp-txt-synch {display:table-cell; vertical-align:middle;}
 .ddp-box-synch .ddp-icon-info {display:inline-block; width:13px; height:12px; margin-right:4px; background:url(../images/icon_info3.png) no-repeat left -41px; vertical-align:middle;}
-.ddp-box-synch .ddp-icon-info2 {display:inline-block; width:14px; height:14px; margin-right:4px; background:url(../images/icon_info3.png) no-repeat left -94px; vertical-align:middle;}
 .ddp-box-synch .ddp-btn-blue {float:right; margin:-4px 12px -4px 0;}
 .ddp-box-synch.type-info {border-color:#e7e7ea; background-color:#f6f6f7; color:#90969f;}
 .ddp-box-synch.type-info .ddp-icon-info {width:13px; height:13px; background-position:left -27px;}
-
-.ddp-box-synch.type-info .ddp-btn-info-close {float:right; position:relative; top:3px; width:9px; height:9px; background:url(../images/btn_sclose.png) no-repeat; background-position:left -28px;}
 .ddp-box-synch.type-error {border-color:#ffcedb; background-color:#ffedf2; color:#dc494f;}
 .ddp-box-synch.type-error .ddp-icon-info {width:13px; height:13px; background-position:left -80px;}
-.ddp-box-synch.type-error .ddp-btn-error-close {float:right; position:relative; top:3px; width:9px; height:9px; background:url(../images/icon_message.png) no-repeat;}
 .ddp-btn-blue {padding:7px 17px 8px 17px; border-radius:2px; background-color:#6174b3; color:#fff; font-size:13px;}
 .ddp-box-synch.type-warning {border-color:#fbe4b3; background-color:#fef6e4; color:#e9b017;}
 .ddp-box-synch.type-warning .ddp-icon-info {background-position:left -67px;}
@@ -665,9 +758,3 @@ ul.ddp-list-typebasic.ddp-view li.ddp-selected a .ddp-icon-plus {display:block;}
 .ddp-btn-blue.ddp-disabled {background-color:#d0d1d8; cursor:no-drop;}
 .ddp-btn-blue .ddp-icon-btn-sync {display:inline-block; margin-right:6px; width:13px; height:12px; background:url(../images/icon_buttons.png) no-repeat; background-position:left -363px;}
 
-/**************************************************************
-  Datepicker
-**************************************************************/
-.datepicker--cell.-selected-,
-.datepicker--cell.-selected-.-current- {background-color:#a9bef4;}
-.datepicker--day-name {color:#666eb2;}

--- a/discovery-frontend/src/assets/css/polaris.v2.layout.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.layout.css
@@ -226,7 +226,7 @@ textarea:-ms-input-placeholder {color: #a7adb2;}
 .ddp-layout-header .ddp-ui-searcing a.ddp-btn-search {display:inline-block; position:absolute; top:50%; left:14px; margin-top:-10px; width:20px; height:20px; background:url(../images/btn_search.png) no-repeat; box-sizing:border-box;}
 .ddp-layout-header .ddp-ui-searcing input {display:block; padding:10px 0 9px 0; width:100%; border:none; background:none; font-size:14px;}
 .ddp-layout-header .ddp-ui-searcing .ddp-box-popup {top:44px; left:0; right:0; margin:0; width:inherit; height:inherit; max-height:486px; overflow:auto;}
-.ddp-layout-header .ddp-ui-searcing .ddp-box-popup span.ddp-label-type {display:block; padding:10px 20px; color:#b7b9c2; font-size:12px;}
+.ddp-layout-header .ddp-ui-searcing .ddp-box-popup span.ddp-label-type {display:block; padding:10px 20px;  color:#b7b9c2; font-size:12px;}
 .ddp-layout-header .ddp-ui-searcing .ddp-box-popup ul.ddp-list-lately li a {display:block; position:relative; padding: 12px 77px 12px 20px; color:#4b515b; font-size:14px; white-space:nowrap; text-overflow:ellipsis; overflow:hidden; word-wrap: normal;}
 .ddp-layout-header .ddp-ui-searcing .ddp-box-popup ul.ddp-list-lately li a .ddp-data-date {position:absolute; top:13px; right:20px; color:#b7b9c2; font-size:12px;}
 .ddp-layout-header .ddp-ui-searcing .ddp-box-popup ul.ddp-list-lately li a:hover {background-color:#f6f6f7;}
@@ -253,14 +253,13 @@ textarea:-ms-input-placeholder {color: #a7adb2;}
 .ddp-layout-contents .ddp-ui-contents-in {position:relative; padding:0 80px;}
 .ddp-layout-contents .ddp-ui-contents-in.ddp-scroll {position:relative; height:100%; box-sizing:border-box;}
 .ddp-layout-contents .ddp-ui-contents-in.ddp-scroll .ddp-ui-contents-list {position:absolute; top:113px; left:0; right:0; bottom:0; padding:0 80px 50px 80px; box-sizing:border-box; overflow:auto;}
-.ddp-layout-contents .ddp-ui-contents-in.ddp-scroll .ddp-ui-contents-list.type-list {top:54px;}
+
 .ddp-layout-contents2 {position:relative; width:100%; height:100%; padding:47px 0 0 0; margin-top:-48px; box-sizing:border-box;}
 .ddp-layout-contents-in {position:relative;}
 .ddp-ui-contentsin {position:absolute;top:54px;left:0;right:0;bottom:0;}
 .ddp-ui-contentsin.ddp-full {top:48px;}
 .ddp-layout-contents.ddp-type {padding-top:0px; z-index:65;}
 .ddp-layout-contents.ddp-type .ddp-ui-contentsin{top:0;z-index: 127;}
-
 /***********************************************************************************************************
     검색결과
 ************************************************************************************************************/
@@ -322,7 +321,7 @@ textarea:-ms-input-placeholder {color: #a7adb2;}
 .ddp-layout-lnb.ddp-selected a.ddp-btn-lnbmenu:before {background-position:left -13px;}
 .ddp-layout-lnb.ddp-selected ul.ddp-list-lnb {display:block;}
 
-ul.ddp-list-lnb {display:none; position:absolute; top:55px; left:0; right:0; bottom:174px; overflow-y:auto;}
+ul.ddp-list-lnb {display:none; position:absolute; top:55px; left:0; right:0; bottom:136px; overflow-y:auto;}
 
 ul.ddp-list-lnb::-webkit-scrollbar-track {background:#3f4349;}
 ul.ddp-list-lnb::-webkit-scrollbar-thumb {border:4px solid #3f4349; background-color:#6d7179;}
@@ -345,7 +344,7 @@ ul.ddp-list-lnb li.ddp-selected a em.ddp-icon-menuview {display:none;}
 ul.ddp-list-lnb li a:hover {background-color:#2a2d33;}
 ul.ddp-list-lnb li.ddp-selected .ddp-list-sub {display:block; padding-bottom:19px;}
 ul.ddp-list-lnb li .ddp-list-sub {display:none;}
-ul.ddp-list-lnb li .ddp-list-sub .ddp-txt-title {display:block; position:relative; padding:10px 40px 10px 56px; font-size:14px; color:#b7b9c2; cursor: pointer;}
+ul.ddp-list-lnb li .ddp-list-sub .ddp-txt-title {display:block; position:relative; padding:10px 40px 10px 56px; font-size:13px; color:#a4a4ae; cursor: pointer;}
 ul.ddp-list-lnb li .ddp-list-sub .ddp-txt-title.ddp-selected {font-weight:bold; background-color:#212429;}
 ul.ddp-list-lnb li .ddp-list-sub .ddp-txt-title.ddp-selected em.ddp-icon-view {display:block;}
 
@@ -375,7 +374,7 @@ ul.ddp-list-lnb li ul.ddp-list-submenu li a:hover {background-color:#212429;}
 ul.ddp-list-lnb li ul.ddp-list-submenu li a:hover em.ddp-icon-view {display:block;}
 ul.ddp-list-lnb li ul.ddp-list-submenu li a:hover {background-color:#212429;}
 ul.ddp-list-lnb li ul.ddp-list-submenu li.ddp-selected a {background-color:#212429;}
-ul.ddp-list-lnb li ul.ddp-list-submenu li a span.ddp-data-listmenu {display:inline-block; max-width:100%; position:relative; padding:10px 0 10px 56px; font-size:14px; color:#b7b9c2; white-space:nowrap; text-overflow:ellipsis; overflow:hidden; word-wrap:normal; box-sizing:border-box;}
+ul.ddp-list-lnb li ul.ddp-list-submenu li a span.ddp-data-listmenu {display:inline-block; max-width:100%; position:relative; padding:10px 0 10px 56px; font-size:13px; color:#a4a4ae; white-space:nowrap; text-overflow:ellipsis; overflow:hidden; word-wrap:normal; box-sizing:border-box;}
 
 ul.ddp-list-lnb li ul.ddp-list-submenu li a span.ddp-data-listmenu em.ddp-icon-new {display:none; position:absolute; top:12px; right:0;font-size:10px; color:#919ae3;}
 ul.ddp-list-lnb li ul.ddp-list-submenu li a span.ddp-data-listmenu em.ddp-icon-new:before {display:inline-block; position:relative; top:-1px; content:''; width:5px; height:5px; margin-right:4px; border-radius:50%; vertical-align: middle; background-color:#919ae3;}
@@ -387,34 +386,29 @@ ul.ddp-list-lnb li ul.ddp-list-submenu li a span.ddp-data-listmenu.ddp-new em.dd
 ul.ddp-list-lnb li ul.ddp-list-submenu li a .ddp-icon-afav {display:inline-block; width:12px; height:12px; position:absolute; top:50%; right:20px; margin-top:-6px; background:url(../images/icon_fav.png) no-repeat; background-position:left -18px;}
 ul.ddp-list-lnb li ul.ddp-list-submenu li a .ddp-icon-afav.ddp-selected {background-position:-13px -18px;}
 
-ul.ddp-list-lnb li ul.ddp-list-sublnb li a {display:block; position:relative; padding:10px 10px 11px 56px; color:#6b6e77; font-size:14px;}
+ul.ddp-list-lnb li ul.ddp-list-sublnb li a {display:block; position:relative; padding:10px 10px 11px 56px; color:#6b6e77; font-size:13px;}
 ul.ddp-list-lnb li ul.ddp-list-sublnb li a em.ddp-icon-dot {display:inline-block; position:absolute; top:12px; left:30px; width:10px; height:10px; background:url(../images/icon_lnbdot.png) no-repeat; background-position:left -3px;}
 ul.ddp-list-lnb li ul.ddp-list-sublnb li.ddp-selected a {background-color:#212429;}
 ul.ddp-list-lnb li ul.ddp-list-sublnb li.ddp-selected a em.ddp-icon-dot {top:17px; width:10px; height:2px; background-position:left top;}
 ul.ddp-list-lnb li ul.ddp-list-sublnb li a:hover {background-color:#212429;}
 ul.ddp-list-lnb li ul.ddp-list-sublnb li ul.ddp-list-sublnb-2depth {display:none;}
 ul.ddp-list-lnb li ul.ddp-list-sublnb li.ddp-selected ul.ddp-list-sublnb-2depth {display:block; margin-bottom:10px;}
-ul.ddp-list-lnb li ul.ddp-list-sublnb li ul.ddp-list-sublnb-2depth li a {color:#b7b9c2; font-size:14px; background-color:#2a2d33;}
+ul.ddp-list-lnb li ul.ddp-list-sublnb li ul.ddp-list-sublnb-2depth li a {color:#a4a4ae; font-size:13px; background-color:#2a2d33;}
 ul.ddp-list-lnb li ul.ddp-list-sublnb li ul.ddp-list-sublnb-2depth li a:hover {background-color:#212429;}
 
-.ddp-layout-lnb .ddp-ui-help {position:absolute; bottom:0; left:0; right:0; padding:34px 0 0 0; background-color:#35393f;}
-.ddp-layout-lnb .ddp-ui-help .ddp-label-type {display:block; }
-.ddp-layout-lnb .ddp-ui-help .ddp-label-type .ddp-fright {margin-right:20px;}
-.ddp-layout-lnb .ddp-ui-help .ddp-label-type .ddp-txt-label {display:inline-block; padding:7px 20px 7px 23px;color:rgba(144,150, 159, 0.6); font-size:12px;}
-.ddp-layout-lnb .ddp-ui-help a.ddp-btn-box {display:inline-block; position:relative; padding:6px 9px 6px 24px; margin-left:4px; color:#90969f; font-size:12px; border:1px solid rgba(112, 123, 129, 0.3); border-radius:2px;}
+.ddp-layout-lnb .ddp-ui-help {position:absolute; bottom:0; left:0; right:0; padding:10px 0 0 0; background-color:#35393f;}
+.ddp-layout-lnb .ddp-ui-help .ddp-label-type {display:block; padding:0 0 0 23px; color:#90969f; font-size:13px;}
+.ddp-layout-lnb .ddp-ui-help a.ddp-btn-box {display:inline-block; position:relative; padding:6px 9px 6px 24px; margin-left:10px; color:#90969f; font-size:12px; border:1px solid rgba(112, 123, 129, 0.3); border-radius:2px;}
 .ddp-layout-lnb .ddp-ui-help a.ddp-btn-box:hover {border:1px solid rgba(112, 123, 129, 1);}
 .ddp-layout-lnb .ddp-ui-help a.ddp-btn-box em.ddp-icon-manual,
 .ddp-layout-lnb .ddp-ui-help a.ddp-btn-box em.ddp-icon-global {display:inline-block; background:url(../images/icon_lnb.png) no-repeat;}
 .ddp-layout-lnb .ddp-ui-help a.ddp-btn-box em.ddp-icon-manual {position:absolute; top:50%; left:7px; margin-top:-7px; width:13px; height:14px;  background-position:left -42px;}
 .ddp-layout-lnb .ddp-ui-help a.ddp-btn-box em.ddp-icon-global {position:absolute; top:50%; left:6px; width:13px; height:13px; margin-top:-7px; background-position:left -57px;}
 .ddp-data-help {padding:10px 23px 20px 23px;}
-.ddp-data-help dl dt {float:left; width:90px; color:#90969f;}
-.ddp-data-help dl dd {display:block; overflow:hidden; color:#90969f}
-.ddp-data-help dl dd a { color:#90969f;}
+.ddp-data-help dl dt {float:left; width:90px; color:rgba(144, 150, 159, 0.4);}
+.ddp-data-help dl dd {display:block; overflow:hidden; color:rgba(144, 150, 159, 0.4);}
+.ddp-data-help dl dd a { color:rgba(144, 150, 159, 0.4);}
 .ddp-layout-lnb .ddp-ui-help .ddp-viersion {padding:0 0 20px 23px; font-size:13px; color:#90969f; opacity:0.6;}
-.ddp-layout-lnb .ddp-data-help .ddp-label-type {padding:0 0 4px 0; color:rgba(144,150,159,0.6)}
-.ddp-layout-lnb .ddp-data-version { padding:0 23px 17px 23px; color:#90969f; font-size:12px;}
-
     /**************************************************************
         lnb folder
     **************************************************************/
@@ -424,7 +418,7 @@ ul.ddp-list-lnb li ul.ddp-list-sublnb li ul.ddp-list-sublnb-2depth li a:hover {b
 
 .ddp-list-locate {white-space:nowrap; word-wrap:normal; text-overflow:ellipsis; overflow:hidden; color:#fff; font-size:13px;}
 .ddp-list-locate span {position:relative; padding-left:14px; margin-left:8px; line-height:32px;}
-.ddp-list-locate span:before {display:inline-block; position:absolute; top:50%; left:0; right:10px; width:4px; height:7px; margin-top:-3px; background:url(../images/icon_dataview.png) no-repeat; background-position:left -11px; content:'';}
+.ddp-list-locate span:before {display:inline-block; position:absolute; top:50%; left:0; width:4px; height:7px; position:absolute; top:50%; right:10px; margin-top:-3px; background:url(../images/icon_dataview.png) no-repeat; background-position:left -11px; content:'';}
 .ddp-list-locate span:first-of-type {padding-left:0px; margin-left:0px;}
 .ddp-list-locate span:first-of-type:before {display:none;}
 
@@ -458,6 +452,7 @@ ul.ddp-list-folder-nav li a:hover {background-color:#e7e7ea}
 .ddp-wrap-layout-popup.ddp-scroll-popup {display:block; overflow:auto;}
 .ddp-wrap-layout-popup.ddp-scroll-popup .ddp-ui-layout-popup {display:table; width:100%; height:100%; text-align:center; }
 .ddp-wrap-layout-popup.ddp-scroll-popup .ddp-pop-contents {display:table-cell; width:100%; height:100%;vertical-align:middle;}
+
 /* 2 */
 .ddp-box-popup {display:inline-block; position:absolute; top:50%; left:50%; margin:-276px 0 0 -479px; width:958px; height:552px; text-align:left; background-color: #fff;
     -moz-box-shadow: 0 0 20px rgba(0,0,0,.3);
@@ -472,7 +467,7 @@ ul.ddp-list-folder-nav li a:hover {background-color:#e7e7ea}
 .ddp-layout-popuptype .ddp-ui-popup {position:absolute; top:0; left:50%; bottom:0; width:960px; overflow-y:auto; margin-left:-480px; background-color:#fff; z-index:127;}
 .ddp-layout-popuptype .ddp-ui-popup .ddp-ui-popup-title {position:relative; padding:44px 280px 44px 50px; text-align:left; overflow:hidden;}
 .ddp-layout-popuptype .ddp-ui-popup .ddp-ui-popup-title .ddp-txt-sub-title {position:absolute; bottom:20px; left:50px; color:#b7b9c2; font-size:13px; font-weight:300;}
-.ddp-layout-popuptype .ddp-ui-popup .ddp-ui-popup-title span.ddp-txt-title-name {position:relative; width:100%; line-height:32px; box-sizing:border-box; color:#222; font-size:18px;}
+.ddp-layout-popuptype .ddp-ui-popup .ddp-ui-popup-title span.ddp-txt-title-name {position:relative; width:100%; line-height:32px; color:#222; box-sizing:border-box; color:#222; font-size:18px;}
 .ddp-layout-popuptype .ddp-ui-popup .ddp-ui-popup-title span.ddp-txt-title-name span.ddp-txt-thin {font-weight:300;}
 .ddp-layout-popuptype .ddp-ui-popup .ddp-ui-popup-title span.ddp-txt-title-name .ddp-txt-det {position:relative; padding:0 0 0 14px; margin-left:12px; color:#b7b9c2; font-size:14px;}
 .ddp-layout-popuptype .ddp-ui-popup .ddp-ui-popup-title span.ddp-txt-title-name .ddp-txt-det:before {display:inline-block; position:absolute; top:50%; left:0; margin-top:-7px; content:''; height:14px; border-left:2px solid #dbdce0;}
@@ -488,10 +483,9 @@ ul.ddp-list-folder-nav li a:hover {background-color:#e7e7ea}
 .ddp-ui-layout-popup {display:table-cell; position:relative; width:100%; height:100%; text-align:center; vertical-align: middle;}
 .ddp-ui-layout-popup .ddp-scroll-popup {width:100%; max-height:100%; overflow:auto;}
 .ddp-ui-layout-popup .ddp-box-popup.ddp-popup-type {position:relative; top:0; left:0; margin:0; width:558px; height:auto; background-color:#fff;
-    -moz-box-shadow: 0 0 20px rgba(0,0,0,.3);
-    -webkit-box-shadow: 0 0 20px rgba(0,0,0,.3);
-    box-shadow: 0 0 20px rgba(0,0,0,.3);}
-
+  -moz-box-shadow: 0 0 20px rgba(0,0,0,.3);
+  -webkit-box-shadow: 0 0 20px rgba(0,0,0,.3);
+  box-shadow: 0 0 20px rgba(0,0,0,.3);}
 .ddp-ui-layout-popup .ddp-box-popup.ddp-popup-type .ddp-pop-title {padding:85px 0 0 0;}
 .ddp-ui-layout-popup .ddp-box-popup.ddp-popup-type .ddp-ui-buttons {padding-bottom:80px;}
 
@@ -523,6 +517,8 @@ ul.ddp-list-folder-nav li a:hover {background-color:#e7e7ea}
 .ddp-box-popup3.ddp-box-fix {height:720px;}
 .ddp-box-popup3.ddp-box-fix .ddp-ui-buttons {position:absolute; bottom:0; left:0; right:0;}
 
+.ddp-box-popup3 .ddp-wrap-message {width:700px;margin:10px auto;text-align: left;}
+
 .ddp-wrap-layout-popup.ddp-wrap-edit .ddp-box-popup {width:679px; height:402px; margin:-201px 0 0 -339px;}
 .ddp-wrap-layout-popup.ddp-wrap-edit .ddp-box-popup .ddp-box-edit {height:324px; margin-bottom:20px; border-bottom:1px solid #e7e7ea;}
 
@@ -535,12 +531,13 @@ ul.ddp-list-folder-nav li a:hover {background-color:#e7e7ea}
 
 .ddp-wrap-layout-popup.type-small .ddp-table-cell .ddp-box-popup .ddp-ui-buttons {padding:15px 0;}
 .ddp-wrap-layout-popup.type-small .ddp-table-cell .ddp-box-popup .ddp-ui-buttons .ddp-btn-type-popup {min-width:80px; padding:6px 10px; box-sizing:border-box; font-size:13px;}
-
 /**************************************************************
     텍스트 위젯 편집 팝업
 **************************************************************/
-.ddp-wrap-layout-popup.ddp-wrap-edit .ddp-box-popup .ddp-ui-popup-title {text-align: left; font-size:18px; padding: 10px 15px; overflow: hidden;}
+.ddp-wrap-layout-popup.ddp-wrap-edit .ddp-box-popup .ddp-ui-popup-title { text-align: left; font-size:18px; padding: 10px 15px; overflow: hidden;}
 .ddp-wrap-layout-popup.ddp-wrap-edit .ddp-box-popup .ddp-ui-popup-title em.ddp-icon-btntext{ margin-top:-4px;}
+
+
 
 /**************************************************************
     공통팝업 레이아웃
@@ -579,10 +576,14 @@ ul.ddp-list-folder-nav li a:hover {background-color:#e7e7ea}
 .ddp-type-contents .ddp-ui-name2.ddp-type {padding:0 0 33px 0; margin-top:-20px;}
 .ddp-type-contents .ddp-ui-name2.ddp-type2 {margin-bottom:0;}
 .ddp-type-contents .ddp-ui-name2.ddp-type3 {padding-top:13px; padding-bottom:15px; margin-bottom:25px;}
+
+
 .ddp-type-contents .ddp-ui-name2 {display:inline-block; position:relative; padding:54px 16px 33px 16px; margin-bottom:52px; color:#666eb2; font-size:18px;}
 .ddp-type-contents.ddp-resize2.ddp-type2 .ddp-ui-name2 {padding:2px 0 15px 0; margin-bottom:0;}
 .ddp-type-contents.ddp-resize.ddp-type {padding:38px 0 78px 0;}
 .ddp-type-contents.ddp-resize.ddp-type .ddp-ui-name2.ddp-type3 .ddp-txt-info {display:block; color:#90969f; font-size:14px; text-align:center;}
+
+
 
 .ddp-type-contents .ddp-ui-name2 .ddp-icon-newlink2,
 .ddp-type-contents .ddp-ui-name2 .ddp-icon-workbench {display:inline-block; position:absolute; top:0; left:50%; margin-left:-15px; width:30px; height:30px; background:url(../images/icon_popup.png) no-repeat;}
@@ -611,9 +612,9 @@ ul.ddp-list-folder-nav li a:hover {background-color:#e7e7ea}
 .ddp-type-contents .ddp-ui-name2 em.ddp-bg-order-type {display:inline-block; position:absolute; bottom:-4px; left:50%; width:75px; margin-left:-38px; border-top:1px solid #666eb2;}
 .ddp-type-contents-in .ddp-txt-info {display:block; padding-bottom:86px; color:#35393f; font-size:28px; text-align:center; font-weight:300;;}
 .ddp-type-contents-in .ddp-txt-info.ddp-type {padding-bottom:88px;}
-.ddp-type-contents .ddp-ui-buttons {padding-top:20px; }
+.ddp-type-contents .ddp-ui-buttons { padding-top:20px;}
 .ddp-type-contents .ddp-ui-buttons a[class*="ddp-btn-type-"] {margin:0 2px;}
-.ddp-type-contents .ddp-ui-buttons.type-shadow {box-shadow: 0 -3px 8px 0 rgba(0, 0, 0, 0.1);}
+
 .ddp-type-contents.ddp-resize {overflow:hidden;}
 .ddp-type-contents.ddp-resize .ddp-type-contents-in {position:absolute; top:154px; left:0; right:0; bottom:80px;}
 .ddp-type-contents.ddp-resize .ddp-type-contents-in.ddp-type {top:0;}
@@ -630,16 +631,15 @@ ul.ddp-list-folder-nav li a:hover {background-color:#e7e7ea}
 .ddp-type-contents.ddp-resize2 .ddp-icon-name .ddp-txt-info
 {display:block; padding-bottom:86px; color:#35393f; font-size:28px; text-align:center; font-weight:300;;}
 
-.ddp-type-contents.ddp-resize2.ddp-type2 .ddp-icon-name {padding-top:38px; padding-bottom:25px;}
+.ddp-type-contents.ddp-resize2.ddp-type2 .ddp-icon-name {padding-top:38px; padding-bottom:40px;}
 .ddp-type-contents.ddp-resize2.ddp-type2 .ddp-icon-name .ddp-txt-info {padding-bottom:0; color:#90969f; font-size:14px; font-weight:normal;}
-.ddp-type-contents.ddp-resize2.ddp-type2 .ddp-icon-name.type-shadow {box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.1);}
 
-.ddp-type-contents.ddp-resize2 .ddp-ui-name2.ddp-type {position:fixed; padding-top:40px; left:0; right:0; margin-top:0; background-color:#fff; z-index:20;}
-.ddp-type-contents.ddp-resize2 .ddp-box-popupcontents4 {padding:120px 0 78px 0;}
+
+.ddp-type-contents.ddp-resize2 .ddp-ui-name2.ddp-type {position:fixed; padding-top:40px; left:0; right:0; margin-top:0; background-color:#fff; background-color:#fff; z-index:20;}
+.ddp-type-contents.ddp-resize2 .ddp-box-popupcontents4 { padding:120px 0 78px 0;}
 .ddp-type-contents.ddp-resize2 .ddp-box-popupcontents4 > .ddp-wrap-edit2:first-of-type {margin-top:0;}
 .ddp-type-contents.ddp-resize2 > .ddp-ui-buttons2,
-.ddp-type-contents.ddp-resize2 > .ddp-ui-buttons {position:fixed; bottom:0; left:0; right:0; padding-bottom:20px; background-color:#fff;}
-.ddp-type-contents.ddp-resize2 .ddp-ui-buttons.type-fix {position:fixed; bottom:0; left:0; right:0; padding-bottom:20px; background-color:#fff;}
+.ddp-type-contents.ddp-resize2 > .ddp-ui-buttons {position:fixed; bottom:0; left:0; right:0; padding-bottom:20px; background-color:#fff; z-index:60}
 .ddp-type-contents.ddp-resize2 .ddp-type-contents-in {position:relative; min-height:100%; padding:356px 0 85px 0; box-sizing:border-box;}
 .ddp-type-contents.ddp-resize2 .ddp-type-contents-in.ddp-scroll {position:absolute; top:136px; left:0; right:0; bottom:78px; padding:0 !important; min-height:auto; overflow:auto;}
 .ddp-type-contents.ddp-resize2.ddp-type2 .ddp-type-contents-in {padding-top:139px;  box-sizing:border-box}
@@ -736,7 +736,7 @@ ul.ddp-list-folder-nav li a:hover {background-color:#e7e7ea}
 .ddp-ui-naviarea .ddp-wrap-naviname:hover span.ddp-data-naviname.ddp-readonly {background:none;}
 .ddp-ui-naviarea .ddp-wrap-naviname.ddp-type span.ddp-data-naviname {cursor:auto;}
 .ddp-ui-naviarea .ddp-wrap-naviname.ddp-type:hover span.ddp-data-naviname {background:none;}
-.ddp-ui-naviarea input.ddp-input-navi {float:left; padding:3px 5px 2px 5px; width:100%; height:25px; font-size:16px; background-color:#d9dadf; box-sizing:border-box; border:none; line-height:1.3em;}
+.ddp-ui-naviarea input.ddp-input-navi {float:left; padding:3px 5px 2px 5px; width:100%; height:25px; font-size:16px; border:1px solid #d9dadf; background-color:#d9dadf; box-sizing:border-box; border:none; line-height:1.3em;}
 .ddp-ui-naviarea input.ddp-input-navi::-webkit-input-placeholder {color:#9ba0ab;}
 .ddp-ui-naviarea input.ddp-input-navi:-ms-input-placeholder {color:#9ba0ab;}
 

--- a/discovery-frontend/src/assets/css/polaris.v2.page.css
+++ b/discovery-frontend/src/assets/css/polaris.v2.page.css
@@ -1,12 +1,23 @@
-@charset "utf-8";
+/*
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
+@charset "utf-8";
 /***********************************************************************************************************
 	로그인
 ************************************************************************************************************/
 .ddp-wrap-login {height:100%; min-height:800px; background:url(../images/login.jpg) no-repeat center center fixed; background-size:cover;}
-.ddp-wrap-login.let-it-snow {height:100%; min-height:auto; overflow:hidden; background:url(../images/login_christmas.jpg) no-repeat center center fixed; background-size:cover;}
-.ddp-wrap-login.let-it-snow .ddp-bg-login,
-.ddp-wrap-login.let-it-snow .ddp-blur2 {display:none;}
 .ddp-ui-login {position:relative;width:410px; height:100%; padding:192px 0 0 0; background-color:rgba(255,255,255,0.7); z-index:1; box-sizing:border-box;}
 .ddp-wrap-login .ddp-blur2{display:block;background:url(../images/login.jpg) no-repeat fixed;; background-size:cover; overflow:hidden; content:'';
 	filter: blur(5px);
@@ -29,7 +40,7 @@
 .ddp-form-login .ddp-form-input span.ddp-input-type {display:block; width:100%; border:none; background:transparent;}
 .ddp-form-login .ddp-form-input span.ddp-input-type input {width:100%; padding:8px 0; border:none;border-bottom:1px solid #b5b5cc; background-color:transparent; color:#272950; font-size:18px;}
 .ddp-form-login .ddp-form-input span.ddp-input-type input:-webkit-autofill {
-	-webkit-box-shadow: 0 0 0 1000px white inset;}
+  -webkit-box-shadow: 0 0 0 1000px white inset;}
 .ddp-form-login .ddp-form-input span.ddp-input-type input:focus {border-bottom:1px solid #272950;}
 .ddp-form-login .ddp-ui-login-option {min-width:360px; max-width:fit-content; margin:26px 0 40px 0; white-space:nowrap; overflow:hidden;}
 .ddp-form-login .ddp-ui-login-option .ddp-wrap-input-checkbox {position:relative; float:left; margin-right:20px; padding-left:20px;}
@@ -75,12 +86,9 @@
 .ddp-wrap-popup {position:fixed;  left:0; right:0; bottom:0; top:0; z-index:126; }
 .ddp-ui-popup-in {position:absolute;  left:0; right:0; bottom:0; top:0; overflow:auto;}
 .ddp-wrap-popup em.ddp-bg-popup {position:fixed; left:0; right:0; bottom:0; top:0; background-color:rgba(208,209,216,0.5);}
-.ddp-ui-popup-table {display:table; width:100%; height:100%;}
 .ddp-wrap-popup .ddp-ui-popup {position:relative; left:50%; width:600px; margin:98px 0 98px -300px; padding:100px 0 60px 0; background-color:#fff; z-index:91;}
 .ddp-wrap-popup .ddp-ui-popup a.ddp-btn-close {display:inline-block; position:absolute; top:20px; right:20px; width:23px; height:23px; background:url(../images/btn_popclose.png) no-repeat; z-index:1;}
 
-.ddp-popup-table-cell {display:table-cell; vertical-align:middle; text-align:center;}
-.ddp-wrap-popup .ddp-popup-table-cell .ddp-ui-popup {display:inline-block; padding-bottom:100px; position:relative; margin:0; left:0;}
 .ddp-wrap-popup .ddp-ui-popup span.ddp-ui-pop-title {display:block; padding-bottom:28px; text-align:center; font-size:28px; font-weight:300; color:#222;}
 .ddp-ui-popup ul.ddp-list-tab {display:block; padding:20px 0 0 0; text-align:center;}
 .ddp-ui-popup ul.ddp-list-tab li {display:inline-block; padding:0 12px 0 12px;}
@@ -130,7 +138,7 @@
 .ddp-ui-user-contet .ddp-ui-input-form .ddp-input-check .ddp-icon-ok {background-position:left -38px;}
 
 .ddp-ui-input-form .ddp-ui-error {visibility:hidden;}
-.ddp-ui-input-form.ddp-type-error .ddp-ui-error {visibility:inherit;}
+.ddp-ui-input-form.ddp-type-error .ddp-ui-error {visibility:inherit;;}
 .ddp-ui-info .ddp-txt-info {display:block; padding-bottom:15px;}
 .ddp-ui-info .ddp-txt-info em.ddp-icon-info {position:relative; top:-1px; margin-right:5px;vertical-align:middle;}
 
@@ -198,7 +206,6 @@
 .ddp-type-top-option .ddp-ui-rightoption a.ddp-link-public.ddp-selected {background-color:#e7e7ea; color:#4b515b; border-radius:2px;}
 .ddp-type-top-option .ddp-ui-rightoption a.ddp-link-public.ddp-selected em.ddp-icon-global-s {background-position:-14px -18px;}
 .ddp-type-top-option .ddp-ui-rightoption .ddp-form-label2 {float:left; margin-left:28px; color:#b7b9c2;}
-.ddp-type-top-option .ddp-ui-rightoption .ddp-btn-selection.type-option {margin-left:6px; color:#90969f;}
 .ddp-type-top-option .ddp-form-label2 .ddp-label-type {font-size:13px;}
 .ddp-type-top-option .ddp-ui-rightoption .ddp-switch {float:left; position:relative; top:9px; margin-left:28px;}
 .ddp-type-top-option .ddp-ui-rightoption .ddp-link-toggle.ddp-fleft {margin-left:28px;}
@@ -235,13 +242,13 @@ dl.ddp-dl-detail dd br {display:block; margin-top:5px;}
 .ddp-box-grid-detail .ddp-wrap-datadetail dl.ddp-dl-detail dd span.ddp-txt-det + span.ddp-txt-det {padding-top:5px;}
 .ddp-box-grid-detail .ddp-wrap-datadetail dl.ddp-dl-detail dd .ddp-data-det,
 .ddp-box-grid-detail .ddp-wrap-datadetail .ddp-dl-detail td .ddp-data-det {overflow: hidden;
-	text-overflow: ellipsis;
-	display: -webkit-box;
-	-webkit-line-clamp: 2; /* 라인수 */
-	/* autoprefixer: off */
-	-webkit-box-orient: vertical;
-	/* autoprefixer: on */
-	word-wrap:break-word; overflow:Hidden;}
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2; /* 라인수 */
+  /* autoprefixer: off */
+  -webkit-box-orient: vertical;
+  /* autoprefixer: on */
+  word-wrap:break-word; overflow:Hidden;}
 .ddp-box-grid-detail .ddp-wrap-datadetail dl.ddp-dl-detail dd .ddp-tags {max-width:110px; padding:6px; border-radius:3px; background-color:#f2f1f8; color:#666eb2; font-size:13px; white-space:nowrap; text-overflow:ellipsis; overflow:hidden; word-wrap:normal; }
 .ddp-box-grid-detail .ddp-wrap-datadetail dl.ddp-dl-detail dd .ddp-tags + .ddp-tags {margin-left:5px;}
 
@@ -373,13 +380,7 @@ dl.ddp-dl-detail dd br {display:block; margin-top:5px;}
 .ddp-pop-preview .ddp-ui-top .ddp-wrap-source-name .ddp-txt-description {display:block; padding:7px 0;color:#b7b9c2; font-size:13px; overflow:hidden;}
 .ddp-pop-preview .ddp-ui-grid {position:absolute; top:38px; left:0; right:0; bottom:0; border:1px solid #4b515b;}
 
-.type-scroll {padding:50px 90px; width:100%; height:100%; box-sizing:border-box;overflow:auto;background-color:rgba(208,209,216,0.5);}
-
-.type-scroll .ddp-pop-preview {position:relative; top:0; left:0; right:0; bottom:0; width:100%; height:100%; margin-right:90px; min-width:850px;}
-.type-scroll .ddp-pop-preview:before {display:none;}
-/*.type-scroll .ddp-pop-preview:before {display:inline-block; content:''; position:fixed; left:0; right:0; bottom:0; top:0; background-color:rgba(208,209,216,0.5);}*/
 .ddp-ui-preview-contents {position:absolute; top:38px; left:0; right:0; bottom:0; border:1px solid #4b515b; background-color:#fff; overflow:auto;}
-.ddp-ui-preview-contents.type-relative {position:Relative; top:0; left:0; right:0; height:100%;}
 .ddp-ui-preview-contents ul.ddp-ui-tab li.ddp-selected a:after {border-bottom:none;}
 .ddp-pop-preview.ddp-type {position:fixed; top:50px; left:90px; right:90px; bottom:52px;}
 .ddp-ui-preview-contents.ddp-add {padding-bottom:38px;}
@@ -395,12 +396,11 @@ dl.ddp-dl-detail dd br {display:block; margin-top:5px;}
 .ddp-ui-preview-contents.ddp-preview-group .ddp-col-table {margin-top:-46px; padding:46px 0 0 0; height:100%; box-sizing:Border-box;}
 .ddp-ui-preview-contents.ddp-preview-group .ddp-col-table .ddp-ui-gridbody2 {top:71px;}
 
-.ddp-ui-preview-contents.ddp-preview-group .ddpƒ√-group-num {padding:15px 29px; font-size:13px; color:#90969f; font-weight:400;}
+.ddp-ui-preview-contents.ddp-preview-group .ddp-group-num {padding:15px 29px; font-size:13px; color:#90969f; font-weight:400;}
 .ddp-ui-preview-contents.ddp-preview-group .ddp-group-num strong {color:#666eb2;}
 .ddp-ui-preview-contents.ddp-preview-group .ddp-part {height:100%;}
 
 .ddp-ui-preview-contents table.ddp-table-type2 tbody tr:hover td {background-color:#f2f1f9;}
-.ddp-ui-preview-contents table.ddp-table-form tbody tr td .ddp-txt-long.ddp-type-button {display:block;}
 .ddp-ui-preview-contents table.ddp-table-form tbody tr td .ddp-txt-long {font-size:14px;}
 .ddp-ui-preview-contents table.ddp-table-form tbody tr td .ddp-txt-long.ddp-type-button .ddp-txt-name {display:block; white-space:nowrap; text-overflow:ellipsis; overflow:hidden; margin-top:6px;}
 .ddp-ui-preview-contents .ddp-table-header {padding-right:18px;}
@@ -510,7 +510,7 @@ dl.ddp-dl-detail dd br {display:block; margin-top:5px;}
 .ddp-ui-column .ddp-data-column:hover em.ddp-icon-select,
 .ddp-ui-column .ddp-data-column.ddp-selected em.ddp-icon-select {display:block;}
 .ddp-ui-column .ddp-data-column select {display:inline-block; position:absolute; top:0; left:0; right:0; bottom:0; width:100%; border:none; background:transparent; opacity:0; cursor:pointer;}
-.ddp-ui-column .ddp-data-column.ddp-data-search input.ddp-input-search {display:block; width:100%; padding:5px 9px 6px 9px; border:none; box-sizing:border-box;}
+.ddp-ui-column .ddp-data-column.ddp-data-search input.ddp-input-search {display:block; width:100%; padding:5px 9px 6px 9px; border:none; padding-left:9px; box-sizing:border-box;}
 
 .ddp-ui-column.ddp-ui-new {background:none; border:none; border-radius:0px;}
 .ddp-ui-column.ddp-ui-new .ddp-data-column {border-radius:3px; background-color:rgba(255,255,255,0.2);}
@@ -528,9 +528,7 @@ dl.ddp-dl-detail dd br {display:block; margin-top:5px;}
 
 .ddp-wrap-order .ddp-ui-result span.ddp-data-result.ddp-selected {color:#444;}
 .ddp-wrap-order .ddp-ui-result span.ddp-data-result.ddp-selected .ddp-icon-eyes2 {background-position:-17px 0}
-.ddp-wrap-order-setting {position:absolute; top:151px; left:50px; right:50px; bottom:0; padding-left:40px; box-sizing:border-box; overflow:auto;}
-.ddp-wrap-order .ddp-tree-number {margin-top:3px;}
-.ddp-wrap-order .ddp-tree-number li {padding:18px 0 17px 14px; width:45px; height:50px; box-sizing:border-box;}
+.ddp-wrap-order-setting {position:absolute; top:151px; left:50px; right:50px; bottom:0; overflow-y:auto; box-sizing:border-box; overflow:auto;}
 ul.ddp-list-order {padding:12px 0;}
 ul.ddp-list-order li {display:table; padding:4px 0; width:100%; table-layout:fixed; cursor: pointer;}
 ul.ddp-list-order li:hover {background-color:#f6f6f7;}
@@ -581,7 +579,7 @@ ul.ddp-list-order li .ddp-data-name .ddp-chart-img {display:inline-block; float:
 .ddp-lnb-dashboard.ddp-close .ddp-wrap-tab2 {display:none;}
 .ddp-lnb-dashboard.ddp-close:hover {z-index:126;}
 .ddp-lnb-dashboard.ddp-close .ddp-ui-toptitle {position:absolute;left:0; }
-.ddp-lnb-dashboard.ddp-close .ddp-btn-folding .ddp-ui-tooltip-info.ddp-down {position:fixed; top:119px; right:auto; left:30px; margin-top:0; width:max-content; white-space:nowrap;;}
+.ddp-lnb-dashboard.ddp-close .ddp-btn-folding .ddp-ui-tooltip-info.ddp-down {position:fixed; top:119px; right:auto; left:30px; margin-top:0; width:max-content; white-space:nowrap;}
 .ddp-lnb-dashboard.ddp-close .ddp-ui-tooltip-info.ddp-down em.ddp-icon-view-top {left:0; transform:rotate(0deg); right:inherit; top:50%; margin-top:-4px;}
 
 .ddp-lnb-dashboard.ddp-close .ddp-btn-folding {width:inherit; height:inherit; top:0; left:0; right:0; bottom:0;}
@@ -670,7 +668,7 @@ a.ddp-link-board-add .ddp-link-add {display:inline-block; position:relative; top
 .ddp-wrap-tab-dashboard .ddp-ui-board-listview {position:absolute; top:183px; left:0; right:0; bottom:80px; box-sizing:border-box; overflow:auto;}
 .ddp-wrap-tab-dashboard .ddp-link-more {margin:10px 0 0 22px; color:#90969f; font-size:14px; text-decoration: underline;}
 .ddp-wrap-tab-dashboard .ddp-link-more:hover {color:#4b515b;}
-.ddp-wrap-tab-dashboard .ddp-wrap-search {padding:20px 20px 0 20px;}
+.ddp-wrap-tab-dashboard .ddp-wrap-search {padding:20px 20px 0 20px; }
 .ddp-wrap-tab-dashboard .ddp-wrap-search .ddp-form-search {width:100%;}
 ul.ddp-list-board-listview {}
 ul.ddp-list-board-listview li a {display:block; position:relative; padding:17px 15px 17px 0;}
@@ -715,6 +713,9 @@ ul.ddp-list-board-thumbview li.ddp-selected a span.ddp-wrap-image:before {displa
 ul.ddp-list-board-thumbview li a:hover .ddp-wrap-image:before {display:inline-block; content:''; position:absolute; top:0; left:0; right:0; bottom:0; background-color:rgba(86,93,101,0.1);}
 ul.ddp-list-board-thumbview li.ddp-selected a span.ddp-data-name {color:#4b515b;}
 
+ul.ddp-list-board-listview li.ddp-disabled a:after {display:inline-block; content:''; position:absolute; top:0; left:0; right:0; bottom:0; background-color:rgba(255,255,255,0.7); cursor:no-drop;}
+ul.ddp-list-board-thumbview li.ddp-disabled a:after {display:inline-block; content:''; position:absolute; top:0; left:0; right:0; bottom:0; background-color:rgba(255,255,255,0.7); cursor:no-drop;}
+
 .ddp-ui-board-filter {position:relative; padding-right:53px;}
 .ddp-ui-board-filter .ddp-btn-slider {position:absolute; top:0px; left:0; bottom:0; width:70px; padding:15px 0; background-color:#fff; z-index:1;}
 .ddp-ui-board-filter .ddp-btn-slider .ddp-btn-prev {border-right:1px solid #e7e7ea;}
@@ -740,11 +741,11 @@ ul.ddp-list-board-thumbview li.ddp-selected a span.ddp-data-name {color:#4b515b;
 .ddp-wrap-board-filter.ddp-slider {padding-left:80px;}
 .ddp-wrap-board-filter.ddp-initial {overflow:initial;}
 .ddp-wrap-board-filter .ddp-list-board-filter {white-space:nowrap; word-wrap:normal;}
-.ddp-wrap-board-filter .ddp-list-board-filter .ddp-box-board-filter {display:inline-block; min-width:224px; max-width:352px; padding:0 3px; box-sizing:border-box; vertical-align:top;}
+.ddp-wrap-board-filter .ddp-list-board-filter .ddp-box-board-filter {display:inline-block; min-width:224px; max-width:352px; padding:0 3px; vertical-align: middle; box-sizing:border-box; vertical-align:top;}
 .ddp-wrap-board-filter .ddp-list-board-filter .ddp-box-board-filter .ddp-box-dataselect {width:100%; padding:7px 10px 6px 10px; color:#d0d1d8; font-size:12px; border:1px dashed #e7e7ea; box-sizing:border-box;}
 .ddp-wrap-board-filter .ddp-box-board-filter  .ddp-type-selectbox ul.ddp-list-selectbox {min-width:100%; right:inherit;}
 .ddp-wrap-board-filter .ddp-box-board-filter  .ddp-type-selectbox ul.ddp-list-selectbox li span.ddp-time {color:#d0d1d8;}
-.ddp-wrap-board-filter .ddp-list-board-filter .ddp-box-board-filter.ddp-time .ddp-type-selectbox span.ddp-txt-selectbox {display:block; max-width:100%; overflow:hidden; white-space:nowrap; text-overflow:ellipsis; word-wrap:normal;}
+.ddp-wrap-board-filter .ddp-list-board-filter .ddp-box-board-filter.ddp-time .ddp-type-selectbox span.ddp-txt-selectbox { display:block; max-width:100%; overflow:hidden; white-space:nowrap; text-overflow:ellipsis; word-wrap:normal;}
 .ddp-box-board-filter .ddp-icon-time4 {margin-right:4px;}
 .ddp-wrap-board-filter .ddp-list-board-filter .ddp-box-board-time {display:inline-block;  position:relative; margin-right:3px;}
 .ddp-wrap-board-filter .ddp-list-board-filter .ddp-btn-time {display:inline-block; position:relative; width:33px; height:30px; border:1px solid #d0d1d9; border-radius:2px; box-sizing:border-box;}
@@ -756,12 +757,11 @@ ul.ddp-list-board-thumbview li.ddp-selected a span.ddp-data-name {color:#4b515b;
 .ddp-wrap-board-filter .ddp-list-board-filter .ddp-box-board-time:hover .ddp-ui-tooltip-info {display:block;}
 .ddp-ui-widget {position:absolute; top:54px; left:0; right:0; bottom:0; padding:10px 10px;}
 .ddp-ui-widget.ddp-type {top:47px;}
-.ddp-ui-edit-contents .ddp-wrap-widget {overflow:initial;}
-.ddp-wrap-widget {position:relative; height:100%; overflow:hidden;}
+.ddp-wrap-widget {position:relative; height:100%;}
 .ddp-wrap-widget.ddp-box-full {position:fixed; left:290px; top:165px; bottom:0; right:0; height:auto; background-color:#fff; z-index:130}
 .ddp-wrap-widget.ddp-box-full .ddp-loading-part {z-index:130;}
 
-.ddp-box-widget {position:relative; background-color:#fff; cursor:pointer; border:1px solid #fff; box-sizing:border-box;}
+.ddp-box-widget {position:relative; background-color:#fff; border:1px solid #fff; box-sizing:border-box;}
 .ddp-box-widget .ddp-ui-graph-name {position:relative; padding:4px 5px 4px 10px; color:#4b515b; font-size:14px; box-sizing:border-box;z-index:30;}
 .ddp-box-widget .ddp-ui-graph-name .ddp-data-name {display:block; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
 .ddp-box-widget .ddp-ui-graph-name .ddp-ui-tooltip-info {display:none; position:absolute; top:35px; left:10px;}
@@ -769,7 +769,7 @@ ul.ddp-list-board-thumbview li.ddp-selected a span.ddp-data-name {color:#4b515b;
 .ddp-box-widget .ddp-ui-graph-name .ddp-ui-tooltip-info em.ddp-icon-view-top {left:20px;}
 
 .ddp-box-widget .ddp-top-control {position:relative; float:right; height:25px;z-index:31; background-color:#fff;}
-.ddp-box-widget .ddp-top-control .ddp-ui-buttons {background-color:rgba(255,255,255,0.8);}
+.ddp-box-widget .ddp-top-control .ddp-ui-buttons { background-color:rgba(255,255,255,0.8);}
 .ddp-box-widget .ddp-top-control .ddp-ui-buttons .ddp-box-btn2,
 .ddp-box-widget .ddp-top-control .ddp-ui-buttons .ddp-box-btn-hover {display:none;}
 .ddp-box-widget .ddp-top-control .ddp-ui-buttons .ddp-box-btn2.ddp-box-download {display:block;}
@@ -778,6 +778,8 @@ ul.ddp-list-board-thumbview li.ddp-selected a span.ddp-data-name {color:#4b515b;
 .ddp-box-widget:hover .ddp-top-control .ddp-ui-buttons .ddp-box-btn2.ddp-box-download span.ddp-txt {display:none;}
 .ddp-box-widget:hover .ddp-top-control .ddp-ui-buttons .ddp-box-btn2,
 .ddp-box-widget:hover .ddp-top-control .ddp-ui-buttons .ddp-box-btn-hover {display:block;}
+.ddp-box-widget .ddp-top-control .ddp-ui-buttons .ddp-box-btn2
+.ddp-box-widget:hover .ddp-top-control .ddp-ui-buttons {display:block;}
 .ddp-box-widget .ddp-top-control .ddp-ui-buttons .ddp-ui-part {float:left; position:relative; top:-3px;  padding-right:7px; margin-right:7px;}
 .ddp-box-widget .ddp-top-control .ddp-ui-buttons .ddp-ui-part:after {display:inline-block; content:''; position:absolute; top:7px; right:0; height:12px; border-right:1px solid #cfd0d5;}
 .ddp-box-widget .ddp-top-control .ddp-box-btn-hover {float:left; background:none;}
@@ -967,6 +969,11 @@ ul.ddp-list-board-thumbview li.ddp-selected a span.ddp-data-name {color:#4b515b;
 .ddp-ui-widget-contents .ddp-form-multy .ddp-box-multy.ddp-form-time .ddp-input-typebasic {width:45%;}
 .ddp-ui-widget-contents .ddp-form-multy .ddp-box-multy.ddp-form-time .ddp-type-selectbox {width:55%;}
 
+.ddp-ui-widget-contents .ddp-list-search-candidate {margin-bottom: 10px;}
+.ddp-ui-widget-contents .ddp-list-search-candidate .ddp-btn-line {float:right;margin-left:4px;cursor: pointer;}
+.ddp-ui-widget-contents .ddp-list-search-candidate .ddp-search-text {overflow:hidden}
+.ddp-ui-widget-contents .ddp-list-search-candidate .ddp-search-text .ddp-input-search {width:100%;padding: 7px 26px 6px 13px;box-sizing: border-box;}
+
 .ddp-view-widget-text {color:#4b515b; font-size:24px;overflow-y: auto;}
 .ddp-view-widget > .ddp-ui-top {}
 .ddp-box-widget:hover .ddp-view-widget > .ddp-ui-top .ddp-no-filter {margin-right:26px;}
@@ -981,8 +988,7 @@ ul.ddp-list-board-thumbview li.ddp-selected a span.ddp-data-name {color:#4b515b;
 
 .ddp-view-widget-parameter .ddp-ui-widget-contents {padding:14px 6px 0 6px;}
 .ddp-view-widget-parameter .ddp-ui-widget-contents .ddp-ui-slider-type {clear:both; margin-top:-10px;}
-
-.ddp-ui-widget-contents .ddp-dateinfo-view {position:relative; padding:0 0 0 0; width:280px;}
+.ddp-ui-widget-contents .ddp-dateinfo-view {position:relative; padding:10px 0 0 0; width:280px;}
 .ddp-ui-widget-contents .ddp-dateinfo-view .ddp-box-preview {padding:6px 0; margin-bottom:10px; border-radius:2px; background-color:#f6f6f7; text-align:center; color:#4c515a; font-size:14px;}
 .ddp-ui-widget-contents .ddp-dateinfo-view .ddp-list-buttons {width:100%;}
 .ddp-ui-widget-contents .ddp-dateinfo-view .ddp-list-buttons li {margin-bottom:11px;}
@@ -1007,7 +1013,7 @@ ul.ddp-list-board-thumbview li.ddp-selected a span.ddp-data-name {color:#4b515b;
 .ddp-form-input-multy input.ddp-input-right {float:right;}
 
 /* 편집 대시보드*/
-.ddp-ui-boardedit .ddp-box-widget .ddp-top-control {position:absolute; top:0; left:0; right:0; height:25px; width:100%; padding-right:120px; background-color:#bdc0c9; box-sizing:border-box;}
+.ddp-ui-boardedit .ddp-box-widget .ddp-top-control {height:25px; width:100%; padding-right:120px; background-color:#bdc0c9; box-sizing:border-box;}
 .ddp-ui-boardedit .ddp-box-widget .ddp-top-control .ddp-data-top {display:block; }
 .ddp-ui-boardedit .ddp-box-widget .ddp-top-control .ddp-ui-buttons {position:absolute; top:0; right:0; background:none;}
 .ddp-ui-boardedit .ddp-box-widget .ddp-top-control .ddp-ui-buttons .ddp-box-btn-hover,
@@ -1068,9 +1074,9 @@ ul.ddp-list-text li a .ddp-data-info span {display:block; color:#4b515b; font-si
 	text-overflow: ellipsis;
 	display: -webkit-box;
 	-webkit-line-clamp: 2; /* 라인수 */
-  	/* autoprefixer: off */
-  	-webkit-box-orient: vertical;
-  	/* autoprefixer: on */
+  /* autoprefixer: off */
+  -webkit-box-orient: vertical;
+  /* autoprefixer: on */
 	word-wrap:break-word;}
 
 /**********************************************************************************
@@ -1135,7 +1141,7 @@ ul.ddp-list-text li a .ddp-data-info span {display:block; color:#4b515b; font-si
 .ddp-wrap-list-filter2 {display:none; position:absolute; top:46px; left:0; right:0; bottom:0; overflow:auto;}
 .ddp-wrap-list-filter2 ul.ddp-list-filter2 {position:absolute; bottom:35px; left:0; right:0; top:0; padding:0 10px 0 13px; overflow:auto;}
 .ddp-wrap-list-filter2 ul.ddp-list-filter2 li {position:Relative;}
-.ddp-wrap-list-filter2 ul.ddp-list-filter2 li a {display:block; position:relative; padding:5px 23px 5px 15px; color:#4b515b; font-size:14px; white-space:nowrap; text-overflow:ellipsis; overflow:hidden;}
+.ddp-wrap-list-filter2 ul.ddp-list-filter2 li a {display:block; position:relative; padding:5px 23px 5px 15px; position:relative; color:#4b515b; font-size:14px; white-space:nowrap; text-overflow:ellipsis; overflow:hidden;}
 .ddp-wrap-list-filter2 ul.ddp-list-filter2 li a .ddp-ui-buttons {float:right; box-sizing:border-box;}
 
 .ddp-wrap-list-filter2 ul.ddp-list-filter2 li a .ddp-ui-buttons .ddp-wrap-datalock,
@@ -1198,11 +1204,10 @@ ul.ddp-list-text li a .ddp-data-info span {display:block; color:#4b515b; font-si
 .ddp-wrap-status .ddp-wrap-edit-set a.ddp-btn-filter em.ddp-icon-view {display:inline-block; width:9px; height:5px; margin-left:10px; background:url(../images/icon_dropdown.png) no-repeat;}
 
 .ddp-wrap-status .ddp-ui-edit-set {display:none; clear:both;position:relative; padding:0 30px 15px 18px; background-color:#f6f6f7; z-index:1;}
-.ddp-ui-edit-set .ddp-label-title {display:block; padding-top:10px; padding-bottom:10px; position:relative; color:#444; font-size:14px;}
+.ddp-ui-edit-set .ddp-label-title {display:block; padding-top:10px; position:relative; color:#444; font-size:14px;}
 .ddp-ui-edit-set .ddp-label-title a.ddp-btn-reset {position:relative; display:inline-block; width:15px; height:13px; margin-left:5px;  background:url(../images/icon_reset.png) no-repeat; background-position:left -20px;vertical-align: middle;}
 .ddp-ui-edit-set .ddp-label-title a.ddp-btn-reset:hover {background-position:-15px -20px;}
-
-.ddp-ui-edit-set .ddp-data-info {display:inline-block; padding:5px 0 0 0; margin-left:5px; color:#4b515b; font-size:12px;}
+.ddp-ui-edit-set .ddp-data-info {display:inline-block; padding:5px 0 10px 0; margin-left:5px; color:#4b515b; font-size:12px;}
 .ddp-ui-edit-set .ddp-data-info span.ddp-data {color:#90969f; font-style:italic;}
 .ddp-ui-edit-set .ddp-data-info span.ddp-data2 {color:#ca4b4b;}
 .ddp-wrap-status .ddp-ui-edit-set .ddp-ui-buttons {padding-top:16px;}
@@ -1267,7 +1272,6 @@ ul.ddp-list-text li a .ddp-data-info span {display:block; color:#4b515b; font-si
 .ddp-ui-filter-set .ddp-ui-part .ddp-wrap-edit3 {margin-bottom:20px;}
 
 .ddp-ui-field-type {width:217px; padding-top:15px;}
-.ddp-ui-field-type .ddp-form-date + .ddp-form-date {padding-top:14px;}
 .ddp-ui-field-type .ddp-ui-top-type {position:relative; margin-bottom:5px;}
 .ddp-ui-field-type .ddp-ui-top-type .ddp-ui-buttons  {position:absolute; top:-3px; right:0; display:inline-block;}
 .ddp-ui-field-type .ddp-ui-top-type [class*="ddp-icon-link-"] {margin-left:6px;}
@@ -1294,6 +1298,7 @@ ul.ddp-list-text li a .ddp-data-info span {display:block; color:#4b515b; font-si
 .ddp-area-boardside .ddp-ui-down-title2 {min-height:50px; margin:0 -10px 0 -17px; padding:0 10px 0 17px;cursor:move;}
 .ddp-area-boardside .ddp-box-down .ddp-wrap-divide {padding-top:0px;}
 .ddp-area-boardside .ddp-contents-divide.ddp-type {margin-top:-10px;}
+.ddp-area-boardside .ddp-contents-divide.ddp-type .search-all-message {color:#b7b9c2;}
 .ddp-area-boardside .ddp-ui-down-title2 .ddp-ui-buttons {position:relative; top:17px; float:right; background:none;}
 .ddp-area-boardside .ddp-ui-down-title2 .ddp-wrap-morebutton {display:inline-block;}
 .ddp-area-boardside .ddp-ui-down-title2 .ddp-ui-buttons .ddp-wrap-datalock,.ddp-area-boardside .ddp-ui-down-title2 .ddp-ui-buttons .ddp-wrap-datarecommend,
@@ -1324,6 +1329,7 @@ ul.ddp-list-text li a .ddp-data-info span {display:block; color:#4b515b; font-si
 .ddp-area-boardside .ddp-wrap-divide.ddp-dropdown.ddp-selected .ddp-ui-divide {padding-bottom:10px; margin-bottom:0;}
 .ddp-area-boardside .ddp-wrap-divide.ddp-dropdown.ddp-selected .ddp-ui-divide .ddp-search-value {margin:5px 0 3px 0;}
 .ddp-area-boardside .ddp-wrap-divide.ddp-dropdown.ddp-selected .ddp-contents-divide{display:block;}
+.ddp-area-boardside .ddp-wrap-divide.ddp-dropdown.ddp-selected .ddp-none-bar {display:block;}
 
 .ddp-area-boardside .ddp-ui-divide .ddp-no-result .ddp-wrap-info {padding:5px 0 0 0;}
 .ddp-area-boardside .ddp-ui-divide .ddp-no-result {}
@@ -1350,14 +1356,10 @@ ul.ddp-list-text li a .ddp-data-info span {display:block; color:#4b515b; font-si
 .ddp-ui-values {padding:6px 0 0 0; margin-bottom:-10px; overflow:hidden;}
 .ddp-ui-values .ddp-data-values {float:left; color:#90969f; font-size:12px;}
 .ddp-ui-values .ddp-label-check-value {display:inline-block; margin-right:3px; vertical-align:middle;}
-.ddp-ui-values .ddp-label-check-value .ddp-value-num { margin-left:4px;vertical-align:top;}
-.ddp-ui-values .ddp-label-check-value .ddp-value { margin-left:4px;font-size:12px; color:#90969f; vertical-align:top;}
-.ddp-ui-values .ddp-label-check-value input[type="checkbox"]:checked + i + .ddp-value-num {display:none;}
-.ddp-ui-values .ddp-label-check-value input[type="checkbox"] + i + .ddp-value-num + .ddp-value {display:none;}
-.ddp-ui-values .ddp-label-check-value input[type="checkbox"]:checked + i + .ddp-value-num + .ddp-value {display:inline-block;}
 .ddp-ui-values .ddp-ui-page {float:right; position:relative; top:-3px;}
 
-.ddp-area-boardside .ddp-ui-down-title2.ddp-flex {display:flex;	align-items:center;}
+.ddp-area-boardside .ddp-ui-down-title2.ddp-flex {display:flex;
+  align-items: center;}
 .ddp-area-boardside .ddp-ui-down-title2.ddp-flex .ddp-itemtype-title {flex: 1 1 auto;}
 .ddp-area-boardside .ddp-ui-down-title2.ddp-flex .ddp-data-itemtype .ddp-txt-itemtype {display:block;}
 .ddp-area-boardside .ddp-ui-down-title2.ddp-flex .ddp-flex-button {margin-left:auto; display:flex; align-items:center;}
@@ -1368,7 +1370,7 @@ ul.ddp-list-text li a .ddp-data-info span {display:block; color:#4b515b; font-si
 .ddp-itemtype-title {min-height:50px; white-space:nowrap; text-overflow:ellipsis; overflow:hidden; word-wrap:normal;}
 .ddp-data-itemtype {display:table; table-layout:fixed;position:relative; width:100%; min-height:50px; padding:10px 0 10px 40px; box-sizing:border-box; font-size:0px;}
 .ddp-data-itemtype.ddp-type .ddp-txt-itemtype {white-space:normal;}
-.ddp-data-itemtype .ddp-icon-box {display:inline-block; position:absolute; top:50%; left:0; margin-top:-14px; width:26px; height:26px; text-align:center; border:1px solid #439fe5; border-radius:4px;}
+.ddp-data-itemtype .ddp-icon-box {display:inline-block; position:absolute; top:50%; left:0; margin-top:-14px; width:26px; height:26px; text-align:center; border:1px solid #439fe5;}
 .ddp-data-itemtype .ddp-icon-box.ddp-measure {float:left; border:1px solid #5fd7a5;}
 .ddp-data-itemtype .ddp-icon-box [class*="ddp-icon-"] {position:relative; top:8px;}
 .ddp-data-itemtype .ddp-icon-box .ddp-icon-dimension-point,
@@ -1384,14 +1386,14 @@ ul.ddp-list-text li a .ddp-data-info span {display:block; color:#4b515b; font-si
 .ddp-data-itemtype .ddp-txt-itemtype .ddp-data-name {display:block; font-size:13px; color:#4b515b; white-space:nowrap; text-overflow:ellipsis; overflow:hidden; word-wrap:normal;}
 
 .ddp-data-itemtype .ddp-txt-itemtype .ddp-data-sub {display:block; max-height:29px; font-size:11px; color:#b7b9c2;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	display: -webkit-box;
-	-webkit-line-clamp: 2; /* 라인수 */
-	/* autoprefixer: off */
-	-webkit-box-orient: vertical;
-	/* autoprefixer: on */
-	word-wrap:break-word;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2; /* 라인수 */
+  /* autoprefixer: off */
+  -webkit-box-orient: vertical;
+  /* autoprefixer: on */
+  word-wrap:break-word;
 }
 
 .ddp-data-itemtype .ddp-txt-itemtype .ddp-txt-chartname {display:block; width:100%; color:#b7b9c2; font-size:12px; white-space:nowrap; text-overflow:ellipsis; overflow:hidden; word-wrap:normal;}
@@ -1403,9 +1405,8 @@ ul.ddp-list-text li a .ddp-data-info span {display:block; color:#4b515b; font-si
 .ddp-wrap-filtertime dl.ddp-dl-time dd {display:block; font-size:13px; color:#b7b9c2; line-height:24px;overflow:hidden;}
 .ddp-wrap-filtertime dl.ddp-dl-time dd.ddp-data-time {color:#4c515a; font-size:13px;}
 .ddp-area-boardside .ddp-ui-divide .ddp-data-preview{color:#4c515a; font-size:14px; text-align:center; }
-.ddp-area-boardside .ddp-ui-divide .ddp-none-bar {position:relative; padding:0 15px; margin:0px -17px 0 -17px; color:#90969f; font-size:12px; font-weight:bold; line-height:24px; background:#efeff1;}
+.ddp-area-boardside .ddp-ui-divide .ddp-none-bar {padding:0 15px; margin:0px -17px 0 -17px; color:#90969f; font-size:12px; font-weight:bold; line-height:24px; background-color:#efeff1; background:#efeff1;}
 .ddp-area-boardside .ddp-ui-divide .ddp-none-bar.ddp-select-bar {cursor:pointer;}
-.ddp-area-boardside .ddp-ui-divide .ddp-none-bar.ddp-select-bar .ddp-wrap-popup2 {left:0; font-weight:normal;}
 .ddp-area-boardside .ddp-ui-divide .ddp-none-bar.ddp-select-bar .ddp-icon-view {display:inline-block; position:relative; top:-1px; width:7px; height:4px; margin-left:9px; background:url(../images/icon_select.png) no-repeat; background-position:-24px top;}
 
 .ddp-wrap-divide .ddp-dropdown-filter + .ddp-dropdown-filter {margin-top:1px;}
@@ -1418,8 +1419,8 @@ ul.ddp-list-text li a .ddp-data-info span {display:block; color:#4b515b; font-si
 .ddp-dropdown-filter .ddp-wrap-popup2 .ddp-label-type {padding:10px 12px 3px 12px; color:#b7b9c2; font-size:12px;}
 .ddp-dropdown-filter.ddp-selected .ddp-wrap-popup2 {display:block; z-index:20;}
 .ddp-dropdown-filter.ddp-selected .ddp-dropdown-data {display:block;}
-.ddp-dropdown-filter .ddp-dropdown-data2 .ddp-contents-divide {padding:12px 0;}
-
+.ddp-dropdown-filter.ddp-selected .ddp-dropdown-data2 {display:block;}
+.ddp-dropdown-filter.ddp-selected .ddp-dropdown-data2 .ddp-contents-divide {padding:12px 0;}
 .ddp-dropdown-filter .ddp-top-summary {cursor:pointer;}
 .ddp-dropdown-filter .ddp-top-summary .ddp-icon-view {display:inline-block; position:relative; top:-1px; width:7px; height:4px; margin-left:9px; background:url(../images/icon_select.png) no-repeat; background-position:-24px top;}
 
@@ -1427,7 +1428,7 @@ ul.ddp-list-text li a .ddp-data-info span {display:block; color:#4b515b; font-si
 .ddp-dropdown-filter.ddp-selected .ddp-top-summary{background-color:#dfe0e4;}
 .ddp-dropdown-filter.ddp-selected .ddp-top-summary .ddp-icon-view {transform:rotate(180deg);}
 .ddp-filter1 .ddp-dropdown-filter.ddp-selected .ddp-wrap-popup2 {left:20px; z-index:20;}
-.ddp-dropdown-data2 {}
+.ddp-dropdown-data2 {display:none;}
 .ddp-dropdown-data {display:none; margin:0 -17px;background-color:#efeff1;}
 .ddp-dropdown-data .ddp-list-data { padding:15px 17px; border-top:1px solid #ddd;}
 .ddp-dropdown-data .ddp-list-data:first-of-type {border-top:none;}
@@ -1467,7 +1468,7 @@ ul.ddp-list-text li a .ddp-data-info span {display:block; color:#4b515b; font-si
 	page : 대시보드 파라미터
 **********************************************************************************/
 .ddp-data-itemtype em.dpd-icon-box-parameter {display:inline-block; position:absolute; top:50%; left:0; margin-top:-14px; width:28px; height:28px; background:url(../images/img_parmeter.png) no-repeat;}
-.ddp-data-itemtype .ddp-txt-itemtype.ddp-type {position:relative; line-height:16px; white-space:normal;
+.ddp-data-itemtype .ddp-txt-itemtype.ddp-type {position:relative; top:10px; line-height:16px; white-space:normal;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	display: -webkit-box;
@@ -1478,9 +1479,9 @@ ul.ddp-list-text li a .ddp-data-info span {display:block; color:#4b515b; font-si
         page: 필터 new add filter        **********************************************************************************/
 
 .ddp-pop-filter {position:absolute; top:85px; left:50%; bottom:85px; margin:0px 0 0 -300px; width:600px; background-color:#fff; z-index:127;
-	-moz-box-shadow: 0 0 20px rgba(0,0,0,.3); /* drop shadow */
-	-webkit-box-shadow: 0 0 20px rgba(0,0,0,.3); /* drop shadow */
-	box-shadow: 0 0 20px rgba(0,0,0,.3); /* drop shadow */
+  -moz-box-shadow: 0 0 20px rgba(0,0,0,.3); /* drop shadow */
+  -webkit-box-shadow: 0 0 20px rgba(0,0,0,.3); /* drop shadow */
+  box-shadow: 0 0 20px rgba(0,0,0,.3); /* drop shadow */
 }
 .ddp-pop-filter .ddp-txt-title-name {padding:17px 25px; color:#4b515b; font-size:16px;}
 .ddp-pop-filter .ddp-txt-title-name .ddp-icon-filter {display:inline-block; width:15px; height:13px; margin-right:5px; background:url(../images/icon_title.png) no-repeat; vertical-align:middle;}
@@ -1506,7 +1507,6 @@ ul.ddp-list-text li a .ddp-data-info span {display:block; color:#4b515b; font-si
 .ddp-pop-filter .ddp-top-filter .ddp-ui-tags .ddp-tag-icon [class*="ddp-icon-"]{float:left; margin-right:10px;}
 .ddp-pop-filter .ddp-top-filter .ddp-ui-tags .ddp-tag-icon .ddp-icon-recommend {position:Relative; top:2px;}
 .ddp-pop-filter .ddp-top-filter .ddp-ui-tags .ddp-tag-icon .ddp-icon-global-s {position:Relative; top:3px;}
-
 
 .ddp-pop-filter .ddp-top-filter .ddp-title {display:block; overflow:hidden;}
 .ddp-pop-filter .ddp-top-filter .ddp-title .ddp-txt-name {display:block; padding:15px 8px 0 8px;color:#545c66; font-size:16px; overflow:hidden;}
@@ -1622,15 +1622,15 @@ ul.ddp-list-text li a .ddp-data-info span {display:block; color:#4b515b; font-si
 .ddp-range-num .ddp-data-num.ddp-max span.ddp-label {text-align:right;}
 
 .ddp-range-num .ddp-min {float:left;}
-.ddp-range-num .ddp-max {float:right; text-align:right;}
-.ddp-range-num input {display:inline-block; padding:5px 10px; width:98px; color:#444; font-size:13px; text-align:center; border:1px solid #ddd; box-sizing:border-box;}
+.ddp-range-num .ddp-max {float:right; text-align:right ;}
+.ddp-range-num input {display:inline-block; padding:5px 10px ; width:98px; color:#444; font-size:13px; text-align:center; border:1px solid #ddd; box-sizing:border-box;}
 .ddp-range-num input.ddp-full {width:100%; text-align:left;}
 
 .ddp-range-num .ddp-input-apply input {width:98px;}
 .ddp-slider-bg .irs-line-left,
 .ddp-slider-bg .irs-line-mid,
 .ddp-slider-bg .irs-line-right {height:9px; background-color:#e7e7ea; border-radius:9px;}
-.ddp-slider-bg .irs-bar {height:9px; background-color:#c1cef1; }
+.ddp-slider-bg .irs-bar {height:9px; background-color:#c1cef1; border-radius:9px;}
 .ddp-slider-bg .irs-line {height:9px;}
 .ddp-slider-bg .irs-slider {background-color:#666eb2; cursor:pointer;}
 .ddp-slider-bg .irs-slider.from,
@@ -1643,7 +1643,7 @@ ul.ddp-list-text li a .ddp-data-info span {display:block; color:#4b515b; font-si
 .ddp-slider-bg .irs-slider.from.state_hover,
 .ddp-slider-bg .irs-slider.to.state_hover,
 .ddp-slider-bg .irs-slider.single.state_hover {bottom:-2px;}
-.ddp-dateinfo-view .ddp-btn-add {display:block; clear:both; padding:4px 7px; margin:0 -5px; color:#90969f; font-size:13px;}
+.ddp-dateinfo-view .ddp-btn-add {display:block; clear:both; padding:4px 7px; margin:0 -5px;color:#90969f; font-size:13px;}
 .ddp-dateinfo-view .ddp-btn-add:hover {background-color:#f6f6f7;}
 .ddp-dateinfo-view .ddp-ui-add {position:relative;}
 .ddp-dateinfo-view .ddp-ui-add.ddp-disabled:before {position:absolute; top:0; left:0; right:0; bottom:0; background-color:rgba(255,255,255,0.5); cursor:no-drop; z-index:1; content:'';}
@@ -1695,12 +1695,12 @@ ul.ddp-list-text li a .ddp-data-info span {display:block; color:#4b515b; font-si
 .ddp-filter-area .ddp-filter-type {padding:49px 0 0 0;}
 .ddp-filter-area .ddp-filter-type .ddp-label-name {display:block; padding-bottom:5px; color:#90969f; font-size:13px;}
 .ddp-filter-area .ddp-filter-type .ddp-btn-time {display:inline-block; position:relative; padding:2px 3px 2px 10px; margin-top:6px; border-radius:2px; background-color:#f6f6f7; cursor:pointer;}
-.ddp-filter-area .ddp-filter-type .ddp-btn-time .ddp-form-multy {margin-top:0px;}
+.ddp-filter-area .ddp-filter-type .ddp-btn-time .ddp-form-multy {margin-top:0px; }
 .ddp-filter-area .ddp-filter-type .ddp-btn-time .ddp-form-multy span.ddp-txt-label {color:#4c515a; font-size:12px;}
 .ddp-filter-area .ddp-filter-type .ddp-btn-time.ddp-selected {background-color:#fff;}
 .ddp-filter-area .ddp-filter-type .ddp-btn-time.ddp-selected .ddp-form-multy  span.ddp-txt-label:before  {display:inline-block; position:relative; margin-right:7px; width:14px; height:10px; background:url(../images/icon_select2.png) no-repeat; background-position-y:-11px; vertical-align: middle; content:'';}
 .ddp-filter-area .ddp-filter-type .ddp-btn-time.ddp-selected:before {position:absolute; top:0; left:0; right:0; bottom:0; border-radius:2px; border:1px solid #90969f; content:'';}
-.ddp-filter-area .ddp-filter-type .ddp-btn-time .ddp-form-multy .ddp-box-multy {top:0px;}
+.ddp-filter-area .ddp-filter-type .ddp-btn-time .ddp-form-multy .ddp-box-multy { top:0px;}
 
 .ddp-filter-form .ddp-option-type {padding:0 25px 0 25px;}
 .ddp-filter-form .ddp-option-type .ddp-option-in {position:Relative; padding:9px 92px 6px 0; border-bottom:1px solid #e7e7ea;}
@@ -1741,32 +1741,24 @@ ul.ddp-list-text li a .ddp-data-info span {display:block; color:#4b515b; font-si
 .ddp-option-btn .ddp-wrap-edit-set.ddp-selected .ddp-btn-box,
 .ddp-option-btn .ddp-btn-box:hover {background-color:#e7e7ea;}
 .ddp-option-btn .ddp-ui-search {position:relative; float:left; cursor:pointer;}
-.ddp-option-btn .ddp-ui-search .ddp-icon-search-default:before {display:inline-block; position:absolute; top:50%; left:50%; margin:-7px 0 0 -7px; width:14px; height:14px; background:url(../images/icon_search.png) no-repeat; background-position:left -12px; content:'';}
+.ddp-option-btn .ddp-ui-search .ddp-icon-search-default:before {display:inline-block;  position:absolute; top:50%; left:50%; margin:-7px 0 0 -7px; width:14px; height:14px; background:url(../images/icon_search.png) no-repeat; background-position:left -12px; content:'';}
 .ddp-option-btn .ddp-ui-search:hover .ddp-icon-search-default:before {background-position-x:-15px;}
 .ddp-option-btn .ddp-ui-search .ddp-form-search {display:none;}
 .ddp-option-btn .ddp-ui-search.ddp-selected .ddp-form-search {display:block;}
 .ddp-option-btn .ddp-ui-search.ddp-selected .ddp-icon-search-default {display:none;}
-.ddp-option-btn .ddp-box-btn2 {position:relative; float:left; margin-left:4px; cursor:pointer;}
-.ddp-option-btn .ddp-box-btn2 .ddp-icon-widget-info2 {float:left; position:relative; top:1px; width:25px; height:25px; font-size:0px; border-radius:2px; box-sizing:border-box; border:1px solid #cdd8f4; background-color:#f0f3fc;}
-
-.ddp-option-btn .ddp-box-btn2 .ddp-icon-widget-info2:before {display:inline-block; position:absolute ;top:50%; left:50%; margin:-7px 0 0 -8px; width:15px; height:14px; background:url(../images/icon_widget.png) no-repeat; background-position:-16px -244px; content:'';}
-.ddp-option-btn .ddp-box-btn2 .ddp-box-info.ddp-limitation {display:none; position:absolute; top:100%; right:0px; padding:6px 10px; width:240px; border-radius:3px; background-color:#7182ba; color:#fff; box-sizing:border-box; z-index:1000;}
-.ddp-option-btn .ddp-box-btn2:hover .ddp-box-info.ddp-limitation {display:block;}
-.ddp-option-btn .ddp-box-btn2 .ddp-box-info.ddp-limitation .ddp-total {display:block; padding-bottom:4px;}
-.ddp-option-btn .ddp-box-btn2 .ddp-box-info.ddp-limitation .ddp-total strong {display:block;}
 
 .ddp-option-btn .ddp-wrap-edit-set {position:relative; float:left;}
 .ddp-option-btn .ddp-wrap-edit-set .ddp-ui-tooltip-info {position:absolute; right:-5px; left:inherit; top:100%; margin-top:8px;}
-.ddp-option-btn .ddp-wrap-edit-set .ddp-ui-edit-set {display:none; position:absolute; top:100%; right:-7px; width:427px; padding:13px 16px;border:1px solid #e7e7ea; border-radius:2px; background-color:#fff; z-index:15;
+.ddp-option-btn .ddp-wrap-edit-set .ddp-ui-edit-set {display:none; position:absolute; top:100%; right:-7px; width:427px; padding:13px 16px;border:1px solid #e7e7ea; border-radius:2px; background-color:#fff; z-index:10;
 	box-shadow:-1px 2px 3px 1px #edeff0;}
 .ddp-option-btn .ddp-wrap-edit-set .ddp-ui-edit-set .ddp-pop-buttons {padding:10px 0 0 0;}
-.ddp-option-btn .ddp-wrap-edit-set.ddp-selected .ddp-ui-edit-set {display:block; border:1px solid #e7e7ea}
+.ddp-option-btn .ddp-wrap-edit-set.ddp-selected .ddp-ui-edit-set {display:block;}
 
 .ddp-option-btn .ddp-wrap-edit-set .ddp-ui-tooltip-info .ddp-icon-view-top {left:inherit; right:17px;}
 
 .ddp-option-btn .ddp-wrap-edit-set .ddp-btn-reset:hover .ddp-ui-tooltip-info {display:block;}
 .ddp-option-btn .ddp-wrap-edit-set .ddp-btn-reset .ddp-ui-tooltip-info .ddp-icon-view-top {right:10px;}
-.ddp-option-btn .ddp-wrap-edit-set a.ddp-btn-filter:before {display:inline-block; position:absolute; top:50%; left:50%; margin:-8px 0 0 -8px;width:15px; height:15px; background:url(../images/icon_filter.png) no-repeat; background-position:left -11px; content:'';}
+.ddp-option-btn .ddp-wrap-edit-set a.ddp-btn-filter:before {display:inline-block; position:relative; position:absolute; top:50%; left:50%; margin:-8px 0 0 -8px;width:15px; height:15px; background:url(../images/icon_filter.png) no-repeat; background-position:left -11px; content:'';}
 .ddp-option-btn .ddp-wrap-edit-set.ddp-selected a.ddp-btn-filter:before,
 .ddp-option-btn .ddp-wrap-edit-set a.ddp-btn-filter:hover:before {background-position-x:-16px;}
 .ddp-option-btn .ddp-wrap-edit-set a.ddp-btn-filter:hover + .ddp-ui-tooltip-info {display:block;}
@@ -1842,7 +1834,6 @@ ul.ddp-list-text li a .ddp-data-info span {display:block; color:#4b515b; font-si
 .ddp-ui-board-title .ddp-ui-setting a.ddp-btn-play em.ddp-icon-play,
 .ddp-ui-board-title .ddp-ui-setting a.ddp-btn-play em.ddp-icon-pause,
 .ddp-ui-board-title .ddp-ui-setting .ddp-btn-out {display:inline-block; margin-right:4px; width:15px; height:15px; background:url(../images/icon_board.png) no-repeat; vertical-align: middle;}
-.ddp-ui-board-title .ddp-ui-setting .ddp-wrap-show span.ddp-lik-set em.ddp-icon-showtime {width:16px; background-position-x:-16px;}
 .ddp-ui-board-title .ddp-ui-setting .ddp-wrap-show span.ddp-lik-set em.ddp-icon-fitscreen {background-position:left -16px;}
 .ddp-ui-board-title .ddp-ui-setting .ddp-wrap-show span.ddp-lik-set em.ddp-icon-fitheight {background-position:-16px -16px;}
 .ddp-ui-board-title .ddp-ui-setting a.ddp-btn-play em.ddp-icon-play {width:8px; height:12px; margin-right:5px; background-position:left -32px;}
@@ -2012,7 +2003,7 @@ ul.ddp-list-text li a .ddp-data-info span {display:block; color:#4b515b; font-si
 
 .ddp-wrap-list-source ul.ddp-list-source li .ddp-wrap-icons .ddp-wrap-user-preview:hover .ddp-ui-tooltip-info {display:block;}
 .ddp-wrap-list-source ul.ddp-list-source li .ddp-wrap-icons .ddp-wrap-user-preview .ddp-ui-tooltip-info { display:none; position:absolute;top: 23px;right:-17px;min-width:100px;max-width:200px;left:inherit;text-align:center;}
-.ddp-wrap-list-source ul.ddp-list-source li .ddp-wrap-icons .ddp-wrap-user-preview .ddp-ui-tooltip-info em.ddp-icon-view-top {padding: 0; right:23px; left:inherit; top: -6px;}
+.ddp-wrap-list-source ul.ddp-list-source li .ddp-wrap-icons .ddp-wrap-user-preview .ddp-ui-tooltip-info em.ddp-icon-view-top {padding: 0; right:23px; left:inherit; top: -6px; }
 .ddp-wrap-list-source ul.ddp-list-source li .ddp-wrap-icons .ddp-wrap-user-preview .ddp-ui-tooltip-info span.ddp-txt-tooltip {display:block; overflow:hidden; white-space:nowrap; text-overflow:ellipsis; word-wrap:normal; box-sizing:border-box;}
 
 .ddp-wrap-list-source ul.ddp-list-source li .ddp-wrap-icons .ddp-icon-control-filter {position:relative; top:1px;}
@@ -2153,20 +2144,16 @@ ul.ddp-list-text li a .ddp-data-info span {display:block; color:#4b515b; font-si
 .ddp-wrap-option-radio .ddp-label-radio span.ddp-txt-radio {font-size:12px;}
 .ddp-box-option-input {position:relative; padding-right:20px; border:1px solid #d0d1d9; background-color:#fff;}
 .ddp-box-option-input input[type="text"],
-.ddp-box-option-input input[type="number"] {display:block; width:100%; padding:6px 5px 7px 5px; border:none; text-align:left; box-sizing:border-box;}
+.ddp-box-option-input input[type="number"] {display:block; width:100%; padding:6px 5px 7px 5px; border:none; text-align:left; box-sizing:border-box; box-sizing:border-box;}
 .ddp-box-option-input input[type="text"]:disabled {background:none; color:#bdc0c9;}
 
 
 .ddp-box-option-input span.ddp-txt-input {position:absolute; top:5px; right:6px; color:#bdc0c9; font-size:12px;}
 .ddp-box-option-input span.ddp-txt-input.ddp-dark {color:#4a515c;}
-.ddp-box-option-input.ddp-inline {display:inline-block; position:relative; top:-7px; width:90px; margin-left:10px; padding-right:30px; box-sizing:border-box;}
+.ddp-box-option-input.ddp-inline {display:inline-block; position:relative; top:-7px; width:90px; margin-left:10px; padding-right:30px; box-sizing:border-box; box-sizing:border-box;}
 .ddp-box-option-input.ddp-inline.type-row {padding-right:33px;}
 .ddp-list-sideoption .ddp-list-sidesub .ddp-txt-label {float:left; color:#4b515b; font-size:13px;}
 .ddp-list-sideoption .ddp-list-sidesub .ddp-checkbox-auto {float:right; position:relative; top:0;}
-.ddp-box-option-input.ddp-type2 {padding:0;}
-.ddp-box-option-input.ddp-type2 .ddp-type-text {display:block; overflow:hidden;}
-.ddp-box-option-input.ddp-type2 .ddp-type-text input {font-size:13px;}
-.ddp-box-option-input.ddp-type2 .ddp-txt-input {position:relative; top:0; right:0; float:right; padding:5px 6px 5px 0; font-size:12px;}
 
 /* CHART */
 .ddp-list-chart {/*position:absolute; top:52px; left:0; right:0; bottom:107px; overflow-y:auto;*/}
@@ -2219,12 +2206,6 @@ ul.ddp-list-chart li a .ddp-btn-control em.ddp-icon-del-s:hover:before {backgrou
 .ddp-list-chart-3depth li a {padding-left:60px;}
 .ddp-list-chart-3depth li:before {display:inline-block; content:''; position:absolute; top:0; left:45px; width:13px; height:23px; background:url(../images/bg_groupline.png) no-repeat;}
 .ddp-list-chart-3depth li .ddp-chart-images {padding-left:0px;}
-.ddp-list-divide-tree {}
-.ddp-list-divide-tree li {position:relative;}
-.ddp-list-divide-tree li .ddp-list-divide-tree li {position:relative; padding-left:33px;}
-.ddp-list-divide-tree li .ddp-list-divide-tree li:before {display:inline-block; content:''; position:absolute; top:0; left:14px; width:13px; height:23px; background:url(../images/bg_groupline.png) no-repeat; z-index:1;}
-.ddp-list-divide-tree li .ddp-list-divide-tree li .ddp-wrap-divide {border-top:none;}
-
 .ddp-chart-boardside .ddp-wrap-downmenu {position:absolute; top:52px; left:0; right:0; bottom:79px; overflow-y:auto; overflow-x:hidden;}
 
 .ddp-chart-boardside .ddp-wrap-downmenu::-webkit-scrollbar-track {background:#f7f7f8;}
@@ -2301,7 +2282,7 @@ ul.ddp-list-chart li a .ddp-btn-control em.ddp-icon-del-s:hover:before {backgrou
 .ddp-box-layout4.ddp-pop-store .ddp-ui-detail {display:block; padding-bottom:20px; color:#4b515b; font-size:12px; border-bottom:1px solid #e7e7ea;}
 .ddp-box-layout4.ddp-pop-store .ddp-ui-detail strong {display:block; padding-bottom:5px; color:#4b515b; font-size:14px;}
 .ddp-box-layout4.ddp-pop-store table.ddp-table-detail {margin-top:13px;}
-.ddp-box-layout4.ddp-pop-store table.ddp-table-detail tbody tr td {padding-right:0px;}
+.ddp-box-layout4.ddp-pop-store table.ddp-table-detail tbody tr td { padding-right:0px;}
 .ddp-box-layout4.ddp-pop-store td ul.ddp-list-type-input li {padding:3px 0;}
 .ddp-box-layout4.ddp-pop-store td ul.ddp-list-type-input li:first-of-type {padding-top:0px;}
 .ddp-box-layout4.ddp-pop-store td ul.ddp-list-type-input li .ddp-input-typebasic {width:75px; box-sizing:border-box;}
@@ -2317,14 +2298,14 @@ ul.ddp-list-chart li a .ddp-btn-control em.ddp-icon-del-s:hover:before {backgrou
 	PAGE : 워크북 데이터 다운로드
 ************************************************************************************************************/
 .ddp-box-layout4.ddp-download {position:fixed; z-index:126; top:100%; margin-top:5px; min-width:355px; padding:20px 0px; box-sizing:border-box;}
-.ddp-box-layout4.ddp-download .ddp-data-title {padding-top:0px; }
+.ddp-box-layout4.ddp-download .ddp-data-title { padding-top : 0px; }
 .ddp-box-layout4.ddp-download .ddp-data-title .ddp-data {margin-left:6px; color:#4b515b; font-size:12px; font-weight:normal;}
 .ddp-box-layout4.ddp-download .ddp-btn-down {display:inline-block;  float:left; padding:9px 0; width:160px; border-radius:2px; border:1px solid #d0d1d7; color:#90969f; font-size:13px; text-align:center; box-sizing:border-box;}
 
 .ddp-box-layout4.ddp-download .ddp-btn-down:hover {color:#4c515a; border:1px solid #b7b9c1;}
 .ddp-box-layout4.ddp-download .ddp-btn-down +  .ddp-btn-down {margin-left:3px;}
 .ddp-box-layout4.ddp-download .ddp-btn-down .ddp-icon-csv {display:inline-block; width:22px; height:20px; margin-right:5px; background:url(../images/img_csv.png) no-repeat;}
-.ddp-box-layout4.ddp-download .ddp-btn-down .ddp-icon-xlsx {display:inline-block; width:22px; height:20px;  margin-right:5px; background:url(../images/img_xlsx.png) no-repeat;}
+.ddp-box-layout4.ddp-download .ddp-btn-down .ddp-icon-xlsx {display:inline-block; display:inline-block; width:22px; height:20px;  margin-right:5px; background:url(../images/img_xlsx.png) no-repeat;}
 .ddp-box-layout4.ddp-download .ddp-txt-det {clear:both; padding:20px 0 0 0; color:#90969f; font-size:12px; line-height:18px;}
 
 /***********************************************************************************************************
@@ -2346,7 +2327,7 @@ ul.ddp-list-chart li a .ddp-btn-control em.ddp-icon-del-s:hover:before {backgrou
 .ddp-box-info .ddp-dl-detail dd {display:block; padding:5px 10px 5px 0; color:#4b515b; font-size:13px; line-height:16px; overflow:hidden;}
 
 .ddp-box-info dl.ddp-dl-detail2 {padding-bottom:30px;}
-.ddp-box-info dl.ddp-dl-detail2 dt {display:block; padding:30px 10px 10px 10px; color:#4b515b; font-size:13px;}
+.ddp-box-info dl.ddp-dl-detail2 dt {display:block; padding:30px 10px 10px 10px; font-size:12px;color:#4b515b; font-size:13px;}
 .ddp-box-info dl.ddp-dl-detail2 dd {padding:0 10px; font-size:13px;}
 .ddp-box-info dl.ddp-dl-detail2 dd .ddp-ui-sub {padding:0 10px;margin-top:10px;}
 .ddp-box-info dl.ddp-dl-detail2 dd a.ddp-link-data {display:block; color:#4b515b; font-size:13px; font-weight:300;}
@@ -2358,7 +2339,7 @@ ul.ddp-list-chart li a .ddp-btn-control em.ddp-icon-del-s:hover:before {backgrou
 .ddp-box-info dl.ddp-dl-detail2 dd span.ddp-data-sub em.ddp-data-result { display:block; color:#90969f; font-weight:normal;}
 .ddp-box-info dl.ddp-dl-detail2 dd .ddp-ui-sub2 + .ddp-ui-sub2{margin-top:20px;}
 .ddp-box-info dl.ddp-dl-detail2 dd .ddp-ui-sub2 label.ddp-label-sub {display:block; padding-bottom:5px; color:#b7b9c2; font-size:13px; font-weight:300;}
-.ddp-box-info dl.ddp-dl-detail2 dd .ddp-ui-sub2 span.ddp-data-sub2 {display:block; color:#4b515b; font-size:13px;}
+.ddp-box-info dl.ddp-dl-detail2 dd .ddp-ui-sub2 span.ddp-data-sub2 {display:block; color:#4b515b; font-size:13px; ;}
 /***********************************************************************************************************
 	PAGE : 워크스페이스 목록 팝업
 ************************************************************************************************************/
@@ -2369,7 +2350,7 @@ ul.ddp-list-chart li a .ddp-btn-control em.ddp-icon-del-s:hover:before {backgrou
 .ddp-wrap-pop-header .ddp-ui-name em.ddp-icon-group2 {display:inline-block; position:relative; top:-2px; width:17px; height:12px; margin-right:9px; background:url(../images/icon_group.png) no-repeat; background-position:left -15px; vertical-align: middle;}
 .ddp-ui-pop-header {position:relative;}
 .ddp-ui-pop-header .ddp-ui-name  {font-size:22px; color:#4b515b; font-weight:bold; letter-spacing: -1px;}
-.ddp-ui-pop-header .ddp-ui-name span.ddp-data-num {color:#90969f; font-weight:normal;}
+.ddp-ui-pop-header .ddp-ui-name span.ddp-data-num {font-weight:normal; color:#90969f; font-weight:normal;}
 .ddp-ui-pop-header .ddp-ui-name a.ddp-btn-add2 {display:inline-block; position:relative; top:-2px; width:18px; height:18px; margin-left:8px; background:url(../images/icon_add2.png) no-repeat; background-position:left -13px; vertical-align: middle;}
 .ddp-ui-pop-header .ddp-ui-name a.ddp-btn-add2:hover {background-position:-19px -13px;}
 .ddp-ui-pop-header a.ddp-btn-line2 {position:absolute; top:0; right:0; }
@@ -2386,7 +2367,7 @@ ul.ddp-list-chart li a .ddp-btn-control em.ddp-icon-del-s:hover:before {backgrou
 .ddp-ui-btn-list .ddp-type-dropdown .ddp-wrap-popup2 {top:26px;}
 .ddp-ui-btn-list:first-of-type:before {display:none;}
 
-a.ddp-btn-list {display:block; padding:6px 12px; font-size:12px; color:#4b515b;}
+a.ddp-btn-list {display:block; padding:6px 12px; color:#4a515c; font-size:12px; color:#4b515b;}
 a.ddp-btn-list:hover {color:#4b515b;}
 a.ddp-btn-list.ddp-btn-fav:hover,
 a.ddp-btn-list.ddp-btn-fav.ddp-selected {color:#666eb2;}
@@ -2419,7 +2400,7 @@ ul.ddp-list-form2 li .ddp-wrap-name span.ddp-data-name span.ddp-data-in {display
 ul.ddp-list-form2 li .ddp-wrap-name span.ddp-data-name em.ddp-icon-new {display:none;background-color:#fff;}
 ul.ddp-list-form2 li:hover .ddp-wrap-name span.ddp-data-name em.ddp-icon-new {background-color:#f6f6f7;}
 ul.ddp-list-form2 li .ddp-wrap-name span.ddp-data-name.ddp-data-new em.ddp-icon-new {display:block; position:absolute; top:50%; right:0; margin-top:-7px;}
-ul.ddp-list-form2 li .ddp-wrap-name span.ddp-data-detail {margin-left:5px; color:#b7bac1; font-size:14px; vertical-align: middle; white-space:nowrap;text-overflow:ellipsis; overflow:hidden;}
+ul.ddp-list-form2 li .ddp-wrap-name span.ddp-data-detail { margin-left:5px; color:#b7bac1; font-size:14px; vertical-align: middle; white-space:nowrap;text-overflow:ellipsis; overflow:hidden;}
 ul.ddp-list-form2 li .ddp-wrap-data-info {float:right; padding-left:10px;}
 ul.ddp-list-form2 li .ddp-wrap-data-info .ddp-wrap-tag {display:inline-block; }
 ul.ddp-list-form2 li .ddp-wrap-data-info .ddp-wrap-power {display:inline-block; margin-right:25px; margin-left:20px;}
@@ -2455,7 +2436,6 @@ ul.ddp-list-form2 li:hover .ddp-btn-control {display:block;}
 .ddp-ui-top-info .ddp-ui-title .ddp-btn-control .ddp-icon-control-info {position:relative; top:2px;}
 .ddp-ui-top-info .ddp-ui-title .ddp-btn-control .ddp-icon-control-fav {position:relative; top:1px; margin-right:5px; float:left;}
 .ddp-ui-top-info .ddp-ui-title a.ddp-btn-line2 {position:absolute; bottom:0; right:0;}
-
 
 .ddp-ui-top-info .ddp-wrap-info-summary {padding:20px 0 0 0;}
 .ddp-ui-top-info .ddp-wrap-info-summary .ddp-data-info-left {float:left;}
@@ -2536,10 +2516,10 @@ em.ddp-icon-control-cut .ddp-ui-tooltip-info.ddp-down em.ddp-icon-view-top {righ
 .ddp-wrap-box-block:after {clear:both;}
 
 .ddp-box-block {position:relative; float:left; margin:3px 8px 10px 8px; padding:55px 0 0 0; width:308px; height:196px; box-sizing:border-box; cursor:pointer; border:1px solid #fff;
-	background-color: #fff; /* layer fill content */
-	-moz-box-shadow: 0 3px 3px rgba(0,0,0,.1); /* drop shadow */
-	-webkit-box-shadow: 0 3px 3px rgba(0,0,0,.1); /* drop shadow */
-	box-shadow: 0 3px 3px rgba(0,0,0,.1); /* drop shadow */
+  background-color: #fff; /* layer fill content */
+  -moz-box-shadow: 0 3px 3px rgba(0,0,0,.1); /* drop shadow */
+  -webkit-box-shadow: 0 3px 3px rgba(0,0,0,.1); /* drop shadow */
+  box-shadow: 0 3px 3px rgba(0,0,0,.1); /* drop shadow */
 }
 .ddp-box-block:hover {border:1px solid #90969f;}
 .ddp-box-block.ddp-selected:before {display:inline-block; content:''; position:absolute; top:-1px; left:-1px; right:-1px; bottom:-1px; border:1px solid #90969f; z-index:1;}
@@ -2563,14 +2543,11 @@ em.ddp-icon-control-cut .ddp-ui-tooltip-info.ddp-down em.ddp-icon-view-top {righ
 .ddp-box-block .ddp-ui-box-contents span.ddp-data-name {display:block; font-size:18px; color:#545b65; font-weight:bold;  overflow:hidden; text-overflow:ellipsis; word-wrap:normal; white-space:nowrap;}
 
 .ddp-box-block .ddp-ui-box-contents span.ddp-data-name.ddp-data-line2 {max-height:44px; white-space:normal; overflow: hidden;
-	overflow: hidden;
 	text-overflow: ellipsis;
 	display: -webkit-box;
 	-webkit-line-clamp: 2; /* 라인수 */
-	/* autoprefixer: off */
 	-webkit-box-orient: vertical;
-	/* autoprefixer: on */
-	word-wrap:break-word;}
+	word-wrap:normal;}
 .ddp-box-block .ddp-ui-box-contents span.ddp-data-date {display:block; padding:7px 0 0 0; font-size:12px; color:#c5c6cd; }
 .ddp-box-block .ddp-ui-box-contents span.ddp-data-date span.ddp-data-ago {color:#4c515a;}
 
@@ -2580,10 +2557,10 @@ em.ddp-icon-control-cut .ddp-ui-tooltip-info.ddp-down em.ddp-icon-view-top {righ
 .ddp-box-block .ddp-box-bottom .ddp-wrap-num span.ddp-data-num em[class*="ddp-icon-"] {margin-right:7px; vertical-align: middle;}
 .ddp-box-block .ddp-box-bottom .ddp-wrap-num span.ddp-data-num .ddp-type-info {display:inline-block; position:relative; top:1px; margin-left:4px; vertical-align:middle; z-index:2;}
 .ddp-box-block .ddp-box-bottom .ddp-wrap-num span.ddp-data-num .ddp-type-info:hover {z-index:50;}
-.ddp-box-block .ddp-box-bottom .ddp-type-info .ddp-ui-tooltip-info.ddp-down {display:none; right:initial; left:-19px; max-width:190px; white-space:normal;}
+.ddp-box-block .ddp-box-bottom .ddp-type-info .ddp-ui-tooltip-info.ddp-down {display:none; right:initial; left:-19px; width:200px; white-space:pre-wrap;}
 .ddp-box-block .ddp-box-bottom .ddp-type-info:hover .ddp-ui-tooltip-info.ddp-down {display:block;}
 .ddp-box-block .ddp-box-bottom .ddp-type-info .ddp-ui-tooltip-info.ddp-down .ddp-icon-view-top {margin-right:0; left:27px; right:initial;}
-.ddp-box-block .ddp-box-bottom .ddp-wrap-data {padding:11px 14px 10px 14px;}
+.ddp-box-block .ddp-box-bottom .ddp-wrap-data {padding:11px 14px 10px 14px; height:15px;}
 .ddp-box-block .ddp-box-bottom .ddp-wrap-data:before,
 .ddp-box-block .ddp-box-bottom .ddp-wrap-data:after {display:table; content:'';}
 .ddp-box-block .ddp-box-bottom .ddp-wrap-data:after {clear:both;}
@@ -2595,14 +2572,14 @@ em.ddp-icon-control-cut .ddp-ui-tooltip-info.ddp-down em.ddp-icon-view-top {righ
 .ddp-box-block .ddp-box-bottom .ddp-wrap-data .ddp-data-name em.ddp-icon-lang-jupyter {margin-top:-8px;}
 .ddp-box-block .ddp-box-bottom .ddp-wrap-data .ddp-data-name em.ddp-icon-result-data {margin-top:-7px;}
 .ddp-box-block .ddp-box-bottom .ddp-wrap-data .ddp-data-name em.ddp-icon-chart2 {margin-top:-8px;}
+.ddp-box-block .ddp-box-bottom .ddp-wrap-data .ddp-data-name em.ddp-icon-dashboard2 {margin-top:-8px;}
 .ddp-box-block .ddp-box-bottom .ddp-wrap-data .ddp-data-name.ddp-data-lang-python:before {margin-top:-6px;}
 .ddp-box-block .ddp-box-bottom .ddp-wrap-data .ddp-data-name.ddp-data-lang-r:before {margin-top:-7px;}
 .ddp-box-block .ddp-box-bottom .ddp-wrap-data .ddp-data-name .ddp-txt-name {display:inline-block; max-width:100%;}
 .ddp-box-block .ddp-box-bottom .ddp-wrap-data .ddp-data-name .ddp-txt-name .ddp-txt-name-in {display:block; overflow:hidden; white-space:nowrap; text-overflow:ellipsis;}
 .ddp-box-block .ddp-box-bottom .ddp-wrap-data .ddp-data-name .ddp-type-info {float:right; position:relative; top:1px; margin-left:6px; z-index:5;}
-
-
-.ddp-box-block .ddp-box-bottom .ddp-data-connection {position:relative; padding:11px 15px 12px 43px; width:100%; color:#90969f; font-size:12px; box-sizing:border-box;}
+.ddp-box-block .ddp-box-bottom em.ddp-icon-error2 {display: block;}
+.ddp-box-block .ddp-box-bottom .ddp-data-connection {position:relative; padding:11px 15px 12px 43px; width:100%; color:#90969f; font-size:12px; box-sizing:border-box; height:38px;}
 .ddp-box-block .ddp-box-bottom .ddp-data-connection .ddp-img {position:absolute; top:50%; left:15px; margin-top:-11px;}
 .ddp-box-block .ddp-box-bottom .ddp-type-info {float:right; position:relative; top:1px; margin-left:5px; z-index:20;}
 .ddp-box-block .ddp-box-bottom .ddp-type-info:hover {z-index:50;}
@@ -2611,7 +2588,7 @@ em.ddp-icon-control-cut .ddp-ui-tooltip-info.ddp-down em.ddp-icon-view-top {righ
 .ddp-box-block.ddp-box-workbench {display:inline-block; background:url(../images/bg_workbench.png) no-repeat right bottom ; background-color:#fff;}
 
 .ddp-ui-space-option {position:relative; padding-right:450px; width:100%; clear:both; z-index:20; box-sizing:border-box;}
-.ddp-ui-space-option .ddp-ui-option-right {position:absolute; top:5px; right:0;}
+.ddp-ui-space-option .ddp-ui-option-right { position:absolute; top:5px; right:0;}
 .ddp-ui-space-option .ddp-ui-space-nav {padding:20px 0 0 0;}
 .ddp-ui-space-option .ddp-ui-space-nav .ddp-data-nav {display:inline-block; min-height:25px; max-width:15%; position:relative; padding-left:19px; margin-right:4px; cursor: pointer; white-space:nowrap; text-overflow:ellipsis; overflow:hidden; word-wrap:normal;}
 .ddp-ui-space-option .ddp-ui-space-nav .ddp-data-nav:after {display:inline-block; content:''; position:absolute; top:50%; left:0; width:4px; height:7px; margin-top:-4px; background:url(../images/icon_dataview.png) no-repeat; background-position:-5px -19px;}
@@ -2659,7 +2636,7 @@ em.ddp-icon-control-cut .ddp-ui-tooltip-info.ddp-down em.ddp-icon-view-top {righ
 .ddp-ui-space-bottom .ddp-ui-link.ddp-disabled a em.ddp-icon-select-move,
 .ddp-ui-space-bottom .ddp-ui-link.ddp-disabled a:hover em.ddp-icon-select-move {background-position:left -14px}
 .ddp-ui-space-bottom .ddp-ui-link.ddp-disabled a em.ddp-icon-select-delete,
-.ddp-ui-space-bottom .ddp-ui-link.ddp-disabled a:hover em.ddp-icon-select-delete {background-position:left -29px}
+.ddp-ui-space-bottom .ddp-ui-link.ddp-disabled a:hover em.ddp-icon-select-delete  {background-position:left -29px}
 
 .ddp-ui-space-bottom .ddp-bottom-right {float:right; padding:10px 80px 10px 0;}
 .ddp-ui-space-bottom .ddp-bottom-right a.ddp-btn-solid2 {margin-left:5px;}
@@ -2727,7 +2704,7 @@ ul.ddp-list-workspace li.ddp-disabled a:hover .ddp-ui-data-list  {background:non
 ul.ddp-list-workspace li.ddp-list-back:hover a em.ddp-icon-folder-back {background-color:#4c515a;}
 ul.ddp-list-workspace li.ddp-txt a {cursor:default;}
 ul.ddp-list-workspace li.ddp-txt a:hover {background:none;}
-ul.ddp-list-workspace li a {display:block;position:relative; padding:12px 60px 12px 124px; border-top:1px solid #ddd;}
+ul.ddp-list-workspace li a {display:block;position:relative; padding:12px 60px 12px 124px; border-top:1px solid #ddd; }
 ul.ddp-list-workspace li a:hover {background-color:#f6f6f7;}
 
 ul.ddp-list-workspace li.ddp-selected a {background-color:#f6f6f7;}
@@ -2750,7 +2727,7 @@ ul.ddp-list-workspace li.ddp-selected a .ddp-wrap-name .ddp-data-name .ddp-icon-
 ul.ddp-list-workspace li a .ddp-wrap-name .ddp-data-name.ddp-data-new {position:relative; padding-right:40px; max-width:100%; overflow:hidden; white-space:nowrap; text-overflow:ellipsis; word-wrap:normal; box-sizing:border-box;}
 ul.ddp-list-workspace li a .ddp-wrap-name .ddp-data-name.ddp-data-new .ddp-icon-new {display:block;}
 ul.ddp-list-workspace li a .ddp-wrap-name .ddp-data-name span.ddp-data-detail {margin-left:5px; color:#b7bac1; font-size:14px;}
-ul.ddp-list-workspace li a .ddp-wrap-name .ddp-data-name span.ddp-data-in {display:inline-block; overflow:hidden;white-space:nowrap;text-overflow:ellipsis;word-wrap:normal;}
+ul.ddp-list-workspace li a .ddp-wrap-name .ddp-data-name span.ddp-data-in {display:inline-block; overflow:hidden;white-space:nowrap;text-overflow:ellipsis;word-wrap:normal;/* display: block; */display: inline-block;}
 
 ul.ddp-list-workspace li a .ddp-data-input {display:none; position:absolute; top:9px; left:124px; right:32px; bottom:9px; background-color:#f6f6f7; z-index:3;}
 ul.ddp-list-workspace li a .ddp-data-input input {display:block; width:100%; height:100%; padding:5px 23px 5px 5px; font-size:14px; border:none; background:none; box-sizing:border-box;}
@@ -2815,6 +2792,7 @@ ul.ddp-list-workspace.ddp-select li a {padding-left:89px;}
 .ddp-wrap-tab-popup .ddp-ui-title .ddp-ui-rightoption .ddp-form-label2 {margin-left:28px;}
 .ddp-wrap-tab-popup .ddp-ui-title .ddp-ui-rightoption .ddp-form-label2 .ddp-wrap-dropdown {width:168px;}
 .ddp-wrap-tab-popup .ddp-popup-dashboard {width:inherit; position:absolute; top:59px; left:33px; bottom:69px; right:33px; min-width:1074px;}
+
 .ddp-wrap-tab-popup .ddp-popup-dashboard table.ddp-table-form tbody tr td .ddp-txt-long.ddp-global {padding-right:66px;}
 .ddp-wrap-tab-popup .ddp-popup-dashboard .ddp-wrap-grid {height:100%;}
 .ddp-wrap-tab-popup .ddp-popup-dashboard .ddp-wrap-grid .ddp-wrap-viewtable {padding-bottom:43px; height:100%; box-sizing:border-box;}
@@ -2874,7 +2852,7 @@ table.ddp-table-form2 tbody tr td em.ddp-icon-group {float:left; margin-right:7p
 table.ddp-table-form2 tbody tr td span.ddp-data-username {display:block; overflow:hidden;}
 
 .ddp-wrap-type-option {position:relative;}
-.ddp-wrap-type-option .ddp-box-layout4.type-time {width:330px; position:absolute; top:100%; right:-30px; margin-top:5px; z-index:15;}
+.ddp-wrap-type-option .ddp-box-layout4.type-time {width:330px; position:absolute; top:100%; right:-30px; margin-top:5px;}
 table.ddp-table-type2 tr td.ddp-info .ddp-wrap-type-option .ddp-ui-info {right:-20px;}
 .ddp-ui-selected-option span.ddp-link-text {display:inline-block; position:relative; width:100%; padding-right:19px; cursor:pointer; box-sizing:border-box;}
 .ddp-ui-selected-option span.ddp-link-text.ddp-txt-icon {padding-left:30px; white-space:nowrap; text-overflow:ellipsis; overflow:hidden; word-wrap:normal; vertical-align:middle;}
@@ -2985,12 +2963,12 @@ ul.ddp-ui-tab li.ddp-selected a em.ddp-icon-zepplin {background-position:left -1
 
 .ddp-layout-chart:before {position:fixed; left:0; right:0; bottom:0; top:0; background-color:rgba(208,209,216,0.5); content:''; }
 .ddp-layout-chart .ddp-layout-contents2 {width:100%; height:100%; margin-top:0px; padding:0px; z-index:31; background-color:#fff; box-sizing:border-box;}
-.ddp-wrap-chart {width:100%; height:100%; padding-bottom:59px; overflow:hidden; box-sizing:border-box;}
+.ddp-wrap-chart {width:100%; height:100%; padding-bottom:59px; overflow:hidden; box-sizing:border-box; box-sizing:Border-box;}
 .ddp-wrap-chart .ddp-ui-buttons2 {position:absolute; bottom:0; left:0; right:0; padding:10px 0;text-align:center; border-top:1px solid #e7e7ea; background-color:#f7f7f8; z-index:70;}
 .ddp-wrap-chart .ddp-ui-buttons2 .ddp-btn-type-popup {margin:0 2px;}
 .ddp-wrap-chart .ddp-wrap-chart-lnb {float:left; width:288px; height:100%; background-color:#35393f; vertical-align: top;}
 .ddp-wrap-chart .ddp-view-chart-lnb {position:relative; height:100%; }
-.ddp-wrap-chart .ddp-ui-chart-lnb {position:absolute; top:0; left:0; right:0; bottom:0; overflow:hidden;}
+.ddp-wrap-chart .ddp-ui-chart-lnb {position:absolute; top:0; left:0; right:0; bottom:0; overflow:hidden; overflow-x:hidden;}
 .ddp-ui-chart-lnb .ddp-box-down {border-bottom:none;}
 .ddp-ui-chart-lnb .ddp-box-down .ddp-list-label {color:#fff;}
 .ddp-ui-chart-lnb .ddp-box-down .ddp-form {margin:0 -2px;}
@@ -3004,6 +2982,7 @@ ul.ddp-ui-tab li.ddp-selected a em.ddp-icon-zepplin {background-position:left -1
 .ddp-ui-chart-lnb .ddp-wrap-slider-down .ddp-list-part-sub {display:none; padding:0 0 0 20px;}
 .ddp-ui-chart-lnb .ddp-wrap-slider-down.ddp-selected .ddp-list-part-sub {display:block;}
 .ddp-ui-chart-lnb .ddp-wrap-slider-down .ddp-list-part-sub .ddp-divide2 .ddp-list-label {padding:7px 0; color:#90969f;}
+
 
 .ddp-wrap-chart .ddp-wrap-chart-contents {float:left; margin-left:-288px; margin-right:-318px; padding-left:288px; width:100%;height:100%;vertical-align: top;overflow:hidden; box-sizing:border-box;}
 
@@ -3096,9 +3075,9 @@ ul.ddp-ui-tab li.ddp-selected a em.ddp-icon-zepplin {background-position:left -1
 .ddp-wrap-chart-menu a.ddp-disabled:hover em.ddp-icon-menu-mapview3 {background-position:left -438px;}
 
 .ddp-wrap-chart-menu a.ddp-disabled:hover em.ddp-icon-menu-analysis {background-position:left -459px;}
-	/**********************************************************************************
-        차트 (lnb)
-    **********************************************************************************/
+/**********************************************************************************
+      차트 (lnb)
+  **********************************************************************************/
 .ddp-wrap-dropmenu {border-bottom:1px solid #35393f;}
 .ddp-ui-dropmenu .ddp-ui-drop-title {position:relative; padding:16px 22px; font-size:16px; color:#fff; font-weight:bold; background-color:#4b515b; cursor: pointer;}
 .ddp-ui-dropmenu .ddp-ui-drop-title span.ddp-data-det {position:absolute; top:50%; right:41px; margin-top:-7px; font-size:12px; color:#90969f ;}
@@ -3108,7 +3087,7 @@ ul.ddp-ui-tab li.ddp-selected a em.ddp-icon-zepplin {background-position:left -1
 .ddp-ui-dropmenu .ddp-ui-drop-contents {display:none; overflow:auto;}
 .ddp-ui-dropmenu .ddp-ui-drop-contents .ddp-wrap-list-source {display:none; position:relative; top:0; overflow:inherit;}
 .ddp-ui-dropmenu.ddp-selected .ddp-ui-drop-contents {display:block;}
-.ddp-ui-drop-contents .ddp-wrap-source-name {padding:9px 13px; margin-bottom:-4px;}
+.ddp-ui-drop-contents .ddp-wrap-source-name {margin-bottom:-10px; padding:9px 13px; margin-bottom:-4px;}
 .ddp-ui-drop-contents .ddp-wrap-source-name .ddp-data-in {width:100%; padding-right:47px;}
 .ddp-ui-drop-contents .ddp-wrap-source-name .ddp-data-in .ddp-btn-info {position:absolute; top:50%; right:27px; margin-top:-6px;opacity:0.6;}
 .ddp-ui-drop-contents .ddp-wrap-source-name .ddp-data-in .ddp-btn-info:hover {opacity:1; background-position-x:-14px;}
@@ -3768,6 +3747,8 @@ em[class*="ddp-bg-chart-"] {display:inline-block; position:absolute; top:50%; le
 
 .ddp-box-down .ddp-ui-point .ddp-point-local .ddp-label-point {float:left; padding:5px 0;}
 
+
+
 .ddp-ui-down-title .ddp-ui-buttons {float:right; margin-right:10px; background-color:#f7f7f8; cursor: default;}
 .ddp-ui-down-title .ddp-ui-buttons em[class*="ddp-icon-"],
 .ddp-ui-down-title .ddp-ui-buttons .ddp-wrap-datalock,
@@ -3777,7 +3758,7 @@ em[class*="ddp-bg-chart-"] {display:inline-block; position:absolute; top:50%; le
 .ddp-ui-down-title .ddp-ui-buttons .ddp-wrap-popup2 em[class*="ddp-icon-"] {margin-left:0;}
 .ddp-ui-down-title .ddp-wrap-morebutton .ddp-wrap-datalock {float:left;}
 .ddp-ui-down-title .ddp-wrap-morebutton {float:left; position:relative; top:-1px;}
-.ddp-ui-down-title .ddp-ui-label {display:inline-block; position:relative; max-width:100px; font-size:12px; color:#4b515b; overflow:hidden; white-space:nowrap; text-overflow:ellipsis; word-wrap:normal;}
+.ddp-ui-down-title .ddp-ui-label {display:inline-block; position:relative; max-width:100px; color:#90969f; font-size:12px; color:#4b515b; overflow:hidden; white-space:nowrap; text-overflow:ellipsis; word-wrap:normal;}
 .ddp-ui-down-title .ddp-ui-label em.ddp-icon-chart {display:inline-block; width:10px; height:11px; margin-right:5px; background:url(../images/icon_chart.png) no-repeat;}
 
 .ddp-ui-option-down .ddp-ui-down-title:before {display:inline-block; content:''; position:absolute; top:0; right:0; left:0; border-top:1px solid #e5e6e8; z-index:1;}
@@ -3809,9 +3790,6 @@ em[class*="ddp-bg-chart-"] {display:inline-block; position:absolute; top:50%; le
 
 .ddp-ui-option-down.ddp-selected .ddp-ui-down-contents {display:block; padding-bottom:20px; padding-left:0;}
 .ddp-ui-option-down.ddp-selected .ddp-ui-down-contents .ddp-data-status {color:#90969f; font-size:12px;}
-
-.ddp-ui-option-down.ddp-selected .ddp-ui-down-contents .ddp-ui-slider-type {margin:0;}
-.ddp-ui-option-down.ddp-selected .ddp-ui-down-contents .ddp-ui-slider-type.type-result .irs-single {display:block !important;}
 .ddp-ui-option-down.ddp-selected .ddp-ui-down-contents .ddp-txt-det {display:block; padding-top:2px;color:#b7b9c2; font-size:12px; font-style:italic;}
 .ddp-ui-option-down.ddp-selected .ddp-ui-down-contents .ddp-txt-det:before {display:inline-block; content:''; width:13px; height:13px; margin-right:4px; background:url(../images/icon_info.png) no-repeat; background-position:left -16px; vertical-align: middle;}
 
@@ -3819,11 +3797,9 @@ em[class*="ddp-bg-chart-"] {display:inline-block; position:absolute; top:50%; le
 
 .ddp-box-down .ddp-ui-down-contents2 {padding:0 0 0px 16px;}
 .ddp-box-down .ddp-wrap-divide {padding:10px 0 0 17px; margin:10px 0 0 -17px;  position:relative; border-top:1px solid #e5e6e8;}
+.ddp-box-down .ddp-wrap-divide.ddp-selected {border-top:2px solid #e5e6e8;}
 .ddp-box-down > .ddp-wrap-divide:first-of-type,
 .ddp-box-down .ddp-wrap-divide.ddp-first {border-top:none; margin-top:0px; padding-top:0;}
-.ddp-box-down .ddp-wrap-divide.ddp-selected {border-top:2px solid #e5e6e8;}
-.ddp-box-down > .ddp-wrap-divide.ddp-selected:first-of-type,
-.ddp-box-down .ddp-wrap-divide.ddp-selected.ddp-first {border-top:1px solid #e5e6e8;}
 
 .ddp-box-down .ddp-wrap-divide .ddp-divide2 {padding-bottom:6px;}
 .ddp-box-down .ddp-wrap-divide .ddp-divide2 .ddp-wrap-colorby-button {margin:0;}
@@ -3880,16 +3856,16 @@ em[class*="ddp-bg-chart-"] {display:inline-block; position:absolute; top:50%; le
 .ddp-list-sub2 .ddp-divide2:last-of-type {padding-bottom:0;}
 .ddp-list-sub2 .ddp-list-sub2 {padding-left:15px;}
 .ddp-list-sub2 .ddp-ui-color-select {padding:9px 0;}
-.ddp-list-sub2 .ddp-ui-color-select .ddp-txt-label {position:relative;}
+.ddp-list-sub2 .ddp-ui-color-select .ddp-txt-label {position:relative; }
 .ddp-list-sub2 .ddp-ui-color-select .ddp-txt-data {display:block; max-height:30px; word-break:break-all;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	display: -webkit-box;
-	-webkit-line-clamp: 2; /* 라인수 */
-	/* autoprefixer: off */
-	-webkit-box-orient: vertical;
-	/* autoprefixer: on */
-	word-wrap:break-word;}
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2; /* 라인수 */
+  /* autoprefixer: off */
+  -webkit-box-orient: vertical;
+  /* autoprefixer: on */
+  word-wrap:break-word;}
 .ddp-list-sub2 .ddp-ui-color-select .ddp-txt-label .ddp-ui-txt {display:block; position:relative; padding:0 17px 0 21px;}
 .ddp-list-sub2 .ddp-ui-color-select .ddp-txt-label .ddp-btn-reset3 {position:absolute; top:50%; right:0; margin-top:-7px;}
 .ddp-list-sub2 .ddp-ui-color-select .ddp-box-color {position:absolute; top:50%; left:0; margin-top:-9px;}
@@ -3945,6 +3921,7 @@ em[class*="ddp-bg-chart-"] {display:inline-block; position:absolute; top:50%; le
 .ddp-list-part .ddp-label-checkbox.ddp-check-full span.ddp-txt-checkbox {font-size:12px;}
 .ddp-list-part2 .ddp-label-checkbox.ddp-check-full span.ddp-txt-checkbox {font-size:12px;}
 .ddp-list-part .ddp-label-radio.ddp-check-full span.ddp-txt-radio {font-size:12px;}
+.ddp-list-part .ddp-btn-line {display:none; float:right; margin-left:4px; cursor: pointer;}
 .ddp-list-part2 .ddp-label-radio.ddp-check-full span.ddp-txt-radio {font-size:12px;}
 .ddp-wrap-option-checkbox {padding:3px 0;}
 .ddp-wrap-option-checkbox .ddp-label-type {line-height:29px; color:#d0d1d8;}
@@ -4178,7 +4155,6 @@ em.ddp-icon-line-curve,.ddp-list-express em.ddp-icon-cross
 .ddp-list-express [class*="ddp-line-bold"] {display:inline-block; position:absolute; top:50%; left:50%; margin-left:-8px; width:16px; height:1px; background-color: #4b515b;}
 .ddp-list-express em.ddp-line-bold2 {height:2px; margin-top:-1px;}
 .ddp-list-express em.ddp-line-bold3 {height:3px; margin-top:-2px;}
-.ddp-list-express em.ddp-line-bold5 {height:5px; margin-top:-3px;}
 
 .ddp-list-express em.ddp-line-dotted,
 .ddp-list-express em.ddp-line-dashed {display:inline-block; position:absolute; top:50%; left:50%; background:url(../images/icon_presentation2_map.png) no-repeat;}
@@ -4186,6 +4162,9 @@ em.ddp-icon-line-curve,.ddp-list-express em.ddp-icon-cross
 .ddp-list-express em.ddp-line-dashed {width:16px; height:3px; margin:-1px 0 0 -8px; background-position:left -3px;}
 .ddp-list-express li.ddp-selected em.ddp-line-dotted {background-position-x:-15px;}
 .ddp-list-express li.ddp-selected em.ddp-line-dashed {background-position-x:-17px;}
+
+
+
 
 
 .ddp-list-express li.ddp-selected [class*="ddp-line-bold"] {background-color:#fff;}
@@ -4523,25 +4502,19 @@ span.ddp-bg8-color4 {background-color:#afafaf;}
 .ddp-lnb-down.ddp-selected .ddp-ui-down-title em.ddp-icon-menumove:before {transform:rotate(0deg); content:'';}
 .ddp-lnb-down span.ddp-label-slider {color:#d0d1d8;}
 .ddp-ui-drop-contents .ddp-ui-option-down .ddp-ui-down-title em.ddp-icon-drop {display:inline-block;}
-.ddp-lnb-down .ddp-ui-sign {position:relative; padding-top:10px;}
-.ddp-lnb-down .ddp-ui-sign.ddp-disabled {opacity:0.3;}
-.ddp-lnb-down .ddp-ui-sign.ddp-disabled:before {display:inline-block; position:absolute; top:0; left:0; right:0; bottom:0; content:''; z-index:1;}
-.ddp-lnb-down .ddp-ui-sign .ddp-txt-label {display:block; color:#90969f;}
-.ddp-lnb-down .ddp-list-part {padding-bottom:20px;}
-.ddp-lnb-down .ddp-list-part:last-of-type {padding-bottom:0; border-bottom:none;}
-.ddp-lnb-down .ddp-list-part .ddp-ui-form-type {padding:0 0 10px 0; }
-.ddp-lnb-down .ddp-list-part .ddp-ui-label {padding:7px 0 7px 0; color:#d0d1d8; font-size:13px;}
-.ddp-lnb-down .ddp-list-part .ddp-form-multy {margin-bottom:10px;}
-.ddp-lnb-down .ddp-list-part-sub {padding:0 0 0 18px;}
+
+.ddp-lnb-down .ddp-list-part {padding-bottom:20px; margin-bottom:19px; border-bottom:1px solid #4b515b;}
+.ddp-lnb-down .ddp-list-part:last-of-type {margin-bottom:0; border-bottom:none;}
+.ddp-lnb-down .ddp-list-part .ddp-ui-label {padding:7px 0 12px 0; color:#d0d1d8; font-size:13px;}
+.ddp-lnb-down .ddp-list-part-sub {padding:0 10px;}
 .ddp-lnb-down .ddp-list-part-sub .ddp-ui-slider-type {margin:10px -10px 10px 0;}
 .ddp-lnb-down .ddp-list-part-sub .ddp-ui-link {text-align:left;}
-.ddp-lnb-down .ddp-ui-link.ddp-setup {padding:10px 0 0 0;}
-.ddp-lnb-down .ddp-ui-link.ddp-setup .ddp-ui-option {display:none;}
-.ddp-lnb-down .ddp-ui-link.ddp-setup.ddp-selected .ddp-ui-option {display:block; clear:both;}
-.ddp-lnb-down .ddp-ui-link .ddp-link-option {display:block; position:relative; float:right; padding-right:12px; text-decoration: underline; font-style:italic;color:#90969f; font-size:12px;}
-.ddp-lnb-down .ddp-ui-link .ddp-link-option:after {display:inline-block; content:''; position:absolute; top:50%; right:0; margin-top:-2px;width:8px; height:4px; background:url(../images/icon_select.png) no-repeat; background-position:-8px top;}
-.ddp-lnb-down .ddp-ui-link.ddp-selected .ddp-link-option:after {transform:rotate(180deg)}
-.ddp-lnb-down .ddp-ui-option .ddp-ui-option-check {padding:15px 0 8px 0;text-align:right;}
+.ddp-lnb-down .ddp-list-part-sub .ddp-ui-link.ddp-setup .ddp-ui-option {display:none;}
+.ddp-lnb-down .ddp-list-part-sub .ddp-ui-link.ddp-setup.ddp-selected .ddp-ui-option {display:block; clear:both;}
+.ddp-lnb-down .ddp-list-part-sub .ddp-ui-link .ddp-link-option {display:block; position:relative; float:right; padding-right:12px; text-decoration: underline; font-style:italic;color:#90969f; font-size:12px;}
+.ddp-lnb-down .ddp-list-part-sub .ddp-ui-link .ddp-link-option:after {display:inline-block; content:''; position:absolute; top:50%; right:0; margin-top:-2px;width:8px; height:4px; background:url(../images/icon_select.png) no-repeat; background-position:-8px top;}
+.ddp-lnb-down .ddp-list-part-sub .ddp-ui-link.ddp-selected .ddp-link-option:after {transform:rotate(180deg)}
+.ddp-lnb-down .ddp-list-part-sub .ddp-ui-option .ddp-ui-option-check {padding:15px 0 15px 0;text-align:right;}
 .ddp-lnb-down .ddp-list-sub-in {position:relative; padding-left:20px;}
 .ddp-lnb-down .ddp-ui-color-select {position:relative; margin-top:7px; margin-bottom:15px; white-space:nowrap;}
 .ddp-lnb-down .ddp-ui-color-select.ddp-mgb0 {margin-bottom:0;}
@@ -4646,15 +4619,16 @@ ul.ddp-list-selectbox.ddp-color-select li a:hover {background-color:#f6f6f7;}
 .ddp-wrap-list .ddp-ui-dataname .ddp-top-title {display:inline-block; position:relative; max-width:100%; padding:0 20px 10px 9px; box-sizing:border-box;}
 .ddp-wrap-list .ddp-ui-dataname .ddp-txt-name {display:inline-block; max-width:100%;font-size:16px; font-weight:bold; color:#4b515b; white-space:nowrap; text-overflow:ellipsis; overflow:hidden;}
 
-.ddp-wrap-list .ddp-ui-dataname .ddp-wrap-info {position:absolute; top:5px; right:0; display:inline-block; vertical-align:top;}
+.ddp-wrap-list .ddp-ui-dataname .ddp-wrap-info {position:absolute; top:0; right:0; display:inline-block; vertical-align:top; top:5px; }
 .ddp-wrap-list .ddp-ui-dataname .ddp-wrap-info .ddp-btn-info2:before
 {display:inline-block; content:''; width:13px; height:13px; margin-left:5px; background:url(../images/icon_info.png) no-repeat; background-position:left -30px;}
 .ddp-wrap-list .ddp-ui-dataname .ddp-wrap-info .ddp-btn-info2:hover:before {background-position:-14px -30px;}
 
 .ddp-wrap-list .ddp-ui-dataname .ddp-wrap-info .ddp-box-layout4 {display:none;position:fixed; top:0; left:0; margin-top:5px;}
-.ddp-wrap-list .ddp-ui-dataname .ddp-wrap-info .ddp-box-layout4.ddp-scheme {max-width:520px; width:auto;}
+.ddp-wrap-list .ddp-ui-dataname .ddp-wrap-info .ddp-box-layout4.ddp-scheme { max-width:520px; width:auto;}
 
 .ddp-wrap-list .ddp-ui-dataname .ddp-wrap-info .ddp-box-layout4.ddp-scheme table.ddp-table-info {table-layout:inherit;}
+
 
 .ddp-wrap-list .ddp-ui-dataname .ddp-wrap-info.ddp-selected .ddp-box-layout4 {display:block;}
 .ddp-wrap-list .ddp-data-namesub {position:relative;}
@@ -4662,12 +4636,12 @@ ul.ddp-list-selectbox.ddp-color-select li a:hover {background-color:#f6f6f7;}
 .ddp-wrap-list .ddp-data-namesub .ddp-data-in:hover {background-color:#fff;}
 .ddp-wrap-list .ddp-data-namesub .ddp-data-in .ddp-txt-dataname {display:block; color:#4b515b; font-size:12px; white-space:nowrap; text-overflow:ellipsis; overflow:hidden; word-wrap:normal; }
 .ddp-wrap-list .ddp-data-namesub .ddp-data-in .ddp-icon-database3 {float:left; margin-right:5px;}
-.ddp-wrap-list .ddp-data-namesub .ddp-data-in .ddp-txt-namesub {display:block; color:#4b515b; font-size:12px; white-space:nowrap; text-overflow:ellipsis; overflow:hidden;}
+.ddp-wrap-list .ddp-data-namesub .ddp-data-in .ddp-txt-namesub {display:block; color:#4b515b; font-size:12px; overflow:hidden; white-space:nowrap; text-overflow:ellipsis; overflow:hidden;}
 .ddp-wrap-list .ddp-data-namesub .ddp-data-in .ddp-icon-view {display:inline-block; position:absolute; top:50%; right:9px; width:7px; height:4px; margin-top:-2px; background:url(../images/icon_select.png) no-repeat; content:'';}
 
 .ddp-wrap-list .ddp-data-namesub .ddp-box-layout4 {display:none; position:absolute; top:100%; left:0; right:0; width:100%; padding:0 0 20px 0; box-sizing:border-box;}
 .ddp-wrap-list .ddp-data-namesub .ddp-box-layout4 .ddp-wrap-search {padding:0 20px;}
-.ddp-wrap-list .ddp-data-namesub .ddp-box-layout4 .ddp-form-search {margin-left:0px;}
+.ddp-wrap-list .ddp-data-namesub .ddp-box-layout4 .ddp-form-search {margin-left:0px; }
 
 .ddp-wrap-list .ddp-data-namesub.ddp-selected .ddp-box-layout4 {display:block;}
 
@@ -4754,7 +4728,6 @@ table.ddp-table-select.type-scTb tbody tr.ddp-selected td:last-of-type:after {di
 .ddp-column-detail .ddp-ui-detail .ddp-wrap-histogram {margin-top:15px;}
 .ddp-column-detail .ddp-ui-detail .ddp-wrap-histogram:first-of-type {margin-top:0;}
 .ddp-column-detail .ddp-ui-detail .ddp-wrap-histogram .ddp-ui-label {padding-bottom:5px; color:#4a515c; font-size:13px;}
-
 .ddp-column-detail .ddp-ui-detail .ddp-box-histogram {height:61px; padding:5px; border:1px solid #dadada;}
 .ddp-column-detail .ddp-ui-detail .ddp-box-valuelist {height:179px; border:1px solid #dadada;  box-sizing:border-box;}
 .ddp-ui-preview-contents.ddp-full {position:absolute; top:0;}
@@ -4771,7 +4744,7 @@ ul.ddp-list-graph li span.ddp-txt-sub {display:block; margin-top:5px; color:#909
 ul.ddp-list-graph li .ddp-box-image {margin-top:5px; height:137px; border:1px solid #dadada;}
 .ddp-wrap-detail.ddp-type table.ddp-table-detail2{padding:0 20px; box-sizing:border-box;}
 table.ddp-table-detail2 {width:100%; table-layout:fixed;}
-table.ddp-table-detail2 tr th {padding:6px 0 6px 20px; text-align:left; font-size:13px; color:#90969f; font-weight:normal;}
+table.ddp-table-detail2 tr th {padding:6px 0 6px 20px; text-align:left; color:#4a515c; font-size:13px; color:#90969f; font-weight:normal;}
 table.ddp-table-detail2 tr th.ddp-th-valid {color:#26af5e;}
 table.ddp-table-detail2 tr th.ddp-th-missing  {color:#ff2a1b;}
 table.ddp-table-detail2 tr td {padding:6px 0;color:#4a515c; font-size:13px;}
@@ -4800,10 +4773,6 @@ table.ddp-table-order tr td {padding:13px 13px; border-top:1px solid #e7e7ea; fo
 .ddp-box-copy-table .ddp-btn-bg:hover {color:#4b515b;}
 .ddp-box-copy-table .ddp-btn-bg:hover .ddp-icon-reset {background-position:-15px -34px;}
 .ddp-box-copy-table .ddp-txt-info {position:absolute; top:-33px; right:0; font-size:12px; color:#b7b9c2;}
-.ddp-box-copy-table .ddp-btn-bg {position:absolute; top:-38px; right:0; padding:7px 12px; border-radius:2px; color:#90969f;}
-.ddp-box-copy-table .ddp-btn-bg .ddp-icon-reset {display:inline-block; margin-right:3px; width:14px; height:13px; background:url(../images/icon_reset.png) no-repeat; background-position:-16px -20px; vertical-align:middle;}
-.ddp-box-copy-table .ddp-btn-bg:hover {color:#4b515b;}
-.ddp-box-copy-table .ddp-btn-bg:hover .ddp-icon-reset {background-position:-15px -34px;}
 .ddp-box-copy-table .ddp-box-add-link3 {position:absolute; bottom:-1px; left:-1px; right:-1px;}
 .ddp-box-copy-table .ddp-view-grid {width:100%; height:100%; overflow:auto;}
 
@@ -4812,15 +4781,12 @@ table.ddp-table-order tr td {padding:13px 13px; border-top:1px solid #e7e7ea; fo
 **********************************************************************************/
 /* 팝업 타이틀 */
 .ddp-label-pop-title {padding:7px 0; color:#b7b9c2; font-size:13px; font-weight:bold;}
-.ddp-ui-top span.ddp-ui-sub-title {display:block; padding:5px 0 0 0; color:#4c515a; font-size:13px; font-weight:bold;}
+.ddp-ui-top span.ddp-ui-sub-title {display:block; padding:12px 0 0 0; color:#4c515a; font-size:13px; font-weight:bold;}
 
 .ddp-ui-popup-contents .ddp-wrap-edit3 {margin-bottom:20px;}
-.ddp-ui-popup-contents .ddp-wrap-edit3.ddp-mgb0 {margin-bottom:0;}
-
-
 .ddp-account-top {padding-bottom:18px; overflow:hidden;}
 .ddp-account-top .ddp-label {color:#4c515a; font-size:13px; font-weight:bold;}
-.ddp-account-top .ddp-error {float:right; color:#ca4b4b; font-style:italic; font-size:13px;}
+.ddp-account-top .ddp-error {float:right; color:#ca4b4b; font-size:13px; font-style:italic; font-size:13px;}
 .ddp-ui-accout-textarea {position:relative; width:100%; height:220px; background-color:#f9f9f9;}
 .ddp-ui-accout-textarea .ddp-wrap-edit {width:100%; height:100%;}
 .ddp-ui-accout-textarea .ddp-wrap-edit .ddp-ui-edit {display:inline-block; padding:25px 30px; width:100%; height:100%; color:#b7b9c2; font-size:13px; line-height:18px; border:none; border-top:1px solid #e7e7ea; border-bottom:1px solid #e7e7ea; overflow-y:auto; white-space:pre-wrap; box-sizing:border-box; z-index:1;}
@@ -4833,22 +4799,14 @@ table.ddp-table-order tr td {padding:13px 13px; border-top:1px solid #e7e7ea; fo
 }
 .ddp-wrap-popup2.ddp-accout-popup {position:fixed; left:0; top:0; width:248px; max-height:230px; z-index:127; overflow-y:auto; word-break: break-all;}
 .ddp-wrap-popup2.ddp-types.ddp-accout-popup ul.ddp-list-popup li a {white-space:normal;}
-.ddp-ui-account-search {position:absolute; top:410px; left:0; right:0; bottom:0; padding:0 50px 30px 50px; box-sizing:border-box;}
-.ddp-ui-popup-contents.page-flex {display:flex; flex-direction: column;}
-.page-flex .ddp-ui-accout-textarea {display:flex;flex:1 1 0; margin-bottom:20px; height:250px;}
-.page-flex .ddp-ui-account-search{display:flex; flex:1 1 0; height:100%; position:relative; top:0; left:0; right:0; bottom:0; padding:0 0 30px 0;}
-.page-flex .ddp-ui-formula {margin-top:-32px; padding-top:32px;}
-.page-flex .ddp-ui-formula .ddp-ui-typebasic {top:37px;}
+.ddp-ui-account-search {height:511px; padding:20px 0 0 0; margin-bottom:30px; box-sizing:border-box;}
 
-.ddp-ui-account-search .ddp-wrap-form-list {float:left; height:100%; margin-top:-30px; padding:30px 0 0 0; box-sizing:border-box;}
-.ddp-ui-account-search .ddp-wrap-add-list {position:relative; float:left; width:305px; height:100%;border-right:1px solid #e7e7ea;  box-sizing:Border-box; z-index:1;}
-.ddp-ui-account-search .ddp-wrap-add-list .ddp-ui-page {position:absolute; bottom:15px; left:10px;}
+.ddp-ui-account-search .ddp-wrap-add-list {position:relative; float:left; width:305px; height:100%; margin-top:-30px; padding-top:30px; border-right:1px solid #e7e7ea;  box-sizing:Border-box; z-index:1;}
+
 .ddp-wrap-add-list .ddp-ui-top {position:relative;}
 .ddp-wrap-add-list .ddp-ui-top .ddp-ui-sub-title {padding-left:10px;}
-.ddp-wrap-add-list .ddp-ui-top .ddp-ui-sort {position:absolute; top:-10px; right:20px; margin-top:0;}
 .ddp-wrap-add-list .ddp-ui-top .ddp-ui-page {position:absolute; top:10px; right:20px;}
-.ddp-wrap-add-list ul.ddp-list-typebasic {position:absolute; top:40px; left:0; right:22px; bottom:0; overflow-y:auto;}
-.ddp-wrap-add-list ul.ddp-list-typebasic.type-page {bottom:36px;}
+.ddp-wrap-add-list ul.ddp-list-typebasic {position:absolute; top:80px; left:0; right:22px; bottom:0; overflow-y:auto;}
 .ddp-wrap-formula {float:left; position:relative; width:100%; height:100%; margin:-30px 0 0 -305px;padding:30px 0 0 325px; border-bottom:1px solid #e7e7ea; box-sizing:border-box;}
 
 @keyframes boxSize {
@@ -4861,38 +4819,27 @@ table.ddp-table-order tr td {padding:13px 13px; border-top:1px solid #e7e7ea; fo
 	to {width: 241px;}
 }
 
-.ddp-ui-formula {float:left; position:relative; width:258px; height:100%; padding:0 9px 0 0; box-sizing:border-box; background-color:#fff; z-index:1;}
+.ddp-ui-formula {float:left; position:relative; width:240px; height:100%; padding:0 9px 0 0; box-sizing:border-box; background-color:#fff; z-index:1;}
 
 .ddp-ui-formula.ddp-full {width:100%;}
 .ddp-view-formula {position:relative; height:100%; margin-top:-28px; padding-top:28px; box-sizing:border-box;}
-.ddp-view-formula .ddp-ui-option {float:left; position:relative; width:100%; z-index:2;}
-.ddp-view-formula .ddp-ui-option .ddp-type-search {float:left; width:240px; box-sizing:border-box;}
-.ddp-view-formula .ddp-ui-option .ddp-wrap-edit3 {float:right; width:auto; margin-bottom:0;}
-.ddp-view-formula .ddp-ui-option .ddp-wrap-edit3 label.ddp-label-type {width:auto; padding-right:6px;}
-.ddp-view-formula .ddp-ui-option .ddp-wrap-edit3 .ddp-type-selectbox {width:155px;}
-.ddp-ui-formula .ddp-form-search {width:100%; margin-bottom:13px;}
+
+.ddp-ui-formula .ddp-form-search {width:100%; margin-bottom:15px;}
+.ddp-ui-formula .ddp-type-selectbox {margin-bottom:18px;}
 .ddp-ui-formula .ddp-ui-typebasic {position:absolute; top:80px; left:0; right:0; bottom:0; overflow-y:auto;}
-.ddp-view-formula .ddp-ui-detail {position:absolute; top:65px; left:270px; bottom:0; right:0; padding:0 10px 20px 10px; box-sizing:border-box; border:1px solid #e7e7ea; border-bottom:none; overflow-y:auto; color:#90969f; font-size:13px;}
-.ddp-view-formula .ddp-ui-detail .ddp-txt-part {display:block;}
-.ddp-view-formula .ddp-ui-detail .ddp-txt-part .ddp-txt-list {display:block; padding-top:10px;}
-.ddp-view-formula .ddp-ui-detail .ddp-txt-part .ddp-txt-list:first-of-type {padding-top:0;}
-.ddp-view-formula .ddp-ui-detail .ddp-txt-part .ddp-txt-list .ddp-txt-sub-det {color:#83ae4a}
+
+.ddp-view-formula .ddp-ui-detail {position:absolute; top:70px; left:241px; bottom:0; width:280px; padding:0 10px; box-sizing:border-box; border:1px solid #e7e7ea; border-bottom:none; overflow-y:auto;}
 .ddp-view-formula .ddp-ui-detail .ddp-btn-close {display:inline-block; position:absolute; right:27px; top:19px; width:16px; height:16px; background:url(../images/btn_close.png) no-repeat; cursor: pointer;}
-.ddp-view-formula .ddp-ui-detail .ddp-ui-det-title {display:block; padding:15px 0 5px 0; color:#4b515b; font-size:13px; font-weight:bold;}
+.ddp-view-formula .ddp-ui-detail .ddp-ui-det-title {display:block; padding:15px 0 10px 0; color:#4b515b; font-size:13px; font-weight:bold;}
 .ddp-view-formula .ddp-ui-detail .ddp-ui-det-category {display:block; padding-bottom:25px; font-size:11px; color:#4b515b;}
 .ddp-view-formula .ddp-ui-detail .ddp-txt-det {display:block; padding-bottom:10px; color:#90969f; font-size:13px; line-height:21px;}
-.ddp-view-formula .ddp-ui-detail .ddp-data-start {color:#2774a1;}
-.ddp-view-formula .ddp-ui-detail .ddp-data-end {color:#dd5e82;}
-.ddp-view-formula .ddp-ui-detail .ddp-list-det {padding:10px 0 0 0;}
 
-.ddp-view-formula .ddp-ui-detail .ddp-list-det li {position:relative; padding-left:10px; color:#90969f; font-size:13px;}
-.ddp-view-formula .ddp-ui-detail .ddp-list-det li:before {display:inline-block; position:absolute; top:6px; left:0; width:4px; height:4px; margin-right:5px; background-color:#90969f; border-radius:50%; vertical-align:middle; content:'';}
 .ddp-view-formula.ddp-full .ddp-ui-detail {display:none;}
 .ddp-ui-userfield {position:absolute; top:240px; left:50px; right:50px; bottom:0; padding:40px 0 0 0; border-top:1px solid #e7e7ea;}
 
 .ddp-ui-userfield .ddp-ui-setting {float:left; width:48%; height:100%; padding-right:20px; box-sizing:border-box; border-right:1px solid #e7e7ea;}
 .ddp-ui-userfield .ddp-ui-account-search {float:left; position:relative; width:52%;padding:0 0 0 20px; box-sizing:border-box;}
-.ddp-ui-userfield .ddp-ui-account-search .ddp-wrap-add-list {width:100%; border-right:none;}
+.ddp-ui-userfield .ddp-ui-account-search .ddp-wrap-add-list {width:100%; border-right:none; }
 .ddp-ui-userfield .ddp-ui-account-search .ddp-wrap-add-list .ddp-ui-top .ddp-ui-page {right:45px;}
 
 /**********************************************************************************
@@ -4929,7 +4876,7 @@ table.ddp-table-order tr td {padding:13px 13px; border-top:1px solid #e7e7ea; fo
 .ddp-top-flow .ddp-data-form .ddp-data-box a.ddp-list-link {display:block; padding:10px 9px; color:#4b525b; font-size:13px;}
 .ddp-top-flow .ddp-data-form .ddp-data-box a.ddp-list-link:hover {background-color:#f6f6f7;}
 .ddp-top-flow .ddp-data-form .ddp-data-box a.ddp-list-link em.ddp-icon-create {display:inline-block; width:13px; height:13px; margin-right:5px; background:url(../images/icon_add.png) no-repeat; background-position:left -22px;}
-.ddp-top-flow .ddp-data-form .ddp-data-box a.ddp-list-link .ddp-icon-drop-re {position:Relative; top:0; left:0; margin-top:0; margin-right:px;}
+.ddp-top-flow .ddp-data-form .ddp-data-box a.ddp-list-link .ddp-icon-drop-re {position:Relative; top:0; left:0; margin-top:0; margin-right:5px;}
 .ddp-top-flow .ddp-wrap-navi {padding:0 0 0 10px; height:48px; box-sizing:border-box; overflow:hidden;}
 .ddp-top-flow .ddp-wrap-navi:before,
 .ddp-top-flow .ddp-wrap-navi:after {display:table; content:'';}
@@ -4996,9 +4943,6 @@ table.ddp-table-order tr td {padding:13px 13px; border-top:1px solid #e7e7ea; fo
 .ddp-top-flow .ddp-ui-buttons {position:absolute; top:50%; right:12px; margin-top:-15px;}
 .ddp-top-flow .ddp-ui-buttons a[class*="ddp-btn-"] {margin-right:5px;}
 
-/*.ddp-top-flow .ddp-ui-more.ddp-selected .ddp-icon-more:before {background-position:left -12px}*/
-/*.ddp-top-flow .ddp-ui-more .ddp-wrap-popup2 {display:none; position:absolute; top:100%; right:-10px; margin-top:10px; width:250px;}*/
-/*.ddp-top-flow .ddp-ui-more.ddp-selected .ddp-wrap-popup2 {display:block;}*/
 em.ddp-icon-shot {display:inline-block; width:16px; height:11px; margin-right:7px; background:url(../images/icon_shot.png) no-repeat; vertical-align:middle;}
 a:hover em.ddp-icon-shot {background-position:-17px top;}
 
@@ -5064,7 +5008,7 @@ ul.ddp-list-snapshot li > .ddp-txt-snapshot.ddp-disabled {opacity:0.3; border-bo
 
 ul.ddp-list-snapshot li .ddp-txt-cancel {padding-bottom:13px; text-align:center; vertical-align:middle;}
 ul.ddp-list-snapshot li .ddp-txt-cancel .ddp-txt-det {display:block; padding-bottom:15px; text-align:center; color:#3e4148; font-size:14px;}
-ul.ddp-list-snapshot li .ddp-txt-cancel a {display:inline-block; margin:0 2px; vertical-align:middle;}
+ul.ddp-list-snapshot li .ddp-txt-cancel a {display:inline-block; vertical-align:middle;}
 ul.ddp-list-snapshot li .ddp-txt-snapshot em.ddp-icon-snap-success,
 ul.ddp-list-snapshot li .ddp-txt-snapshot em.ddp-icon-snap-failed,
 ul.ddp-list-snapshot li .ddp-txt-snapshot em.ddp-icon-snap-cancel,
@@ -5082,7 +5026,7 @@ ul.ddp-list-snapshot li a .ddp-data-det .ddp-data-date {display:block; color:#b7
 
 ul.ddp-list-snapshot li a em.ddp-icon-snap-failed {background-position:left -33px;}
 .ddp-ui-rule-flow {position:absolute; top:56px; left:0; right:0; bottom:0; overflow-y:auto;}
-.ddp-ui-rule-flow .ddp-ui-link {position:absolute; bottom:0; left:0; right:0; padding:23px 0; text-align:center;}
+.ddp-ui-rule-flow .ddp-ui-link {position:absolute; bottom:0; left:0; right:0; bottom:0; padding:23px 0; text-align:center;}
 .ddp-wrap-tab-contents .ddp-wrap-rules-flow.ddp-snapshot {right:0;}
 .ddp-wrap-rules-flow.ddp-snapshot {position:absolute; bottom:0; right:291px; left:0; height:255px; padding:0 17px;}
 .ddp-wrap-rules-flow.ddp-snapshot ul.ddp-list-rule2 li {cursor:default; padding:6px 17px;}
@@ -5124,7 +5068,7 @@ ul.ddp-list-rule2 li .ddp-view-data.ddp-edit .ddp-ui-edit-button .ddp-btn-link {
 ul.ddp-list-rule2 li .ddp-view-data.ddp-edit .ddp-btn-icon {display:none;}
 ul.ddp-list-rule2 li .ddp-view-data.ddp-edit .ddp-btn-link {display:block;}
 ul.ddp-list-rule2 li .ddp-wrap-line-add {position:absolute; left:0; right:0; top:100%;cursor:pointer; padding:6px 0 0 0; height:6px; box-sizing:border-box; overflow:hidden; z-index:10;}
-ul.ddp-list-rule2 li .ddp-wrap-line-add.ddp-top {position:absolute; top:0px;}
+ul.ddp-list-rule2 li .ddp-wrap-line-add.ddp-top {position:absolute; top:0px; }
 ul.ddp-list-rule2 li .ddp-wrap-line-add:hover{position:relative; height:29px; padding-top:0; clear:both;
 	-webkit-transition: height 0.2s; /* Safari */
 	transition: height 0.2s;
@@ -5195,7 +5139,7 @@ ul.ddp-list-rule2 li.ddp-disabled2 .ddp-wrap-line-add {display:block;}
 .ddp-box-contents .ddp-wrap-part .ddp-box-part .ddp-btn-bg {display:inline-block; margin-left:7px; padding:8px 12px; vertical-align:middle;}
 .ddp-wrap-addrule {position:absolute; bottom:0; left:0; right:0;}
 .ddp-wrap-addrule.ddp-split {position:relative; top:0; left:0; right:0; bottom:0; height:inherit;}
-.ddp-wrap-addrule .ddp-box-top {position:fixed; left:0; right:0; bottom:180px;}
+.ddp-wrap-addrule .ddp-box-top {position:fixed; left:0; right:0; bottom:180px;  }
 .ddp-wrap-addrule .ddp-box-top.ddp-split {position:relative; top:0; left:0; right:0; bottom:0;}
 .ddp-wrap-addrule .ddp-box-title {padding:15px 15px 5px 15px; color:#4b515b; font-size:12px; font-weight:bold;}
 .ddp-wrap-addrule .ddp-box-title a.ddp-link-switch {margin-left:10px; font-size:11px; font-weight:normal; color:#727ab7; text-decoration: underline;}
@@ -5212,9 +5156,9 @@ ul.ddp-list-rule2 li.ddp-disabled2 .ddp-wrap-line-add {display:block;}
 .ddp-wrap-addrule ul.ddp-list-command li a span.ddp-ui-code {display:block; padding:5px 0 0 29px; color:#b7b9c2; font-size:12px;}
 
 
-.ddp-box-contents .ddp-box-part .ddp-box-title {position:relative; padding:0 0 5px 0; z-index:2; }
+.ddp-box-contents .ddp-box-part .ddp-box-title {position:relative; padding:0 0 5px 0; z-index:2;}
 .ddp-box-contents .ddp-box-part .ddp-list-buttons {width:100%;}
-.ddp-box-contents .ddp-box-part .ddp-list-buttons li {width:50%; min-width:auto; box-sizing:border-box;}
+.ddp-box-contents .ddp-box-part .ddp-list-buttons li {width:50%; box-sizing:border-box; min-width: auto}
 
 .ddp-box-contents .ddp-box-part:hover .ddp-ui-info {display:block;}
 .ddp-box-contents .ddp-box-part .ddp-ui-info {display:none; position:absolute; top:0; right:0;}
@@ -5261,14 +5205,14 @@ ul.ddp-list-rule2 li.ddp-disabled2 .ddp-wrap-line-add {display:block;}
 .ddp-box-info .ddp-input-title {display:block; padding:0 0 10px 0; margin-bottom:10px; text-align:center; border-bottom:1px solid #ddd; font-size:15px;}
 .ddp-box-info strong.ddp-ex {display:block; padding:20px 0 10px 0;}
 .ddp-box-contents .ddp-box-title .ddp-ui-open-view {display:inline-block; position:relative; vertical-align:middle;}
-.ddp-box-contents .ddp-box-title .ddp-ui-open-view .ddp-icon-view {display:inline-block; position:relative; top:-2px; width:17px; height:17px; cursor:pointer;}
+.ddp-box-contents .ddp-box-title .ddp-ui-open-view .ddp-icon-view {display:inline-block; position:relative; top:-2px; position:relative; width:17px; height:17px; cursor:pointer;}
 .ddp-box-contents .ddp-box-title .ddp-ui-open-view .ddp-icon-view em {display:inline-block; position:absolute; top:50%; left:50%; width:9px; height:5px; margin:-3px 0 0 -5px; background:url(../images/icon_drop2.png) no-repeat;}
 .ddp-box-contents .ddp-box-title .ddp-ui-open-view.ddp-selected .ddp-icon-view {background-color:#e7e7ea;}
 .ddp-box-contents .ddp-box-title .ddp-ui-open-view.ddp-selected .ddp-icon-view em {background-position:left -6px;}
 .ddp-box-contents .ddp-box-title .ddp-ui-open-view.ddp-selected + .ddp-box-select-check {display:block;}
 .ddp-box-contents .ddp-box-title .ddp-ui-open-view .ddp-ui-selected-option {position:relative; z-index:1;}
 
-.ddp-box-contents .ddp-box-title ul.ddp-box-select-check {display:none; position:absolute; bottom:109%; left:0; right:-70px; width:282px; z-index:15;  white-space:initial;}
+.ddp-box-contents .ddp-box-title ul.ddp-box-select-check {display:none; position:absolute; bottom:109%; left:0; right:-70px; width:282px; z-index:15; white-space:inherit; white-space:initial;}
 .ddp-box-contents .ddp-box-title ul.ddp-box-select-check  li.ddp-txt-view-name {display:block; padding:4px 20px 10px 20px; color:#b7b9c2; font-size:12px; font-weight:bold; text-align:left;}
 .ddp-box-contents .ddp-box-title ul.ddp-box-select-check li a span.ddp-data-pattern {display:block;}
 .ddp-box-contents .ddp-box-title ul.ddp-box-select-check li a span.ddp-data-pattern em:last-child {position:relative; padding:0 7px; margin-left:7px; color:#444; font-size:12px;}
@@ -5294,9 +5238,8 @@ ul.ddp-list-rule2 li.ddp-disabled2 .ddp-wrap-line-add {display:block;}
 .ddp-ui-popup-contents {position:relative; height:100%; margin-top:-120px; padding:120px 50px 0 50px; box-sizing: border-box;}
 .ddp-ui-popup-contents.ddp-info {padding-top:134px;}
 .ddp-ui-popup-contents.ddp-info2 {padding-top:168px;}
-.ddp-ui-popup-contents .ddp-box-message {position:absolute; top:84px; left:50px; right:50px;}
-.ddp-ui-popup-contents .ddp-popup-viewtable {position:absolute; top:170px; left:50px; right:50px; bottom:90px;}
-.ddp-ui-popup-contents .ddp-popup-viewtable .ddp-box-add-link {position:absolute; bottom:0; left:0; right:0;}
+.ddp-ui-popup-contents .ddp-box-message {position:absolute; top:84px; left:50px; right:50px;}.ddp-ui-popup-contents .ddp-popup-viewtable {position:absolute; top:170px; left:50px; right:50px; bottom:90px;}
+.ddp-ui-popup-contents .ddp-popup-viewtable .ddp-box-add-link {position:absolute; bottom:0; left:0; right:0; bottom:0;}
 .ddp-ui-popup-contents .ddp-box-viewtable {height:100%; box-sizing:Border-box;}
 .ddp-box-viewtable.ddp-viewtable-type .ddp-ui-gridbody {bottom:35px;}
 .ddp-box-viewtable.ddp-viewtable-type .ddp-box-add-link  {position:absolute; left:0; right:0; bottom:0; padding:12px 0 13px 0; text-align:center; border:none; border-top:1px solid #d0d1d8; background-color: #fff;
@@ -5320,10 +5263,6 @@ ul.ddp-list-rule2 li.ddp-disabled2 .ddp-wrap-line-add {display:block;}
 .ddp-wrap-flow2 .ddp-empty-flow .ddp-empty-title {display:block; padding-bottom:20px; color:#d0d1d8; font-size:28px; text-align:center;}
 .ddp-wrap-flow2 .ddp-empty-flow .ddp-empty-det {display:block; padding-bottom:25px; color:#b7b9c2; font-size:14px; text-align:center;}
 .ddp-wrap-flow2.ddp-type .ddp-box-flowdetail {position:relative; float:left; top:0; right:0; bottom:0; height:100%; border:none;}
-.ddp-wrap-flow2.ddp-type .ddp-box-flowdetail .ddp-no-data {display:table; width:100%; height:100%; position:absolute; top:0; left:0; right:0; bottom:0; background-color:#f6f6f7; z-index:2;}
-.ddp-wrap-flow2.ddp-type .ddp-box-flowdetail .ddp-no-data .ddp-no-data-in {display:table-cell; width:100%; height:100%; vertical-align:middle; text-align:center;}
-.ddp-wrap-flow2.ddp-type .ddp-box-flowdetail .ddp-no-data .ddp-no-data-in .ddp-btn-solid {width:166px;}
-.ddp-wrap-flow2.ddp-type .ddp-box-flowdetail .ddp-no-data .ddp-no-data-in .ddp-txt-data {display:block; padding-bottom:14px; color:#4b515b; font-size:16px;}
 .ddp-wrap-flow2.ddp-type.ddp-full .ddp-split-chart {width:100% !important;}
 .ddp-box-flowdetail {position:absolute; top:5px; right:6px; bottom:5px; width:288px; border:1px solid #90969f; background-color:#fff;}
 .ddp-box-flowdetail .ddp-box-in {position:absolute; top:0; left:0; right:0; bottom:35px; overflow-y:auto;}
@@ -5337,7 +5276,7 @@ ul.ddp-list-rule2 li.ddp-disabled2 .ddp-wrap-line-add {display:block;}
 .ddp-box-flowdetail .ddp-data-filename .ddp-ui-input .ddp-btn-check:hover {background-color:#9ca2cc;}
 .ddp-box-flowdetail .ddp-data-filename .ddp-ui-input {display:none; position:relative;z-index:1; }
 .ddp-box-flowdetail .ddp-data-filename.ddp-selected .ddp-ui-textarea {display:block;}
-.ddp-box-flowdetail .ddp-data-filename.ddp-selected .ddp-ui-input {display:block; position:relative; left:-4px; padding-right:30px; border:1px solid #b7b9c2; border-radius:3px; overflow:hidden;}
+.ddp-box-flowdetail .ddp-data-filename.ddp-selected .ddp-ui-input {display:block; position:Relative; top:-4px; left:-4px; padding-right:30px; border:1px solid #b7b9c2; border-radius:3px; overflow:hidden;}
 .ddp-box-flowdetail .ddp-data-filename .ddp-ui-input input {position:relative; padding:4px 0 4px 8px; width:100%; font-size:16px; font-weight:bold; border:none; box-sizing:border-box;}
 .ddp-box-flowdetail .ddp-data-filename.ddp-selected .ddp-ui-input textarea {display:block; width:100%; height:100%; padding:1px 0 2px 5px; font-family:sans-serif; font-size:16px; font-weight:bold; line-height:22px; border:none; background-color:#f6f6f7; box-sizing:border-box;}
 
@@ -5345,34 +5284,32 @@ ul.ddp-list-rule2 li.ddp-disabled2 .ddp-wrap-line-add {display:block;}
 .ddp-box-flowdetail .ddp-data-filename em.ddp-icon-dbdata {position:absolute; top:0; left:18px;}
 .ddp-box-flowdetail .ddp-data-filename em.ddp-icon-wrangled-m {position:absolute; top:0; left:18px;}
 .ddp-box-flowdetail .ddp-data-filename em.ddp-icon-file-sql {position:absolute; top:-2px; left:18px;}
-.ddp-box-flowdetail .ddp-data-filename span.ddp-txt-filename {display:inline-block; position:relative; max-width:100%; max-height:49px; padding:5px 23px 3px 5px;font-size:16px; color:#35393f; font-weight:bold; line-height:21px; font-family:sans-serif;box-sizing:border-box;overflow:hidden; cursor:pointer;
-	text-overflow: ellipsis;
-	display: -webkit-box;
-	-webkit-line-clamp: 2; /* 라인수 */
-	/* autoprefixer: off */
-	-webkit-box-orient: vertical;
-	/* autoprefixer: on */
-	word-wrap:break-word;
-}
+.ddp-box-flowdetail .ddp-data-filename span.ddp-txt-filename {display:inline-block; position:relative; max-width:100%; padding:0 23px 0 5px;font-size:16px; color:#35393f; font-weight:bold; line-height:22px; font-family:sans-serif;box-sizing:border-box;overflow:hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2; /* 라인수 */
+  /* autoprefixer: off */
+  -webkit-box-orient: vertical;
+  /* autoprefixer: on */
+  word-wrap:break-word; }
+.ddp-box-flowdetail .ddp-data-filename span.ddp-txt-filename .ddp-txt-filename-in {display:inline-block;}
+
 .ddp-box-flowdetail .ddp-data-filename.ddp-selected span.ddp-txt-filename {display:none;}
-.ddp-box-flowdetail .ddp-data-filename span.ddp-txt-filename .ddp-link-edit {display:none; position:absolute; top:6px; right:0; padding:3px 5px; vertical-align:top; font-size:0px;}
-.ddp-box-flowdetail .ddp-data-filename span.ddp-txt-filename:hover {background-color:#f6f6f7;}
-.ddp-box-flowdetail .ddp-data-filename span.ddp-txt-filename:hover .ddp-link-edit{display:inline-block;}
-.ddp-box-flowdetail .ddp-data-filename span.ddp-txt-filename:hover .ddp-link-edit .ddp-icon-edit2 {background-position:-11px top;}
+.ddp-box-flowdetail .ddp-data-filename span.ddp-txt-filename .ddp-link-edit {display:none; position:absolute; bottom:3px; right:0; padding:3px 5px; background-color:#fff; vertical-align:top; font-size:0px;}
+.ddp-box-flowdetail .ddp-data-filename:hover span.ddp-txt-filename .ddp-link-edit {display:inline-block;}
 .ddp-box-flowdetail .ddp-data-filename .ddp-icon-db {position:absolute; top:-4px; left:10px; display:inline-block; width:24px; height:24px;}
-.ddp-box-flowdetail .ddp-data-explain {position:relative; margin:5px 10px 0 10px;}
-.ddp-box-flowdetail .ddp-data-explain .ddp-txt-explain {display:inline-block; position:relative; max-width:100%; max-height:57px; padding:4px 23px 3px 6px; margin:-2px 0; line-height:17px; color:#b7b9c2; font-size:12px; font-family:sans-serif; box-sizing:border-box; overflow:hidden; cursor:pointer;
-	text-overflow: ellipsis;
-	display: -webkit-box;
-	-webkit-line-clamp: 3; /* 라인수 */
-	/* autoprefixer: off */
-	-webkit-box-orient: vertical;
-	/* autoprefixer: on */
-	word-wrap:break-word;}
-.ddp-box-flowdetail .ddp-data-explain .ddp-tag-target {display:inline-block; padding:2px 3px; margin:4px 0 0 6px;background-color:#f6f6f7; color:#90969f; font-size:10px;}
-.ddp-box-flowdetail .ddp-data-explain .ddp-txt-explain:hover {background-color:#f6f6f7;}
-.ddp-box-flowdetail .ddp-data-explain.ddp-selected .ddp-ui-input {display:block; position:relative; padding-right:23px; margin:-1px 0 0 0; border-radius:3px; border:1px solid #b7b9c2; overflow:hidden; box-sizing:border-box;}
-.ddp-box-flowdetail .ddp-data-explain.ddp-selected .ddp-ui-input textarea {display:block; width:100%; box-sizing:border-box; padding:5px 5px; height:51px; border:none; font-size:12px; line-height:17px; font-family:sans-serif;}
+.ddp-box-flowdetail .ddp-data-explain {position:relative; height:49px; margin:15px 10px 0 10px;}
+.ddp-box-flowdetail .ddp-data-explain .ddp-txt-explain {display:inline-block; position:relative; max-width:100%; padding:0 23px 0 5px; line-height:16px; color:#b7b9c2; font-size:12px; font-family:sans-serif; box-sizing:border-box; overflow:hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 3; /* 라인수 */
+  /* autoprefixer: off */
+  -webkit-box-orient: vertical;
+  /* autoprefixer: on */
+  word-wrap:break-word;}
+
+.ddp-box-flowdetail .ddp-data-explain.ddp-selected .ddp-ui-input {display:block; position:relative; top:-5px; padding-right:23px; border-radius:3px; border:1px solid #b7b9c2; overflow:hidden; box-sizing:border-box;}
+.ddp-box-flowdetail .ddp-data-explain.ddp-selected .ddp-ui-input textarea {display:block; width:100%; box-sizing:border-box; padding:5px 5px; height:51px; border:none; font-size:12px; line-height:16px; font-family:sans-serif;}
 .ddp-box-flowdetail .ddp-data-explain.ddp-selected .ddp-txt-explain {display:none;}
 
 .ddp-box-flowdetail .ddp-data-explain .ddp-ui-input {display:none; position:relative;}
@@ -5380,12 +5317,11 @@ ul.ddp-list-rule2 li.ddp-disabled2 .ddp-wrap-line-add {display:block;}
 .ddp-box-flowdetail .ddp-data-explain .ddp-ui-input .ddp-btn-check:hover {background-color:#9ca2cc;}
 .ddp-box-flowdetail .ddp-data-explain .ddp-ui-input input {width:100%;padding:8px 31px 8px 8px; border:none; background:#f6f6f7; box-sizing:border-box;}
 
-.ddp-box-flowdetail .ddp-data-explain .ddp-link-edit {display:none; position:absolute; right:0; top:4px; padding:3px 5px; z-index:1;}
+.ddp-box-flowdetail .ddp-data-explain .ddp-link-edit {display:none; position:absolute; right:0; bottom:2px; padding:3px 5px; background-color:#fff; z-index:1;}
 .ddp-box-flowdetail .ddp-data-explain.ddp-selected .ddp-link-edit {display:none;}
-.ddp-box-flowdetail .ddp-txt-explain:hover .ddp-link-edit {display:block; }
-.ddp-box-flowdetail .ddp-txt-explain:hover .ddp-link-edit .ddp-icon-edit2 {background-position:-11px top;}
+.ddp-box-flowdetail .ddp-data-explain:hover .ddp-link-edit {display:block;}
 
-.ddp-box-flowdetail .ddp-ui-databuttons {padding:10px 10px 0 10px; text-align:center;}
+.ddp-box-flowdetail .ddp-ui-databuttons {padding:15px 10px 0 10px; text-align:center;}
 .ddp-box-flowdetail .ddp-ui-databuttons .ddp-databuttons {margin-right:-35px;}
 .ddp-box-flowdetail .ddp-ui-databuttons .ddp-databuttons [class*="ddp-btn-"] {font-size:13px; padding:6px 10px;}
 .ddp-box-flowdetail .ddp-ui-databuttons .ddp-databuttons [class*="ddp-col-"] + [class*="ddp-col-"] {padding-left:6px;}
@@ -5420,8 +5356,7 @@ ul.ddp-list-rule2 li.ddp-disabled2 .ddp-wrap-line-add {display:block;}
 .ddp-box-flowdetail .ddp-ui-preview.ddp-type-rule .ddp-box-preview ul.ddp-list-rule2 li {padding-right:0;}
 .ddp-box-flowdetail .ddp-ui-preview.ddp-type-rule .ddp-box-preview ul.ddp-list-rule2 li + li {padding:5px 0 0 0;}
 .ddp-box-flowdetail .ddp-ui-preview.ddp-type-rule .ddp-data-rule {color:#b7bac2; font-size:12px;}
-.ddp-box-flowdetail dl.ddp-dl-detail.type-part {margin-top:10px}
-.ddp-box-flowdetail dl.ddp-dl-detail {padding:3px 0; clear:both;}
+.ddp-box-flowdetail dl.ddp-dl-detail {padding:5px 0; clear:both;}
 .ddp-box-flowdetail dl.ddp-dl-detail:before,
 .ddp-box-flowdetail dl.ddp-dl-detail:after {display:table; content:'';}
 .ddp-box-flowdetail dl.ddp-dl-detail:after {clear:both;}
@@ -5442,8 +5377,6 @@ ul.ddp-list-rule2 li.ddp-disabled2 .ddp-wrap-line-add {display:block;}
 .ddp-box-flowdetail dl.ddp-dl-detail dd .ddp-wrap-popup2 {position:absolute; top:20px; left:90px; max-width:155px;;}
 .ddp-box-flowdetail dl.ddp-dl-detail dd .ddp-wrap-popup2 ul li a {padding-left:34px;}
 .ddp-box-flowdetail dl.ddp-dl-detail dd .ddp-wrap-popup2 ul li a em.ddp-icon-flow {position:absolute; top:6px; left:12px;}
-.ddp-box-flowdetail dl.ddp-dl-detail.type-date {padding-left:10px;}
-.ddp-box-flowdetail dl.ddp-dl-detail.type-date dd .ddp-data-by {color:#90969f; display:block;}
 .ddp-box-flowdetail .ddp-wrap-part {margin:0 10px; padding-bottom:10px; border-bottom:1px solid #e7e7ea;}
 .ddp-box-flowdetail .ddp-wrap-part.ddp-bg {background-color:#f6f6f7; margin:20px 0 0 0; padding:0 10px 10px 10px;}
 .ddp-box-flowdetail .ddp-wrap-part.ddp-bg .ddp-ui-preview {padding-top:10px;}
@@ -5465,52 +5398,52 @@ a.ddp-type-link2 {color:#b7b9c2; font-size:12px; text-decoration: underline;}
 a.ddp-type-link2:hover {color:#4b515b;}
 a.ddp-type-link2:hover em.ddp-icon-delete2 {opacity:1;}
 
-/*em.ddp-icon-flow-dataset,*/
-/*em.ddp-icon-flow-wrangled,*/
-/*em.ddp-icon-flow-db,*/
-/*em.ddp-icon-flow-oracle,*/
-/*em.ddp-icon-flow-mysql,*/
-/*em.ddp-icon-flow-post,*/
-/*em.ddp-icon-flow-hive,*/
-/*em.ddp-icon-flow-presto,*/
-/*em.ddp-icon-flow-phoenix,*/
-/*em.ddp-icon-flow-tibero,*/
-/*em.ddp-icon-flow-file,*/
-/*em.ddp-icon-flow-xls,*/
-/*em.ddp-icon-flow-xlsx,*/
-/*em.ddp-icon-flow-csv,*/
-/*em.ddp-icon-flow-sql,*/
-/*em.ddp-icon-flow-json {display:inline-block; background:url(../images/icon_flow.png) no-repeat; vertical-align: middle;}*/
+em.ddp-icon-flow-dataset,
+em.ddp-icon-flow-wrangled,
+em.ddp-icon-flow-db,
+em.ddp-icon-flow-oracle,
+em.ddp-icon-flow-mysql,
+em.ddp-icon-flow-post,
+em.ddp-icon-flow-hive,
+em.ddp-icon-flow-presto,
+em.ddp-icon-flow-phoenix,
+em.ddp-icon-flow-tibero,
+em.ddp-icon-flow-file,
+em.ddp-icon-flow-xls,
+em.ddp-icon-flow-xlsx,
+em.ddp-icon-flow-csv,
+em.ddp-icon-flow-sql,
+em.ddp-icon-flow-json {display:inline-block; background:url(../images/icon_flow.png) no-repeat; vertical-align: middle;}
 
-/*em.ddp-icon-flow-dataset {width:19px; height:19px;}*/
-/*em.ddp-icon-flow-wrangled {width:16px; height:16px; background-position:left -20px;}*/
-/*em.ddp-icon-flow-db {width:16px; height:19px; background-position:left -37px;}*/
+em.ddp-icon-flow-dataset {width:19px; height:19px;}
+em.ddp-icon-flow-wrangled {width:16px; height:16px; background-position:left -20px;}
+em.ddp-icon-flow-db {width:16px; height:19px; background-position:left -37px;}
 
-/*em.ddp-icon-flow-oracle {width:21px; height:21px; background-position:left -57px;}*/
-/*em.ddp-icon-flow-mysql {width:21px; height:22px; background-position:left -79px;}*/
-/*em.ddp-icon-flow-post {width:21px; height:22px; background-position:left -102px;}*/
-/*em.ddp-icon-flow-hive {width:23px; height:22px; background-position:left -125px;}*/
-/*em.ddp-icon-flow-presto {width:20px; height:17px; background-position:left -148px;}*/
-/*em.ddp-icon-flow-phoenix {width:16px; height:25px; background-position:left -167px;}*/
-/*em.ddp-icon-flow-tibero  {width:19px; height:22px; background-position:left -192px;}*/
+em.ddp-icon-flow-oracle {width:21px; height:21px; background-position:left -57px;}
+em.ddp-icon-flow-mysql {width:21px; height:22px; background-position:left -79px;}
+em.ddp-icon-flow-post {width:21px; height:22px; background-position:left -102px;}
+em.ddp-icon-flow-hive {width:23px; height:22px; background-position:left -125px;}
+em.ddp-icon-flow-presto {width:20px; height:17px; background-position:left -148px;}
+em.ddp-icon-flow-phoenix {width:16px; height:25px; background-position:left -167px;}
+em.ddp-icon-flow-tibero  {width:19px; height:22px; background-position:left -192px;}
 
-/*em.ddp-icon-flow-file {width:16px; height:20px; background-position:left -215px;}*/
-/*em.ddp-icon-flow-xls {width:22px; height:20px; background-position:left -236px;}*/
-/*em.ddp-icon-flow-xlsx {width:22px; height:20px; background-position:left -257px;}*/
-/*em.ddp-icon-flow-csv {width:22px; height:20px; background-position:left -278px;}*/
-/*em.ddp-icon-flow-sql {width:22px; height:20px; background-position:left -299px;}*/
-/*em.ddp-icon-flow-json {width:22px; height:20px; background-position:left -336px;}*/
+em.ddp-icon-flow-file {width:16px; height:20px; background-position:left -215px;}
+em.ddp-icon-flow-xls {width:22px; height:20px; background-position:left -236px;}
+em.ddp-icon-flow-xlsx {width:22px; height:20px; background-position:left -257px;}
+em.ddp-icon-flow-csv {width:22px; height:20px; background-position:left -278px;}
+em.ddp-icon-flow-sql {width:22px; height:20px; background-position:left -299px;}
+em.ddp-icon-flow-json {width:22px; height:20px; background-position:left -336px;}
 /****	상세보기  *****/
 table.ddp-table-detail tbody tr td .ddp-box-sub {width:710px;}
 table.ddp-table-detail tbody tr td .ddp-txt-cut{
-	overflow:hidden;
-	text-overflow: ellipsis;
-	display: -webkit-box;
-	-webkit-line-clamp: 2; /* 라인수 */
-	/* autoprefixer: off */
-	-webkit-box-orient: vertical;
-	/* autoprefixer: on */
-	word-wrap:break-word;
+  overflow:hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2; /* 라인수 */
+  /* autoprefixer: off */
+  -webkit-box-orient: vertical;
+  /* autoprefixer: on */
+  word-wrap:break-word;
 }
 table.ddp-table-detail tbody tr td .ddp-data-form {display:block; padding-top:5px;}
 table.ddp-table-detail tbody tr td .ddp-data-form:first-of-type {padding-top:0px;}
@@ -5593,8 +5526,8 @@ table.ddp-table-detail tbody tr td .ddp-ui-summary ul.ddp-list-sub li a {color:#
 .ddp-edit-description.ddp-line:after {position:absolute; bottom:0; left:0; right:0;border-bottom:1px dotted #ccc; content:'';}
 .ddp-edit-description .ddp-box-textarea {display:none;}
 .ddp-edit-description .ddp-txt-description {position:relative; top:-3px;  font-size:13px; line-height:18px; cursor:pointer;}
-
-.ddp-edit-description .ddp-data-description {position:relative; padding-bottom:20px;}
+.ddp-edit-description .ddp-txt-description.ddp-nodata {color:#b7bac1;}
+.ddp-edit-description .ddp-data-description {position:relative; padding-bottom:30px;}
 .ddp-edit-description .ddp-data-description:hover .ddp-btn-edit {display:inline-block;}
 .ddp-edit-description .ddp-data-description .ddp-btn-edit {display:none; padding:4px 7px; position:absolute; bottom:0; left:0;  height:21px; color:#91969e; font-size:12px; font-style:italic; background-color:#f3f3f4; box-sizing:border-box;}
 .ddp-edit-description .ddp-data-description .ddp-btn-edit .ddp-icon-edit {display:inline-block; width:12px; height:13px; margin-right:3px; background:url(../images/icon_control.png) no-repeat; background-position:-39px -96px; vertical-align:top;}
@@ -5607,6 +5540,7 @@ table.ddp-table-detail tbody tr td .ddp-ui-summary ul.ddp-list-sub li a {color:#
 .ddp-edit-description.ddp-edit .ddp-box-textarea .ddp-textarea-buttons .ddp-box-btn:hover {background-color:#9ca2cc;}
 .ddp-edit-description.ddp-edit .ddp-box-textarea .ddp-textarea-buttons .ddp-box-btn em.ddp-icon-cancel {display:inline-block; width:9px; height:9px; position:absolute; top:50%; left:50%; margin:-5px 0 0 -5px; background:url(../images/btn_close.png) no-repeat; background-position:-20px -82px;}
 .ddp-edit-description.ddp-edit .ddp-box-textarea .ddp-textarea-buttons .ddp-box-btn .ddp-icon-check {display:inline-block; position:absolute; top:50%; left:50%; margin:-4px 0 0 -6px;  width:11px; height:8px; background:url(../images/icon_select2.png) no-repeat; background-position:-27px top;}
+
 
 
 .ddp-wrap-table-detail .ddp-wrap-edit3.ddp-type .ddp-label-type.ddp-normal {font-size:16px;}
@@ -5661,7 +5595,6 @@ table.ddp-table-solid tbody tr td .ddp-txt-long {display:inline-block; position:
 table.ddp-table-solid tbody tr td .ddp-txt-long .ddp-data-long {display:block; overflow:hidden; white-space:nowrap; text-overflow:ellipsis;}
 
 table.ddp-table-solid tbody tr td .ddp-txt-long .ddp-tag-global.type-tag {float:right; position:relative; margin-top:-1px; right:0; margin-left:5px; width:auto;}
-
 table.ddp-table-solid tbody tr td span.ddp-txt-colortype {color:#b7b9c2; font-size:14px;}
 table.ddp-table-solid tbody tr td .ddp-txt-long.ddp-global {padding-right:66px;}
 table.ddp-table-solid tbody tr td .ddp-txt-long.ddp-connection {padding-right:101px;}
@@ -5797,7 +5730,6 @@ em.ddp-icon-boxbtn-hadoop {display:inline-block; margin-right:15px; width:128px;
 em.ddp-icon-boxbtn-url,
 .ddp-btn-select.ddp-disabled:hover em.ddp-icon-boxbtn-url {width:23px; height:22px; background-position:left -299px;}
 
-
 .ddp-btn-select.ddp-disabled:before {display:inline-block; content:''; position:absolute; top:0; left:0; right:0; bottom:0; background-color:rgba(255,255,255,0.4); cursor: no-drop;}
 .ddp-btn-select.ddp-disabled:hover {background:none;  color:#4b515b;}
 
@@ -5861,16 +5793,9 @@ table.ddp-table-detail {table-layout:fixed; width:100%; margin-top:30px;}
 table.ddp-table-detail.ddp-mgt20 {margin-top:20px;}
 table.ddp-table-detail tbody tr > th,
 table.ddp-table-detail tbody tr > td {padding:7px 0; vertical-align: top; font-weight:normal;}
-table.ddp-table-detail tbody tr th {color:#91969e; font-size:13px; text-align:left;}
-table.ddp-table-detail tbody tr th .ddp-wrap-hover-info {display:inline-block; position:relative; cursor:pointer;}
-table.ddp-table-detail tbody tr th .ddp-wrap-hover-info .ddp-icon-info3 {display:inline-block; width:11px; height:11px; background:url(../images/icon_que.png) no-repeat; background-position:left -12px;}
-table.ddp-table-detail tbody tr th .ddp-wrap-hover-info .ddp-box-layout4 {display:none; position:absolute; bottom:-30px; left:100%; margin-left:5px;width:350px;}
-table.ddp-table-detail tbody tr th .ddp-wrap-hover-info:hover .ddp-box-layout4 {display:block;}
+table.ddp-table-detail tbody tr th {color:#b7bac1; font-size:13px; text-align:left;}
 table.ddp-table-detail tbody tr td {padding-right:40px;color:#4b515b; font-size:13px;}
 table.ddp-table-detail tbody tr td.ddp-line {line-height:30px;}
-table.ddp-table-detail tbody tr td > .ddp-box-det {width:500px; margin-top:7px;padding:10px 20px; background-color:#f6f6f7; border-radius:2px;}
-table.ddp-table-detail tbody tr td > .ddp-box-det .ddp-list-det li {padding:6px 0; font-size:13px;}
-table.ddp-table-detail tbody tr td > .ddp-box-det .ddp-list-det li:before {display:inline-block; margin-right:7px; vertical-align:middle; content:'•'}
 table.ddp-table-detail tr td .ddp-data-total {padding:15px 0 10px 0; color:#b7b9c2;}
 table.ddp-table-detail tr td .ddp-btn-pop {margin-top:-7px;}
 table.ddp-table-detail tr td .ddp-btn-pop.ddp-bg-black {border:1px solid #90969f; background-color:#90969f;}
@@ -5887,7 +5812,7 @@ ul.ddp-list-detail li .ddp-box-tag2 {display:inline-block; position:relative; fl
 ul.ddp-list-detail li .ddp-wrap-detailname {display:block; max-width:100%; overflow:hidden; white-space:nowrap; word-wrap:normal; text-overflow:ellipsis;}
 ul.ddp-list-detail li .ddp-wrap-detailname span.ddp-data-detailname {display:inline-block; color:#4c515a; font-size:14px; white-space:nowrap; text-overflow:ellipsis; overflow:hidden; word-wrap:normal; vertical-align: middle;}
 ul.ddp-list-detail li .ddp-wrap-detailname span.ddp-data-detailname span.ddp-data-in {display:inline-block; white-space:nowrap; text-overflow:ellipsis; overflow:hidden; word-wrap:normal;}
-ul.ddp-list-detail li .ddp-wrap-detailname span.ddp-data-summary  {color:#b7bac1; font-size:14px; vertical-align: middle;}
+ul.ddp-list-detail li .ddp-wrap-detailname span.ddp-data-summary  {color:#b7bac1; font-size:14px; vertical-align: top; vertical-align: middle;}
 ul.ddp-list-detail li .ddp-data-no {display:inline-block; float:left; width:45px; margin-left:-25px; text-align:center;}
 ul.ddp-list-detail li .ddp-wrap-detailinfo .ddp-type-lang {float:left; min-width:60px; color:#4c515a;}
 ul.ddp-list-detail li .ddp-wrap-detailinfo .ddp-data-state {float:left; min-width:65px; }
@@ -5898,7 +5823,7 @@ ul.ddp-list-detail.ddp-list-model li .ddp-wrap-detailname {text-overflow:ellipsi
 /**********************************************************************************
 	모델 매니저리스트
 **********************************************************************************/
-.ddp-ui-contents-top {position:fixed; left:0; right:0; top:54px; padding:0 80px; border-bottom:1px solid #d0d0d3; z-index:20;
+.ddp-ui-contents-top {position:fixed; left:0; right:0; top:54px; padding:0 80px; background-color:#fff; border-bottom:1px solid #d0d0d3; z-index:20;
 	background-color: #fff; /* layer fill content */
 	-moz-box-shadow: 0 1px 3px rgba(0,0,0,.15); /* drop shadow */
 	-webkit-box-shadow: 0 1px 3px rgba(0,0,0,.15); /* drop shadow */
@@ -5941,7 +5866,7 @@ ul.ddp-list-top-tab li.ddp-selected a {border-bottom:3px solid #666eb2; color:#6
 .ddp-ui-contents-list .ddp-ui-option span.ddp-data-total.ddp-type:after {display:none}
 .ddp-ui-contents-list .ddp-ui-option .ddp-list-option {position:relative; float:left; padding:0 17px 0 17px;}
 .ddp-ui-contents-list .ddp-ui-option .ddp-list-option .ddp-wrap-info {display:inline-block; position:relative; top:2px; vertical-align:top;}
-.ddp-ui-contents-list .ddp-ui-option .ddp-list-option .ddp-wrap-info .ddp-icon-info {display:inline-block; width:13px; height:13px; background:url(../images/icon_info.png) no-repeat; background-position:-14px -30px; cursor:pointer;}
+.ddp-ui-contents-list .ddp-ui-option .ddp-list-option .ddp-wrap-info .ddp-icon-info  {display:inline-block; width:13px; height:13px; background:url(../images/icon_info.png) no-repeat; background-position:-14px -30px; cursor:pointer;}
 .ddp-ui-contents-list .ddp-ui-option .ddp-list-option .ddp-wrap-info .ddp-icon-info:hover {background-position:-28px -30px;}
 .ddp-ui-contents-list .ddp-ui-option .ddp-list-option .ddp-wrap-info .ddp-box-layout4 {display:none; position:absolute; top:100%; left:-43px; width:235px; margin-top:8px;}
 .ddp-ui-contents-list .ddp-ui-option .ddp-list-option .ddp-wrap-info:hover .ddp-box-layout4 {display:block;}
@@ -6015,7 +5940,7 @@ ul.ddp-list-detail li .ddp-wrap-detailinfo .ddp-data-history .ddp-data-success {
 .ddp-wrap-union-list ul.ddp-list-union li .ddp-box-column:hover {border:1px solid #b7b9c2;}
 .ddp-wrap-union-list ul.ddp-list-union li .ddp-box-column em.ddp-icon-type-ab {position:absolute; top:50%; left:17px;}
 .ddp-wrap-union-list ul.ddp-list-union li .ddp-box-column input.ddp-input-column {display:none; width:100%; padding:6px 0; color:#4b515b; font-size:12px; border:none; box-sizing:border-box;}
-.ddp-wrap-union-list ul.ddp-list-union li .ddp-box-column span.ddp-data-column {display:block; width:100%; padding:6px 0; color:#4b515b; font-size:12px; white-space:nowrap; text-overflow:ellipsis; overflow:hidden; word-wrap:normal;}
+.ddp-wrap-union-list ul.ddp-list-union li .ddp-box-column span.ddp-data-column {display:block; width:100%; padding:6px 0; color:#4b515b; font-size:12px;  white-space:nowrap; text-overflow:ellipsis; overflow:hidden; word-wrap:normal;}
 
 .ddp-wrap-union-list ul.ddp-list-union li.ddp-selected .ddp-box-column input.ddp-input-column {display:block;}
 .ddp-wrap-union-list ul.ddp-list-union li.ddp-selected .ddp-box-column span.ddp-data-column {display:none}
@@ -6027,6 +5952,9 @@ ul.ddp-list-detail li .ddp-wrap-detailinfo .ddp-data-history .ddp-data-success {
 .ddp-ui-popup-contents a.ddp-dataset {position:absolute; top:93px; right:50px; font-weight:normal; cursor:pointer;}
 .ddp-ui-popup-contents a.ddp-dataset .ddp-icon-link-plus {margin-right:5px;}
 .ddp-ui-popup-contents.ddp-union {padding-top:140px;}
+
+
+
 
 .ddp-ui-union-set .ddp-ui-title a.ddp-btn-line:hover .ddp-icon-link-plus {background-position:-20px -2px; }
 .ddp-wrap-union-set {position:absolute; top:53px; left:0; right:0; bottom:0;}
@@ -6112,7 +6040,7 @@ table.ddp-table-union tr td .ddp-data-dropped strong {color:#666eb2; font-weight
 .ddp-box-file-create.ddp-file-single.type-upload .ddp-box-default .ddp-txt-file-info {padding-bottom:5px;}
 
 .ddp-box-file-create.ddp-file-single .ddp-file-progress {display:none; position:relative; width:100%; height:100%; vertical-align:middle; text-align:center; background-color:#fff;}
-.ddp-box-file-create.ddp-file-single.type-upload .ddp-file-progress {display:table-cell}
+.ddp-box-file-create.ddp-file-single.type-upload .ddp-file-progress {display:table-cell;}
 .ddp-box-file-create.ddp-file-single .ddp-file-progress.ddp-disabled:before {display:inline-block; position:absolute; top:0; left:0; right:0; bottom:0; content:''; z-index:1; background-color:rgba(255,255,255,0.7);}
 .ddp-box-file-create.ddp-file-single .ddp-file-progress .ddp-data-name {padding-bottom:7px; font-size:14px; color:#4b515b; font-weight:bold;}
 
@@ -6131,7 +6059,7 @@ table.ddp-table-union tr td .ddp-data-dropped strong {color:#666eb2; font-weight
 .ddp-box-file-create.ddp-file-single .ddp-file-progress .ddp-ui-condition .ddp-data-condition .ddp-txt-error {position:relative; font-style:normal; cursor:pointer;}
 .ddp-box-file-create.ddp-file-single .ddp-file-progress .ddp-ui-condition .ddp-data-condition .ddp-txt-error .ddp-box-layout4 {display:none; position:absolute; top:100%; right:0; margin-top:4px; width:275px; text-align:left; z-index:2;}
 .ddp-box-file-create.ddp-file-single .ddp-file-progress .ddp-ui-condition .ddp-data-condition .ddp-txt-error:hover .ddp-box-layout4 {display:block;}
-.ddp-box-file-create.ddp-file-single .ddp-file-progress .ddp-ui-condition .ddp-data-condition .ddp-txt-error .ddp-box-layout4 .ddp-data-det {font-weight:normal; color:#4b515b;}
+.ddp-box-file-create.ddp-file-single .ddp-file-progress .ddp-ui-condition .ddp-data-condition .ddp-txt-error .ddp-box-layout4 .ddp-data-det { font-weight:normal; color:#4b515b;}
 
 .ddp-txt-file-info .ddp-link-file {display:inline-block; position:relative; color:#4b515b; font-size:18px; text-decoration: underline; cursor: pointer;}
 .ddp-txt-file-info .ddp-link-file:hover {font-weight:bold;}
@@ -6171,8 +6099,6 @@ table.ddp-table-union tr td .ddp-data-dropped strong {color:#666eb2; font-weight
 .ddp-wrap-sheet .ddp-ui-sheet-list ul.ddp-list-sheet li label.ddp-label-checkbox input {left:14px}
 .ddp-wrap-sheet .ddp-ui-sheet-list ul.ddp-list-sheet li label.ddp-label-checkbox i {left:14px;}
 .ddp-wrap-sheet .ddp-ui-sheet-list ul.ddp-list-sheet li span.ddp-txt-checkbox {display:block; padding:14px 28px 14px 0; font-size:14px; color:#4c515a;}
-.ddp-wrap-sheet .ddp-ui-sheet-list ul.ddp-list-sheet li span.ddp-txt-checkbox .ddp-icon-error2 {margin-left:3px; position:relative; top:-2px;}
-
 
 .ddp-wrap-sheet .ddp-ui-sheet-list ul.ddp-list-sheet li label.ddp-label-radio {display:inline-block; position:absolute; top:0; left:0;  width:35px; height:100%; box-sizing:border-box;}
 .ddp-wrap-sheet .ddp-ui-sheet-list ul.ddp-list-sheet li label.ddp-label-radio input {left:14px;}
@@ -6219,9 +6145,10 @@ table.ddp-table-union tr td .ddp-data-dropped strong {color:#666eb2; font-weight
 .ddp-wrap-layout-popup.type-setting .ddp-wrap-advance .ddp-wrap-boxtype table tr td .ddp-wrap-info .type-hover:hover .ddp-ui-tooltip-info {display:block;}
 .ddp-wrap-layout-popup.type-setting .ddp-wrap-advance .ddp-wrap-boxtype table tr td .ddp-wrap-info .type-hover .ddp-ui-tooltip-info {top:100%; left:-100px; margin-top:5px; width:340px; white-space:normal;}
 .ddp-wrap-layout-popup.type-setting .ddp-wrap-advance .ddp-wrap-boxtype table tr td .ddp-wrap-info .type-hover .ddp-ui-tooltip-info .ddp-icon-view-top {left:105px; margin:0;}
-	/**********************************************************************************
-        page : 데이터 프리퍼레이션 리메인
-    **********************************************************************************/
+
+/**********************************************************************************
+	page : 데이터 프리퍼레이션 리메인
+**********************************************************************************/
 .ddp-page-rename {margin-top:-120px; padding:120px 50px 49px 50px; height:100%; box-sizing:border-box;}
 .ddp-wrap-rename {position:relative; height:100%;}
 .ddp-wrap-rename .ddp-result {position:absolute; top:-20px; left:0; right:0;}
@@ -6252,7 +6179,7 @@ table.ddp-table-column tr td .ddp-txt-error {display:block; padding:5px 0 0 0;}
 table.ddp-table-column tr td .ddp-txt-column {line-height:30px;}
 
 /**********************************************************************************
-	데이터소스 druid
+        데이터소스 druid
 **********************************************************************************/
 .ddp-wrap-sheet.ddp-wrap-druid {height:514px;}
 .ddp-wrap-sheet.ddp-wrap-druid .ddp-select-all {padding:9px 14px ; background-color:#f6f6f7; border-bottom:1px solid #e6e6e9;}
@@ -6269,7 +6196,7 @@ table.ddp-table-column tr td .ddp-txt-column {line-height:30px;}
 .ddp-layout-popuptype em.ddp-bg-popup {position:fixed; left:0; right:0; bottom:0; top:0; background-color:rgba(208,209,216,0.5); z-index:126;}
 
 .ddp-ui-popup-title {padding:49px 330px 49px 50px; text-align:left; overflow:hidden;}
-.ddp-ui-popup-title span.ddp-txt-title-name {width:100%; line-height:32px; box-sizing:border-box; color:#222; font-size:16px;}
+.ddp-ui-popup-title span.ddp-txt-title-name {width:100%; line-height:32px; color:#222; box-sizing:border-box; color:#222; font-size:16px;}
 
 .ddp-ui-popup {position:fixed; top:0; left:50%; bottom:0; width:960px; margin-left:-480px; background-color: #fff; /* layer fill content */
 	-moz-box-shadow: 0 0 20px rgba(0,0,0,.3); /* drop shadow */
@@ -6279,6 +6206,7 @@ table.ddp-table-column tr td .ddp-txt-column {line-height:30px;}
 .ddp-ui-pop-buttons {position:absolute; top:49px; right:47px;}
 .ddp-ui-pop-buttons .ddp-btn-pop {float:left;}
 .ddp-ui-pop-buttons .ddp-btn-pop + .ddp-btn-pop {margin-left:4px;}
+
 .ddp-box-pop-contents {position:absolute; top:104px; left:50px; right:50px; bottom:35px; background-color:#fafafa;}
 
 .ddp-ui-pop-top {padding:19px 10px; color:#b7b9c2; font-weight:bold; font-size:13px;}
@@ -6308,7 +6236,7 @@ table.ddp-table-column tr td .ddp-txt-column {line-height:30px;}
 .ddp-ui-popup-join .ddp-box-pop-contents.ddp-type {bottom:318px;}
 .ddp-ui-popup-join .ddp-box-pop-contents.ddp-type.ddp-default {bottom:55px;}
 .ddp-ui-popup-join .ddp-box-pop-contents.ddp-type .ddp-ui-part .ddp-data-none {bottom:22px; top:116px;}
-.ddp-ui-popup-join .ddp-box-pop-contents.ddp-type .ddp-ui-part .ddp-ui-grid-form {bottom:22px; top:116px; min-height:100px; overflow:auto;}
+.ddp-ui-popup-join .ddp-box-pop-contents.ddp-type .ddp-ui-part .ddp-ui-grid-form {bottom:22px; top:116px;}
 .ddp-ui-popup-join .ddp-box-pop-contents.ddp-type .ddp-ui-part .ddp-checkall {position:absolute;top:96px;left:9px;}
 .ddp-comment {color:#b7b9c2; font-size:11px;}
 .ddp-comment em {color:#666eb2;}
@@ -6361,7 +6289,7 @@ table.ddp-table-column tr td .ddp-txt-column {line-height:30px;}
 .ddp-ui-popup-join .ddp-btn-bottom {position:absolute; bottom:0; right:0; left:0; text-align:right; padding:15px 50px; }
 .ddp-ui-popup-join .ddp-btn-bottom .ddp-txt-error {font-style:italic;}
 .ddp-ui-popup-join .ddp-btn-bottom .ddp-btn-solid2 {position:relative; margin-left:10px;}
-.ddp-ui-popup-join .ddp-btn-bottom .ddp-btn-solid2 .ddp-ui-tooltip-info {display:none; right:100%; left:inherit; top:1px; margin-right:9px;}
+.ddp-ui-popup-join .ddp-btn-bottom .ddp-btn-solid2 .ddp-ui-tooltip-info {display:none; right:100%; margin-right:9px; left:inherit; top:1px; margin-right:9px;}
 .ddp-ui-popup-join .ddp-btn-bottom .ddp-btn-solid2.ddp-disabled:hover .ddp-ui-tooltip-info {display:block;}
 .ddp-ui-data-join {height:100%; border-bottom:1px solid #dbdce0}
 .ddp-ui-join-type .ddp-data-join {float:left; position:relative; width:50%; height:100%; padding:0 84px 0 20px; box-sizing:border-box;}
@@ -6421,7 +6349,7 @@ ul.ddp-list-form-join li em.ddp-icon-control-cut {position:absolute; top:5px; ri
 /* 에러 메세지 */
 .ddp-wrap-errortxt {position:absolute; top:0; left:0; right:0; bottom:0; text-align: center;}
 .ddp-wrap-errortxt:before {content: ""; display: inline-block; width: 1px; height: 100%; margin-right: 0; vertical-align: middle;}
-
+.ddp-txt-error {display: inline-block; color:#ca4b4b; font-size:13px;}
 .ddp-type-selectbox.ddp-type {position:relative; padding-left:28px; height:28px; box-sizing:border-box;}
 .ddp-type-selectbox.ddp-type ul.ddp-list-selectbox {position:relative; bottom:inherit; box-shadow:none; border:none;}
 .ddp-type-selectbox.ddp-type .ddp-box-selecbox {display:none; position:absolute; top:34px; left:0; right:0;  padding-bottom:10px; background-color:#fff; border:1px solid #ddd;
@@ -6517,9 +6445,9 @@ ul.ddp-list-dbtype li .ddp-label-dbtype:hover {border:1px solid #4b515b; color:#
 ul.ddp-list-dbtype li .ddp-label-dbtype .ddp-icon-db,
 ul.ddp-list-dbtype li .ddp-label-dbtype .ddp-img-icon{display:inline-block; position:absolute; top:50%; left:10px; margin-top:-12px; width:24px; height:24px;}
 
-/*ul.ddp-list-dbtype li .ddp-label-dbtype.type-postgre {width:122px; font-size:11px;}*/
+/*ul.ddp-list-dbtype li .ddp-label-dbtype.type-postgre {width:140px; font-size:11px;}*/
 
-/*ul.ddp-list-dbtype li .ddp-label-dbtype.type-pache {padding:10px 20px 10px 44px; font-size:12px;}*/
+/*ul.ddp-list-dbtype li .ddp-label-dbtype.type-pache {padding:10px 30px 10px 44px; font-size:12px;}*/
 /*ul.ddp-list-dbtype li .ddp-label-dbtype[class*="type-"]:before {display:inline-block; position:absolute; top:50%; left:14px;  background:url(../images/icon_dbtype_s.png) no-repeat;content:'';}*/
 /*ul.ddp-list-dbtype li .ddp-label-dbtype.type-oracle:before {width:21px; height:21px; margin-top:-11px;}*/
 /*ul.ddp-list-dbtype li .ddp-label-dbtype.type-mysql:before {width:22px; height:22px; margin-top:-11px; background-position:left -22px;}*/
@@ -6534,7 +6462,8 @@ ul.ddp-list-dbtype li .ddp-label-dbtype .ddp-img-icon{display:inline-block; posi
 .ddp-ui-dbconnect .ddp-ui-db-type label.ddp-label-type {display:block; padding-bottom:13px; color:#444; font-weight:bold;}
 .ddp-ui-dbconnect .ddp-ui-db-type label.ddp-label-type.ddp-type {font-weight:bold; font-size:13px;}
 .ddp-ui-dbconnect .ddp-ui-db-type .ddp-wrap-edit3.ddp-type {margin-bottom:20px;}
-.ddp-ui-dbconnect .ddp-ui-db-type .ddp-wrap-edit3.ddp-type .ddp-label-type {display:table-cell;}
+.ddp-ui-dbconnect .ddp-ui-db-type .ddp-wrap-edit3.ddp-type
+.ddp-label-type {display:table-cell;}
 
 .ddp-ui-dbconnect .ddp-ui-db-type ul.ddp-list-db-type {float:left; margin-bottom:10px; width:100%; border-radius:3px; border:1px solid #ddd; }
 .ddp-ui-dbconnect .ddp-ui-db-type ul.ddp-list-db-type li {float:left; position:relative; width:50%; height:98px; border-right:1px solid #ddd; border-bottom:1px solid #ddd; margin-bottom:-1px; box-sizing:border-box;}
@@ -6654,7 +6583,7 @@ ul.ddp-list-dbtype li .ddp-label-dbtype .ddp-img-icon{display:inline-block; posi
 
 .ddp-ui-import-option .ddp-ui-option-select .ddp-ui-input-form {padding-bottom:0px;}
 .ddp-ui-import-option .ddp-ui-option-select .ddp-ui-edit-db .ddp-wrap-edit {width:100%; border-top:1px solid #e7e7ea; border-bottom:1px solid #e7e7ea;}
-.ddp-ui-import-option .ddp-ui-option-select .ddp-ui-edit-db .ddp-ui-edit {display:block; position:relative; width:100%; height:250px; padding:28px 30px; font-size:14px; color:#444; border:none; background-color:#f9f9f9; white-space:pre-wrap; box-sizing:border-box; outline:none;}
+.ddp-ui-import-option .ddp-ui-option-select .ddp-ui-edit-db .ddp-ui-edit {display:block; position:relative; width:100%; height:250px; padding:28px 30px; font-size:14px; color:#444; box-sizing:border-box; border:none; background-color:#f9f9f9; white-space:pre-wrap; box-sizing:border-box; outline:none;}
 
 .ddp-ui-import-option .ddp-ui-option-select .ddp-ui-edit-db .ddp-ui-edit .ddp-wrap-editor {position:absolute; top:0; left:0; right:0; bottom:0; background-color:#f9f9f9;}
 .ddp-ui-import-option .ddp-ui-option-select .ddp-ui-edit-db .ddp-wrap-edit .ace_scroller {background-color:#f9f9f9;}
@@ -6698,10 +6627,6 @@ table.ddp-table-detail td .ddp-data-permission span.ddp-data-name {color:#b7bac1
 .ddp-ui-datadetail .ddp-label-detail  {display:block; margin-bottom:15px;}
 .ddp-ui-datadetail .ddp-box-synch {position:absolute; top:0; left:0; right:0;}
 .ddp-ui-datadetail .ddp-btn-solid2.type-link {position:absolute; top:40px; right:60px;}
-.ddp-ui-datadetail.type-detail .ddp-label-detail {font-size:13px;}
-.ddp-ui-datadetail.type-detail table.ddp-table-detail {padding:0 20px;}
-.ddp-ui-datadetail.type-detail {border-top:none; }
-.ddp-ui-datadetail.type-detail + .ddp-ui-datadetail.type-detail {margin-top:0; padding-top:30px}
 table.ddp-table-detail tr td dl.ddp-dl-detail {margin-top:16px;}
 table.ddp-table-detail tr td dl.ddp-dl-detail:first-of-type {margin-top:0;}
 table.ddp-table-detail tr td dl.ddp-dl-detail:last-of-type {margin-bottom:30px;}
@@ -6745,15 +6670,13 @@ table.ddp-table-detail tr td .ddp-box-sub dl.ddp-dl-detail:last-of-type {margin-
 **********************************************************************************/
 .ddp-pop-datadetail {overflow:inherit;}
 .ddp-pop-datadetail .ddp-wrap-grid-option .ddp-fleft {padding:7px 14px 6px 14px;}
-.ddp-pop-datadetail .ddp-wrap-grid-option .ddp-form-search {float:left; width:150px; margin-right:25px;}
+.ddp-pop-datadetail .ddp-wrap-grid-option .ddp-form-search {float:left; width:363px; margin-right:25px;}
 .ddp-pop-datadetail .ddp-wrap-grid-option .ddp-wrap-edit3 {float:left; width:auto;}
 .ddp-pop-datadetail .ddp-wrap-grid-option .ddp-wrap-edit3 label.ddp-label-type {width:inherit; padding-right:15px;}
 .ddp-pop-datadetail .ddp-wrap-grid-option .ddp-btn-reset3 {float:left;}
 .ddp-pop-datadetail .ddp-wrap-grid-option .ddp-form-label2 {float:Left; margin-left:40px;}
 .ddp-pop-datadetail .ddp-wrap-grid-option .ddp-form-label2 .ddp-type-selectbox {background-color:transparent;}
 .ddp-pop-datadetail .ddp-wrap-grid-option .ddp-form-label2 .ddp-type-selectbox.ddp-selected .ddp-wrap-popup2 {white-space:nowrap; right:inherit;}
-.ddp-pop-datadetail .ddp-wrap-grid-option .ddp-form-label2.ddp-mgl0 {margin-left:0;}
-.ddp-pop-datadetail .ddp-wrap-grid-option .ddp-form-label2 .ddp-type-selectbox {width:110px;}
 .ddp-pop-datadetail .ddp-wrap-grid-option .ddp-btn-reset3 {position:relative; top:7px; margin-left:10px;}
 .ddp-pop-datadetail .ddp-wrap-grid-option .ddp-data-form {padding:9px 13px 10px 13px;}
 .ddp-type-preview .ddp-ui-tab-contents.ddp-pop-datadetail .ddp-ui-grid2 {top:53px}
@@ -6817,12 +6740,13 @@ ul.ddp-ui-tab.ddp-type li .ddp-box-layout4.ddp-information a {padding:0px; borde
 .ddp-wrap-workbench {position:absolute; top:101px; left:0; right:0; bottom:0; width:initial; height:auto; overflow:hidden;}
 .ddp-wrap-workbench .ddp-ui-rnb {position:relative; display:table-cell;width:52px; background-color:#f8f7f9; z-index:31; vertical-align:top;}
 
+
 .ddp-wrap-workbench .ddp-layout-table {display:table; width:100%; height:100%;}
 .ddp-wrap-workbench .ddp-ui-benchlnb {display:table-cell; position:relative; width:455px; min-width:455px;  height:100%; background-color:#35393f; vertical-align: top; z-index:20;}
 .ddp-wrap-workbench .ddp-ui-benchlnb.ddp-fold {width:280px; min-width:260px;}
 .ddp-wrap-workbench .ddp-ui-benchlnb.ddp-fold .ddp-view-benchlnb {width:100%;}
 .ddp-wrap-workbench .ddp-ui-benchlnb.ddp-fold .ddp-ui-benchtable {display:none;}
-.ddp-wrap-workbench .ddp-ui-benchlnb .ddp-view-benchlnb {position:relative; float:left; height:100%; width:55%; min-width:250px;}
+.ddp-wrap-workbench .ddp-ui-benchlnb .ddp-view-benchlnb {position:relative; float:left; height:100%; width:55%;}
 .ddp-ui-benchlnb.ddp-close {width:9px; min-width:9px;}
 .ddp-ui-benchlnb.ddp-none {display:none;}
 .ddp-ui-benchlnb.ddp-close .ddp-view-benchlnb {width:9px; min-width:auto;}
@@ -6847,7 +6771,7 @@ ul.ddp-ui-tab.ddp-type li .ddp-box-layout4.ddp-information a {padding:0px; borde
 
 .ddp-ui-benchlnb .ddp-data-name .ddp-wrap-info {position:absolute; top:1px; right:0px; padding:3px; font-size:0px;}
 .ddp-ui-benchlnb .ddp-data-name .ddp-wrap-info .ddp-btn-info2 {display:inline-block; vertical-align: middle;}
-.ddp-ui-benchlnb .ddp-data-name .ddp-wrap-info .ddp-box-layout4 {display:none; width:auto; min-width:320px; max-width:520px;  position:fixed; top:140px; left:20px; z-index:10;}
+.ddp-ui-benchlnb .ddp-data-name .ddp-wrap-info .ddp-box-layout4 {display:none; width:auto; max-width:520px; min-width:320px; position:fixed; top:140px; left:20px; z-index:10;}
 .ddp-ui-benchlnb .ddp-data-name .ddp-wrap-info .ddp-box-layout4 .ddp-form-scroll {max-height:480px; overflow:auto;}
 .ddp-ui-benchlnb .ddp-data-name .ddp-wrap-info .ddp-box-layout4 table.ddp-table-info {table-layout:inherit; }
 
@@ -6952,7 +6876,7 @@ ul.ddp-list-table li em.ddp-icon-tableinfo.ddp-disabled:hover:before {background
 .ddp-box-layout4.ddp-layout-tableinfo .ddp-ui-list-type ul {padding:0 ;}
 .ddp-box-layout4 a.ddp-btn-close {display:inline-block; position:absolute; top:17px; right:20px; width:11px; height:11px !important; background:url(../images/btn_close.png) no-repeat; background-position:-12px -58px;}
 
-.ddp-box-layout4 .ddp-data-explain {padding:11px 15px; color:#b7bac1; font-size:12px; border-bottom:1px solid #e7e7ea; white-space:nowrap; text-overflow:ellipsis; overflow:hidden; box-sizing:border-box;}
+.ddp-box-layout4 .ddp-data-explain {padding:11px 15px; color:#b7bac1; font-size:12px; border-bottom:1px solid #e7e7ea; white-space:nowrap; text-overflow:ellipsis; overflow:hidden; overflow:hidden; box-sizing:border-box;}
 
 .ddp-box-layout4 .ddp-txt-strong {padding:20px 0 0 0; color:#d62d1f; font-size:12px;}
 .ddp-box-layout4 table.ddp-table-info {width:100%;padding:10px 0;}
@@ -6980,7 +6904,6 @@ ul.ddp-list-table li em.ddp-icon-tableinfo.ddp-disabled:hover:before {background
 .ddp-box-layout4 ul.ddp-list-type.ddp-list-popup li a {padding-right:30px;}
 .ddp-box-layout4 ul.ddp-list-type.ddp-list-popup li.ddp-selected a .ddp-data-name {color:#666eb2;}
 .ddp-box-layout4 .ddp-btn-more {display:inline-block; margin:0 20px 0 20px; color:#4b515b; font-size:12px; text-decoration: underline;}
-
 
 ul.ddp-list-rnb li a {display:block; position:relative; width:52px; height:52px;}
 ul.ddp-list-rnb li.ddp-selected a {background-color:#90969f;}
@@ -7094,13 +7017,13 @@ em.ddp-icon-navimenu {margin:-8px 0 0 -8px; width:16px; height:16px; background-
 .ddp-form-multy2 .ddp-ui-calen input.ddp-input-typebasic {padding-right:23px; width:100%; text-align:left; border:1px solid #d0d1d9; box-sizing:border-box;}
 .ddp-form-multy2 .ddp-ui-calen input.ddp-input-typebasic:focus {border:1px solid #b7b9c2;}
 
-.ddp-wrap-table-simple .ddp-table-thead {padding-right:18px; background-color:#e7e7eb;}
-table.ddp-table-simple {table-layout:fixed; width:100%;}
+.ddp-wrap-table-simple .ddp-table-thead { padding-right:18px; background-color:#e7e7eb;}
+table.ddp-table-simple { table-layout:fixed; width:100%;}
 table.ddp-table-simple tr th {position:relative; padding:2px 5px; color:#90969f; font-size:11px; text-align:left; font-weight:normal;}
 table.ddp-table-simple tr th em[class*="ddp-icon-array-"] {display:inline-block;}
 table.ddp-table-simple tr td {padding:5px 5px;text-align:left; color:#4b515b; font-size:12px; white-space:nowrap; text-overflow:ellipsis; overflow:hidden; word-wrap:normal; cursor: pointer;}
 table.ddp-table-simple tr td .ddp-icon-user-s,
-table.ddp-table-simple tr td .ddp-icon-group-s {display:inline-block; margin-right:5px; width:17px; text-align:right;}
+table.ddp-table-simple tr td .ddp-icon-group-s {display:inline-block;  margin-right:5px; width:17px; text-align:right;}
 table.ddp-table-simple tr td .ddp-icon-user-s {position:relative; right:2px;}
 table.ddp-table-simple tr td .ddp-icon-user-s:before,
 table.ddp-table-simple tr td .ddp-icon-group-s:before {display:inline-block; content:''; width:8px; height:10px; background:url(../images/icon_group.png) no-repeat; background-position:left -54px;}
@@ -7219,7 +7142,7 @@ table.ddp-table-simple tr td .ddp-ui-time {width:100%; color:#90969f; font-size:
 
 .ddp-wrap-editor {position:absolute; top:33px; left:0; right:0; bottom:41px; background-color:#fff; text-align:left; z-index:10; }
 .ddp-ui-empty {padding:18px 20px; color:#b7b9c3; font-size:12px;}
-.ddp-ui-empty2 {padding:15px 15px; color:#b7b9c3; font-size:12px;}
+
 .ddp-ui-error-message {padding:15px 15px; color:#e70000; font-size:12px;}
 .ddp-box-editer a.ddp-btn-beautifier {position:relative; float:left; width:32px; height:32px;  background:rgba(75,81,91,0.05); margin-right:2px;}
 .ddp-box-editer a.ddp-btn-beautifier:hover .ddp-ui-tooltip-info {display:block;}
@@ -7378,7 +7301,7 @@ table.ddp-table-simple tr td .ddp-ui-time {width:100%; color:#90969f; font-size:
 .ddp-box-query-result .ddp-wrap-result .ddp-ui-buttons .ddp-ui-link.ddp-selected .ddp-wrap-popup2 {display:block; position:absolute; bottom:100%; right:-20px; margin-top:5px; white-space:nowrap;}
 
 .ddp-box-query-result .ddp-wrap-result .ddp-ui-buttons .ddp-ui-link.ddp-selected .ddp-ui-tooltip-info {display:none !important;}
-.ddp-box-query-result .ddp-wrap-result .ddp-ui-buttons .ddp-ui-link .ddp-wrap-popup2 {display:none;}
+.ddp-box-query-result .ddp-wrap-result .ddp-ui-buttons .ddp-ui-link .ddp-wrap-popup2 {display:none; }
 .ddp-box-query-result .ddp-wrap-result .ddp-ui-buttons .ddp-ui-link.ddp-selected  .ddp-wrap-popup2 {display:block;}
 
 .ddp-box-query-result .ddp-wrap-result .ddp-ui-buttons a.ddp-btn-link > [class*="ddp-icon-"]{position:absolute; top:50%; left:50%;}
@@ -7463,8 +7386,6 @@ table.ddp-table-type2 tr td.ddp-info:hover {background-color:#f1f1f3 !important;
 table.ddp-table-type2 tr td.ddp-info .ddp-ui-info {position:absolute; top:50%; right:9px; margin-top:-7px; cursor:pointer; font-size:0px;}
 table.ddp-table-type2 tr td.ddp-info.ddp-selected .ddp-ui-info,
 table.ddp-table-type2 tr td.ddp-info:hover .ddp-ui-info {right:8px;}
-
-
 table.ddp-table-type2 tr td.ddp-info .ddp-ui-info .ddp-icon-error2 {position:relative; top:0;}
 table.ddp-table-type2 tr td.ddp-info .ddp-ui-info.ddp-selected .ddp-box-layout4.type-time {display:block; z-index:23;}
 table.ddp-table-type2 tr td.ddp-info .ddp-ui-info .ddp-box-layout4.type-time {display:none; width:330px; position:absolute; top:100%; right:-30px; margin-top:5px;}
@@ -7570,7 +7491,7 @@ table.ddp-table-form tbody tr td .ddp-txt-edit.ddp-selected + .ddp-icon-time {di
 table.ddp-table-form tbody tr td em.ddp-icon-error2 {position:absolute; right:0; top:1px; }
 
 table.ddp-table-form tbody tr td .ddp-txt-error-type {display:inline-block; max-width:100%;
-	white-space:nowrap; text-overflow:ellipsis; overflow:hidden;}
+  white-space:nowrap; text-overflow:ellipsis; overflow:hidden;}
 table.ddp-table-form tbody tr td .ddp-txt-error-type .ddp-icon-error2 {position:relative; top:0; left:0;float:right; margin-left:4px;}
 table.ddp-table-form tbody tr td .ddp-txt-error-type .ddp-txt-data {}
 
@@ -7586,7 +7507,7 @@ table.ddp-table-view tbody tr:hover td {background-color:#f0f0f2;}
 table.ddp-table-view tbody tr td .ddp-icon-view  {display:none; content:''; width:6px; height:11px; position:absolute; top:50%; right:0; margin-top:-6px; background:url(../images/icon_dataview.png) no-repeat; background-position:left -68px;}
 
 table.ddp-table-view tbody tr:hover td .ddp-icon-view {display:block;}
-table.ddp-table-view tbody tr.ddp-selected td {background-color:#f2f1f8;}
+table.ddp-table-view tbody tr.ddp-selected td { background-color:#f2f1f8;  }
 /*table.ddp-table-view tbody tr.ddp-selected td:before {position:absolute; top:0; left:0; right:-1px; bottom:0; border-top:1px solid #666eb2; border-bottom:1px solid #666eb2;content:'';}*/
 /*table.ddp-table-view tbody tr.ddp-selected td:first-of-type:before {border-left:1px solid #666eb2;}*/
 /*table.ddp-table-view tbody tr.ddp-selected td:last-of-type:before{right:0; border-right:1px solid #666eb2;}*/
@@ -7684,11 +7605,12 @@ ul.ddp-list-value li.ddp-total {color:#b7b9c2;}
 .ddp-wrap-value-setting .ddp-ui-setting .ddp-wrap-edit3 .ddp-ui-label-name .ddp-icon-recommend {display:inline-block; margin-left:5px;  position:relative; vertical-align: middle;}
 .ddp-wrap-value-setting .ddp-ui-setting .ddp-wrap-edit3 .ddp-view-label {float:left; width:100%;}
 .ddp-wrap-value-setting .ddp-ui-setting .ddp-wrap-edit3 .ddp-view-label .ddp-ui-label-name {float:left; width:initial;}
-.ddp-wrap-value-setting .ddp-ui-setting .ddp-wrap-edit3 .ddp-ui-error {display:block; margin-top:5px;}
+.ddp-wrap-value-setting .ddp-ui-setting .ddp-wrap-edit3 .ddp-ui-error {display:block; margin-top:5px; margin-left:0px; color:#eb5f58; font-size:12px; white-space:normal;}
+.ddp-wrap-value-setting .ddp-ui-setting .ddp-wrap-edit3 .ddp-ui-error.ddp-italic {font-style:italic;}
 
 .ddp-wrap-value-setting .ddp-ui-setting .ddp-wrap-edit3 .ddp-apply .ddp-ui-error {margin-right:-52px;}
 .ddp-wrap-value-setting .ddp-ui-setting .ddp-wrap-edit3 .ddp-ui-error.ddp-full {padding:0; margin-left:0;}
-.ddp-wrap-value-setting .ddp-ui-setting .ddp-wrap-edit3 .ddp-ui-error em.ddp-icon-error {display:inline-block; position:relative; top:0; margin-right:5px; width:13px; height:13px; background:url(../images/icon_info.png) no-repeat; background-position:-28px 0; vertical-align:middle;}
+.ddp-wrap-value-setting .ddp-ui-setting .ddp-wrap-edit3 .ddp-ui-error em.ddp-icon-error {display:inline-block; position:relative; top:-1px; margin-right:5px; width:11px; height:11px; background:url(../images/icon_info.png) no-repeat; background-position:-16px 0; vertical-align:middle;}
 .ddp-wrap-value-setting .ddp-ui-setting .ddp-wrap-edit3 .ddp-ui-label-name .ddp-wrap-hover-info {z-index:inherit;}
 .ddp-wrap-edit3 .ddp-ui-label-name .ddp-wrap-hover-info .ddp-box-layout4.ddp-box-time {width:290px; box-sizing:border-box;}
 .ddp-wrap-edit3 .ddp-ui-label-name .ddp-wrap-hover-info .ddp-box-layout4 .ddp-data-det dl.ddp-dl-det {padding:5px 0; overflow:hidden;}
@@ -7713,8 +7635,8 @@ ul.ddp-list-value li.ddp-total {color:#b7b9c2;}
 .ddp-wrap-value-setting .ddp-ui-setting .ddp-wrap-edit3 ul.ddp-list-checktype li .ddp-ui-example em.ddp-icon-check {display:inline-block; position:absolute; top:4px; left:0;width:8px; height:6px; background:url(../images/icon_select2.png) no-repeat; background-position:-47px top;}
 
 .ddp-wrap-value-setting .ddp-ui-setting .ddp-wrap-edit3 ul.ddp-list-checktype li .ddp-ui-error {display:block; padding:5px 0 0 16px; white-space:normal;}
-.ddp-ui-setting .ddp-ui-option-in {padding:0 0 0 12px;}
-.ddp-wrap-value-setting .ddp-ui-setting ul.ddp-list-dataview {margin:0 0 0 -12px; border-top:1px solid #e9e9ec; border-bottom:1px solid #e9e9ec}
+.ddp-ui-setting .ddp-ui-option-in {padding:9px 0 0 12px;}
+.ddp-wrap-value-setting .ddp-ui-setting ul.ddp-list-dataview {margin:0 -12px; border-top:1px solid #e9e9ec; border-bottom:1px solid #e9e9ec}
 .ddp-wrap-value-setting .ddp-ui-setting ul.ddp-list-dataview li {padding:5px 17px; color:#4b525b; font-size:13px;}
 .ddp-wrap-value-setting .ddp-ui-setting ul.ddp-list-dataview li.ddp-total {color:#b7b9c2; font-size:12px;}
 .ddp-wrap-value-setting .ddp-ui-setting ul.ddp-list-dataview li.ddp-nodata {color:#b6b9c1; font-size:13px;}
@@ -7803,6 +7725,7 @@ ul.ddp-ui-tab li.ddp-selected em.ddp-icon-group-s2 {opacity:1;}
 .ddp-wrap-permission .ddp-wrap-switch .ddp-form-search {width:270px;}
 .ddp-wrap-permission table.ddp-table-type2 tbody tr > td .ddp-data-owner {float:left; color:#b7b9c2;}
 .ddp-wrap-permission table.ddp-table-type2 tbody tr > td .ddp-txt-data {float:left; padding-right:4px;}
+
 .ddp-box-popupcontents2.ddp-setting-source {width:666px;}
 .ddp-box-popupcontents2.ddp-setting-source > .ddp-wrap-edit2:first-of-type {margin-top:0;}
 /**********************************************************************************
@@ -7816,6 +7739,7 @@ ul.ddp-ui-tab li.ddp-selected em.ddp-icon-group-s2 {opacity:1;}
 .ddp-box-grid-detail .ddp-script-preview {border-top:1px solid #eaeaed;overflow:auto; }
 .ddp-box-grid-detail .ddp-script-preview .ddp-txt-error3 {padding:10px; color:#ca4b4b; font-size:12px;}
 
+.ddp-box-grid-detail .ddp-script-preview {border-top:1px solid #eaeaed;overflow:auto;}
 .ddp-wrap-datadetail .ddp-label-name {display:block; padding:0 0 5px 0; color:#4b515b; font-size:12px; }
 .ddp-datagrid .ddp-ui-option .ddp-wrap-edit {padding-left:30px;}
 .ddp-datagrid .ddp-ui-option .ddp-reset {display:inline-block; float:Left; position:relative; top:8px; margin-left:10px;}
@@ -7865,8 +7789,7 @@ ul.ddp-ui-tab li.ddp-selected em.ddp-icon-group-s2 {opacity:1;}
 table.ddp-table-base {position:relative; width:100%; table-layout:fixed;overflow:Hidden;}
 table.ddp-table-base thead tr th,
 table.ddp-table-base tr td {padding:5px 0px; background-color:#e7e7ea; font-weight:normal; text-align:center;}
-
-table.ddp-table-base tr th {border:1px solid #fff; text-align:center; color:#4B515B;}
+table.ddp-table-base tr th {border:1px solid #fff; text-align:center; color:rgba(25,81,91,0.7);}
 table.ddp-table-base thead tr:last-of-type th {background-color:#fdfdfd;}
 table.ddp-table-base thead tr th .ddp-data-name {display:inline-block; float:left; width:33.333%; text-align:center; box-sizing:border-box;}
 table.ddp-table-base thead tr th .ddp-data-name2 {display:inline-block; float:left; width:50%; text-align:center; box-sizing:border-box;}
@@ -7933,7 +7856,7 @@ table.ddp-table-list2 tr th .ddp-link-edit em.ddp-icon-edit {display:inline-bloc
 
 table.ddp-table-list2 tr th:nth-child(2) {padding-left:25px;}
 table.ddp-table-list2 tr td {position:relative; padding:5px 50px 5px 25px; color:#4b515b; font-size:13px; border-bottom:4px solid #fff; background-color:#f6f6f7;}
-table.ddp-table-list2 tr td .ddp-wrap-info {position:absolute; top:50%; right:30px; margin-top:-7px;}
+table.ddp-table-list2 tr td .ddp-wrap-info {position:absolute; top:50%; right:30px; margin-top:-7px; }
 table.ddp-table-list2 tr td .ddp-wrap-info em.ddp-icon-info {display:inline-block; width:13px; height:13px; background:url(../images/icon_info.png) no-repeat; background-position:-14px -30px; cursor:pointer;}
 table.ddp-table-list2 tr td .ddp-wrap-info em.ddp-icon-info:hover {background-position:-28px -30px;}
 table.ddp-table-list2 tr td .ddp-wrap-info:hover .ddp-pop-form {display:block; min-width:683px; z-index:90}
@@ -7965,7 +7888,7 @@ ddp-box-source-create.ddp-box-type .ddp-wrap-edit3.ddp-type .ddp-type-selectbox 
 [class*="ddp-wrap-edit"] .ddp-box-sub .ddp-box-sub-option .ddp-label-type {width:100%;}
 [class*="ddp-wrap-edit"] .ddp-box-sub .ddp-box-sub-option .ddp-option-in label.ddp-label-radio + label.ddp-label-radio {margin-left:28px;}
 [class*="ddp-wrap-edit"] .ddp-box-sub .ddp-box-sub-option .ddp-label-radio + .ddp-box-option-input {top:-5px; }
-[class*="ddp-wrap-edit"] .ddp-box-sub .ddp-box-sub-option .ddp-label-radio + .ddp-box-option-input + .ddp-txt-error {position:relative; margin-left:5px; vertical-align:top;}
+[class*="ddp-wrap-edit"] .ddp-box-sub .ddp-box-sub-option .ddp-label-radio + .ddp-box-option-input + .ddp-txt-error {position:relative; top:-5px; margin-left:5px;}
 [class*="ddp-wrap-edit"] .ddp-box-sub .ddp-box-sub-option .ddp-label-radio {vertical-align:top; position:relative; top:2px;}
 
 /* 삭제 예정 */
@@ -8010,7 +7933,7 @@ table.ddp-wrap-boxdata tr td ul.ddp-list-sub li .ddp-sub {padding-left:15px;colo
 .ddp-form-time em.ddp-icon-time {position:absolute; top:50%; left:10px; margin-top:-7px; }
 
 .ddp-form-wrapper {display:inline-block; border-radius:3px; border:1px solid #d2d2d6; background-color:#fff;}
-.ddp-form-wrapper .ddp-type-selectbox {width:120px !important; float:Left; margin-right:0px; border:none; border-radius:0; border-right:1px solid #d2d2d6;}
+.ddp-form-wrapper .ddp-type-selectbox {width:120px !important; float:Left;  margin-right:0px; border:none; border-radius:0; border-right:1px solid #d2d2d6;}
 .ddp-form-wrapper .ddp-form-time {width:120px; border:none;}
 .ddp-ui-cycle .ddp-input-typebasic,
 .ddp-ui-cycle .ddp-input-apply{display:inline-block; width:250px; box-sizing:border-box;}
@@ -8019,10 +7942,10 @@ table.ddp-wrap-boxdata tr td ul.ddp-list-sub li .ddp-sub {padding-left:15px;colo
 table.ddp-table-form tr.ddp-tr-select td {color:rgba(76,81,90,0.5);}
 em.ddp-icon-select2 {display:inline-block; width:8px; height:6px; background:url(../images/icon_select2.png) no-repeat; background-position:-47px top;}
 
-.ddp-wrap-partition {position:relative; padding:10px 0 0 16px; overflow:Hidden; box-sizing:border-box;}
+.ddp-wrap-partition {position:relative;  padding:10px 0 0 16px; overflow:Hidden;box-sizing:border-box;}
 
 .ddp-fix-label {position:relative; z-index:1;}
-.ddp-ui-partition {display:block; white-space:nowrap; overflow:auto;}
+.ddp-ui-partition {display:block; white-space:nowrap;overflow:auto;}
 .ddp-list-partition {padding:0 2px 10px 2px;}
 .ddp-list-partition li {display:inline-block; position:relative; width:143px; padding-right:6px; box-sizing:border-box;}
 .ddp-list-partition li.ddp-disabled:before {display:inline-block; position:absolute; top:0; left:0; right:0; bottom:0; opacity:0.5; background-color:#fff; content:'';}
@@ -8063,9 +7986,8 @@ table.ddp-table-type3.ddp-popup tr td {padding:10px 10px 11px 10px;}
 
 .ddp-data-details .ddp-ui-detail .ddp-bar {position:relative; width:200px; height:15px; border-radius:2px; background-color:#f3f3f4;}
 .ddp-data-details .ddp-ui-detail .ddp-bar span {display:inline-block; position:absolute; top:0; left:0; bottom:0; border-radius:2px; background-color:#666eb2;}
-.ddp-wrap-detail.ddp-type label.ddp-label-detail + .ddp-ui-detail-in .ddp-box-histogram {margin:15px 0 50px 0;}
 .ddp-wrap-detail .ddp-box-histogram,
-.ddp-data-details .ddp-box-histogram {padding:10px; margin:0 0 50px 0; height:118px; border:1px solid #dddde2; box-sizing:border-box;}
+.ddp-data-details .ddp-box-histogram {padding:10px; margin:30px 0 50px 0; height:118px; border:1px solid #dddde2; box-sizing:border-box;}
 .ddp-data-details table.ddp-table-order {width:100%; margin-top:15px;}
 .ddp-data-details table.ddp-table-order tr td {padding:11px 13px;}
 .ddp-data-details ul.ddp-list-graph {margin:30px -12px 0 -12px; }
@@ -8073,8 +7995,10 @@ table.ddp-table-type3.ddp-popup tr td {padding:10px 10px 11px 10px;}
 .ddp-data-details.ddp-ui-preview-contents {position:relative; top:0; height:100%; padding-left:0; border:1px solid #d0d1d8; box-sizing:border-box; overflow:auto;}
 .ddp-data-details.ddp-ui-preview-contents.type-border {border:1px solid #cdd0e2;}
 .ddp-data-details.ddp-ui-preview-contents.type-border .ddp-table-detail4 {border:none; border-bottom:1px solid #cdd0e2;}
+.ddp-data-details.ddp-ui-preview-contents .ddp-table-form {white-space:nowrap;}
 .ddp-data-details.ddp-ui-preview-contents table tr th {border-bottom:1px solid #e9e9ec;}
 .ddp-data-details.ddp-ui-preview-contents .ddp-ui-selected-option.ddp-selected .ddp-wrap-popup2 {left:inherit; right:0px; width:140px; z-index:20;}
+
 
 .ddp-ui-preview-contents table.ddp-table-form.ddp-table-details tbody tr:nth-child(odd):hover td {background-color:#fafafa;}
 .ddp-ui-preview-contents table.ddp-table-form.ddp-table-details tbody tr:nth-child(even):hover td {background-color:#fff;}
@@ -8087,21 +8011,21 @@ table.ddp-table-type3.ddp-popup tr td {padding:10px 10px 11px 10px;}
 .ddp-ui-preview-contents table.ddp-table-form.ddp-table-details tbody tr td.ddp-info.ddp-disabled {cursor:initial !important;}
 .ddp-ui-preview-contents table.ddp-table-type2 tbody tr td.ddp-selected .ddp-input-form input.ddp-txt-input {display:inline-block; position:absolute; top:0; right:0; bottom:0; left:0; padding:12px 9px 13px 9px; content:'';}
 
-.ddp-ui-preview-contents .ddp-data-details.ddp-info {top:76px;}
-.ddp-ui-preview-contents .ddp-data-details {position:absolute; top:46px; left:0; right:0; bottom:0;}
-.ddp-ui-preview-contents .ddp-data-details .ddp-wrap-sourcename {top:0; overflow:auto;}
+
+
+.ddp-ui-preview-contents .ddp-data-details {margin-top:-46px; height:100%; padding-top:46px; box-sizing:border-box;}
+.ddp-ui-preview-contents .ddp-data-details .ddp-wrap-sourcename {top:46px; overflow:auto;}
 .ddp-ui-preview-contents .ddp-data-details .ddp-wrap-detail {overflow:auto; height:100%; box-sizing:border-box;}
 .ddp-data-details .ddp-wrap-table-detail {margin-right:0; margin-left:0px; padding:40px 0;}
 
 
 .ddp-data-details.ddp-ui-preview-contents .ddp-type-input tbody tr > td.ddp-padding-none {padding:0;}
 .ddp-data-details.ddp-ui-preview-contents .ddp-type-input tbody tr > td .ddp-input-form {position:static;}
-
 /**********************************************************************************
         사용자 리스트
 **********************************************************************************/
 a.ddp-link-selection {display:inline-block; width:88px; padding:5px 0; margin-right:2px; color:#666eb2; text-align:center; font-size:12px; border-radius:3px; border:1px solid  #666eb2; background-color:#f2f1f8;}
-a.ddp-link-selection:hover {color:#fff; border:1px solid #666eb2; background-color:#666eb2;}
+a.ddp-link-selection:hover {color:#fff; border:1px solid #666eb2; background-color:#666eb2; }
 a.ddp-link-selection em.ddp-icon-check {display:inline-block; width:11px; height:8px; margin-right:8px; background:url(../images/icon_select2.png) no-repeat; background-position:-15px -9px;}
 a.ddp-link-selection:hover em.ddp-icon-check {background-position:-15px -28px;}
 a.ddp-link-selection em.ddp-icon-close {display:inline-block; width:9px; height:9px; margin-right:8px; background:url(../images/btn_close.png) no-repeat; background-position:left -82px;}
@@ -8183,7 +8107,7 @@ a.ddp-btn-linktype:hover .ddp-icon-link-edit{background-position:-39px -97px;}
 
 table.ddp-list-form2 {width:100%; table-layout:fixed; margin-top:15px; border-top:1px solid #b7b9c2;border-bottom:1px solid #b7b9c2;}
 table.ddp-list-form2 tr td {padding:15px 18px; color:#4c515a; font-size:13px; font-weight:300;border-bottom:1px solid #e7e7ea;}
-table.ddp-list-form2 tr:last-of-type td {border-bottom:none;}
+table.ddp-list-form2 tr:last-of-type td {border-bottom:none; }
 table.ddp-list-form2 tr td .ddp-link-info.ddp-normal {position:relative; font-weight:normal;}
 table.ddp-list-form2 tr td .ddp-link-info.ddp-normal:hover {font-weight:bold;}
 table.ddp-list-form2 tr td .ddp-link-info.ddp-group {position:relative; padding-right:17px;color:#4c515a; font-size:13px; font-weight:normal;}
@@ -8278,7 +8202,7 @@ table.ddp-table-list tr td .ddp-txt-sql {
 .ddp-data-flow .ddp-title {padding:7px 0; color:#4b515b; font-size:13px; font-weight:bold; text-align:center;}
 .ddp-data-flow table.ddp-table-grid {border-bottom:none;}
 .ddp-data-flow .ddp-wrap-table {overflow:auto;}
-table.ddp-table-grid {table-layout:fixed; width:100%; border-collapse:collapse; border-top:1px solid #ebebed; border-bottom:1px solid #ebebed;;}
+table.ddp-table-grid {table-layout:fixed; table-layout:fixed; width:100%; border-collapse:collapse; border-top:1px solid #ebebed; border-bottom:1px solid #ebebed;;}
 table.ddp-table-grid tr th {padding:10px 7px; color:#4b515b; font-size:12px; text-align:left; font-weight:normal; border-left:1px solid #ebebed; border-bottom:1px solid #ebebed;}
 table.ddp-table-grid tr td {padding:5px 7px; font-size:12px; color:#4a525c; text-align:left; border-left:1px solid #ebebed; white-space:nowrap; text-overflow:ellipsis; overflow:hidden;}
 table.ddp-table-grid tr:nth-child(odd) td {background-color:#fafafa;}
@@ -8385,7 +8309,7 @@ em.ddp-icon-mt-data {width:13px; height:14px; background-position:left -59px;}
 **********************************************************************************/
 .ddp-logdetail {text-align:left;}
 .ddp-logdetail .ddp-data-logdet {display:block; white-space:nowrap; text-overflow:ellipsis; overflow:hidden;}
-.ddp-logdetail .ddp-data-logdet span{display:inline-block;}
+.ddp-logdetail .ddp-data-logdet span {display:inline-block;}
 .ddp-logdetail .ddp-data-logdet.ddp-long {display:block; text-overflow:ellipsis; overflow:hidden; word-wrap:normal;}
 .ddp-logdetail .ddp-wrap-logdetail {float:right; margin-top:-3px; display:none;}
 .ddp-logdetail .ddp-wrap-logdetail .ddp-btn-detail {position:relative; display:inline-block; margin-left:5px; width:19px; height:19px; }
@@ -8410,7 +8334,7 @@ em.ddp-icon-mt-data {width:13px; height:14px; background-position:left -59px;}
 **********************************************************************************/
 .ddp-wrap-error {display:table; width:100%; height:100%; background:url(../images/bg_error.png) no-repeat; background-size:100% 100%;}
 .ddp-wrap-error .ddp-ui-error {display:table-cell; width:100%; text-align:center; vertical-align: middle;}
-.ddp-wrap-error .ddp-ui-error .ddp-num-error {display:block; color:#7575ea; font-size:110px; font-weight: 100; }
+.ddp-wrap-error .ddp-ui-error .ddp-num-error {display:block; color:#7575ea; font-size:110px; font-family: "Avenir Next"; font-weight: 100; }
 .ddp-wrap-error .ddp-ui-error .ddp-txt-error {display:block; color:#7575ea; font-size:28px; font-weight: 300;}
 .ddp-wrap-error .ddp-ui-error .ddp-det-error {display:block; padding:40px 0 0 0; color:#272950; font-size:16px; font-weight: 300;}
 .ddp-wrap-error .ddp-ui-error .ddp-ui-buttons {padding:40px 0 0 0 ;text-align:center;}
@@ -8427,7 +8351,7 @@ a.ddp-btn-linetype:hover {border:1px solid #7575ea; color:#7575ea;}
 .ddp-box-application {float:left; width:50%; height:500px; padding:19px 19px; border-right:1px solid #d0d1d8;background-color:#f6f6f7; box-sizing:border-box; overflow:auto;}
 .ddp-box-application ul.ddp-list-application li {width:50%; float:left; padding:5px 5px; box-sizing:border-box;}
 .ddp-box-application ul.ddp-list-application li a {display:table; height:98px; width:100%; }
-.ddp-box-application ul.ddp-list-application li a .ddp-add-application {display:table-cell; position:relative; width:100%; height:100%; border:1px solid #ddd; background-color:#fff; text-align:center; vertical-align:middle;}
+.ddp-box-application ul.ddp-list-application li a .ddp-add-application {display:table-cell; position:relative; width:100%; height:100%; border:1px solid #f6f6f7; border:1px solid #ddd; background-color:#fff; text-align:center; vertical-align:middle;}
 .ddp-box-application ul.ddp-list-application li a:hover .ddp-add-application:before,
 .ddp-box-application ul.ddp-list-application li.ddp-selected a .ddp-add-application:before{display:inline-block; position:absolute; top:0; left:0; right:0; bottom:0; border:1px solid #454545; content:'';}
 .ddp-box-application ul.ddp-list-application li a .ddp-add-application span.ddp-bg-selected {display:none; position:absolute; bottom:0; left:0; right:0; height:24px; background-color:#454545;}
@@ -8515,13 +8439,14 @@ ul.ddp-list-setinfo li .ddp-setinfo-contents .ddp-ui-setinfo .ddp-txt-title {col
 .ddp-sso-loading .ddp-txt-welcome {padding-bottom:10px; color:#272950; font-size:22px; text-align:center;}
 .ddp-sso-loading .ddp-txt-message {color:#272950; font-size:16px; font-weight:300; text-align:center;}
 
+
 /**********************************************************************************
 	메타데이터
 **********************************************************************************/
 .ddp-ui-meta {width:666px; margin:0 auto; text-align:left;}
 .ddp-wrap-create { position:relative;}
 .ddp-wrap-create .ddp-list-option {position:absolute; top:-7px; right:0;}
-.ddp-wrap-create .ddp-list-option .ddp-btn-line-s {font-size:12px; float:left; margin-left:4px;}
+.ddp-wrap-create .ddp-list-option .ddp-btn-line-s {font-size:12px;}
 .ddp-wrap-create .ddp-label-title {display:block; padding-bottom:25px; color:#4c515a; font-weight:bold; font-size:14px;}
 .ddp-ui-meta .ddp-wrap-edit3.ddp-type .ddp-label-type {width:160px}
 .ddp-ui-meta.ddp-dictionary .ddp-wrap-edit3.ddp-type .ddp-label-type {width:200px;}
@@ -8553,13 +8478,15 @@ table.ddp-table-type2 tbody tr td table.ddp-table-code tr td {background:none; c
 .ddp-list-code [class*="ddp-col-"] {padding:0 3px;}
 .ddp-list-code .ddp-icon-close {display:inline-block; position:absolute; top:8px; right:0; width:14px; height:14px; background:url(../images/btn_sclose.png) no-repeat; background-position:-15px -131px;}
 .ddp-list-code .ddp-data-error {display:block; padding:0 3px; color:#e70000; font-size:12px; font-style:italic;}
-.ddp-list-code .ddp-data-error:before {display:inline-block; position:relative; top:-1px; width:13px; height:13px; vertical-align:middle; background:url(../images/icon_info.png) no-repeat; background-position:-28px top; content:'';}
+.ddp-list-code .ddp-data-error:before {display:inline-block; width:13px; height:13px; vertical-align:middle; background:url(../images/icon_info.png) no-repeat; background-position:-28px top; content:'';}
 .ddp-list-code .ddp-txt-label {display:block; padding:7px 9px;color:#90969f; font-size:13px;}
 .ddp-list-code .ddp-ui-radio.ddp-select-radio {position:absolute; top:50%; left:-20px; margin-top:-6px;}
 .ddp-list-code.ddp-btn-multy {padding-right:133px;}
 
 .ddp-list-code.ddp-btn-multy .ddp-btn-gray {position:absolute; top:0; right:27px; width:100px; padding:7px; text-align:center; box-sizing:border-box;}
 .ddp-list-code.ddp-btn-multy .ddp-input-typebasic.ddp-permission {width:100%; margin-right:-107px;}
+
+
 
 .ddp-list-code .ddp-input-value {margin-right:-108px;}
 .ddp-box-code .ddp-btn-add {display:inline-block; padding:7px 14px; margin-right:68px;border-radius:2px; color:#fff; font-size:13px; background-color:#b7b9c2;}
@@ -8572,91 +8499,12 @@ table.ddp-table-type2 tbody tr td table.ddp-table-code tr td {background:none; c
 .ddp-wrap-codetable .ddp-txt-right .ddp-btn-pop { margin-left:4px;}
 .ddp-wrap-codetable .ddp-list-option {position:absolute; top:-7px; right:0;}
 
-.ddp-wrap-codetable .ddp-list-option  .ddp-btn-line-s {font-size:12px; float:left; margin-left:4px;}
+.ddp-wrap-codetable .ddp-list-option  .ddp-btn-line-s {font-size:12px;}
 .ddp-wrap-codetable .ddp-code-btn {text-align:right;}
 
 /**********************************************************************************
-	메타데이터 (Admin)
+	메타데이터 (01meta data)
 **********************************************************************************/
-.ddp-wrap-flow2.type-admin {top:219px;}
-.ddp-wrap-flow2.type-admin .ddp-box-chart {top:0;}
-.ddp-wrap-flow2.type-admin .ddp-box-flowdetail .ddp-box-in {bottom:0;}
-.ddp-admin-detail {padding:17px 50px 0 50px;}
-.ddp-admin-detail .ddp-wrap-tab {margin-bottom:0;}
-.ddp-flow-option {margin:9px 8px; padding:6px 0; background-color:#f6f6f7;}
-.ddp-flow-option .ddp-wrap-edit {float:left; margin-left:15px}
-.ddp-flow-option .ddp-wrap-edit + .ddp-wrap-edit {margin-left:20px;}
-.ddp-flow-option .ddp-wrap-edit .ddp-type-selectbox {width:125px; background-color:#fff;}
-.ddp-flow-option .ddp-wrap-edit .ddp-ui-edit-option.ddp-inline .ddp-label-radio {margin-right:10px;}
-.ddp-flow-option .ddp-fright {padding-right:15px;}
-.ddp-flow-option .ddp-box-btn2,
-.ddp-flow-option .ddp-list-tab-button {float:left;}
-.ddp-flow-option .ddp-box-btn2 {position:relative; top:8px; padding-right:12px; margin-right:12px; color:#4b515b;}
-.ddp-flow-option .ddp-box-btn2:before {display:inline-block; position:absolute; top:-3px; right:0; height:20px; border-left:1px solid #e7e7ea; content:'';}
-.ddp-flow-option .ddp-box-btn2 .ddp-icon-widget-gridsave {margin-right:2px; vertical-align:middle;}
-.ddp-flow-option .ddp-list-tab-button {position:relative; top:3px; margin:0;}
-ul.ddp-list-tab-button li a .ddp-icon-lineage-depth,
-ul.ddp-list-tab-button li a .ddp-icon-lineage-grid {display:inline-block; width:13px; height:13px; position:absolute; top:50%; left:50%; margin:-7px 0 0 -7px; background:url(../images/icon_lineage_grid.png) no-repeat;}
-ul.ddp-list-tab-button li a .ddp-icon-lineage-grid {background-position:left -14px;}
-
-ul.ddp-list-tab-button li.ddp-selected a .ddp-icon-lineage-depth,
-ul.ddp-list-tab-button li.ddp-selected a .ddp-icon-lineage-grid {background-position-x:-14px;}
-.ddp-wrap-flow2.type-admin .ddp-box-chart .ddp-wrap-grid {position:relative; padding:0 8px;overflow:hidden;}
-.ddp-wrap-flow2.type-admin .ddp-box-chart .ddp-wrap-grid .ddp-icon-view {display:inline-block; position:absolute; top:0; left:50%; margin-left:-20px; width:40px; height:32px; border-radius:4px; border:2px solid #4b515b; background-color:#f6f6f7; box-sizing:border-box;}
-.ddp-wrap-flow2.type-admin .ddp-box-chart .ddp-wrap-grid .ddp-icon-view:before {display:inline-block; position:absolute; top:50%; left:50%; margin:-6px 0 0 -7px; width:14px; height:12px; background:url(../images/icon_move.png) no-repeat; background-position:left -28px; content:'';}
-.ddp-chart-grid {float:left; width:50%; border-radius:2px; border:1px solid #d3d3da; box-sizing:Border-box;}
-.ddp-chart-grid .ddp-top-title {padding:7px 0; background-color:#90969f; color:#fff; font-size:14px; font-weight:bold; text-align:center;}
-.ddp-chart-grid .ddp-top-title.type-to {background-color:#4b515b;}
-.ddp-chart-grid table.ddp-table-basic {}
-.ddp-chart-grid table.ddp-table-basic tr th {padding:8px 0 8px 20px; color:#90969f; font-size:12px; text-align:left; font-weight:normal; border-bottom:1px solid #d0d1d8;}
-.ddp-chart-grid table.ddp-table-basic tr td {padding:8px 0 8px 20px; color:#4b515b;}
-
-.ddp-chart-grid table.ddp-table-basic tr:nth-child(odd) td {background-color:#f7f7f8;}
-
-/**********************************************************************************
-	메타데이터 (Admin_lineage)
-**********************************************************************************/
-.ddp-tag-type {display:inline-block; min-width:50px; text-align:center; border-radius:2px; padding:1px; color:#fff; font-size:10px; line-height:16px; }
-.ddp-tag-type.type-column {background-color:#93a3ba; opacity:0.8;}
-.ddp-tag-type.type-metadata {background-color:#566b8a;}
-.ddp-wrap-grid.type-information {position:relative; padding-bottom:30px;}
-.ddp-wrap-grid.type-information .ddp-icon-view {display:inline-block; position:absolute; top:0; left:50%; margin-left:-20px; width:40px; height:26px; border:2px solid #4b515b; border-radius:4px; background-color:#f6f6f7; box-sizing:border-box;}
-.ddp-wrap-grid.type-information .ddp-icon-view:before {display:inline-block; position:absolute; top:50%; left:50%; margin:-6px 0 0 -7px; width:14px; height:12px; background:url(../images/icon_move.png) no-repeat; background-position:left -28px; content:'';}
-.ddp-wrap-grid.type-information .ddp-chart-grid {border:none;}
-.ddp-wrap-grid.type-information .ddp-chart-grid .ddp-top-title {padding:5px 0; font-size:13px; font-weight:normal;}
-.ddp-wrap-grid.type-information .ddp-chart-grid .ddp-wrap-edit3 {margin-top:8px;}
-.ddp-wrap-grid.type-information .ddp-chart-grid .ddp-view-edit {padding:0 16px 0 17px; margin-top:22px;}
-.ddp-type-contents-in .ddp-box-edit {clear:both; padding:20px; background-color:#f6f6f7;}
-.ddp-type-contents-in .ddp-box-edit .ddp-txt-title {display:block; padding-bottom:10px; color:#4b515b; font-size:13px;}
-.ddp-type-contents-in .ddp-box-edit textarea {display:block; width:100%; height:90px; padding:17px 10px; border-radius:2px; background-color:#fff; border:1px solid #d0d1d8; box-sizing:border-box;}
-
-.ddp-box-popupcontents.type-file {padding-bottom:40px; box-sizing:border-box;}
-.ddp-box-popupcontents.type-file .ddp-box-synch {position:absolute; bottom:0; left:0;}
-.ddp-box-synch a.ddp-link {float:right; font-size:12px; text-decoration:underline; color:rgba(75, 81, 91, 0.8);}
-.ddp-box-synch a.ddp-link em.ddp-icon-download2 {margin-right:4px; }
-.ddp-box-popupcontents.ddp-wrap-file-create2 {width:1192px;}
-.ddp-wrap-variable.type-total {padding-top:22px !important; position:relative;}
-.ddp-wrap-variable.type-total .ddp-txt-total {position:absolute; top:0; left:0; color:#4b515b; font-size:12px;}
-.ddp-wrap-variable.type-vertical .ddp-wrap-sheet {display:flex; flex-direction: column; justify-content:center; align-items:center;}
-.ddp-wrap-variable.type-vertical .ddp-wrap-sheet .ddp-txt-result {display:flex; color:#90969f; font-size:18px;}
-.ddp-wrap-variable.type-vertical .ddp-wrap-sheet .ddp-btn-selection {margin-top:15px;}
-.ddp-wrap-variable.type-vertical .ddp-wrap-sheet .ddp-btn-selection .ddp-icon-download2 {margin-right:6px; vertical-align:middle;}
-.ddp-wrap-variable.type-vertical .ddp-wrap-sheet .ddp-txt-result.type-error {color:#dc494f;}
-.ddp-wrap-variable .ddp-grid-detail {border:1px solid #d0d1d8; height:100%; overflow:auto; box-sizing:border-box;}
-.ddp-wrap-variable .ddp-grid-detail .ddp-table-form {white-space:nowrap;}
-.ddp-type-top-option .ddp-type-search.type-edit-search {width:240px; position:relative;}
-.ddp-configure-schema .ddp-flex .ddp-type-top-option {padding-bottom:5px;}
-.ddp-configure-schema .ddp-flex {display:flex; flex-direction: column;width:100%; height:100%; padding-bottom:32px; box-sizing:border-box;}
-.ddp-configure-schema .ddp-flex .ddp-data-details.ddp-ui-preview-contents {position:relative; flex:auto; top:0; left:0; right:0; bottom:0;}
-.ddp-ui-preview-contents table.ddp-table-form.ddp-table-details.ddp-cursor tbody tr td .ddp-btn-control {display:none; position:absolute; top:50%; right:13px; margin-top:-10px;}
-.ddp-ui-preview-contents table.ddp-table-form.ddp-table-details.ddp-cursor tbody tr:hover td {background-color:#f6f6f7;}
-.ddp-ui-preview-contents table.ddp-table-form.ddp-table-details.ddp-cursor tbody tr:hover td .ddp-btn-control {display:block; }
-.ddp-ui-preview-contents table.ddp-table-form.ddp-table-details.ddp-cursor tbody tr.ddp-add td {background-color:#f2f1f8; border-bottom:1px solid #dddddd;}
-.ddp-ui-preview-contents table.ddp-table-form.ddp-table-details.ddp-cursor tbody tr.ddp-add td.ddp-selected {border-bottom:1px solid #9ca2cc; }
-.ddp-ui-preview-contents table.ddp-table-form.ddp-table-details.ddp-cursor tbody tr.ddp-add .ddp-btn-control {display:block;}
-.ddp-ui-preview-contents table.ddp-table-form.ddp-table-details.ddp-cursor tbody tr td.ddp-input-form:hover {background:#f2f1f8 !important}
-/**********************************************************************************
-	메타데이터 (01meta data)    **********************************************************************************/
 .ddp-wrap-meatadata {width:600px; margin:0 auto 0 auto; text-align:left;}
 .ddp-wrap-meatadata .ddp-type-data {width:390px;}
 
@@ -8685,13 +8533,14 @@ ul.ddp-list-tab-button li.ddp-selected a .ddp-icon-lineage-grid {background-posi
 .ddp-wrap-catalogs .ddp-type-label {padding:47px 24px 10px 24px; color:#4b515b; font-size:16px;}
 .ddp-wrap-catalogs .ddp-btn-folding {position:absolute; top:50%; left:50%; margin:-6px 0 0 -7px;}
 .ddp-wrap-catalogs .ddp-btn-folding:before {display:inline-block; width:14px; height:11px; background:url(../images/icon_folding2.png) no-repeat; background-position:-30px top; content:'';}
+.ddp-ui-searching {position:relative; margin:0 24px 0 24px; padding:0 25px 0 40px; background-color:#f6f6f7}
 .ddp-wrap-catalogs .ddp-btn-folding:hover:before {background-position-x:-45px;}
 .ddp-wrap-catalogs .ddp-btn-folding .ddp-ui-tooltip-info.ddp-down {right:inherit; left:-10px;}
 .ddp-wrap-catalogs .ddp-btn-folding .ddp-ui-tooltip-info.ddp-down .ddp-icon-view-top {left:16px; right:inherit;}
-
-
+.ddp-ui-searching .ddp-icon-search {display:inline-block; position:absolute; top:50%; left:11px; margin-top:-9px;  width:20px; height:19px; background:url(../images/btn_search.png) no-repeat;}
+.ddp-ui-searching input {display:block; width:100%; padding:8px 0; border:none; color:#666db7; font-size:14px; line-height:21px; background:none;}
 .ddp-ui-catalog-contents {position:absolute; top:114px; left:0; right:0;bottom:0; overflow:auto;}
-.ddp-ui-catalog-contents.ddp-type {top:41px}
+.ddp-ui-catalog-contents.ddp-type {top:38px}
 .ddp-ui-catalog-contents.ddp-type .ddp-ui-favorite {border-top:none}
 .ddp-ui-favorite {border-top:4px solid #f0eff7;}
 .ddp-ui-favorite .ddp-ui-label {padding:14px 18px 10px 18px;color:#90969f;}
@@ -8705,33 +8554,27 @@ ul.ddp-list-tab-button li.ddp-selected a .ddp-icon-lineage-grid {background-posi
 .ddp-list-favorite li a .ddp-data-txt {}
 .ddp-list-favorite li a .ddp-data-navi {display:block; color:#adb0ba; font-size:11px; white-space:nowrap; text-overflow:ellipsis; overflow:hidden;}
 .ddp-list-favorite li a .ddp-data-name {display:block; margin-top:2px; font-size:13px; color:#424751;}
-.ddp-wrap-catalogs .ddp-ui-tags {position:absolute; top:92px; left:0; right:0; bottom:0;overflow:auto; padding-top:10px;}
-ul.ddp-list-tags li a {display:block; padding:10px 16px;}
-ul.ddp-list-tags li a .ddp-icon-tag {float:left; position:relative; top:2px; margin-right:4px; width:12px; height:12px; background:url(../images/icon_tag.png) no-repeat;}
-ul.ddp-list-tags li .ddp-txt-data {display:inline-block; max-width:100%; overflow:hidden; box-sizing:border-box;}
+.ddp-wrap-catalogs .ddp-ui-tags {position:absolute; top:110px; left:0; right:0; bottom:0;overflow:auto;}
+ul.ddp-list-tags li {padding:10px 16px;}
+ul.ddp-list-tags li .ddp-txt-data {display:inline-block; max-width:100%; overflow:hidden;}
 ul.ddp-list-tags li .ddp-txt-data .ddp-data-num {float:right; margin-left:4px; color:#c2c3cb;}
 ul.ddp-list-tags li .ddp-txt-data .ddp-data-name {display:block; white-space:nowrap; text-overflow:ellipsis; overflow:Hidden;}
-ul.ddp-list-tags li .ddp-txt-data .ddp-data-name .ddp-txt-search {color:#666db7;}
-ul.ddp-list-tags li.ddp-selected a {background-color:#f3f4f9;}
 .ddp-ui-tree {position:relative; padding:0 15px;}
 .ddp-ui-tree:before {display:inline-block;position:absolute; left:15px; right:15px; top:0; border-top:1px dashed #d0d1d8; content:'';}
 .ddp-ui-tree ul.ddp-list-tree {margin-left:-15px;}
 .ddp-ui-tree ul.ddp-list-tree > li em.ddp-view {}
 .ddp-ui-tree ul.ddp-list-tree li a {display:block; position:relative; padding:10px 0 10px 61px; font-size:13px; color:#4b515b; white-space:nowrap;}
-.ddp-ui-tree ul.ddp-list-tree li ul li a:before {display:inline-block; position:absolute; top:-17px; left:0; width:18px; height:39px; background:url(../images/icon_tree_line.png) no-repeat left bottom; content:'';}
+
+.ddp-ui-tree ul.ddp-list-tree li ul li a:before {display:inline-block; position:absolute; top:-17px; left:0; width:27px; height:39px; background:url(../images/icon_tree_line.png) no-repeat left bottom; content:'';}
 .ddp-ui-tree ul.ddp-list-tree li a .ddp-txt-link{display:block;}
-.ddp-ui-tree ul.ddp-list-tree li.ddp-open > a .ddp-txt-link {font-weight:bold;}
-.ddp-ui-tree ul.ddp-list-tree li a .ddp-txt-link:hover {text-decoration:underline;}
-.ddp-ui-tree ul.ddp-list-tree li.ddp-selected > a > .ddp-txt-link {font-weight:bold; text-decoration:underline;}
+.ddp-ui-tree ul.ddp-list-tree li a .ddp-txt-link:hover {font-weight:bold;}
 .ddp-ui-tree ul.ddp-list-tree li a span.ddp-txt-search{color:#666db7; font-size:13px;}
 .ddp-ui-tree ul.ddp-list-tree li .ddp-view {display:none; position:absolute; top:0; left:16px; bottom:0; width:18px; cursor:pointer; z-index:1;}
 .ddp-ui-tree ul.ddp-list-tree li .ddp-view:before {display:inline-block;  position:absolute; top:50%; left:7px; margin-top:-2px;width:7px; height:3px; background:url(../images/icon_select.png) no-repeat; background-position:-24px top; content:''; transform:rotate(-90deg); cursor:pointer;}
 
 .ddp-ui-tree ul.ddp-list-tree li a.ddp-depth .ddp-view {display:block;}
-.ddp-ui-tree ul.ddp-list-tree li a .ddp-icon-folder {position:absolute; top:50%; left:32px; margin-top:-11px; background-color:#fff; border:4px solid #fff; z-index:1;}
+.ddp-ui-tree ul.ddp-list-tree li a .ddp-icon-folder {position:absolute; top:50%; left:36px; margin-top:-7px; background-color:#fff; z-index:1;}
 .ddp-ui-tree ul.ddp-list-tree li a .ddp-icon-question {display:inline-block; width:7px; height:11px; position:absolute; top:50%; left:41px; margin-top:-6px; background:url(../images/icon_que.png) no-repeat; background-position:left -41px;}
-.ddp-ui-tree ul.ddp-list-tree li.ddp-unclass a .ddp-icon-question {background-position-x:-9px;}
-.ddp-ui-tree ul.ddp-list-tree li.ddp-unclass a .ddp-txt-link {color:#b4b9c3;}
 .ddp-ui-tree ul.ddp-list-tree li a span.ddp-txt-search {color:#666db7;}
 
 
@@ -8746,10 +8589,9 @@ ul.ddp-list-tags li.ddp-selected a {background-color:#f3f4f9;}
 table.ddp-table-form tr td em.ddp-icon-fav {display:inline-block; width:13px; height:12px; background:url(../images/icon_fav.png) no-repeat; cursor: pointer; background-position:0 -31px;}
 table.ddp-table-form tr td em.ddp-icon-fav.ddp-selected { background-position:-14px -31px;}
 .ddp-td-tags {}
-table.ddp-table-form tr td .ddp-tags {display:inline-block; max-width:110px; padding:3px 6px; height:22px; border-radius:3px; background-color:#f2f1f8; color:#666eb2; font-size:13px; white-space:nowrap; text-overflow:ellipsis; overflow:hidden; word-wrap:normal; vertical-align:middle; box-sizing:border-box;}
-table.ddp-table-form tr td .ddp-tags .ddp-txt-search.type-search {position:relative; top:1px;}
+table.ddp-table-form tr td .ddp-tags {display:inline-block; max-width:110px; padding:6px; border-radius:3px; background-color:#f2f1f8; color:#666eb2; font-size:13px; white-space:nowrap; text-overflow:ellipsis; overflow:hidden; word-wrap:normal; }
 table.ddp-table-form tr td .ddp-wrap-tags {margin:-3px 0 0 0;}
-table.ddp-table-form tr td .ddp-tag-more {color:#666eb2;vertical-align:middle;}
+table.ddp-table-form tr td .ddp-tags {margin:3px 5px 0 0;}
 table.ddp-table-form tr td .ddp-tags:last-of-type {margin-right:0;}
 table.ddp-table-form tr td .ddp-bar {width:100px; height:16px; background-color:#e6e8f3; border-radius:2px;}
 table.ddp-table-form tr td .ddp-bar span {display:inline-block; height:100%; border-radius:2px; background-color:#666db7;}
@@ -8852,42 +8694,41 @@ table.ddp-table-line tbody tr td .ddp-btn-control {display:none; position:absolu
 table.ddp-table-line tbody tr:hover td .ddp-btn-control {display:block;}
 table.ddp-table-line tbody tr td .ddp-ui-popularity .ddp-icon-popularity {display:inline-block; float:left; width:18px; height:14px; margin-right:8px; background:url(../images/icon_popularity.png) no-repeat;}
 table.ddp-table-line tbody tr td .ddp-ui-popularity .ddp-bar {float:left;}
-.ddp-layout-meta .ddp-ui-contents-top {height:190px; text-align:center; background:none; box-shadow:none; border-bottom:none;}
-.ddp-layout-meta .ddp-ui-contents-top .ddp-ui-title {padding:35px 0 0 0; text-align:center; font-family:'Titillium Web'; font-size:28px;}
+.ddp-layout-meta .ddp-ui-contents-top {height:190px; text-align:center; background:none; box-shadow:none; border-bottom:none;
+  -webkit-transition: height 0.05s; /* Safari */
+  transition: height 0.05s;}
+.ddp-layout-meta .ddp-ui-contents-top .ddp-ui-title {padding:35px 0 0 0; text-align:center; font-family:'Titillium Web'; font-size:22px;}
 .ddp-layout-meta .ddp-ui-contents-top .ddp-ui-tag {padding-top:5px; font-weight:bold; text-align:center;}
-.ddp-layout-meta .ddp-ui-contents-top .ddp-ui-tag .ddp-box-tag-value.ddp-disabled {opacity:0.3;}
-.ddp-layout-meta .ddp-ui-contents-top .ddp-ui-tag .ddp-box-tag-value + .ddp-box-tag-value {margin-left:4px;}
+.ddp-layout-meta .ddp-ui-contents-top .ddp-ui-tag  .ddp-box-tag-value {margin:0 2px;}
+
 .ddp-meta-search {display:inline-block; margin-top:30px; border:1px solid #d0d1d9; border-radius:2px; background-color:#fff;}
-.ddp-meta-search .ddp-search-select {display:inline-block; float:left; position:relative; width:185px; padding:0 40px 0 15px; text-align:left; border-right:1px solid #d0d1d9; cursor:pointer; vertical-align:top;}
+.ddp-meta-search .ddp-search-select {display:inline-block; position:relative; width:185px; padding:0 40px 0 30px; text-align:left; border-right:1px solid #d0d1d9; cursor:pointer; vertical-align:top;}
 .ddp-meta-search .ddp-search-select:before {display:inline-block; position:absolute; top:50%; right:25px; margin-top:-2px; width:7px; height:4px; background:url(../images/icon_select.png) no-repeat; background-position:-8px top; content:'';}
 .ddp-meta-search .ddp-search-select span.ddp-data {display:block; padding:15px 0 15px 0; color:#4b515b; font-size:16px; }
 .ddp-meta-search .ddp-search-select .ddp-wrap-popup2 {display:none; position:absolute; top:100%; left:-1px; right:-1px; background-color:#fff; box-sizing:border-box;}
 .ddp-meta-search .ddp-search-select.ddp-selected .ddp-wrap-popup2 {display:block;}
-.ddp-meta-search .ddp-search-b {display:inline-block; float:left; position:relative; width:515px; padding:0 0 0 40px; box-sizing:border-box;}
+.ddp-meta-search .ddp-search-b {display:inline-block; position:relative; width:515px; padding:0 0 0 40px; box-sizing:border-box;}
 .ddp-meta-search .ddp-search-b .ddp-icon-search {display:inline-block; position:absolute; top:50%; left:10px; margin-top:-9px; width:17px; height:17px; background:url(../images/btn_search.png) no-repeat; background-position:left -20px;}
-.ddp-meta-search .ddp-search-b input {display:block; width:100%; padding:15px 35px 15px 0;  font-size:16px;  background:none; box-sizing:border-box; border:none; font-family:'Titillium Web';}
-.ddp-meta-search .ddp-search-b.type-search input {position:relative; color:#666db7; z-index:1;}
-.ddp-meta-search .ddp-search-b.type-focus:before {display:inline-block; position:absolute; top:-1px; left:-1px; right:-1px; bottom:-1px; border:1px solid #90969f; content:'';}
-.ddp-meta-search .ddp-search-b .ddp-btn-delete {display:inline-block; position:absolute; top:50%; right:10px; margin-top:-8px; width:15px; height:15px; background:url(../images/btn_close.png) no-repeat; background-position:-16px -132px; z-index:1;}
-/* scroll 시 */
-.ddp-layout-meta.ddp-scroll .ddp-ui-contents-top {padding:0; height:80px; text-align:left; background-color:#fff;;
-	-webkit-transition: height 0.3s; /* Safari */
-	transition: height 0.3s;
-	-moz-box-shadow: 0 1px 3px rgba(0,0,0,.15); /* drop shadow */
-	-webkit-box-shadow: 0 1px 3px rgba(0,0,0,.15); /* drop shadow */
+.ddp-meta-search .ddp-search-b input {display:block; width:100%; padding:15px 10px 15px 0;  font-size:16px; color:#666db7; background:none; box-sizing:border-box; border:none; font-family:'Titillium Web';}
 
+/* scroll 시 */
+.ddp-layout-meta.ddp-scroll .ddp-ui-contents-top {padding:0; height:80px; text-align:left; background-color:#fff;
+  -webkit-transition: height 0.05s; /* Safari */
+  transition: height 0.05s;
+  -moz-box-shadow: 0 1px 3px rgba(0,0,0,.15); /* drop shadow */
+  -webkit-box-shadow: 0 1px 3px rgba(0,0,0,.15); /* drop shadow */
+  box-shadow: 0 1px 3px rgba(0,0,0,.15); /* drop shadow */
 }
-.ddp-layout-meta.ddp-scroll .ddp-ui-contents-top .ddp-ui-title {display:inline-block; float:left; text-align:left; padding:20px 20px 5px 24px;}
-.ddp-layout-meta.ddp-scroll .ddp-ui-contents-top .ddp-ui-tag {display:inline-block; float:left; padding:33px 0;}
+.ddp-layout-meta.ddp-scroll .ddp-ui-contents-top .ddp-ui-title {text-align:left; padding:20px 24px 5px 24px;}
+.ddp-layout-meta.ddp-scroll .ddp-ui-contents-top .ddp-ui-tag {padding:0 24px; text-align:left;}
 .ddp-layout-meta.ddp-scroll .ddp-meta-search {position:absolute; top:15px; right:24px; margin-top:0;}
 .ddp-layout-meta.ddp-scroll .ddp-ui-contents-list.ddp-type {padding-top:134px;}
 .ddp-layout-meta.ddp-scroll .ddp-wrap-catalogs {top:134px;}
 .ddp-layout-meta .ddp-wrap-catalogs {top:245px; border-top:1px solid rgba(44,34,141,0.1); border-right:1px solid rgba(44,34,141,0.1);
-	-moz-box-shadow: 0 1px 3px rgba(0,0,0,.15); /* drop shadow */
-	-webkit-box-shadow: 0 1px 3px rgba(0,0,0,.15); /* drop shadow */
-	box-shadow: 0 1px 3px rgba(0,0,0,.15); /* drop shadow */}
-.ddp-layout-meta .ddp-wrap-catalogs .ddp-ui-searching {margin:0;}
-.ddp-layout-meta .ddp-wrap-catalogs .ddp-wrap-searching {padding:10px 16px 10px 16px; border-bottom:3px solid #f3f4f9;}
+  -moz-box-shadow: 0 1px 3px rgba(0,0,0,.15); /* drop shadow */
+  -webkit-box-shadow: 0 1px 3px rgba(0,0,0,.15); /* drop shadow */
+  box-shadow: 0 1px 3px rgba(0,0,0,.15); /* drop shadow */}
+.ddp-layout-meta .ddp-wrap-catalogs .ddp-ui-searching {margin:18px 18px 0 18px;}
 .ddp-layout-meta .ddp-wrap-catalogs.ddp-close {width:26px; border:2px solid #eaeaea;}
 .ddp-layout-meta .ddp-wrap-catalogs.ddp-close * {display:none;}
 .ddp-layout-meta .ddp-wrap-catalogs.ddp-close .ddp-btn-folding {display:block; position:absolute; top:10px; right:3px;}
@@ -8903,47 +8744,30 @@ table.ddp-table-line tbody tr td .ddp-ui-popularity .ddp-bar {float:left;}
 .ddp-layout-meta .ddp-wrap-catalogs ul.ddp-ui-tab li a {padding:16px 10px 15px 10px; height:41px; text-align:center;}
 .ddp-layout-meta .ddp-wrap-catalogs ul.ddp-ui-tab li.ddp-selected a:before {position:absolute; bottom:0; left:0; right:0; content:''; border-bottom:1px solid #fff; }
 .ddp-layout-meta .ddp-wrap-catalogs ul.ddp-ui-tab li:last-of-type a {border-right:none;}
-.ddp-layout-meta em.ddp-bg-back {position:fixed; top:0; left:0; right:0; bottom:0; background:url(../images/bg_meta.png) no-repeat; background-size:100% 100%;}
-.ddp-layout-meta .ddp-view-catalog.type-view .ddp-ui-contents-list.ddp-type {padding-top:129px;}
+.ddp-layout-meta em.ddp-bg-back {background-color:#fefbfd;}
 .ddp-layout-meta .ddp-ui-contents-list.ddp-type {padding-top:190px;}
 .ddp-layout-meta .ddp-ui-contents-list.ddp-type.ddp-close {padding-left:0;}
-.ddp-layout-meta .ddp-meta-list .ddp-no-data {padding:42px 0; color:#b5b9c2; border-top:1px solid #e7e7ea; text-align:center;}
 .ddp-layout-meta .ddp-meta-list .ddp-type-label {padding:0 0 20px 0;color:#4b515b; font-size:16px;}
 
 .ddp-layout-meta .ddp-meta-list .ddp-type-label em.ddp-icon-fav {display:inline-block; position:relative; top:-2px; width:13px; height:12px; background:url(../images/icon_fav.png) no-repeat; cursor: pointer; background-position:0 -31px; vertical-align: middle;}
 .ddp-layout-meta .ddp-meta-list .ddp-type-label em.ddp-icon-fav.ddp-selected { background-position:-14px -31px;}
-.ddp-layout-meta .ddp-meta-list .ddp-box-list {padding:16px 20px; background-color:#fff;
-	-webkit-box-shadow: 0px 2px 2px 1px rgba(231,231,234,1);
-	-moz-box-shadow: 0px 2px 2px 1px rgba(231,231,234,1);
-	box-shadow: 0px 2px 2px 1px rgba(231,231,234,1);}
-.ddp-layout-meta .ddp-meta-list .ddp-box-list .ddp-data-total {float:left; padding-bottom:17px; color:#4b515b;}
-.ddp-layout-meta .ddp-meta-list .ddp-box-list .ddp-data-total .ddp-txt-search {color:#666eb2; font-weight:bold;}
-.ddp-layout-meta .ddp-meta-list .ddp-box-list .ddp-data-box {position:relative; top:-5px;padding:4px 26px 3px 7px; height:26px;float:right;background:#f3f4f9; border:1px solid #e8e9f4; border-radius:2px; vertical-align:middle; box-sizing:border-box;}
-.ddp-layout-meta .ddp-meta-list .ddp-box-list .ddp-data-box .ddp-icon-folder {position:relative; top:0; left:0; margin:0 4px 0 0;}
-.ddp-layout-meta .ddp-meta-list .ddp-box-list .ddp-data-box .ddp-ui-root {float:left;}
-.ddp-layout-meta .ddp-meta-list .ddp-box-list .ddp-data-box .ddp-list-root + .ddp-list-root {position:relative; padding:0 0 0 12px; margin-left:4px;}
-.ddp-layout-meta .ddp-meta-list .ddp-box-list .ddp-data-box .ddp-list-root + .ddp-list-root:before {display:inline-block; position:absolute; top:50%; left:0; margin-top:-4px; width:4px; height:8px; background:url(../images/icon_dataview.png) no-repeat; background-position:left -40px; content:'';}
-.ddp-layout-meta .ddp-meta-list .ddp-box-list .ddp-data-box .ddp-list-root:hover {text-decoration:underline;}
-.ddp-layout-meta .ddp-meta-list .ddp-box-list .ddp-data-box .ddp-ui-root .ddp-list-root:last-of-type {font-weight:bold ;}
-.ddp-layout-meta .ddp-meta-list .ddp-box-list .ddp-data-box .ddp-icon-control-fav {position:relative; top:-1px; margin-right:3px; vertical-align:top;}
-.ddp-layout-meta .ddp-meta-list .ddp-box-list .ddp-data-box .ddp-link-reset {display:inline-block; position:absolute; top:0; right:0; width:26px; height:24px; background-color:#e9ebf3;}
-.ddp-layout-meta .ddp-meta-list .ddp-box-list .ddp-data-box .ddp-link-reset .ddp-btn-reset {display:inline-block; position:absolute; top:50%; left:50%; margin:-7px -7px; width:14px; height:13px; background:url(../images/icon_reset.png) no-repeat -16px -20px;}
-.ddp-layout-meta .ddp-meta-list .ddp-box-list .ddp-data-box .ddp-data-tag {margin-right:6px; color:#4b515b;}
-.ddp-layout-meta .ddp-meta-list .ddp-box-list .ddp-data-box .ddp-data-tag .ddp-icon-tag {display:inline-block; position:relative; top:-1px; width:12px; height:12px; margin-right:3px; vertical-align:middle; background:url(../images/icon_tag.png) no-repeat;}
+.ddp-layout-meta .ddp-meta-list .ddp-box-list {padding:20px; background-color:#fff;
+  -webkit-box-shadow: 0px 2px 2px 1px rgba(231,231,234,1);
+  -moz-box-shadow: 0px 2px 2px 1px rgba(231,231,234,1);
+  box-shadow: 0px 2px 2px 1px rgba(231,231,234,1);}
 .ddp-layout-meta .ddp-meta-list .ddp-box-page {border:none;
-	-webkit-box-shadow: 0px 2px 2px 1px rgba(231,231,234,1);
-	-moz-box-shadow: 0px 2px 2px 1px rgba(231,231,234,1);
-	box-shadow: 0px 2px 2px 1px rgba(231,231,234,1);}
+  -webkit-box-shadow: 0px 2px 2px 1px rgba(231,231,234,1);
+  -moz-box-shadow: 0px 2px 2px 1px rgba(231,231,234,1);
+  box-shadow: 0px 2px 2px 1px rgba(231,231,234,1);}
 .ddp-ui-banner {padding:14px 0 0 0;}
 .ddp-ui-banner .ddp-type-label {padding-bottom:13px; font-size:14px; font-weight:bold;}
 .ddp-box-banner {display:flex; height:340px;}
 .ddp-box-banner .ddp-banner-main {display:table; height:100%; width:100%; background:url(../images/bg_banner01.png) no-repeat; background-size:100% 100%; align-items: center; justify-content: center; }
-.ddp-box-banner .ddp-banner-list {width:333px; min-width:333px;}
+.ddp-box-banner .ddp-banner-list {width:333px; }
 .ddp-box-banner .ddp-ui-banner-link.type-banner01 {display:table-cell; vertical-align:middle;}
 .ddp-box-banner .ddp-ui-banner-link.type-banner01 .ddp-banner-title {padding-bottom:18px; color:#ffffff; font-size:22px; font-weight:bold; text-align:center;}
-.ddp-box-banner .ddp-ui-banner-link.type-banner01 .ddp-banner-title .ddp-data-images {margin-right:10px; vertical-align:middle;}
-.ddp-box-banner .ddp-ui-banner-link.type-banner01 .ddp-banner-title .ddp-data-images svg {position:relative; top:-3px; width:30px; height:30px; vertical-align:middle;}
-
+.ddp-box-banner .ddp-ui-banner-link .ddp-banner-title .ddp-icon-datasource {display:inline-block; width:26px; height:32px; background:url(../images/icon_data_meta.png) no-repeat;}
+.ddp-box-banner .ddp-ui-banner-link.type-banner01 .ddp-banner-title .ddp-icon-datasource {margin-right:17px;}
 .ddp-box-banner .ddp-ui-banner-link.type-banner01 .ddp-txt-detail {text-align:center; color:#fff; font-size:13px; opacity:0.4;}
 .ddp-box-banner .ddp-ui-banner-link.type-banner01 .ddp-banner-tags {padding-top:9px; text-align:center;}
 .ddp-box-banner .ddp-ui-banner-link.type-banner01 .ddp-banner-tags .ddp-tags {padding:7px 10px; margin-left:6px; border-radius:5px; background-color:#343865; color:#9da9ff;}
@@ -8954,71 +8778,72 @@ table.ddp-table-line tbody tr td .ddp-ui-popularity .ddp-bar {float:left;}
 .ddp-box-banner .ddp-ui-banner-link.type-banner04 {background:url(../images/bg_banner04.png) no-repeat; background-size:100% 100%;}
 .ddp-box-banner .ddp-ui-banner-link.type-banner05 {background:url(../images/bg_banner05.png) no-repeat; background-size:100% 100%;}
 .ddp-box-banner .ddp-banner-list [class*="ddp-ui-banner-link"] .ddp-banner-title {position:relative; padding-left:66px;}
-.ddp-box-banner .ddp-banner-list .ddp-banner-title [class*="ddp-data-images"] {display:inline-block;position:absolute; top:50%; left:29px; margin-top:-16px;}
+.ddp-box-banner .ddp-banner-list .ddp-banner-title [class*="ddp-icon-"] {display:inline-block;position:absolute; top:50%; left:29px; margin-top:-16px; background:url(../images/icon_data_meta.png) no-repeat;}
+.ddp-box-banner .ddp-banner-list .ddp-banner-title .ddp-icon-hive {left:22px; width:38px; height:38px; margin-top:-20px; background-position:left -33px;}
+.ddp-box-banner .ddp-banner-list .ddp-banner-title .ddp-icon-stagingdb {width:34px; height:36px; margin-top:-18px; background-position:left -72px;}
+.ddp-box-banner .ddp-banner-list .ddp-banner-title .ddp-icon-database {width:25px; height:29px; margin-top:-15px; background-position:left -108px;}
 
-.ddp-box-banner .ddp-banner-list .ddp-banner-title [class*="ddp-data-images"].type-svg {background:none;}
-.ddp-box-banner .ddp-banner-list .ddp-banner-title [class*="ddp-data-images"].type-svg svg {width:30px;height:30px;}
 .ddp-wrap-meta-summary {display:flex;}
 .ddp-wrap-meta-summary .ddp-wrap-box {flex:1 auto; margin-top:15px;}
-.ddp-wrap-meta-summary .ddp-type-summary-label {padding:15px 25px 15px 25px;font-size:14px; color:#4b515b; font-weight:bold; border-bottom:1px solid #e7e8eb;}
+.ddp-wrap-meta-summary .ddp-type-summary-label {padding-bottom:9px; font-size:14px; color:#4b515b; font-weight:bold; border-bottom:1px solid #e7e8eb;}
 .ddp-wrap-meta-summary .ddp-data-images {display:inline-block; position:relative; width:50px; height:50px; border-radius:5px;}
-.ddp-wrap-meta-summary .ddp-data-images.type-svg:before {background:none;}
-.ddp-wrap-meta-summary .ddp-data-images.type-svg svg {display:inline-block; width:30px; height:30px; position:absolute; top:50%; left:50%; margin:-15px 0 0 -15px;}
 .ddp-wrap-meta-summary .ddp-data-images.type-database {background-color:#526198;}
 .ddp-wrap-meta-summary .ddp-data-images.type-datasource {background-color:#5b8fe5;}
 .ddp-wrap-meta-summary .ddp-data-images.type-stagingdb {background-color:#f35787;}
 .ddp-wrap-meta-summary .ddp-data-images.type-dataset {background-color:#8576df;}
 .ddp-wrap-meta-summary .ddp-data-images.type-hive {background-color:#353a5c;}
-
+.ddp-wrap-meta-summary .ddp-data-images:before {display:inline-block; position:absolute; top:50%; left:50%;  background:url(../images/icon_data_meta.png) no-repeat; content:'';}
+.ddp-wrap-meta-summary .ddp-data-images.type-hive:before {width:38px;height:38px; margin:-19px 0 0 -19px; background-position:left -33px;}
+.ddp-wrap-meta-summary .ddp-data-images.type-database:before {width:25px; height:29px; margin:-15px 0 0 -12px; background-position:left -108px;}
+.ddp-wrap-meta-summary .ddp-data-images.type-stagingdb:before {width:31px; height:33px;  margin:-16px 0 0 -14px;background-position:left -72px;}
+.ddp-wrap-meta-summary .ddp-data-images.type-dataset:before {width:26px; height:27px; margin:-14px 0 0 -13px; background-position:left -138px;}
+.ddp-wrap-meta-summary .ddp-data-images.type-datasource:before {width:26px; height:32px; margin:-16px 0 0 -13px;background-position:left top;}
 
 .ddp-wrap-meta-summary .ddp-data-images.type-hive:before {}
-.ddp-wrap-meta-summary .ddp-wrap-box .ddp-box-summary {margin-bottom:18px; background-color:#fff;
-	-moz-box-shadow: 0 0 20px rgba(206,210,237); /* drop shadow */
-	-webkit-box-shadow: 0 0 20px rgba(206,210,237); /* drop shadow */
-	box-shadow: 0 0 20px rgba(206,210,237); /* drop shadow */}
-.ddp-wrap-meta-summary .ddp-wrap-list-summary {padding:31px 0 0 25px; width:333px;box-sizing:Border-box;}
-.ddp-wrap-meta-summary .ddp-wrap-list-summary .ddp-type-summary-label {padding:0 0 15px 0;}
-.ddp-wrap-meta-summary .ddp-wrap-list-summary .ddp-type-summary-label .ddp-btn-more  {float:right; padding:3px 7px; background-color:rgba(156, 162, 204, 0.2); color:#4c515a; font-size:12px; font-weight:normal; border-radius:2px;}
-.ddp-wrap-meta-summary .ddp-wrap-list-summary .ddp-type-summary-label .ddp-btn-more:hover {background-color:rgba(156, 162, 204, 0.4);}
-.ddp-wrap-meta-summary .ddp-wrap-box .ddp-wrap-summary {padding:20px 15px 20px 15px;}
-.ddp-wrap-meta-summary .ddp-wrap-box .ddp-list-summary + .ddp-list-summary {padding-top:20px;}
-.ddp-wrap-meta-summary .ddp-wrap-box .ddp-list-summary > li {width:50%; float:left; box-sizing:border-box;}
-.ddp-wrap-meta-summary .ddp-wrap-box .ddp-list-summary li a {display:block; padding:10px 25px 10px 10px;}
+.ddp-wrap-meta-summary .ddp-wrap-box .ddp-box-summary {padding:25px; margin-bottom:18px; background-color:#fff;
+  -moz-box-shadow: 0 0 20px rgba(206,210,237); /* drop shadow */
+  -webkit-box-shadow: 0 0 20px rgba(206,210,237); /* drop shadow */
+  box-shadow: 0 0 20px rgba(206,210,237); /* drop shadow */}
+.ddp-wrap-meta-summary .ddp-wrap-list-summary {padding:40px 0 0 25px;  min-width:333px;box-sizing:Border-box;}
+.ddp-wrap-meta-summary .ddp-wrap-list-summary .ddp-type-summary-label {padding:0 0 10px 0;}
+.ddp-wrap-meta-summary .ddp-wrap-list-summary .ddp-type-summary-label .ddp-btn-more  {float:right; padding:3px 7px; background-color:#f2e9f0; color:#4c515a; font-size:12px; font-weight:normal; border-radius:2px;}
 
-.ddp-wrap-meta-summary .ddp-wrap-box .ddp-list-summary li a:hover { background-color:rgba(156, 162, 204, 0.15); border-radius:4px;}
-.ddp-wrap-meta-summary .ddp-wrap-box .ddp-list-summary li .ddp-wrap-data {position:relative; padding-left:65px; }
+.ddp-wrap-meta-summary .ddp-wrap-box .ddp-list-summary {padding:25px 0 0 0; margin:-10px -77px;}
+.ddp-wrap-meta-summary .ddp-wrap-box .ddp-list-summary > li {width:50%; height:115px; padding:10px 77px; float:left; box-sizing:border-box;}
+.ddp-wrap-meta-summary .ddp-wrap-box .ddp-list-summary li a {display:block;}
+
+.ddp-wrap-meta-summary .ddp-wrap-box .ddp-list-summary li a:hover .ddp-data-txt .ddp-data-name {font-weight:bold;}
+.ddp-wrap-meta-summary .ddp-wrap-box .ddp-list-summary li .ddp-wrap-data {position:relative; padding-left:76px; }
 .ddp-wrap-meta-summary .ddp-wrap-box .ddp-list-summary li .ddp-wrap-data .ddp-data-images {position:absolute; top:0; left:0;}
 
 .ddp-wrap-meta-summary .ddp-wrap-box .ddp-list-summary li .ddp-data-txt {}
 .ddp-wrap-meta-summary .ddp-wrap-box .ddp-list-summary li .ddp-data-txt .ddp-data-name {color:#4b515b; font-size:14px; white-space:nowrap; text-overflow:ellipsis; overflow:hidden;}
-.ddp-wrap-meta-summary .ddp-wrap-box .ddp-list-summary li .ddp-data-txt .ddp-data-detail {color:rgba(75,81,91,0.5); white-space:nowrap; text-overflow:ellipsis; overflow:hidden;}
-.ddp-wrap-meta-summary .ddp-wrap-box .ddp-list-summary li .ddp-data-txt .ddp-ui-popularity {padding:6px 0;}
+.ddp-wrap-meta-summary .ddp-wrap-box .ddp-list-summary li .ddp-data-txt .ddp-data-detail {padding-bottom:8px; color:rgba(75,81,91,0.5); white-space:nowrap; text-overflow:ellipsis; overflow:hidden;}
+
 .ddp-wrap-meta-summary .ddp-wrap-box .ddp-list-summary li .ddp-data-txt .ddp-ui-popularity .ddp-icon-popularity
-{display:inline-block; float:left; width:18px; height:14px; margin-right:3px; background:url(../images/icon_popularity.png) no-repeat;}
-.ddp-wrap-meta-summary .ddp-wrap-box .ddp-list-summary li .ddp-data-txt .ddp-ui-popularity .ddp-bar {position:relative; top:3px; float:left; width:70px; height:10px; background-color:#e6e8f3; border-radius:2px;}
-.ddp-wrap-meta-summary .ddp-wrap-box .ddp-list-summary li .ddp-data-txt .ddp-ui-popularity .ddp-bar span {display:inline-block; position:absolute; top:0; left:0; height:100%; border-radius:2px; background-color:#666eb2;}
+{display:inline-block; float:left; width:18px; height:14px; margin-right:8px; background:url(../images/icon_popularity.png) no-repeat;}
+.ddp-wrap-meta-summary .ddp-wrap-box .ddp-list-summary li .ddp-data-txt .ddp-ui-popularity .ddp-bar {position:relative; float:left; width:100px; height:16px; background-color:#e6e8f3; border-radius:2px;}
+.ddp-wrap-meta-summary .ddp-wrap-box .ddp-list-summary li .ddp-data-txt .ddp-ui-popularity .ddp-bar span {display:inline-block; height:100%; border-radius:2px; background-color:#666db7;}
 .ddp-wrap-meta-summary .ddp-wrap-box .ddp-list-summary li .ddp-data-txt .ddp-ui-popularity .ddp-bar .ddp-box-layout4 {display:none; position:absolute; top:100%; margin-top:5px; text-align:left;}
 .ddp-wrap-meta-summary .ddp-wrap-box .ddp-list-summary li .ddp-data-txt .ddp-ui-popularity .ddp-bar .ddp-box-layout4.ddp-popularity {width:360px;}
 .ddp-wrap-meta-summary .ddp-wrap-box .ddp-list-summary li .ddp-data-txt .ddp-ui-popularity .ddp-bar:hover .ddp-box-layout4 {display:block;}
-.ddp-wrap-meta-summary .ddp-wrap-box .ddp-list-summary li .ddp-data-txt .ddp-ui-popularity .ddp-data-by {display:block; padding-left:6px; overflow:hidden; color:#90969f; white-space:nowrap; text-overflow:ellipsis;}
-.ddp-wrap-meta-summary .ddp-wrap-box .ddp-list-summary li .ddp-list-tags {clear:both; width:100%; height:22px; margin-top:0; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;}
-.ddp-wrap-meta-summary .ddp-wrap-box .ddp-list-summary li .ddp-list-tags .ddp-tags {padding:3px 6px; margin:0 3px 0 0; background-color:rgba(156, 162, 204, 0.15)}
+.ddp-wrap-meta-summary .ddp-wrap-box .ddp-list-summary li .ddp-data-txt .ddp-ui-popularity .ddp-data-by {display:block; padding-left:9px; overflow:Hidden; color:#4b515b; white-space:nowrap; text-overflow:ellipsis;}
+.ddp-wrap-meta-summary .ddp-wrap-box .ddp-list-summary li .ddp-list-tags {clear:both; width:100%; padding:10px 0 0 0; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;}
+.ddp-wrap-meta-summary .ddp-wrap-box .ddp-list-summary li .ddp-list-tags .ddp-tags:first-of-type {margin-left:0;}
+.ddp-wrap-meta-summary .ddp-wrap-box .ddp-list-summary li .ddp-list-tags .ddp-tags {margin-left:3px; padding:3px 9px;}
 .ddp-wrap-meta-summary .ddp-wrap-list-summary .ddp-ui-list-summary:first-of-type {padding-top:0;}
-.ddp-ui-list-summary {padding-top:25px;}
-.ddp-ui-list-summary .ddp-list-data {padding:5px 0;}
-.ddp-ui-list-summary .ddp-list-data li a {display:block; position:relative;padding:5px 10px 5px 75px; min-height:60px; box-sizing:border-box;}
-.ddp-ui-list-summary .ddp-list-data li a:hover {background-color:rgba(156, 162, 204, 0.15); border-radius:4px;}
-.ddp-ui-list-summary .ddp-list-data li a .ddp-data-images {position:absolute; top:5px; left:10px;}
-.ddp-ui-list-summary .ddp-list-data li a .ddp-data-profile {display:inline-block; width:50px; height:50px; position:absolute; top:5px; left:10px; background:url(../images/img_profile.png) no-repeat left -82px; border-radius:50%; overflow:hidden; }
-.ddp-ui-list-summary .ddp-list-data li a .ddp-data-txt .ddp-list-tags {padding-top:6px; white-space:nowrap; text-overflow:ellipsis; overflow:hidden;}
-.ddp-ui-list-summary .ddp-list-data li a .ddp-data-txt .ddp-list-tags .ddp-tags {padding:3px 6px; margin:0 3px 0 0; background-color:#e2dff5;}
-.ddp-ui-list-summary .ddp-list-data li a .ddp-data-txt .ddp-data-name {display:block;padding:3px 0 5px 0; font-size:14px; color:#4b515b; white-space:nowrap;text-overflow:ellipsis; overflow:hidden}
-.ddp-ui-list-summary .ddp-list-data li a .ddp-data-txt .ddp-data-create {display:block;padding:3px 0 5px 0; font-size:12px; color:#90969f; white-space:nowrap;text-overflow:ellipsis; overflow:hidden}
+.ddp-ui-list-summary {padding-top:37px;}
+.ddp-ui-list-summary .ddp-list-data li {padding:8px 0;}
+.ddp-ui-list-summary .ddp-list-data li a {display:block; position:relative;padding-left:76px;}
+.ddp-ui-list-summary .ddp-list-data li a .ddp-data-images {position:absolute; top:0; left:0;}
+.ddp-ui-list-summary .ddp-list-data li a .ddp-data-txt {height:50px;}
+.ddp-ui-list-summary .ddp-list-data li a .ddp-data-txt .ddp-data-name {display:block;padding:8px 0 5px 0; font-size:14px; color:#4b515b; white-space:nowrap;text-overflow:ellipsis; overflow:hidden}
+.ddp-ui-list-summary .ddp-list-data li a:hover .ddp-data-txt .ddp-data-name {font-weight:bold;}
 .ddp-ui-list-summary .ddp-list-data li a .ddp-data-txt .ddp-data-by {display:block; width:100%;color:#4b515b; opacity:0.6; white-space:nowrap;text-overflow:ellipsis; overflow:hidden;}
 
-	/**************************************************************
-      메타데이터 used workspace popup
-    **************************************************************/
+/**************************************************************
+    메타데이터 used workspace popup
+  **************************************************************/
 .ddp-used-workspace {padding:0 50px; }
 .ddp-ui-usedworkspace:last-of-type {border-bottom:1px solid #e4e5eb;}
 .ddp-ui-usedworkspace .ddp-data-name  {display:block; padding:10px 17px; background-color:#f6f6f7; border-top:1px solid #e4e5eb; color:#35393f; font-size:14px; font-weight:bold; cursor:pointer;}
@@ -9038,10 +8863,10 @@ table.ddp-table-line tbody tr td .ddp-ui-popularity .ddp-bar {float:left;}
 **************************************************************/
 .ddp-pop-meta-detail {position:fixed; left:0; right:0; bottom:0; top:0; background:rgba(208,209,216,0.5);}
 .ddp-box-meta {position:absolute; top:30px; left:40px; right:40px; bottom:30px; background-color:#fff;
-	-moz-box-shadow: 0 0 20px rgba(0,0,0,.3); /* drop shadow */
-	-webkit-box-shadow: 0 0 20px rgba(0,0,0,.3); /* drop shadow */
-	box-shadow: 0 0 20px rgba(0,0,0,.3); /* drop shadow */
-	z-index:91; }
+  -moz-box-shadow: 0 0 20px rgba(0,0,0,.3); /* drop shadow */
+  -webkit-box-shadow: 0 0 20px rgba(0,0,0,.3); /* drop shadow */
+  box-shadow: 0 0 20px rgba(0,0,0,.3); /* drop shadow */
+  z-index:91; }
 
 .ddp-box-meta .ddp-btn-close {display:inline-block; position:absolute; top:20px; right:20px; width:22px; height:22px; background:url(../images/btn_popclose.png) no-repeat; background-position:left -112px;}
 .ddp-box-meta .ddp-pop-top {padding:16px 62px 16px 40px;}
@@ -9049,8 +8874,8 @@ table.ddp-table-line tbody tr td .ddp-ui-popularity .ddp-bar {float:left;}
 .ddp-box-meta .ddp-pop-top:after {display:table; content:'';}
 .ddp-box-meta .ddp-pop-top:after {clear:both;}
 .ddp-box-meta .ddp-pop-top .ddp-ui-title {padding-top:4px; float:left;}
-.ddp-box-meta .ddp-pop-top .ddp-label-title {position:relative; top:-2px; float:left; max-width:570px; margin-right:12px; font-weight:bold; color:#4b515b; font-size:16px; vertical-align:middle; white-space:nowrap; text-overflow:ellipsis; overflow:hidden;}
-.ddp-box-meta .ddp-pop-top .ddp-box-tag-value {float:left; margin-right:7px; vertical-align:middle;}
+.ddp-box-meta .ddp-pop-top .ddp-label-title {margin-right:12px; font-weight:bold; color:#4b515b; font-size:16px; vertical-align:middle;}
+.ddp-box-meta .ddp-pop-top .ddp-box-tag-value {margin-right:7px; vertical-align:middle;}
 .ddp-box-meta .ddp-pop-top .ddp-wrap-info {position:relative;display:inline-block; margin-right:3px; cursor:pointer; z-index:2;}
 .ddp-box-meta .ddp-pop-top .ddp-wrap-info .ddp-icon-info {display:inline-block; width:13px; height:13px; background:url(../images/icon_info.png) no-repeat; background-position:left -30px;}
 .ddp-box-meta .ddp-pop-top .ddp-wrap-info .ddp-box-layout4 {display:none; position:absolute; top:100%; margin-top:6px;}
@@ -9063,13 +8888,12 @@ table.ddp-table-line tbody tr td .ddp-ui-popularity .ddp-bar {float:left;}
 
 .ddp-box-meta .ddp-pop-top .ddp-ui-title .ddp-data-name {display:inline-block; position:relative; top:2px;margin-left:17px; color:#b7bac1; font-size:13px;}
 .ddp-box-meta .ddp-pop-top .ddp-ui-title .ddp-data-name .ddp-txt-name {color:#4b515b; font-size:13px; text-decoration:underline;}
-.ddp-detail-view.ddp-left {position:relative; float:left; width:475px; height:100%;z-index:1;}
-.ddp-detail-view.ddp-right {float:left; position:relative; width:100%; margin-left:-475px; padding-left:514px; box-sizing:border-box;}
-.ddp-detail-view.ddp-right:before {display:block; position:absolute; left:476px; bottom:0; top:0; border-left:1px solid #e5e7f0;; content:'';}
+.ddp-detail-view.ddp-left {position:relative; float:left; width:475px; border-right:1px solid #e5e7f0;z-index:1;}
+.ddp-detail-view.ddp-right {float:left; width:100%; margin-left:-475px; padding-left:514px; box-sizing:border-box;}
 .ddp-detail ul.ddp-list-user {overflow:hidden; margin:-3px -3px;}
 .ddp-detail ul.ddp-list-user li {float:left; padding:3px 3px; width:33.3333%; box-sizing:border-box;}
 .ddp-detail ul.ddp-list-user li .ddp-box-user {display:block; border:1px solid #e5e7f0; overflow:hidden; cursor:pointer;}
-.ddp-detail ul.ddp-list-user li .ddp-box-user .ddp-data-photo {display:inline-block; float:left; width:50px; height:50px; margin:22px 10px 22px 13px;border-radius:50%; overflow:hidden; background-color:#c9cad3; background:url(../images/img_profile.png) no-repeat;}
+.ddp-detail ul.ddp-list-user li .ddp-box-user .ddp-data-photo {display:inline-block; float:left; width:50px; height:50px; margin:22px 10px 22px 13px;border-radius:50%; overflow:hidden; background-color:#c9cad3;}
 .ddp-detail ul.ddp-list-user li .ddp-box-user .ddp-data-photo img {display:block; width:100%; height:100%;}
 .ddp-detail ul.ddp-list-user li .ddp-box-user .ddp-wrap-data {display:block; margin-left:-78px; padding-left:78px; width:100%; float:left; box-sizing:border-box;}
 
@@ -9136,7 +8960,7 @@ table.ddp-table-detail tbody tr td .ddp-box-confidence:hover .ddp-ui-tooltip-inf
 .ddp-detail-contents .type-sampledata .ddp-data-details.ddp-ui-preview-contents {margin-top:0; top:10px;}
 
 
-.ddp-detail-contents .ddp-data-details.ddp-ui-preview-contents {position:absolute;margin-top:-25px;}
+.ddp-detail-contents .ddp-data-details.ddp-ui-preview-contents {margin-top:-25px;}
 .ddp-detail-contents .ddp-data-details.ddp-ui-preview-contents .ddp-bar {background-color:#ecedf3;}
 .ddp-detail-contents .ddp-data-details.ddp-ui-preview-contents .ddp-bar span {background-color:#9ca2cc;}
 .ddp-detail-contents table.ddp-table-form.ddp-table-details tr th .ddp-box-layout4.ddp-popularity {top:100%;}
@@ -9151,11 +8975,11 @@ table.ddp-table-detail tbody tr td .ddp-box-confidence:hover .ddp-ui-tooltip-inf
 .ddp-detail-view .ddp-box-table {border:1px solid #e7e7ea;}
 .ddp-detail-view .ddp-box-table .ddp-label {padding:18px 17px;color:#4c515a; font-weight:bold;}
 .ddp-detail-contents .ddp-box-catalogs {font-weight:bold;}
+.ddp-detail-contents .ddp-data-details.ddp-ui-preview-contents {position:absolute;}
 table.ddp-table-form2.ddp-type tr th {background-color:#f6f6f7; font-weight:normal;}
 table.ddp-table-form2.ddp-type tr td .ddp-ui-photo {margin:-4px 0}
 table.ddp-table-form2.ddp-type tr td .ddp-data-used {font-weight:bold; white-space:nowrap; text-overflow:ellipsis; overflow:hidden; }
-.ddp-detail-view .ddp-detail {padding:30px 0 0 0;}
-.ddp-detail-view .ddp-detail:first-of-type {padding-top:0;}
+.ddp-detail-view .ddp-detail {padding:20px 0 0 0;}
 .ddp-detail-view .ddp-detail .ddp-label {padding-bottom:10px; font-weight:bold; color:#4c515a; font-size:13px;}
 .ddp-detail-view .ddp-detail .ddp-label .ddp-link {margin-left:10px; color:#90969f; font-size:13px; text-decoration:underline; font-weight:normal;}
 .ddp-detail-view .ddp-detail .ddp-label .ddp-link:hover {color:#4b515b;}
@@ -9305,71 +9129,6 @@ ul.ddp-list-essential li .ddp-data-det .ddp-txt-label {color:#b7b9c2;}
 .ddp-ui-popup-join.ddp-multy .ddp-box-key {padding:6px 0; margin:-10px 0 6px 0; background-color:#f2f2f4; text-align:center; color:#b7b9c2; font-size:14px;}
 .ddp-ui-popup-join.ddp-multy .ddp-box-key.ddp-selected {background-color:#f2f1f8; color:#666eb2;}
 
-/**************************************************************
-      메타데이터 discussion
-**************************************************************/
-.ddp-type-top-option.type-discussion {margin-top:-13px; }
-.ddp-type-top-option.type-discussion .ddp-type-search {width:250px;}
-
-.ddp-box-comment {border:1px solid #d0d1d8; border-radius:3px;}
-.ddp-box-comment .ddp-top-comment {border-bottom:1px solid #d0d1d8; background-color:#e7e7e9; }
-.ddp-box-comment .ddp-top-comment .ddp-wrap-select {position:relative; width:200px;}
-.ddp-box-comment .ddp-top-comment .ddp-wrap-select:after {display:inline-block; position:absolute; top:8px; height:25px; border-left:1px solid #d0d1d8; content:'';}
-.ddp-box-comment .ddp-top-comment .ddp-type-select {display:block;  position:relative; padding:12px 30px 10px 13px; width:100%; height:40px; float:left; box-sizing:border-box; cursor:pointer;}
-.ddp-box-comment .ddp-top-comment .ddp-type-select .ddp-icon-view {display:inline-block; position:absolute; top:50%; right:15px; width:7px; height:4px; background:url(../images/icon_select.png) no-repeat -8px top;}
-.ddp-box-comment .ddp-top-comment .ddp-type-select .ddp-txt-result {position:relative; padding:0 0 0 36px; font-size:13px;}
-.ddp-box-comment .ddp-top-comment .ddp-type-select .ddp-txt-result.type-success {color:#10bf83;}
-.ddp-box-comment .ddp-top-comment .ddp-type-select .ddp-txt-result.type-warning {color:#ffba01;}
-.ddp-box-comment .ddp-top-comment .ddp-type-select .ddp-txt-result.type-error {color:#dc494f;}
-.ddp-box-comment .ddp-icon-success-r,
-.ddp-box-comment .ddp-icon-warning-r,
-.ddp-box-comment .ddp-icon-error-r {display:inline-block; position:absolute; top:50%; left:6px; background:url(../images/icon_confidence.png) no-repeat; vertical-align:middle;}
-.ddp-box-comment .ddp-icon-success-r {width:20px; height:20px; margin-top:-10px;}
-.ddp-box-comment .ddp-icon-warning-r {width:20px; height:18px; margin-top:-9px; background-position:left -21px;}
-.ddp-box-comment .ddp-icon-error-r {width:20px; height:20px; margin-top:-10px; background-position:left -57px;}
-
-.ddp-box-comment .ddp-top-comment .ddp-type-buttons {float:right; position:relative;}
-.ddp-box-comment .ddp-top-comment .ddp-type-buttons:before {display:inline-block; position:absolute; top:8px; left:0; height:25px; border-left:1px solid #d0d1d8; content:'';}
-.ddp-box-comment .ddp-top-comment .ddp-type-buttons .ddp-btn-summit {display:block;position:relative; padding:12px 20px 12px 36px;color:#4b515b; font-size:13px;}
-.ddp-box-comment .ddp-top-comment .ddp-type-buttons .ddp-btn-summit .ddp-icon-check {display:inline-block; position:absolute; top:50%; left:20px; margin-top:-4px;  width:11px; height:8px; background:url(../images/icon_select2.png) no-repeat; background-position:-68px top;}
-
-.ddp-box-comment .ddp-wrap-textarea {height:62px;}
-.ddp-box-comment .ddp-wrap-textarea textarea {display:block; width:100%; height:100%; padding:10px 15px; box-sizing:border-box; border:none; font-size:13px; border-radius:0 0 3px 3px;}
-
-.ddp-wrap-discussion {}
-.ddp-ui-discussion {position:relative; padding:20px 0 20px 54px; border-bottom:1px solid #e7e7e9;}
-.ddp-ui-discussion .ddp-ui-top {padding-bottom:10px;}
-.ddp-ui-discussion .ddp-data-top {display:inline-block; padding-top:4px;}
-.ddp-ui-discussion .ddp-data-top .ddp-data-name {display:block; font-weight:bold; color:#4b515b;  overflow:hidden;}
-.ddp-ui-discussion .ddp-data-top .ddp-data-date {float:right; margin-left:6px; color:#90969f;}
-.ddp-ui-discussion .ddp-data-photo {display:inline-block; position:absolute; top:20px; left:0; width:30px; height:30px; border-radius:50%; background:url(../images/img_profile.png) no-repeat; background-position:left -51px;}
-.ddp-ui-discussion .ddp-data-photo img {display:inline-block; width:100%; height:100%;}
-.ddp-ui-discussion .ddp-ui-status-block {padding-bottom:8px;}
-.ddp-ui-discussion .ddp-box-condition {display:inline-block; position:relative; padding:5px 5px 5px 28px; border-radius:2px; font-size:13px;}
-.ddp-ui-discussion .ddp-box-condition.type-warning {background-color:rgba(255, 182, 2, 0.1); color:#ffba01;}
-.ddp-ui-discussion .ddp-box-condition.type-success {background-color:rgba(16, 191, 131, 0.1); color:#10bf83;}
-.ddp-ui-discussion .ddp-box-condition.type-error {background-color:rgba(220, 73, 79, 0.1); color:#dc494f;}
-.ddp-ui-discussion .ddp-icon-success-r,
-.ddp-ui-discussion .ddp-icon-warning-r,
-.ddp-ui-discussion .ddp-icon-error-r {display:inline-block; position:absolute; top:50%; left:6px; background:url(../images/icon_confidence.png) no-repeat; vertical-align:middle;}
-.ddp-ui-discussion .ddp-icon-success-r {width:20px; height:20px; margin-top:-10px;}
-.ddp-ui-discussion .ddp-icon-warning-r {width:20px; height:18px; margin-top:-9px; background-position:left -21px;}
-.ddp-ui-discussion .ddp-icon-error-r {width:20px; height:20px; margin-top:-10px; background-position:left -57px;}
-
-.ddp-ui-discussion .ddp-link-reply {position:absolute; top:61px; right:0; color:#90969f; text-decoration:underline;}
-.ddp-ui-discussion .ddp-txt-det {padding-bottom:10px; font-size:13px;}
-
-.ddp-ui-discussion .ddp-ui-reply {padding:20px; margin-top:10px; background-color:#f6f6f7;}
-.ddp-ui-discussion .ddp-ui-reply + .ddp-ui-reply {margin-top:4px;}
-.ddp-ui-discussion .ddp-ui-reply .ddp-txt-det {padding-bottom:0;}
-.ddp-ui-discussion .ddp-ui-reply .ddp-ui-reply-top {padding-bottom:10px;}
-.ddp-ui-discussion .ddp-ui-reply .ddp-ui-reply-top .ddp-top-in {display:inline-block; max-width:100%;}
-.ddp-ui-discussion .ddp-ui-reply .ddp-ui-reply-top .ddp-data-reply-date {float:right; margin-left:10px;}
-.ddp-ui-discussion .ddp-ui-reply .ddp-ui-reply-top .ddp-data-reply-name {display:block;font-weight:bold; overflow:hidden; white-space:nowrap; text-overflow:ellipsis;}
-.ddp-ui-discussion .ddp-ui-reply .ddp-ui-textarea {height:62px; border:1px solid #d0d1d8; border-radius:2px; box-sizing:border-box; background-color:#fff;}
-.ddp-ui-discussion .ddp-ui-reply .ddp-ui-textarea .ddp-box-textarea {display:block; height:100%; overflow:hidden;}
-.ddp-ui-discussion .ddp-ui-reply .ddp-ui-textarea .ddp-box-textarea textarea {display:block; padding:9px 10px; width:100%; height:100%; background:none; border:none; box-sizing:border-box;}
-.ddp-ui-discussion .ddp-ui-reply .ddp-ui-textarea .ddp-btn-selection {float:right; margin:16px 24px 16px 10px;}
 
 /**************************************************************
   멀티데이터 가이드
@@ -9467,8 +9226,7 @@ em.ddp-icon-layer2 {background-position:-18px -16px;}
 .ddp-list-datavalue li.ddp-add:after {display:inline-block; position:absolute; top:50%; right:14px; width:7px; height:4px; margin-left:9px; margin-top:-2px; background:url(../images/icon_select.png) no-repeat; transform:rotate(180deg); content:'';}
 .ddp-list-datavalue li.ddp-add.ddp-selected:after {transform:rotate(0)}
 .ddp-data-value {position:relative;}
-.ddp-data-value .ddp-box-layout4 {display:none; position:absolute; top:100%; left:0; right:0; padding:12px 0 0 0;width:auto; max-height:334px; overflow:auto; z-index:10;}
-.ddp-data-value .ddp-box-layout4 .ddp-form-search {margin:0; width:auto; margin:0 10px;}
+.ddp-data-value .ddp-box-layout4 {display:none; position:absolute; top:100%; left:0; right:0; padding:12px 0 0 0;width:auto; max-height:334px; overflow:auto; }
 .ddp-data-value .ddp-list-typebasic {padding:11px 0 ;}
 .ddp-data-value .ddp-list-typebasic.ddp-list-popup li a {padding-left:38px; padding-right:16px;}
 .ddp-data-value .ddp-list-typebasic.ddp-list-popup li a em[class*="ddp-icon-dimension-"],
@@ -9503,7 +9261,13 @@ ul.ddp-list-tab-type {display:inline-block;  }
 ul.ddp-list-tab-type li {display:inline-block; position:relative;float:left; }
 ul.ddp-list-tab-type li + li {margin-left:1px;}
 ul.ddp-list-tab-type li a {display:inline-block; width:46px; height:46px;}
-ul.ddp-list-tab-type li a em[class*="ddp-img-map-"] {display:inline-block;  width:46px; height:46px;background:url(../images/img_maptype.png) no-repeat; }
+
+ul.ddp-list-tab-type li a em[class*="ddp-img-map-"] {
+  display: inline-block;
+  width: 46px;
+  height: 46px;
+  background: url(../images/img_maptype.png) no-repeat;
+}
 ul.ddp-list-tab-type li a em.ddp-img-map-sign {}
 ul.ddp-list-tab-type li a em.ddp-img-map-line {background-position:-47px 0;}
 ul.ddp-list-tab-type li a em.ddp-img-map-polygon {background-position:-94px 0;}
@@ -9514,30 +9278,113 @@ ul.ddp-list-tab-type li a:hover em[class*="ddp-img-map-"],
 ul.ddp-list-tab-type li.ddp-selected a em[class*="ddp-img-map-"]{background-position-y:-47px;}
 ul.ddp-list-tab-type li a:hover + .ddp-ui-tooltip-info {display:block; top:100%; margin-top:5px; left:0;}
 
-.ddp-list-tab-type2 {border-radius:2px; margin:0 -1px;}
-.ddp-list-tab-type2 li {float:left; position:relative; width:25%; padding:0 1px; box-sizing:border-box;}
+.ddp-list-tab-type2 {
+  border-radius: 2px;
+  margin: 0 -1px;
+}
 
-.ddp-list-tab-type2 li a {display:block; width:100%; height:58px; position:relative; border:2px solid #e3e3e6; background:url(../images/bg_maptype.png) no-repeat; box-sizing:border-box;}
-.ddp-list-tab-type2 li a:hover {border-color:#b6b9c1;}
+.ddp-list-tab-type2 li {
+  float: left;
+  position: relative;
+  width: 25%;
+  padding: 0 1px;
+  box-sizing: border-box;
+}
+
+.ddp-list-tab-type2 li a {
+  display: block;
+  width: 100%;
+  height: 58px;
+  position: relative;
+  border: 2px solid #e3e3e6;
+  background: url(../images/bg_maptype.png) no-repeat;
+  box-sizing: border-box;
+}
+
+.ddp-list-tab-type2 li a:hover {
+  border-color: #b6b9c1;
+}
 .ddp-list-tab-type2 li a [class*='ddp-icon-map-'] {display:inline-block; position:absolute; top:50%; left:50%; background:url(../images/img_maptype2.png) no-repeat;}
-.ddp-list-tab-type2 li a .ddp-icon-map-point {width:41px; height:38px; margin:-19px 0 0 -20px;}
-.ddp-list-tab-type2 li a .ddp-icon-map-heatmap {width:39px; height:36px; margin:-18px 0 0 -19px; background-position-y:-39px;}
-.ddp-list-tab-type2 li a .ddp-icon-map-hexagon {width:42px; height:41px; margin:-21px 0 0 -21px; background-position-y:-76px;}
-.ddp-list-tab-type2 li a .ddp-icon-map-cluster {width:40px; height:41px; margin:-20px 0 0 -21px; background-position-y:-118px;}
-.ddp-list-tab-type2 li.ddp-selected a {border-color:#9ca2c9;}
-.ddp-list-tab-type2 li.ddp-selected a .ddp-icon-map-point {background-position-x:-42px;}
-.ddp-list-tab-type2 li.ddp-selected a .ddp-icon-map-heatmap {background-position-x:-42px;}
-.ddp-list-tab-type2 li.ddp-selected a .ddp-icon-map-hexagon {background-position-x:-43px;}
-.ddp-list-tab-type2 li.ddp-selected a .ddp-icon-map-cluster {background-position-x:-41px;}
-.ddp-list-tab-type2 li .ddp-txt-type {display:block; color:#91969e; font-size:12px; text-align:center; letter-spacing:-0.5px;}
-.ddp-list-tab-type2 li.ddp-selected .ddp-txt-type {color:#666fad;}
-.ddp-list-tab-type2 li.ddp-disabled {opacity:0.5;}
-.ddp-list-tab-type2 li.ddp-disabled:before {position:absolute; top:0; left:0; right:0; bottom:0;  content:''; z-index:1;}
-.ddp-list-tab-type2 li.ddp-disabled a {cursor:no-drop;}
 
-	/**********************************************************************************
-         데이터셋치환
-        **********************************************************************************/
+.ddp-list-tab-type2 li a .ddp-icon-map-point {
+  width: 41px;
+  height: 38px;
+  margin: -19px 0 0 -20px;
+}
+
+.ddp-list-tab-type2 li a .ddp-icon-map-heatmap {
+  width: 39px;
+  height: 36px;
+  margin: -18px 0 0 -19px;
+  background-position-y: -39px;
+}
+
+.ddp-list-tab-type2 li a .ddp-icon-map-hexagon {
+  width: 42px;
+  height: 41px;
+  margin: -21px 0 0 -21px;
+  background-position-y: -76px;
+}
+
+.ddp-list-tab-type2 li a .ddp-icon-map-cluster {
+  width: 40px;
+  height: 41px;
+  margin: -20px 0 0 -21px;
+  background-position-y: -118px;
+}
+
+.ddp-list-tab-type2 li.ddp-selected a {
+  border-color: #9ca2c9;
+}
+
+.ddp-list-tab-type2 li.ddp-selected a .ddp-icon-map-point {
+  background-position-x: -42px;
+}
+
+.ddp-list-tab-type2 li.ddp-selected a .ddp-icon-map-heatmap {
+  background-position-x: -42px;
+}
+
+.ddp-list-tab-type2 li.ddp-selected a .ddp-icon-map-hexagon {
+  background-position-x: -43px;
+}
+
+.ddp-list-tab-type2 li.ddp-selected a .ddp-icon-map-cluster {
+  background-position-x: -41px;
+}
+
+.ddp-list-tab-type2 li .ddp-txt-type {
+  display: block;
+  color: #91969e;
+  font-size: 12px;
+  text-align: center;
+  letter-spacing: -0.5px;
+}
+
+.ddp-list-tab-type2 li.ddp-selected .ddp-txt-type {
+  color: #666fad;
+}
+
+.ddp-list-tab-type2 li.ddp-disabled {
+  opacity: 0.5;
+}
+
+.ddp-list-tab-type2 li.ddp-disabled:before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  content: '';
+  z-index: 1;
+}
+
+.ddp-list-tab-type2 li.ddp-disabled a {
+  cursor: no-drop;
+}
+/**********************************************************************************
+     데이터셋치환
+**********************************************************************************/
 .ddp-type-dataset .ddp-ui-popup-contents {position:relative;}
 .ddp-type-dataset .ddp-popup-dashboard {position:absolute; top:120px; left:50px; right:50px; bottom:50px; width:auto;}
 .ddp-type-dataset .ddp-wrap-variable {position:absolute; top:43px; left:0; right:0; bottom:0;}
@@ -9615,8 +9462,7 @@ ul.ddp-list-tab-type li a:hover + .ddp-ui-tooltip-info {display:block; top:100%;
 .icon-db-phoenix .st2{fill:url(#SVGID_3_);}
 .icon-db-phoenix .st3{fill:url(#SVGID_4_);}
 
-.icon-db-post,
-.icon-db-post-b {display:inline-block; width:24px; height:24px;}
+.icon-db-post {display:inline-block; width:24px; height:24px;}
 .icon-db-post .st0{fill:#336791;}
 .icon-db-post .st1{fill:#FFFFFF;}
 .icon-db-post .st2{fill:none;stroke:#FFFFFF;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;}
@@ -9699,10 +9545,9 @@ ul.ddp-list-tab-type li a:hover + .ddp-ui-tooltip-info {display:block; top:100%;
 .icon-file-b {display:inline-block; width:24px; height:24px;}
 .icon-file-b .st0{fill:#6E727B;}
 
-.icon-file-csv-b {display:inline-block; width:24px; height:24px; enable-background:new 0 0 24 24;}
+.icon-file-csv-b {display:inline-block; width:24px; height:24px;}
 .icon-file-csv-b .st0{fill:none;}
 .icon-file-csv-b .st1{fill:#6E727B;}
-
 
 .icon-file-csv-big {display:inline-block; width:24px; height:24px; enable-background:new 0 0 24 24;}
 .icon-file-csv-big .st0{fill:none;}
@@ -9939,7 +9784,6 @@ ul.ddp-list-tab-type li a:hover + .ddp-ui-tooltip-info {display:block; top:100%;
 .icon-chart-file.type-xml .st2{fill:none;}
 .icon-chart-file.type-xml .st3{fill:#4B515A;}
 
-
 /**************************************************************
   Page : 대시보드
 **************************************************************/
@@ -9949,3 +9793,10 @@ ul.ddp-list-tab-type li a:hover + .ddp-ui-tooltip-info {display:block; top:100%;
 .ddp-box-widget .ddp-top-control .ddp-ui-buttons .ddp-box-btn2 .ddp-box-info.ddp-limitation .ddp-total {display:block;padding-bottom:4px;}
 .ddp-box-widget .ddp-top-control .ddp-ui-buttons .ddp-box-btn2 .ddp-box-info.ddp-limitation .ddp-total strong {display:block;}
 .ddp-box-widget .ddp-top-control .ddp-ui-buttons .ddp-box-btn2:hover .ddp-box-info.ddp-limitation {display:block;}
+
+
+
+
+
+
+


### PR DESCRIPTION
### Description
crashed style sheets by issue #2266
so we restored the style sheet

restored 5 css files from commit **2e236028b** to commit **a8cb97f1b**

discovery-frontend/src/assets/css/polaris.v2.component.css
discovery-frontend/src/assets/css/polaris.v2.layout.css
discovery-frontend/src/assets/css/polaris.v2.page.css
discovery-frontend/src/assets/css/metatron/polaris.metatron.page.css
discovery-frontend/src/assets/css/metatron/component/component.tag.css

**Related Issue** : 
[#2266 ](https://github.com/metatron-app/metatron-discovery/issues/2266)

### How Has This Been Tested?
check the pages of discovery-frontend globally

#### Need additional checks?
issue #2008 is affected. 
we will be check it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
