### PR TITLE
#2584 disable spark engine when not properly configured

### DIFF
--- a/discovery-frontend/src/app/data-preparation/component/create-snapshot-popup.component.html
+++ b/discovery-frontend/src/app/data-preparation/component/create-snapshot-popup.component.html
@@ -191,7 +191,7 @@
                     <span class="ddp-txt-radio">{{'msg.dp.th.ss.etl-engine.embedded' | translate }}</span>
                   </label>
                   <label class="ddp-label-radio ddp-inline">
-                    <input type="radio" (change)="changeEtlEngine(Engine.SPARK)" name="EtlEngineRadio">
+                    <input type="radio" [disabled]="false===isSparkEnabled()" (change)="changeEtlEngine(Engine.SPARK)" name="EtlEngineRadio">
                     <i class="ddp-icon-radio"></i>
                     <span class="ddp-txt-radio">{{'msg.dp.th.ss.etl-engine.spark' | translate }}</span>
                   </label>

--- a/discovery-frontend/src/app/data-preparation/component/create-snapshot-popup.component.ts
+++ b/discovery-frontend/src/app/data-preparation/component/create-snapshot-popup.component.ts
@@ -601,7 +601,11 @@ export class CreateSnapshotPopup extends AbstractPopupComponent implements OnIni
 
       this.dataflowService.getConfiguration(this.datasetId).then((conf) => {
 
-        this._isSparkEngineEnabled = conf['sparkEngineEnabled'];
+        if(conf['sparkEngineEnabled']) {
+          this._isSparkEngineEnabled = conf['sparkEngineEnabled'];
+        } else {
+          this._isSparkEngineEnabled = false;
+        }
 
         this.ssName = this._getDefaultSnapshotName(conf['ss_name']);
 


### PR DESCRIPTION
### Description
if dataprep.etl.spark option is disabled, 
the spark option should be unselectable on creating snapshot popup

**Related Issue** : 
[#2584 ](https://github.com/metatron-app/metatron-discovery/issues/2584)

### How Has This Been Tested?
1. Do not give spark option (refer below):
![스크린샷 2019-09-09 오후 2 52 22](https://user-images.githubusercontent.com/42257727/64506272-ec11b900-d311-11e9-8770-4ee15de86e82.png)
Just delete spark: option and its children.
2. Import & wrangle s5k_1.csv.txt
3. Click "Snapshot" button
4. Click "Advanced settings"
5. Spark should be disabled.


#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
