### PR TITLE
#2568 constrained file name

### DIFF
--- a/discovery-frontend/src/app/data-preparation/component/create-snapshot-popup.component.html
+++ b/discovery-frontend/src/app/data-preparation/component/create-snapshot-popup.component.html
@@ -120,6 +120,7 @@
                   <input type="text"
                          class="ddp-input-typebasic"
                          [(ngModel)]="snapshot.storedUri"
+                         (ngModelChange)="onChangeStoredUri($event, selection)"
                          (keydown)="fileUriKeyDown()">
                   <span class="ddp-data-error" *ngIf="fileUrlErrorMsg !== ''"> {{fileUrlErrorMsg}}</span>
                 </div>

--- a/discovery-frontend/src/app/data-preparation/component/create-snapshot-popup.component.ts
+++ b/discovery-frontend/src/app/data-preparation/component/create-snapshot-popup.component.ts
@@ -97,6 +97,7 @@ export class CreateSnapshotPopup extends AbstractPopupComponent implements OnIni
   public ssNameErrorMsg: string = '';
   public tblErrorMsg: string = '';
 
+  public storedUriChangedDirectly: boolean = false;
 
   @Output()
   public snapshotCreateFinishEvent = new EventEmitter();
@@ -250,10 +251,23 @@ export class CreateSnapshotPopup extends AbstractPopupComponent implements OnIni
    * When snapshot Name change, modify file type uris
    * */
   public changeSSUri(){
-    if(this.snapshot.storedUri && this.snapshot.storedUri.lastIndexOf("/") > 0) {
-      this.snapshot.storedUri = this.snapshot.storedUri.substring(0,this.snapshot.storedUri.lastIndexOf("/")+1)
-        + this.snapshot.ssName.replace(/\s/gi, "")
-        + '.'+this.uriFileFormat.toString().toLowerCase();
+    if( this.storedUriChangedDirectly === true) {
+      return;
+    }
+
+    let fileName = this.snapshot.ssName.replace(/[^\w_가-힣]/gi, "_") +'.'+ this.uriFileFormat.toString().toLowerCase();
+    this.changeStoredUri(fileName);
+  }
+
+  public changeStoredUri(fileName: string = null){
+    var slashIndex = this.snapshot.storedUri.lastIndexOf("/");
+    if(this.snapshot.storedUri && slashIndex > 0) {
+      if(fileName===null) {
+        fileName = this.snapshot.storedUri.substring(slashIndex+1);
+      }
+      let replacedFileName = fileName.replace(/[^\w_.가-힣]/gi, "_");
+
+      this.snapshot.storedUri = this.snapshot.storedUri.substring(0,slashIndex+1) + replacedFileName;
     }
   }
 
@@ -413,6 +427,15 @@ export class CreateSnapshotPopup extends AbstractPopupComponent implements OnIni
     this.isErrorShow = false
   }
 
+  /**
+   * Check if it has changed directly
+   */
+  public onChangeStoredUri(event, selection) {
+    if(event) {
+      this.storedUriChangedDirectly = true;
+      this.changeStoredUri();
+    }
+  }
 
   /**
    * Remove error msg when keydown in file uri

--- a/discovery-frontend/src/app/data-preparation/component/create-snapshot-popup.component.ts
+++ b/discovery-frontend/src/app/data-preparation/component/create-snapshot-popup.component.ts
@@ -265,7 +265,7 @@ export class CreateSnapshotPopup extends AbstractPopupComponent implements OnIni
       if(fileName===null) {
         fileName = this.snapshot.storedUri.substring(slashIndex+1);
       }
-      let replacedFileName = fileName.replace(/[^\w_.가-힣]/gi, "_");
+      let replacedFileName = fileName.replace(/[^\w_.ㄱ-힣]/gi, "_");
 
       this.snapshot.storedUri = this.snapshot.storedUri.substring(0,slashIndex+1) + replacedFileName;
     }


### PR DESCRIPTION
### Description
The file URL of snapshot is from snapshot name.
Snapshot name can contain special characters. But the file name is not.
So replace the special character with _

In addition, if the user manually changes the URL, 
the URL does not follow the snapshot name.

The rules: file name is a combination of alphanumeric, hangul, _ and .

**Related Issue** : 
[#2568 ](https://github.com/metatron-app/metatron-discovery/issues/2568)

### How Has This Been Tested?
1. go to the popup to create snapshot
2. you can change the snapshot name. type special characters
3. change file URL on advanced settings. and type special characters
4. change the snapshot name again. It does not work. This is the intended behavior.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
