### PR TITLE
Fn confirm button to delete snapshot is corrected

### DIFF
--- a/discovery-frontend/src/app/data-preparation/data-snapshot/data-snapshot.component.ts
+++ b/discovery-frontend/src/app/data-preparation/data-snapshot/data-snapshot.component.ts
@@ -257,7 +257,7 @@ export class DataSnapshotComponent extends AbstractComponent implements OnInit, 
     const modal = new Modal();
     modal.name = this.translateService.instant('msg.dp.alert.ss.del.title');
     modal.description = dataset.finishTime ? this.translateService.instant('msg.dp.alert.ss.del.description') : 'Snapshot is preparing. Are you sure you want to stop this process and delete it?';
-    modal.btnName = this.translateService.instant('msg.comm.ui.del');
+    modal.btnName = this.translateService.instant('msg.comm.ui.confirm');
 
     this.selectedDeletessId = dataset.ssId;
     this.deleteModalComponent.init(modal);

--- a/discovery-frontend/src/app/data-preparation/data-snapshot/data-snapshot.component.ts
+++ b/discovery-frontend/src/app/data-preparation/data-snapshot/data-snapshot.component.ts
@@ -257,6 +257,7 @@ export class DataSnapshotComponent extends AbstractComponent implements OnInit, 
     const modal = new Modal();
     modal.name = this.translateService.instant('msg.dp.alert.ss.del.title');
     modal.description = dataset.finishTime ? this.translateService.instant('msg.dp.alert.ss.del.description') : 'Snapshot is preparing. Are you sure you want to stop this process and delete it?';
+    modal.btnName = this.translateService.instant('msg.comm.btn.modal.done');
 
     this.selectedDeletessId = dataset.ssId;
     this.deleteModalComponent.init(modal);

--- a/discovery-frontend/src/app/data-preparation/data-snapshot/data-snapshot.component.ts
+++ b/discovery-frontend/src/app/data-preparation/data-snapshot/data-snapshot.component.ts
@@ -257,7 +257,7 @@ export class DataSnapshotComponent extends AbstractComponent implements OnInit, 
     const modal = new Modal();
     modal.name = this.translateService.instant('msg.dp.alert.ss.del.title');
     modal.description = dataset.finishTime ? this.translateService.instant('msg.dp.alert.ss.del.description') : 'Snapshot is preparing. Are you sure you want to stop this process and delete it?';
-    modal.btnName = this.translateService.instant('msg.comm.btn.modal.done');
+    modal.btnName = this.translateService.instant('msg.comm.ui.del');
 
     this.selectedDeletessId = dataset.ssId;
     this.deleteModalComponent.init(modal);

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow.component.ts
@@ -193,7 +193,7 @@ export class DataflowComponent extends AbstractComponent implements OnInit, OnDe
     const modal = new Modal();
     modal.name = this.translateService.instant('msg.comm.ui.del.description');
     modal.description = this.translateService.instant('msg.dp.alert.df.del.description');
-    modal.btnName = this.translateService.instant('msg.comm.btn.modal.done');
+    modal.btnName = this.translateService.instant('msg.comm.ui.del');
 
     this.selectedDeletedfId = id;
     this.deleteModalComponent.init(modal);

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow.component.ts
@@ -193,7 +193,7 @@ export class DataflowComponent extends AbstractComponent implements OnInit, OnDe
     const modal = new Modal();
     modal.name = this.translateService.instant('msg.comm.ui.del.description');
     modal.description = this.translateService.instant('msg.dp.alert.df.del.description');
-    modal.btnName = this.translateService.instant('msg.comm.ui.del');
+    modal.btnName = this.translateService.instant('msg.comm.ui.confirm');
 
     this.selectedDeletedfId = id;
     this.deleteModalComponent.init(modal);

--- a/discovery-frontend/src/app/data-preparation/dataset/dataset.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataset/dataset.component.ts
@@ -268,7 +268,7 @@ export class DatasetComponent extends AbstractComponent implements OnInit {
     const modal = new Modal();
     modal.name = this.translateService.instant('msg.comm.ui.del.description');
     modal.description = this.translateService.instant('msg.dp.alert.ds.del.description');
-    modal.btnName = this.translateService.instant('msg.comm.ui.del');
+    modal.btnName = this.translateService.instant('msg.comm.ui.confirm');
 
     this.selectedDeletedsId = dataset.dsId;
     this.deleteModalComponent.init(modal);

--- a/discovery-frontend/src/app/data-preparation/dataset/dataset.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataset/dataset.component.ts
@@ -268,7 +268,7 @@ export class DatasetComponent extends AbstractComponent implements OnInit {
     const modal = new Modal();
     modal.name = this.translateService.instant('msg.comm.ui.del.description');
     modal.description = this.translateService.instant('msg.dp.alert.ds.del.description');
-    modal.btnName = this.translateService.instant('msg.comm.btn.modal.done');
+    modal.btnName = this.translateService.instant('msg.comm.ui.del');
 
     this.selectedDeletedsId = dataset.dsId;
     this.deleteModalComponent.init(modal);


### PR DESCRIPTION
### Description
on snapshot deletion popup in korean 
the button name was 'done'
it is changed to 'confirm'

**Related Issue** : 
METATRON-2898

### How Has This Been Tested?
choose language as korean
delete a snapshot
you can see the button 'confirm' not 'done'

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
