### PR TITLE
#2266 metadata menu tab uses old design styles

### DIFF
--- a/discovery-frontend/src/app/meta-data-management/meta-data-management.component.html
+++ b/discovery-frontend/src/app/meta-data-management/meta-data-management.component.html
@@ -14,66 +14,34 @@
 
 <em class="ddp-bg-back"></em>
 <div class="ddp-ui-contents-in ddp-pad0 ddp-scroll">
-  <!-- top -->
-  <div class="ddp-layout-top-menu ddp-clear">
-    <!-- label -->
-    <div class="ddp-top-label">
-      Meta data
-    </div>
-    <!-- //label -->
-    <!-- menu -->
-    <div class="ddp-top-menu">
-      <ul class="ddp-list-top-menu">
-        <li [class.ddp-selected]="tabId === 'metadata'">
-          <a href="javascript:" (click)="gotoTab('metadata')">{{'msg.comm.menu.manage.metadata.metadata' | translate}}</a>
-        </li>
-        <li [class.ddp-selected]="tabId === 'column-dictionary'">
-          <a href="javascript:" (click)="gotoTab('column-dictionary')">{{'msg.metadata.ui.dictionary.title' | translate}}</a>
-        </li>
-        <li [class.ddp-selected]="tabId === 'code-table'">
-          <a href="javascript:" (click)="gotoTab('code-table')">{{'msg.metadata.ui.codetable.title' | translate}}</a>
-        </li>
-        <li [class.ddp-selected]="tabId === 'lineage'">
-          <a href="javascript:" (click)="gotoTab('lineage')">{{'msg.metadata.ui.lineage.title' | translate}}</a>
-        </li>
-        <li [class.ddp-selected]="tabId === 'catalog'">
-          <a href="javascript:" (click)="gotoTab('catalog')">{{'msg.metadata.ui.catalog' | translate }}</a>
-        </li>
-      </ul>
 
+  <!-- top -->
+  <div class="ddp-ui-contents-top">
+    <div class="ddp-ui-title">
+      {{'msg.comm.menu.manage.metadata' | translate}}
     </div>
-    <!-- menu -->
-    <!-- option -->
-    <div class="ddp-ui-header-option">
-      <a href="javascript:" class="ddp-link-info"></a>
-      <!--
-          클릭시 ddp-selected 추가
-      -->
-      <div class="ddp-ui-more ">
-        <a href="javascript:" class="ddp-icon-more"></a>
-        <!-- popup -->
-        <div class="ddp-wrap-popup2 ddp-types">
-          <ul class="ddp-list-popup">
-            <li>
-              <a href="javascript:">
-                <em class="ddp-icon-drop-cluster"></em>
-                Set Druid Cluster
-              </a>
-            </li>
-            <li>
-              <a href="javascript:">
-                <em class="ddp-icon-drop-guide"></em>
-                Druid Guide
-              </a>
-            </li>
-          </ul>
-        </div>
-        <!-- //popup -->
-      </div>
-    </div>
-    <!-- //option -->
+    <!-- tab -->
+    <ul class="ddp-list-top-tab">
+      <li [class.ddp-selected]="tabId === 'metadata'">
+        <a href="javascript:" (click)="gotoTab('metadata')">{{'msg.comm.menu.manage.metadata.metadata' | translate}}</a>
+      </li>
+      <li [class.ddp-selected]="tabId === 'column-dictionary'">
+        <a href="javascript:" (click)="gotoTab('column-dictionary')">{{'msg.metadata.ui.dictionary.title' | translate}}</a>
+      </li>
+      <li [class.ddp-selected]="tabId === 'code-table'">
+        <a href="javascript:" (click)="gotoTab('code-table')">{{'msg.metadata.ui.codetable.title' | translate}}</a>
+      </li>
+      <li [class.ddp-selected]="tabId === 'lineage'">
+        <a href="javascript:" (click)="gotoTab('lineage')">{{'msg.metadata.ui.lineage.title' | translate}}</a>
+      </li>
+      <li [class.ddp-selected]="tabId === 'catalog'">
+        <a href="javascript:" (click)="gotoTab('catalog')">{{'msg.metadata.ui.catalog' | translate }}</a>
+      </li>
+    </ul>
+    <!-- //tab -->
+
   </div>
-  <!-- //top -->
+
   <!-- metadata -->
   <app-metadata *ngIf="tabId === 'metadata'"></app-metadata>
   <!-- //metadatra -->

--- a/discovery-frontend/src/assets/css/metatron/polaris.metatron.page.css
+++ b/discovery-frontend/src/assets/css/metatron/polaris.metatron.page.css
@@ -32,6 +32,8 @@
 @import url('page/metatron.page.05Management_datasourceList.css');
 /* 05_매니지먼트_00데이터저장소_02데이터소스상세 */
 @import url('page/metatron.page.05Management_datasourceDetail.css');
+/* 05_매니지먼트_00메타데이터 */
+@import url('page/metatron.page.05Management_metadata.css');
 
 /* 99_데이터프리퍼레이션_01데이터플로우_03룰2 */
 @import url('page/metatron.page.99Preperation_dataflow_rule.css');


### PR DESCRIPTION
### Description
metadata menu tab is changed according to recovered style sheet

**Related Issue** : 
[#2266 ](https://github.com/metatron-app/metatron-discovery/issues/2266)

### How Has This Been Tested?
Check that the metadata menu is well displayed overall

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
