### PR TITLE
fn-fix_workbook-datasource-detail-error

### DIFF
--- a/discovery-frontend/src/app/common/component/data-preview/data.preview.component.ts
+++ b/discovery-frontend/src/app/common/component/data-preview/data.preview.component.ts
@@ -1112,10 +1112,12 @@ export class DataPreviewComponent extends AbstractPopupComponent implements OnIn
     // 메타데이터가 존재한다면
     if (this.isExistMetaData(source)) {
       const fieldMetaData: MetadataColumn = _.find(source.uiMetaData.columns, {'physicalName': field.name});
-      // code table
-      field['codeTable'] = fieldMetaData.codeTable;
-      // dictionary
-      field['dictionary'] = fieldMetaData.dictionary;
+      if (!_.isUndefined(fieldMetaData)) {
+        // code table
+        field['codeTable'] = fieldMetaData.codeTable;
+        // dictionary
+        field['dictionary'] = fieldMetaData.dictionary;
+      }
     }
   }
 


### PR DESCRIPTION
- fix data source detail popup error

### Description
<!--- Describe your changes in detail -->

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
METATRON 2925

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Move to https://dev-discovery.metatron.app/app/v2/workspace
2. login using metatron id 
3. choose ysv_workbook
4. click the datasource icon which is next to presentation view button
5. check detail modal shows without error

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
