### PR TITLE
fix presto array column handling as string

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/PrestoDialect.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/PrestoDialect.java
@@ -393,7 +393,8 @@ public class PrestoDialect implements JdbcDialect {
       if(originalObj instanceof Timestamp){
         return originalObj.toString();
       } else if (originalObj instanceof PrestoArray) {
-        return ((PrestoArray) originalObj).getArray();
+        Object[] prestoArray = (Object[]) ((PrestoArray) originalObj).getArray();
+        return StringUtils.join(prestoArray, ",");
       } else {
         return originalObj;
       }


### PR DESCRIPTION
### Description
Error occurs when querying array column data of presto.
If the query result is an array, join it with comma delimiter and convert it to String.

### How Has This Been Tested?
1. goto workbench (presto)
2. create table with array column and insert rows.
```
create table if not exists default.arr_test (a varchar, b array<varchar>);

insert into default.arr_test 
values ('1', array['aa', 'bb']), ('2', array['cc', 'dd']), ('3', array['ee', 'ff']);
```
3. select query or create datasource.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
