### PR TITLE
#2491 index of selected node will be clear when reloading linege view

### DIFF
--- a/discovery-frontend/src/app/meta-data-management/detail/component/lineage-view/lineage-view.component.ts
+++ b/discovery-frontend/src/app/meta-data-management/detail/component/lineage-view/lineage-view.component.ts
@@ -353,12 +353,14 @@ export class LineageViewComponent extends AbstractComponent implements OnInit, O
   public onChangeAlignment(_alignment: any) {
     if(this.alignment !== _alignment.value) {
       this.alignment = _alignment.value;
+      this.selectedNode = null;
       this.getLineageMap();
     }
   }
   public onChangeNodeCount(_nodeCount: any) {
     if( this.nodeCount !== _nodeCount.value) {
       this.nodeCount = _nodeCount.value;
+      this.selectedNode = null;
       this.getLineageMap();
     }
   }
@@ -514,11 +516,11 @@ export class LineageViewComponent extends AbstractComponent implements OnInit, O
                 var sourceName = params.data.frMetaName;
                 var targetName = params.data.toMetaName;
                 var sourceColName = params.data.frColName;
-                if(0<sourceColName.length) {
+                if(sourceColName && 0<sourceColName.length) {
                   sourceName = sourceName +'('+ sourceColName +')';
                 }
                 var targetColName = params.data.toColName;
-                if(0<targetColName.length) {
+                if(targetColName && 0<targetColName.length) {
                   targetName = targetName +'('+ targetColName +')';
                 }
                 return sourceName +' to '+ targetName;

--- a/discovery-frontend/src/app/meta-data-management/lineage/component/create-lineage-confirm-grid.component.ts
+++ b/discovery-frontend/src/app/meta-data-management/lineage/component/create-lineage-confirm-grid.component.ts
@@ -105,6 +105,21 @@ export class CreateLineageConfirmGridComponent extends AbstractPopupComponent im
 
   public complete() {
     let params = this.lineageData.rows;
+    for(let edge of params) {
+      if(!edge.frMetaId && !edge.frMetaName) {
+        Alert.error('frMetaName is needed');
+        return;
+      }
+      if(!edge.toMetaId && !edge.toMetaName) {
+        Alert.error('toMetaName is needed');
+        return;
+      }
+      if(!edge.tier) {
+        Alert.error('tier field of number type is needed');
+        return;
+      }
+    }
+
     this._lineageService.createLineages(params).then((result) => {
       this.loadingHide();
 

--- a/discovery-frontend/src/app/meta-data-management/lineage/component/create-lineage-confirm-grid.component.ts
+++ b/discovery-frontend/src/app/meta-data-management/lineage/component/create-lineage-confirm-grid.component.ts
@@ -107,15 +107,11 @@ export class CreateLineageConfirmGridComponent extends AbstractPopupComponent im
     let params = this.lineageData.rows;
     for(let edge of params) {
       if(!edge.frMetaId && !edge.frMetaName) {
-        Alert.error('frMetaName is needed');
+        Alert.error('frMetaId or frMetaName is required');
         return;
       }
       if(!edge.toMetaId && !edge.toMetaName) {
-        Alert.error('toMetaName is needed');
-        return;
-      }
-      if(!edge.tier) {
-        Alert.error('tier field of number type is needed');
+        Alert.error('toMetaId or toMetaName is required');
         return;
       }
     }

--- a/discovery-frontend/src/app/meta-data-management/lineage/component/create-lineage-upload-file.component.html
+++ b/discovery-frontend/src/app/meta-data-management/lineage/component/create-lineage-upload-file.component.html
@@ -38,7 +38,7 @@
             or drop file here
           </div>
           <div class="ddp-txt-file-info2">
-            .csv formats are allowed
+            .txt .csv formats are allowed
           </div>
         </div>
       </div>

--- a/discovery-frontend/src/app/meta-data-management/lineage/component/create-lineage-upload-file.component.ts
+++ b/discovery-frontend/src/app/meta-data-management/lineage/component/create-lineage-upload-file.component.ts
@@ -110,7 +110,7 @@ export class CreateLineageUploadFileComponent extends AbstractPopupComponent imp
         max_file_size : 0,
         prevent_duplicate: true,
         mime_types: [
-          {title: "Lineage Edge files", extensions: "csv"}
+          {title: "Lineage Edge files", extensions: "csv,txt"}
         ],
 
       },


### PR DESCRIPTION
### Description
1. index of selected node will be clear when reloading linege view
2. test file has txt extension. now txt is supported
3. test file has not a tier field. it is not a right format. now this will make an error.

**Related Issue** :
[#2491](https://github.com/metatron-app/metatron-discovery/issues/2491)

### How Has This Been Tested?
1. decrease the node count. 
2. click all nodes.

If all nodes are selected. that is ok

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
