### PR TITLE
#2651 Uppercase table name of postgresql to create dataset

### DIFF
--- a/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-name.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-name.component.ts
@@ -770,13 +770,17 @@ export class CreateDatasetNameComponent extends AbstractPopupComponent implement
 
     // Error when creating dataflow with dataset with no querystmt
     if (type.rsType === RsType.TABLE) {
+      var databaseName = tableInfo.databaseName;
       var tableName = tableInfo.tableName;
       if(type.dataconnection.connection.implementor==="POSTGRESQL") {
+        if( /^[a-z0-9]+$/.test(databaseName) === false ) {
+          databaseName = `"${databaseName}"`;
+        }
         if( /^[a-z0-9]+$/.test(tableName) === false ) {
           tableName = `"${tableName}"`;
         }
       }
-      params['queryStmt'] = `select * from ${tableInfo.databaseName}.${tableName}`;
+      params['queryStmt'] = `select * from ${databaseName}.${tableName}`;
     }
 
     this.loadingShow();

--- a/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-name.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-name.component.ts
@@ -693,10 +693,10 @@ export class CreateDatasetNameComponent extends AbstractPopupComponent implement
     // For postgre dbName is database not databaseName!
     if (jdbc.rsType === RsType.QUERY) {
       jdbc.queryStmt = jdbc.sqlInfo.queryStmt;
-      jdbc.dbName = jdbc.dataconnection.connection.implementor === 'POSTGRESQL'? jdbc.dataconnection.connection.database : jdbc.sqlInfo.databaseName;
+      jdbc.dbName = jdbc.sqlInfo.databaseName;
     } else {
       jdbc.tblName = jdbc.tableInfo.tableName;
-      jdbc.dbName = jdbc.dataconnection.connection.implementor === 'POSTGRESQL'? jdbc.dataconnection.connection.database : jdbc.tableInfo.databaseName;
+      jdbc.dbName = jdbc.tableInfo.databaseName;
     }
     return jdbc
   }
@@ -770,7 +770,13 @@ export class CreateDatasetNameComponent extends AbstractPopupComponent implement
 
     // Error when creating dataflow with dataset with no querystmt
     if (type.rsType === RsType.TABLE) {
-      params['queryStmt'] = `select * from ${tableInfo.databaseName}.${tableInfo.tableName}`;
+      var tableName = tableInfo.tableName;
+      if(type.dataconnection.connection.implementor==="POSTGRESQL") {
+        if( /^[a-z0-9]+$/.test(tableName) === false ) {
+          tableName = `"${tableName}"`;
+        }
+      }
+      params['queryStmt'] = `select * from ${tableInfo.databaseName}.${tableName}`;
     }
 
     this.loadingShow();

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetDatabaseService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetDatabaseService.java
@@ -159,12 +159,22 @@ public class PrepDatasetDatabaseService {
 
     int limit = Integer.parseInt(size);
     String sql = dataset.getRsType() == RS_TYPE.QUERY ? dataset.getQueryStmt() :
-            String.format("SELECT * FROM %s.%s", dataset.getDbName(), getTableName(dataset));
+            String.format("SELECT * FROM %s.%s", getDatabaseName(dataset), getTableName(dataset));
 
     dataFrame = teddyImpl.loadJdbcDataFrame(dataConnection, sql, limit, null);
 
     countTotalLines(dataset, dataConnection);
     return dataFrame;
+  }
+
+  public String getDatabaseName(PrDataset dataset) {
+    String dbName = dataset.getDbName();
+    if( dataset.getDcImplementor().equalsIgnoreCase("PostgreSQL")==true ) {
+      if( dbName.matches("[a-z0-9]+")==false) {
+        dbName = '"' + dbName + '"';
+      }
+    }
+    return dbName;
   }
 
   public String getTableName(PrDataset dataset) {

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetDatabaseService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetDatabaseService.java
@@ -159,12 +159,22 @@ public class PrepDatasetDatabaseService {
 
     int limit = Integer.parseInt(size);
     String sql = dataset.getRsType() == RS_TYPE.QUERY ? dataset.getQueryStmt() :
-            String.format("SELECT * FROM %s.%s", dataset.getDbName(), dataset.getTblName());
+            String.format("SELECT * FROM %s.%s", dataset.getDbName(), getTableName(dataset));
 
     dataFrame = teddyImpl.loadJdbcDataFrame(dataConnection, sql, limit, null);
 
     countTotalLines(dataset, dataConnection);
     return dataFrame;
+  }
+
+  public String getTableName(PrDataset dataset) {
+    String tblName = dataset.getTblName();
+    if( dataset.getDcImplementor().equalsIgnoreCase("PostgreSQL")==true ) {
+      if( tblName.matches("[a-z0-9]+")==false) {
+        tblName = '"' + tblName + '"';
+      }
+    }
+    return tblName;
   }
 }
 


### PR DESCRIPTION
### Description
Dataset had a bug when postgresql table name contains uppercase letters

Fixed this bug.

**Related Issue** : 
[#2651](https://github.com/metatron-app/metatron-discovery/issues/2651)

### How Has This Been Tested?

1. Create connection to postgresql
2. Create table with Upper case
ex) create table "Table1" (i int);
3. Create DataSet.
4. No error should occur.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
