### PR TITLE
Fn show sheet name on dataset info

### DIFF
--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/dataset-info-popup/dataset-info-popup.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/dataset-info-popup/dataset-info-popup.component.ts
@@ -694,7 +694,8 @@ export class DatasetInfoPopupComponent extends AbstractComponent implements OnIn
       ];
 
       // EXCEL
-      if (PreparationCommonUtil.getFileNameAndExtension(dataset.filenameBeforeUpload)[1].toUpperCase() === 'EXCEL') {
+      var re = /.+\.xlsx?$/i;
+      if (re.test(dataset.filenameBeforeUpload) === true) {
         this.datasetInformationList.push({name : this.translateService.instant('msg.dp.th.sheet'), value : this.getSheetName() })
       }
 


### PR DESCRIPTION
### Description
If imported dataset if from EXCEL, sheet name will be shown.

**Related Issue** : 
METATRON-3007

### How Has This Been Tested?
click an imported dataset of EXCEL on dataflow detail page.
there is a sheet name on info area.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
