### PR TITLE
fix grid chart measure alias

### DIFF
--- a/discovery-frontend/src/app/common/component/chart/type/grid-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/grid-chart.component.ts
@@ -16,9 +16,17 @@
  * Created by Dolkkok on 2017. 7. 18..
  */
 
-import { AfterViewInit, Component, ElementRef, Injector, Input, OnDestroy, OnInit } from '@angular/core';
-import { BaseChart, ChartSelectInfo } from '../base-chart';
-import { BaseOption } from '../option/base-option';
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  Injector,
+  Input,
+  OnDestroy,
+  OnInit
+} from '@angular/core';
+import {BaseChart, ChartSelectInfo} from '../base-chart';
+import {BaseOption} from '../option/base-option';
 import {
   CellColorTarget,
   CHART_STRING_DELIMITER,
@@ -32,11 +40,11 @@ import {
   UIOrient,
   UIPosition
 } from '../option/define/common';
-import { Pivot } from '../../../../domain/workbook/configurations/pivot';
+import {Pivot} from '../../../../domain/workbook/configurations/pivot';
 import * as _ from 'lodash';
-import { UIChartColorByCell, UIOption } from '../option/ui-option';
-import { UIGridChart } from '../option/ui-option/ui-grid-chart';
-import { UIChartColorGradationByCell } from '../option/ui-option/ui-color';
+import {UIChartColorByCell, UIOption} from '../option/ui-option';
+import {UIGridChart} from '../option/ui-option/ui-grid-chart';
+import {UIChartColorGradationByCell} from '../option/ui-option/ui-color';
 
 declare let pivot: any;
 
@@ -319,7 +327,7 @@ export class GridChartComponent extends BaseChart implements OnInit, OnDestroy, 
     if( (<UIGridChart>this.uiOption).dataType == GridViewType.MASTER ) {
 
       // for setting aggregations original name
-      let originAggregations: any = this.fieldOriginInfo.aggs.map((name) => {
+      let originAggregations: any = this.fieldInfo.aggs.map((name) => {
         return {name, digits: 2};
       });
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
In the grid chart, dimension values ​​are aliased.
Measures are not aliased.

**Related Issue** : #2533
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Go to workbook.
2. Create a grid chart.
3. Change original type.
4. Apply aliases to the measurements.
5. Check that aliases are applied to the dimension values ​​and the measured values.


#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
