### PR TITLE
fix can add an aggregate rule without group

### DIFF
--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-aggregate.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule/edit-rule-aggregate.component.ts
@@ -91,23 +91,22 @@ export class EditRuleAggregateComponent extends EditRuleComponent implements OnI
     const formulaValueList = this.ruleSuggestInput
                                  .map(el => el.getFormula())
                                  .filter( v => (!isUndefined(v) && v.trim().length > 0) );
-    
+
     if ( !formulaValueList || formulaValueList.length === 0) {
       Alert.warning(this.translateService.instant('msg.dp.alert.insert.expression'));
       return undefined;
-    }  
+    }
 
     const value = formulaValueList.join(',');
-    
-    // 그룹
-    if (this.selectedFields.length === 0) {
-      Alert.warning(this.translateService.instant('msg.dp.alert.enter.groupby'));
-      return undefined;
+
+    var ruleString = `aggregate value: ${value}`;
+    if (0 < this.selectedFields.length) {
+      ruleString = `${ruleString} group: ${this.getColumnNamesInArray(this.selectedFields, true).toString()}`;
     }
 
     return {
       command: 'aggregate',
-      ruleString: `aggregate value: ${value} group: ${this.getColumnNamesInArray(this.selectedFields, true).toString()}`,
+      ruleString: `${ruleString}`,
       uiRuleString: {
         name: 'aggregate',
         expression: formulaValueList,

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepRuleChecker.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepRuleChecker.java
@@ -14,6 +14,13 @@
 
 package app.metatron.discovery.domain.dataprep.transform;
 
+import com.google.common.collect.Lists;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
 import app.metatron.discovery.domain.dataprep.exceptions.PrepErrorCodes;
 import app.metatron.discovery.domain.dataprep.exceptions.PrepException;
 import app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey;
@@ -22,40 +29,11 @@ import app.metatron.discovery.domain.dataprep.rule.ExprFunctionCategory;
 import app.metatron.discovery.domain.dataprep.teddy.exceptions.TeddyException;
 import app.metatron.discovery.prep.parser.exceptions.RuleException;
 import app.metatron.discovery.prep.parser.preparation.RuleVisitorParser;
-import app.metatron.discovery.prep.parser.preparation.rule.Aggregate;
-import app.metatron.discovery.prep.parser.preparation.rule.CountPattern;
-import app.metatron.discovery.prep.parser.preparation.rule.Delete;
-import app.metatron.discovery.prep.parser.preparation.rule.Derive;
-import app.metatron.discovery.prep.parser.preparation.rule.Drop;
-import app.metatron.discovery.prep.parser.preparation.rule.Extract;
-import app.metatron.discovery.prep.parser.preparation.rule.Flatten;
-import app.metatron.discovery.prep.parser.preparation.rule.Header;
-import app.metatron.discovery.prep.parser.preparation.rule.Join;
-import app.metatron.discovery.prep.parser.preparation.rule.Keep;
-import app.metatron.discovery.prep.parser.preparation.rule.Merge;
-import app.metatron.discovery.prep.parser.preparation.rule.Move;
-import app.metatron.discovery.prep.parser.preparation.rule.Nest;
-import app.metatron.discovery.prep.parser.preparation.rule.Pivot;
-import app.metatron.discovery.prep.parser.preparation.rule.Rename;
-import app.metatron.discovery.prep.parser.preparation.rule.Replace;
-import app.metatron.discovery.prep.parser.preparation.rule.Rule;
-import app.metatron.discovery.prep.parser.preparation.rule.Set;
-import app.metatron.discovery.prep.parser.preparation.rule.SetFormat;
-import app.metatron.discovery.prep.parser.preparation.rule.SetType;
-import app.metatron.discovery.prep.parser.preparation.rule.Sort;
-import app.metatron.discovery.prep.parser.preparation.rule.Split;
-import app.metatron.discovery.prep.parser.preparation.rule.Union;
-import app.metatron.discovery.prep.parser.preparation.rule.Unnest;
-import app.metatron.discovery.prep.parser.preparation.rule.Unpivot;
-import app.metatron.discovery.prep.parser.preparation.rule.Window;
+import app.metatron.discovery.prep.parser.preparation.rule.*;
 import app.metatron.discovery.prep.parser.preparation.rule.expr.Constant;
 import app.metatron.discovery.prep.parser.preparation.rule.expr.Expr;
 import app.metatron.discovery.prep.parser.preparation.rule.expr.Expression;
 import app.metatron.discovery.prep.parser.preparation.rule.expr.Identifier;
-import com.google.common.collect.Lists;
-import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class PrepRuleChecker {
 
@@ -329,11 +307,6 @@ public class PrepRuleChecker {
   private static void checkAggregate(Aggregate aggregate) {
     Expression group = aggregate.getGroup();
     Expression value = aggregate.getValue();
-    if (null == group) {
-      LOGGER.error("confirmRuleStringForException(): aggregate group is null");
-      throw PrepException.create(PrepErrorCodes.PREP_TRANSFORM_ERROR_CODE,
-              PrepMessageKey.MSG_DP_ALERT_TEDDY_PARSE_FAILED_BY_AGGREGATE_GROUP);
-    }
     if (null == value) {
       LOGGER.error("confirmRuleStringForException(): aggregate value is null");
       throw PrepException.create(PrepErrorCodes.PREP_TRANSFORM_ERROR_CODE,

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformRuleService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformRuleService.java
@@ -14,37 +14,25 @@
 
 package app.metatron.discovery.domain.dataprep.transform;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import app.metatron.discovery.common.GlobalObjectMapper;
 import app.metatron.discovery.domain.dataprep.entity.PrDataset;
 import app.metatron.discovery.domain.dataprep.repository.PrDatasetRepository;
 import app.metatron.discovery.domain.dataprep.teddy.exceptions.CannotSerializeIntoJsonException;
 import app.metatron.discovery.prep.parser.preparation.RuleVisitorParser;
-import app.metatron.discovery.prep.parser.preparation.rule.Aggregate;
-import app.metatron.discovery.prep.parser.preparation.rule.CountPattern;
-import app.metatron.discovery.prep.parser.preparation.rule.Delete;
-import app.metatron.discovery.prep.parser.preparation.rule.Derive;
-import app.metatron.discovery.prep.parser.preparation.rule.Drop;
-import app.metatron.discovery.prep.parser.preparation.rule.Extract;
-import app.metatron.discovery.prep.parser.preparation.rule.Flatten;
-import app.metatron.discovery.prep.parser.preparation.rule.Header;
-import app.metatron.discovery.prep.parser.preparation.rule.Join;
-import app.metatron.discovery.prep.parser.preparation.rule.Keep;
-import app.metatron.discovery.prep.parser.preparation.rule.Merge;
-import app.metatron.discovery.prep.parser.preparation.rule.Move;
-import app.metatron.discovery.prep.parser.preparation.rule.Nest;
-import app.metatron.discovery.prep.parser.preparation.rule.Pivot;
-import app.metatron.discovery.prep.parser.preparation.rule.Rename;
-import app.metatron.discovery.prep.parser.preparation.rule.Replace;
-import app.metatron.discovery.prep.parser.preparation.rule.Rule;
-import app.metatron.discovery.prep.parser.preparation.rule.Set;
-import app.metatron.discovery.prep.parser.preparation.rule.SetFormat;
-import app.metatron.discovery.prep.parser.preparation.rule.SetType;
-import app.metatron.discovery.prep.parser.preparation.rule.Sort;
-import app.metatron.discovery.prep.parser.preparation.rule.Split;
-import app.metatron.discovery.prep.parser.preparation.rule.Union;
-import app.metatron.discovery.prep.parser.preparation.rule.Unnest;
-import app.metatron.discovery.prep.parser.preparation.rule.Unpivot;
-import app.metatron.discovery.prep.parser.preparation.rule.Window;
+import app.metatron.discovery.prep.parser.preparation.rule.*;
 import app.metatron.discovery.prep.parser.preparation.rule.expr.Constant.ArrayExpr;
 import app.metatron.discovery.prep.parser.preparation.rule.expr.Expr;
 import app.metatron.discovery.prep.parser.preparation.rule.expr.Expr.BinaryNumericOpExprBase;
@@ -55,16 +43,6 @@ import app.metatron.discovery.prep.parser.preparation.rule.expr.Expr.UnaryNotExp
 import app.metatron.discovery.prep.parser.preparation.rule.expr.Expression;
 import app.metatron.discovery.prep.parser.preparation.rule.expr.Identifier;
 import app.metatron.discovery.prep.parser.preparation.rule.expr.Identifier.IdentifierArrayExpr;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 
 @Service
 public class PrepTransformRuleService {
@@ -502,6 +480,7 @@ public class PrepTransformRuleService {
   private final String FMTSTR_REPLACE = "replace %s from %s with %s";              // on, col, with
   private final String FMTSTR_REPLACES = "replace %s";                              // col
   private final String FMTSTR_MERGE = "concatenate %s separated by %s";          // col, with
+  private final String FMTSTR_AGGREGATE_NO_GROUP = "aggregate with %s";         // value
   private final String FMTSTR_AGGREGATE = "aggregate with %s grouped by %s";         // value, group
   private final String FMTSTR_MOVE = "move %s %s";                              // col, before/after
   private final String FMTSTR_JOIN_UNION = "%s with %s";                              // command, strDsNames
@@ -599,7 +578,11 @@ public class PrepTransformRuleService {
         shortRuleString = String.format(FMTSTR_UNNEST, mapStrExp.get("col"));
         break;
       case "aggregate":
-        shortRuleString = String.format(FMTSTR_AGGREGATE, mapStrExp.get("value"), mapStrExp.get("group").toColList());
+        if(mapStrExp.get("group")!=null) {
+          shortRuleString = String.format(FMTSTR_AGGREGATE, mapStrExp.get("value"), mapStrExp.get("group").toColList());
+        } else {
+          shortRuleString = String.format(FMTSTR_AGGREGATE_NO_GROUP, mapStrExp.get("value"));
+        }
         break;
       case "sort":
         shortRuleString = String.format(FMTSTR_SORT, mapStrExp.get("order"), mapStrExp.get("type"));


### PR DESCRIPTION
### Description
The aggregate rule of dataflow don't have to contain group

**Related Issue** : None

### How Has This Been Tested?
go to [data preparation]-[dataflow]-[dataflow detail]-[edit rules]
add an aggregate rule without group
there is no warning and your rule will be added

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
