### PR TITLE
Add timer to cancel button in workbench

### DIFF
--- a/discovery-frontend/src/app/workbench/workbench.component.html
+++ b/discovery-frontend/src/app/workbench/workbench.component.html
@@ -450,7 +450,7 @@
                   <!-- box status -->
                   <div *ngIf="isExecutingQuery && !visibleResultTab.result" class="ddp-box-status-button">
 
-                    <a href="javascript:" class="ddp-btn-log-status" (click)="cancelRunningQuery(true)">Cancel</a>
+                    <a href="javascript:" class="ddp-btn-log-status" (click)="cancelRunningQuery(true)" [class.ddp-disabled]="!isCancelAvailable">Cancel</a>
                     <span class="ddp-txt-log-status">
                       <span > {{currentRunningTab?.getExecuteStatusMsg()}} </span>
                       ({{currentRunningIndex+1}}/{{executeTabIds.length}})

--- a/discovery-frontend/src/app/workbench/workbench.component.ts
+++ b/discovery-frontend/src/app/workbench/workbench.component.ts
@@ -306,6 +306,9 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
 
   public hideResultButtons: boolean = false;
 
+  private _cancelTimer;
+  public isCancelAvailable: boolean = false;
+
   constructor(private workspaceService: WorkspaceService,
               protected activatedRoute: ActivatedRoute,
               protected workbenchService: WorkbenchService,
@@ -1079,6 +1082,9 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
     resultTab.executeTimer();
     this.runningResultTabId = resultTab.id;
     this.hideResultButtons = false;
+
+    //disable cancel in 10 sec
+    this.setCancelButtonTimer(10);
 
     this.workbenchService.runSingleQueryWithInvalidQuery(resultTab.queryEditor, additionalParams)
       .then((result) => {
@@ -2030,6 +2036,11 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
   }
 
   public cancelRunningQuery(useLog: boolean = false) {
+    // cannot cancel until cancel timer tick.
+    if(!this.isCancelAvailable){
+      return;
+    }
+
     this.isCanceling = true;
     if (useLog) {
       this.safelyDetectChanges();
@@ -2579,6 +2590,24 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
       this.textList[this.selectedTabNum]['query'] = currQuery;
       this.saveLocalStorage(currQuery, this.textList[this.selectedTabNum]['editorId']);
     }
+  }
+
+  public setCancelButtonTimer(sec: number) {
+    // disable button
+    this.isCancelAvailable = false;
+
+    // if timer exist..
+    if(this._cancelTimer != undefined){
+      // clear existed timer
+      clearTimeout(this._cancelTimer);
+    }
+
+    // start new timer
+    this._cancelTimer = setTimeout(() => {
+      // restore button
+      this.isCancelAvailable = true;
+    }, sec * 1000);
+
   }
 
 }

--- a/discovery-frontend/src/app/workbench/workbench.component.ts
+++ b/discovery-frontend/src/app/workbench/workbench.component.ts
@@ -1083,8 +1083,8 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
     this.runningResultTabId = resultTab.id;
     this.hideResultButtons = false;
 
-    //disable cancel in 10 sec
-    this.setCancelButtonTimer(10);
+    //disable cancel in 5 sec
+    this.setCancelButtonTimer(5);
 
     this.workbenchService.runSingleQueryWithInvalidQuery(resultTab.queryEditor, additionalParams)
       .then((result) => {

--- a/discovery-frontend/src/assets/css/metatron/page.css
+++ b/discovery-frontend/src/assets/css/metatron/page.css
@@ -8176,6 +8176,7 @@ table.ddp-table-simple tr td .ddp-ui-time {width:100%; color:#90969f; font-size:
 
 .ddp-box-query-result .ddp-box-status-button {position:absolute; bottom:39px; left:10px; right:10px; padding:13px 15px; height:56px; border-radius:3px; background-color:#f6f6f7; box-sizing:border-box;}
 .ddp-box-query-result .ddp-btn-log-status {display:inline-block; position:relative; padding:7px 11px; min-width:72px; margin-right:14px; border-radius:2px; background-color:#90969f; box-sizing:border-box; color:#fff; font-size:12px; text-align:center;}
+.ddp-box-query-result .ddp-btn-log-status.ddp-btn-log-status.ddp-disabled {opacity:0.5;cursor:no-drop;}
 .ddp-box-query-result .ddp-btn-log-status.ddp-retry {padding-left:32px; background-color:#dc494f;}
 .ddp-box-query-result .ddp-btn-log-status.ddp-retry:before {display:inline-block; position:absolute; top:50%; left:12px; margin-top:-6px; width:13px; height:12px; background:url(../../images/btn_refresh.png) no-repeat; background-position:left -63px; content:''; vertical-align:middle;}
 .ddp-box-query-result .ddp-btn-log-status.ddp-retry2 {padding-left:32px;}


### PR DESCRIPTION
### Description
An error occurs if the workbench cancels a query too soon for a hive.
Prevent error by disabling cancel button for 10 seconds after executing query.

<img width="309" alt="metatron_Discovery" src="https://user-images.githubusercontent.com/3770446/65594539-fe584c00-dfcd-11e9-8992-2e2f0d17747c.png">


**Related Issue** : 
METATRON-3043

### How Has This Been Tested?
1. goto workbench (hive)
2. execute query
sample : 
```
select currentdatabase, owner, sourcetablename, targettablename, count(*), max(eventtime)
from default.lineage
group by currentdatabase, owner, sourcetablename, targettablename;
```
3. see cancel button disabled for 10 seconds

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
