### PR TITLE
#2470 navigation tab on lineage view

### DIFF
--- a/discovery-frontend/src/app/meta-data-management/detail/component/lineage-view/lineage-view.component.html
+++ b/discovery-frontend/src/app/meta-data-management/detail/component/lineage-view/lineage-view.component.html
@@ -14,8 +14,8 @@
 
 <!-- tab contents -->
 <div [ngClass]="['ddp-ui-tab-contents']">
-  <div class="ddp-type-contents2">
-    <!-- //툴바 영역 -->
+  <div class="ddp-type-contents2 ddp-lineage-view-content">
+  <!-- //툴바 영역 -->
     <div [ngClass]="['ddp-lineage-view-toolbar']">
       <div class="ddp-flow-option ddp-clear">
         <div class="ddp-fleft">

--- a/discovery-frontend/src/assets/css/metatron/page/metatron.page.05Management_metadata.css
+++ b/discovery-frontend/src/assets/css/metatron/page/metatron.page.05Management_metadata.css
@@ -1,6 +1,6 @@
 @charset "utf-8";
 
-.ddp-lineage-view-content { top: 164px; z-index: -1; }
+.ddp-lineage-view-content { top: 164px; }
 
 /**** lineage list  *****/
 .ddp-lineage-list .ddp-lineage-none {position:relative; float:left; width:100%; padding:28px 53px 28px 0; color:#9c9c9c; font-size:14px; box-sizing:border-box;}
@@ -9,7 +9,7 @@
 
 /**** lineage view  *****/
 
-.ddp-flow-option {margin:0px 0px 0px 25px; padding:0px 0px 0px 0px; background-color:#f6f6f7;}
+.ddp-flow-option {margin:9px 8px; padding:6px 0; background-color:#f6f6f7;}
 .ddp-flow-option .ddp-wrap-edit {float:left; margin-left:15px}
 .ddp-flow-option .ddp-wrap-edit + .ddp-wrap-edit {margin-left:20px;}
 .ddp-flow-option .ddp-wrap-edit .ddp-type-selectbox {width:125px; background-color:#fff;}
@@ -22,8 +22,8 @@
 .ddp-flow-option .ddp-box-btn2 .ddp-icon-widget-gridsave {margin-right:2px; vertical-align:middle;}
 .ddp-flow-option .ddp-list-tab-button {position:relative; top:3px; margin:0;}
 
-.ddp-lineage-view-toolbar {z-index:10; left:0; top:0px; right:0; bottom:0; padding:0px; height:50px; background-color:#fff;}
-.ddp-lineage-view {position:fixed; left:0; top:194px; right:0; bottom:0; background-color:#fff;}
+.ddp-lineage-view-toolbar {z-index:10; position:fixed; left:0; top:192px; right:0; bottom:0; height:50px; background-color:#fff;}
+.ddp-lineage-view {position:fixed; left:0; top:242px; right:0; bottom:0; background-color:#fff;}
 .ddp-lineage-view .ddp-split-chart {position:relative; float:left; height:100%; width:100%;}
 .ddp-lineage-view .ddp-box-lineage-detail {position:relative; float:left; top:0; right:0; bottom:0; height:100%; border:none;}
 

--- a/discovery-frontend/src/assets/css/metatron/page/metatron.page.05Management_metadata.css
+++ b/discovery-frontend/src/assets/css/metatron/page/metatron.page.05Management_metadata.css
@@ -1,5 +1,7 @@
 @charset "utf-8";
 
+.ddp-lineage-view-content { top: 164px; z-index: -1; }
+
 /**** lineage list  *****/
 .ddp-lineage-list .ddp-lineage-none {position:relative; float:left; width:100%; padding:28px 53px 28px 0; color:#9c9c9c; font-size:14px; box-sizing:border-box;}
 
@@ -7,7 +9,7 @@
 
 /**** lineage view  *****/
 
-.ddp-flow-option {margin:9px 8px; padding:6px 0; background-color:#f6f6f7;}
+.ddp-flow-option {margin:0px 0px 0px 25px; padding:0px 0px 0px 0px; background-color:#f6f6f7;}
 .ddp-flow-option .ddp-wrap-edit {float:left; margin-left:15px}
 .ddp-flow-option .ddp-wrap-edit + .ddp-wrap-edit {margin-left:20px;}
 .ddp-flow-option .ddp-wrap-edit .ddp-type-selectbox {width:125px; background-color:#fff;}
@@ -20,8 +22,8 @@
 .ddp-flow-option .ddp-box-btn2 .ddp-icon-widget-gridsave {margin-right:2px; vertical-align:middle;}
 .ddp-flow-option .ddp-list-tab-button {position:relative; top:3px; margin:0;}
 
-.ddp-lineage-view-toolbar {z-index:10; position:fixed; left:0; top:100px; right:0; bottom:0; height:50px; background-color:#fff;}
-.ddp-lineage-view {position:fixed; left:0; top:150px; right:0; bottom:0; background-color:#fff;}
+.ddp-lineage-view-toolbar {z-index:10; left:0; top:0px; right:0; bottom:0; padding:0px; height:50px; background-color:#fff;}
+.ddp-lineage-view {position:fixed; left:0; top:194px; right:0; bottom:0; background-color:#fff;}
 .ddp-lineage-view .ddp-split-chart {position:relative; float:left; height:100%; width:100%;}
 .ddp-lineage-view .ddp-box-lineage-detail {position:relative; float:left; top:0; right:0; bottom:0; height:100%; border:none;}
 


### PR DESCRIPTION
### Description
the lineage view page has the tabs for navigation now

**Related Issue** : 
[#2470 ](https://github.com/metatron-app/metatron-discovery/issues/2470)

### How Has This Been Tested?
go to [Management]-[Explore data]-[metadata]-[lineage view]
there are the navigation tabs
if it works, then ok

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
