### PR TITLE
#2617 Keep sorting conditions used in the workspace

### DIFF
--- a/discovery-frontend/src/app/common/component/abstract.component.ts
+++ b/discovery-frontend/src/app/common/component/abstract.component.ts
@@ -46,6 +46,8 @@ import {filter} from 'rxjs/operators';
 import {isUndefined} from "util";
 import {ImplementorType} from "../../domain/dataconnection/dataconnection";
 import {LogicalType} from '../../domain/datasource/datasource';
+import {UsedCriteria} from "../value/used-criteria.data.value";
+import {LocalStorageConstant} from "../constant/local-storage.constant";
 
 declare let moment;
 
@@ -979,6 +981,28 @@ export class AbstractComponent implements OnInit, AfterViewInit, OnDestroy, CanC
       };
     }
   } // function - commonExceptionHandler
+
+  protected getUsedCriteriaFromLocalStorage(): UsedCriteria {
+    if(localStorage) {
+      const usedCriteria = localStorage.getItem(LocalStorageConstant.KEY.USED_CRITERIA);
+      let criteria : UsedCriteria;
+      if(usedCriteria) {
+        criteria = JSON.parse(usedCriteria);
+      } else {
+        criteria = new UsedCriteria();
+        this.setUsedCriteriaToLocalStorage(criteria);
+      }
+      return criteria;
+    } else {
+      return new UsedCriteria();
+    }
+  }
+
+  protected setUsedCriteriaToLocalStorage(criteria: UsedCriteria): void {
+    if(localStorage) {
+      localStorage.setItem(LocalStorageConstant.KEY.USED_CRITERIA,  JSON.stringify(criteria));
+    }
+  }
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Private Method

--- a/discovery-frontend/src/app/common/constant/local-storage.constant.ts
+++ b/discovery-frontend/src/app/common/constant/local-storage.constant.ts
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class LocalStorageKey {
+  // 사용자가 최근 사용한 조건들(정렬, 뷰 종류, 북 종류 등등)
+  public USED_CRITERIA = "USED_CRITERIA";
+}
+
+export class LocalStorageConstant {
+  public static KEY: LocalStorageKey = new LocalStorageKey();
+}

--- a/discovery-frontend/src/app/common/value/used-criteria.data.value.ts
+++ b/discovery-frontend/src/app/common/value/used-criteria.data.value.ts
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class UsedCriteria {
+  workspace : WorkspaceCriteria = new WorkspaceCriteria();
+}
+
+export class WorkspaceCriteria {
+  contentSortIndex: number;
+  viewType: string;
+  contentFilterIndex: number;
+}

--- a/discovery-frontend/src/app/workspace/workspace.component.html
+++ b/discovery-frontend/src/app/workspace/workspace.component.html
@@ -179,6 +179,7 @@
       <component-drop-box
         [array]="contentFilter"
         [viewKey]="'value'"
+        [defaultIndex]="contentFilterIndex"
         (onSelected)="selectedFilter($event)"
       ></component-drop-box>
       <!-- //dropdown -->
@@ -186,7 +187,7 @@
       <!-- 클릭시 ddp-selected 추가 -->
       <component-sort-drop-box
         [array]="contentSort"
-        [defaultIndex]="3"
+        [defaultIndex]="contentSortIndex"
         [viewKey]="'value'"
         (onSelected)="selectedSort($event)"
       ></component-sort-drop-box>


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
사용자가 워크스페이스에서 3가지 조건(정렬, 뷰타입,워크북 종류)을 선택하면 이를 저장하여 다른 화면으로 가거나 브라우저를 종료 하더라도 유지할 수 있도록 하였습니다.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#2617 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
