### PR TITLE
fn-fix_datastorage_default_filter error

### DIFF
--- a/discovery-frontend/src/app/data-storage/component/criterion/criterion-extension-box.component.html
+++ b/discovery-frontend/src/app/data-storage/component/criterion/criterion-extension-box.component.html
@@ -21,7 +21,8 @@
       <!-- list -->
       <ul class="ddp-list-popup">
         <li  *ngFor="let criterion of criterionList">
-          <a href="javascript:" (click)="onChangeCheckedCriterion(criterion); $event.preventDefault()">
+
+          <a *ngIf="criterion.criterionKey !== 'SOURCE_TYPE'" href="javascript:" (click)="onChangeCheckedCriterion(criterion); $event.preventDefault()">
             <label class="ddp-label-checkbox">
               <input type="checkbox" [checked]="isCheckedCriterion(criterion)">
               <i class="ddp-icon-checkbox"></i>

--- a/discovery-frontend/src/app/data-storage/component/criterion/criterion.component.ts
+++ b/discovery-frontend/src/app/data-storage/component/criterion/criterion.component.ts
@@ -29,7 +29,6 @@ export class CriterionComponent extends AbstractComponent {
 
   @Input()
   public readonly criterionApiFunc;
-
   // used criterion list
   public usedCriterionList: Criteria.ListCriterion[];
   // extension criterion list
@@ -61,6 +60,10 @@ export class CriterionComponent extends AbstractComponent {
     // if exist extension criterion list in criterion list param
     if (!_.isNil(extensionCriterion)) {
       this._extensionCriterionList = _.cloneDeep(extensionCriterion.subCriteria);
+      // add source type filter as default filter
+      this.usedCriterionList.push(this._extensionCriterionList.find(extensionCriterion => {
+        return extensionCriterion.criterionKey === Criteria.ListCriterionKey.SOURCE_TYPE
+      }))
     }
     // if exist default filters
     if (!_.isNil(criterionResult.defaultFilters) && criterionResult.defaultFilters.length > 0) {
@@ -107,6 +110,7 @@ export class CriterionComponent extends AbstractComponent {
    * @param {Criteria.ListCriterion} criterion
    */
   public addExtensionCriterion(criterion: Criteria.ListCriterion): void {
+    console.log(criterion);
     // add criterion in used criterion list
     this.usedCriterionList.push(criterion);
     // if not exist extensions

--- a/discovery-frontend/src/app/data-storage/component/criterion/criterion.component.ts
+++ b/discovery-frontend/src/app/data-storage/component/criterion/criterion.component.ts
@@ -54,16 +54,25 @@ export class CriterionComponent extends AbstractComponent {
    * @param {{criteria: Criteria.ListCriterion[]; defaultFilters: Criteria.ListFilter[]}} criterionResult
    */
   public initCriterionList(criterionResult: Criteria.Criterion): void {
+
+    // add source type in default criteria
+    criterionResult.criteria.push(criterionResult.criteria[4].subCriteria[2]);
+
+    // remove source type criterion in MORE subcriteria
+    criterionResult.criteria[4].subCriteria.slice(2);
     // set used criterion list
     this.usedCriterionList = _.cloneDeep(criterionResult.criteria);
+
     const extensionCriterion = this.usedCriterionList.find(filter => filter.criterionKey === Criteria.ListCriterionKey.MORE && !_.isNil(filter.subCriteria));
     // if exist extension criterion list in criterion list param
     if (!_.isNil(extensionCriterion)) {
       this._extensionCriterionList = _.cloneDeep(extensionCriterion.subCriteria);
-      // add source type filter as default filter
-      this.usedCriterionList.push(this._extensionCriterionList.find(extensionCriterion => {
-        return extensionCriterion.criterionKey === Criteria.ListCriterionKey.SOURCE_TYPE
-      }))
+
+      this._extensionCriterionList.reduce(([], extensionCriterion) => {
+        return extensionCriterion.criterionKey !== "SOURCE_TYPE" ?  extensionCriterion : null;
+      });
+
+      this.changedFilter.emit();
     }
     // if exist default filters
     if (!_.isNil(criterionResult.defaultFilters) && criterionResult.defaultFilters.length > 0) {
@@ -110,7 +119,6 @@ export class CriterionComponent extends AbstractComponent {
    * @param {Criteria.ListCriterion} criterion
    */
   public addExtensionCriterion(criterion: Criteria.ListCriterion): void {
-    console.log(criterion);
     // add criterion in used criterion list
     this.usedCriterionList.push(criterion);
     // if not exist extensions
@@ -130,6 +138,7 @@ export class CriterionComponent extends AbstractComponent {
   public removeExtensionCriterion(criterion: Criteria.ListCriterion): void {
     // remove criterion in used criterion list
     this.usedCriterionList.splice(this.usedCriterionList.findIndex(usedCriterion => usedCriterion.criterionKey === criterion.criterionKey),1);
+
     // remove criterion in search params
     this.queryParams[Criteria.KEY_EXTENSIONS].splice(this.queryParams[Criteria.KEY_EXTENSIONS].findIndex(paramItem => paramItem === criterion.criterionKey), 1);
     Object.keys(this.queryParams).forEach((key) => {
@@ -157,6 +166,8 @@ export class CriterionComponent extends AbstractComponent {
    * @return {boolean}
    */
   public isExtensionCriterion(criterion: Criteria.ListCriterion): boolean {
+    // do not allow remove source type from default criterion
+    if (criterion.criterionKey === "SOURCE_TYPE") return false;
     return this._extensionCriterionList.findIndex(extensionCriterion => extensionCriterion.criterionKey === criterion.criterionKey) !== -1;
   }
 


### PR DESCRIPTION
Set source type as a default filter

### Description
<!--- Describe your changes in detail -->

In datastorage default of extension filter was no filter was selected, so set source type as a default option

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
METATRON 2833

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Management -> Datasource
2. Check if source type filter is selected as an default filter
#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
