### PR TITLE
#2375 use type from snapshot2

### DIFF
--- a/discovery-frontend/src/app/data-preparation/data-snapshot/data-snapshot-detail.component.ts
+++ b/discovery-frontend/src/app/data-preparation/data-snapshot/data-snapshot-detail.component.ts
@@ -23,7 +23,12 @@ import {
   Output,
   ViewChild
 } from '@angular/core';
-import {OriginDsInfo, PrDataSnapshot, SsType, Status} from '../../domain/data-preparation/pr-snapshot';
+import {
+  OriginDsInfo,
+  PrDataSnapshot,
+  SsType,
+  Status
+} from '../../domain/data-preparation/pr-snapshot';
 import {DataSnapshotService} from './service/data-snapshot.service';
 import {PopupService} from '../../common/service/popup.service';
 import {GridComponent} from '../../common/component/grid/grid.component';
@@ -32,7 +37,7 @@ import {DsType, Field} from '../../domain/data-preparation/pr-dataset';
 import {GridOption} from '../../common/component/grid/grid.option';
 import {Alert} from '../../common/util/alert.util';
 import {PreparationAlert} from '../util/preparation-alert.util';
-import {isNull, isNullOrUndefined, isUndefined} from 'util';
+import {isNull, isUndefined} from 'util';
 import {saveAs} from 'file-saver';
 import * as pixelWidth from 'string-pixel-width';
 import {AbstractComponent} from '../../common/component/abstract.component';
@@ -43,7 +48,6 @@ import {
   DatasourceInfo,
   DataSourceType,
   FieldRole,
-  LogicalType,
   SourceType
 } from "../../domain/datasource/datasource";
 import {CreateSnapShotData} from "../../data-storage/service/data-source-create.service";
@@ -317,6 +321,8 @@ export class DataSnapshotDetailComponent extends AbstractComponent implements On
     switch (type) {
       case 'INTEGER':
       case 'FLOAT':
+      case 'LONG':
+      case 'DOUBLE':
         return FieldRole.MEASURE;
       default:
         return FieldRole.DIMENSION;

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/service/PrSnapshotController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/service/PrSnapshotController.java
@@ -14,29 +14,19 @@
 
 package app.metatron.discovery.domain.dataprep.service;
 
-import app.metatron.discovery.domain.dataprep.PrepDatasetStagingDbService;
 import app.metatron.discovery.domain.dataprep.PrepProperties;
-import app.metatron.discovery.domain.dataprep.PrepUtil;
-import app.metatron.discovery.domain.dataprep.csv.PrepCsvParseResult;
-import app.metatron.discovery.domain.dataprep.csv.PrepCsvUtil;
 import app.metatron.discovery.domain.dataprep.entity.PrSnapshot;
 import app.metatron.discovery.domain.dataprep.entity.PrSnapshotProjections;
 import app.metatron.discovery.domain.dataprep.exceptions.PrepErrorCodes;
 import app.metatron.discovery.domain.dataprep.exceptions.PrepException;
 import app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey;
-import app.metatron.discovery.domain.dataprep.json.PrepJsonParseResult;
-import app.metatron.discovery.domain.dataprep.json.PrepJsonUtil;
-import app.metatron.discovery.domain.dataprep.repository.PrDataflowRepository;
-import app.metatron.discovery.domain.dataprep.repository.PrDatasetRepository;
 import app.metatron.discovery.domain.dataprep.repository.PrSnapshotRepository;
-import app.metatron.discovery.domain.dataprep.teddy.DataFrame;
 import com.google.common.collect.Maps;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,12 +51,6 @@ public class PrSnapshotController {
   private static Logger LOGGER = LoggerFactory.getLogger(PrSnapshotController.class);
 
   @Autowired
-  private PrDatasetRepository datasetRepository;
-
-  @Autowired
-  private PrDataflowRepository dataflowRepository;
-
-  @Autowired
   private PrSnapshotRepository snapshotRepository;
 
   @Autowired
@@ -77,9 +61,6 @@ public class PrSnapshotController {
 
   @Autowired
   private PrepProperties prepProperties;
-
-  @Autowired(required = false)
-  private PrepDatasetStagingDbService datasetStagingDbPreviewService;
 
   @RequestMapping(value = "/{ssId}", method = RequestMethod.GET)
   @ResponseBody
@@ -179,84 +160,7 @@ public class PrSnapshotController {
           @RequestParam(value = "offset", required = false, defaultValue = "0") Integer offset,
           @RequestParam(value = "target", required = false, defaultValue = "1") Integer target
   ) {
-    Map<String, Object> responseMap = new HashMap<String, Object>();
-    try {
-      PrSnapshot snapshot = this.snapshotRepository.findOne(ssId);
-      if (snapshot != null) {
-        DataFrame gridResponse = new DataFrame();
-
-        PrSnapshot.SS_TYPE ss_type = snapshot.getSsType();
-        if (PrSnapshot.SS_TYPE.URI == ss_type) {
-          String storedUri = snapshot.getStoredUri();
-
-          String snapshotDisplayUri = snapshot.getStoredUri();
-          if (null == snapshotDisplayUri) {
-            String errorMsg = "[" + ssId + "] isn't a saved snapshot.";
-            throw PrepException
-                    .create(PrepErrorCodes.PREP_SNAPSHOT_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_SNAPSHOT_NOT_SAVED,
-                            errorMsg);
-          }
-
-          // We generated JSON snapshots to have ".json" at the end of the URI.
-          Configuration hadoopConf = PrepUtil.getHadoopConf(prepProperties.getHadoopConfDir(false));
-          if (storedUri.endsWith(".json")) {
-            PrepJsonParseResult result = PrepJsonUtil.parseJson(snapshot.getStoredUri(), 10000, null, hadoopConf);
-            gridResponse.setByGridWithJson(result);
-          } else {
-            PrepCsvParseResult result = PrepCsvUtil.parse(snapshot.getStoredUri(), ",", 10000, null, hadoopConf, true);
-            gridResponse.setByGrid(result);
-          }
-
-          responseMap.put("offset", gridResponse.rows.size());
-          responseMap.put("size", gridResponse.rows.size());
-          responseMap.put("gridResponse", gridResponse);
-        } else if (PrSnapshot.SS_TYPE.STAGING_DB == ss_type) {
-          String dbName = snapshot.getDbName();
-          String tblName = snapshot.getTblName();
-          String sql = "SELECT * FROM " + dbName + "." + tblName;
-          Integer size = offset + target;
-          gridResponse = datasetStagingDbPreviewService
-                  .getPreviewStagedbForDataFrame(sql, dbName, tblName, String.valueOf(size));
-          if (null == gridResponse) {
-            gridResponse = new DataFrame();
-          } else {
-            int rowSize = gridResponse.rows.size();
-            int lastIdx = offset + target - 1;
-            if (0 <= lastIdx && offset < rowSize) {
-              if (rowSize <= lastIdx) {
-                lastIdx = rowSize;
-              }
-              gridResponse.rows = gridResponse.rows.subList(offset, lastIdx);
-            } else {
-              gridResponse.rows.clear();
-            }
-          }
-          Integer gridRowSize = gridResponse.rows.size();
-          responseMap.put("offset", offset + gridRowSize);
-          responseMap.put("size", gridRowSize);
-          responseMap.put("gridResponse", gridResponse);
-        }
-
-        // We put the info below as attributes of the entity
-        //                Map<String,Object> originDs = Maps.newHashMap();
-        //                String dsName = snapshot.getOrigDsInfo("dsName");
-        //                String queryStmt = snapshot.getOrigDsInfo("queryStmt");
-        //                String filePath = snapshot.getOrigDsInfo("filePath");
-        //                String createdTime = snapshot.getOrigDsInfo("createdTime");
-        //                originDs.put("dsName",dsName);
-        //                originDs.put("qryStmt",queryStmt);
-        //                originDs.put("filePath",filePath);
-        //                originDs.put("createdTime",createdTime);
-        //                responseMap.put("originDsInfo", originDs);
-      } else {
-        String errorMsg = "snapshot[" + ssId + "] does not exist";
-        throw PrepException
-                .create(PrepErrorCodes.PREP_SNAPSHOT_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_NO_SNAPSHOT, errorMsg);
-      }
-    } catch (Exception e) {
-      LOGGER.error("getContents(): caught an exception: ", e);
-      throw PrepException.create(PrepErrorCodes.PREP_SNAPSHOT_ERROR_CODE, e);
-    }
+    Map<String, Object> responseMap = snapshotService.getContents(ssId, offset, target);
 
     return ResponseEntity.status(HttpStatus.SC_OK).body(responseMap);
   }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DataFrame.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DataFrame.java
@@ -281,6 +281,10 @@ public class DataFrame implements Serializable, Transformable {
     return colDescs.get(colno);
   }
 
+  public void setColDesc(int colno, ColumnDescription colDesc) {
+    colDescs.set(colno, colDesc);
+  }
+
   public ColumnType getColType(int colno) {
     return colDescs.get(colno).getType();
   }


### PR DESCRIPTION
### Description
Now, when we create a datasource with a data snapshot, the types and roles will be set automatically with the information from the snapshot.

**Related Issue** : https://github.com/metatron-app/metatron-discovery/issues/2375

### How Has This Been Tested?
1. Import and wrangle [s5k_1.csv.txt](https://github.com/metatron-app/metatron-discovery/files/3651207/s5k_1.csv.txt)
2. Create a snapshot without any change.
3. See the snapshot detail page.
4. Click "Create datasource" button.
5. See the datasource creating pop-up with appropriate types, roles, timestamp setttings.

#### Need additional checks?
Yes, please.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
