### PR TITLE
#2629 fix uppercase table name in postgresql

### DIFF
--- a/discovery-frontend/src/app/workbench/component/detail-workbench/detail-workbench-table/detail-workbench-table.ts
+++ b/discovery-frontend/src/app/workbench/component/detail-workbench/detail-workbench-table/detail-workbench-table.ts
@@ -401,7 +401,7 @@ export class DetailWorkbenchTable extends AbstractWorkbenchComponent implements 
    * @param item
    */
   public setTableSql(item) {
-    if( ImplementorType.DRUID === this.implementorType ) {
+    if( ImplementorType.DRUID === this.implementorType || ImplementorType.POSTGRESQL === this.implementorType ) {
       this.sqlIntoEditorEvent.emit('\nSELECT * FROM ' + this.inputParams.dataconnection.database + '."' + item + '";');
     } else {
       this.sqlIntoEditorEvent.emit('\nSELECT * FROM ' + this.inputParams.dataconnection.database + '.' + item + ';');

--- a/discovery-frontend/src/app/workbench/component/detail-workbench/detail-workbench-table/detail-workbench-table.ts
+++ b/discovery-frontend/src/app/workbench/component/detail-workbench/detail-workbench-table/detail-workbench-table.ts
@@ -402,7 +402,7 @@ export class DetailWorkbenchTable extends AbstractWorkbenchComponent implements 
    */
   public setTableSql(item) {
     if( ImplementorType.DRUID === this.implementorType || ImplementorType.POSTGRESQL === this.implementorType ) {
-      this.sqlIntoEditorEvent.emit('\nSELECT * FROM ' + this.inputParams.dataconnection.database + '."' + item + '";');
+      this.sqlIntoEditorEvent.emit('\nSELECT * FROM "' + this.inputParams.dataconnection.database + '"."' + item + '";');
     } else {
       this.sqlIntoEditorEvent.emit('\nSELECT * FROM ' + this.inputParams.dataconnection.database + '.' + item + ';');
     }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/accessor/PostgresqlDataAccessor.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/accessor/PostgresqlDataAccessor.java
@@ -77,7 +77,7 @@ public class PostgresqlDataAccessor extends AbstractJdbcDataAccessor {
     } catch (Exception e) {
       LOGGER.error("Fail to get list of table : {}", e.getMessage());
       throw new JdbcDataConnectionException(JdbcDataConnectionErrorCodes.INVALID_QUERY_ERROR_CODE,
-                                            "Fail to get list of database : " + e.getMessage());
+                                            "Fail to get list of table : " + e.getMessage());
     }
 
     Map<String, Object> databaseMap = new LinkedHashMap<>();

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/PostgresqlDialect.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/PostgresqlDialect.java
@@ -169,7 +169,7 @@ public class PostgresqlDialect implements JdbcDialect {
     }
 
     if(StringUtils.isNotEmpty(schemaNamePattern)){
-      builder.append(" AND SCHEMA_NAME LIKE '%" + schemaNamePattern.toLowerCase() + "%' ");
+      builder.append(" AND LOWER(SCHEMA_NAME) LIKE '%" + schemaNamePattern.toLowerCase() + "%' ");
     }
     builder.append(" ORDER BY SCHEMA_NAME ");
     if(pageSize != null && pageNumber != null){
@@ -192,7 +192,7 @@ public class PostgresqlDialect implements JdbcDialect {
     }
 
     if(StringUtils.isNotEmpty(schemaNamePattern)){
-      builder.append(" AND SCHEMA_NAME LIKE '%" + schemaNamePattern.toLowerCase() + "%' ");
+      builder.append(" AND LOWER(SCHEMA_NAME) LIKE '%" + schemaNamePattern.toLowerCase() + "%' ");
     }
     return builder.toString();
   }
@@ -208,12 +208,12 @@ public class PostgresqlDialect implements JdbcDialect {
   @Override
   public String getTableQuery(JdbcConnectInformation connectInfo, String catalog, String schema, String tableNamePattern, List<String> excludeTables, Integer pageSize, Integer pageNumber) {
     StringBuilder builder = new StringBuilder();
-    builder.append(" SELECT TABLE_NAME as name, TABLE_TYPE as type, obj_description((TABLE_SCHEMA||'.'||TABLE_NAME)::regclass, 'pg_class') as comment ");
+    builder.append(" SELECT TABLE_NAME as name, TABLE_TYPE as type, obj_description((quote_ident(TABLE_SCHEMA)||'.'||quote_ident(TABLE_NAME))::regclass, 'pg_class') as comment ");
     builder.append(" FROM INFORMATION_SCHEMA.TABLES ");
     builder.append(" WHERE TABLE_TYPE = 'BASE TABLE' ");
     builder.append(" AND TABLE_SCHEMA NOT IN ('pg_catalog', 'information_schema') ");
     if(StringUtils.isNotEmpty(schema)){
-      builder.append(" AND TABLE_SCHEMA = '" + schema.toLowerCase() + "' ");
+      builder.append(" AND TABLE_SCHEMA = '" + schema + "' ");
     }
 
     if(excludeTables != null){
@@ -223,7 +223,7 @@ public class PostgresqlDialect implements JdbcDialect {
     }
 
     if(StringUtils.isNotEmpty(tableNamePattern)){
-      builder.append(" AND TABLE_NAME LIKE '%" + tableNamePattern.toLowerCase() + "%' ");
+      builder.append(" AND LOWER(TABLE_NAME) LIKE '%" + tableNamePattern.toLowerCase() + "%' ");
     }
     builder.append(" ORDER BY TABLE_NAME ");
     if(pageSize != null && pageNumber != null){
@@ -240,7 +240,7 @@ public class PostgresqlDialect implements JdbcDialect {
     builder.append(" WHERE TABLE_TYPE = 'BASE TABLE' ");
     builder.append(" AND TABLE_SCHEMA NOT IN ('pg_catalog', 'information_schema') ");
     if(StringUtils.isNotEmpty(schema)){
-      builder.append(" AND TABLE_SCHEMA = '" + schema.toLowerCase() + "' ");
+      builder.append(" AND TABLE_SCHEMA = '" + schema + "' ");
     }
     builder.append(" ORDER BY TABLE_NAME ");
     return builder.toString();
@@ -254,7 +254,7 @@ public class PostgresqlDialect implements JdbcDialect {
     builder.append(" WHERE TABLE_TYPE = 'BASE TABLE' ");
     builder.append(" AND TABLE_SCHEMA NOT IN ('pg_catalog', 'information_schema') ");
     if(StringUtils.isNotEmpty(schema)){
-      builder.append(" AND TABLE_SCHEMA = '" + schema.toLowerCase() + "' ");
+      builder.append(" AND TABLE_SCHEMA = '" + schema + "' ");
     }
 
     if(excludeTables != null){
@@ -264,7 +264,7 @@ public class PostgresqlDialect implements JdbcDialect {
     }
 
     if(StringUtils.isNotEmpty(tableNamePattern)){
-      builder.append(" AND TABLE_NAME LIKE '%" + tableNamePattern.toLowerCase() + "%' ");
+      builder.append(" AND LOWER(TABLE_NAME) LIKE '%" + tableNamePattern.toLowerCase() + "%' ");
     }
     return builder.toString();
   }
@@ -392,9 +392,9 @@ public class PostgresqlDialect implements JdbcDialect {
   @Override
   public String getTableName(JdbcConnectInformation connectInfo, String catalog, String schema, String table) {
     if(StringUtils.isEmpty(schema)) {
-      return table;
+      return "\"" + table + "\"";
     }
-    return schema + "." + table;
+    return "\"" + schema + "\".\"" + table + "\"";
   }
 
   @Override


### PR DESCRIPTION
### Description
Workbench, datasource, and dataset errors when postgresql table name contains uppercase letters

**Related Issue** : #2629 

### How Has This Been Tested?
1. Create connection to postgresql
2. Create table with Upper case
     ex) create table "Table1" (i int);
3. Create workbench, DataSource, DataSet.
4. Check if it runs normally.

#### Need additional checks?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
