### PR TITLE
fn-fix_monitoring error

### DIFF
--- a/discovery-frontend/src/app/monitoring/audit/log-statistics/log-statistics.component.ts
+++ b/discovery-frontend/src/app/monitoring/audit/log-statistics/log-statistics.component.ts
@@ -268,11 +268,13 @@ export class LogStatisticsComponent extends AbstractComponent implements OnInit,
             series: [
               {
                 name: 'Success', type: 'bar', stack: 'count', data: result.series.SUCCESS,
-                itemStyle: { normal: { color: '#4c92e0' } }
+                itemStyle: { normal: { color: '#4c92e0' } },
+                cursor: 'default'
               },
               {
                 name: 'Fail', type: 'bar', stack: 'count', data: result.series.FAIL,
-                itemStyle: { normal: { color: '#eb5f58' } }
+                itemStyle: { normal: { color: '#eb5f58' } },
+                cursor: 'default'
               }
             ]
           });


### PR DESCRIPTION
Need to show default cursor on query success, failure rate bar chart

### Description
<!--- Describe your changes in detail -->
When mouse cursor is on the query success/failure rate bar chart cursor type is pointer

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
METATRON-2845

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Using LNB -> Management -> Data Monitoring -> Log statistics
2. check if mouse is on query success/failure rate barchart, cursor type is default.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
