### PR TITLE
#2477 not all fields on the origin need to be filled

### DIFF
--- a/discovery-frontend/src/app/data-preparation/data-snapshot/data-snapshot-detail.component.html
+++ b/discovery-frontend/src/app/data-preparation/data-snapshot/data-snapshot-detail.component.html
@@ -239,8 +239,8 @@
               <div class="ddp-ui-sub" *ngIf="originDsInfo.qryStmt">
                 <span class="ddp-data-sub">{{'msg.dp.th.query.stmt' | translate}} <em class="ddp-data-result">{{ originDsInfo.qryStmt }}</em></span>
               </div>
-              <div class="ddp-ui-sub" *ngIf="originDsInfo.filePath">
-                <span class="ddp-data-sub">{{'msg.dp.th.file.path' | translate}} <em class="ddp-data-result">{{ originDsInfo.filePath }}</em></span>
+              <div class="ddp-ui-sub" *ngIf="originDsInfo.storedUri">
+                <span class="ddp-data-sub">{{'msg.dp.th.file.path' | translate}} <em class="ddp-data-result">{{ originDsInfo.storedUri }}</em></span>
               </div>
               <div class="ddp-ui-sub" *ngIf="originDsInfo.createdTime">
                 <span class="ddp-data-sub">{{'msg.comm.ui.list.created' | translate}} <em class="ddp-data-result">{{originDsInfo.createdTime | mdate:'YYYY-MM-DD HH:mm'}}</em></span>

--- a/discovery-frontend/src/app/data-preparation/data-snapshot/data-snapshot-detail.component.ts
+++ b/discovery-frontend/src/app/data-preparation/data-snapshot/data-snapshot-detail.component.ts
@@ -612,25 +612,28 @@ export class DataSnapshotDetailComponent extends AbstractComponent implements On
     let sourceInfo = this.selectedDataSnapshot.sourceInfo;
 
     if( isUndefined(sourceInfo) ) {
-      //Alert.warning(this.translateService.instant('msg.dp.alert.imported.ds.info'));
-      this.originDsInfo.dsName = '';
+      this.originDsInfo.dsName = null;
       this.originDsInfo.qryStmt = null;
-      this.originDsInfo.filePath = null;
+      this.originDsInfo.storedUri = null;
       this.originDsInfo.createdTime = null;
     } else {
       if( isUndefined(sourceInfo.origDsName) ) {
-        Alert.warning(this.translateService.instant('msg.dp.alert.imported.ds.name'));
-        this.originDsInfo.dsName = '';
+        this.originDsInfo.dsName = null;
       } else {
         this.originDsInfo.dsName = sourceInfo.origDsName;
       }
       if( isUndefined(sourceInfo.origDsQueryStmt) ) {
-        Alert.warning(this.translateService.instant('msg.dp.alert.imported.ds.querystmt'));
+        this.originDsInfo.qryStmt = null;
       } else {
         this.originDsInfo.qryStmt = sourceInfo.origDsQueryStmt;
       }
+      if( isUndefined(sourceInfo.origDsStoredUri) ) {
+        this.originDsInfo.storedUri = null;
+      } else {
+        this.originDsInfo.storedUri = sourceInfo.origDsStoredUri;
+      }
       if( isUndefined(sourceInfo.origDsCreatedTime) ) {
-        Alert.warning(this.translateService.instant('msg.dp.alert.imported.ds.createdtime'));
+        this.originDsInfo.createdTime = null;
       } else {
         this.originDsInfo.createdTime = sourceInfo.origDsCreatedTime;
       }

--- a/discovery-frontend/src/app/domain/data-preparation/pr-snapshot.ts
+++ b/discovery-frontend/src/app/domain/data-preparation/pr-snapshot.ts
@@ -62,7 +62,7 @@ public dsModifiedTime: Date;
 export class OriginDsInfo {
 public dsName: string;
 public qryStmt: string;
-public filePath: string;
+public storedUri: string;
 public createdTime: string;
 }
 
@@ -73,6 +73,7 @@ export class LineageInfo {
     public dsId: string;
     public dsName: string;
     public origDsName: string;
+    public origDsStoredUri: string;
     public origDsQueryStmt: string;
     public origDsCreatedTime: string;
 }


### PR DESCRIPTION
### Description
![스크린샷 2019-08-20 오후 5 57 53](https://user-images.githubusercontent.com/42257727/63336826-c6306e80-c37a-11e9-8138-5fb69f227acb.png)
original dataset information has not all fields.

**Related Issue** : 
[#2477 ](https://github.com/metatron-app/metatron-discovery/issues/2477)

### How Has This Been Tested?
See the details of a snapshot.
If no warning pops up, it is ok.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
