### PR TITLE
Fn default node count is 7 on lineage view

### DIFF
--- a/discovery-frontend/src/app/meta-data-management/detail/component/lineage-view/lineage-view.component.ts
+++ b/discovery-frontend/src/app/meta-data-management/detail/component/lineage-view/lineage-view.component.ts
@@ -88,7 +88,7 @@ export class LineageViewComponent extends AbstractComponent implements OnInit, O
   public nodeCount: number;
   public alignment: string;
 
-  public defaultNodeCountIndex = 1;
+  public defaultNodeCountIndex = 2;
   public defaultAlignmentIndex = 0;
 
   @Input()


### PR DESCRIPTION
### Description
default node count is 7

**Related Issue** : 
METATRON-2983

### How Has This Been Tested?
1. Login as admin
2. management -> explore data -> metadata -> metadata detail -> lineage tab
3. check the node count. 7 is right

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
