### PR TITLE
#2063 adding union rule shows field type as icon correctly

### DIFF
--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/rule-union-popup/rule-union-popup.component.html
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/rule-union-popup/rule-union-popup.component.html
@@ -54,7 +54,13 @@
             <ul class="ddp-list-union" *ngFor="let colInfo of resultFields; let i = index">
               <li [ngClass]="{'ddp-selected':editResultColumnName == colInfo.name}">
                 <div class="ddp-box-column" >
-                  <em class="ddp-icon-type-ab"></em>
+                  <em class="ddp-icon-type-ab"  *ngIf="colInfo.type === 'STRING' || colInfo.type === 'USER_DEFINED' || colInfo.type === 'TEXT'"></em>
+                  <em class="ddp-icon-type-local" *ngIf="colInfo.type === 'LNG' || colInfo.type === 'LNT'"></em>
+                  <em class="ddp-icon-type-calen" *ngIf="colInfo.type === 'TIMESTAMP'"></em>
+                  <em class="ddp-icon-type-sharp" *ngIf="colInfo.type === 'LONG' || colInfo.type === 'INTEGER' || colInfo.type === 'DOUBLE' || colInfo.type === 'CALCULATED'"></em>
+                  <em class="ddp-icon-type-tf" *ngIf="colInfo.type === 'BOOLEAN'"></em>
+                  <em class="ddp-icon-type-array" *ngIf="colInfo.type === 'ARRAY'"></em>
+                  <em class="ddp-icon-type-map" *ngIf="colInfo.type === 'MAP'"></em>
                   <span class="ddp-data-column">{{colInfo.name}}</span>
                 </div>
               </li>
@@ -96,7 +102,13 @@
                 <tr *ngFor="let data of masterDataset.gridData.fields">
                   <td>
                     <div class="ddp-box-column">
-                      <em class="ddp-icon-type-ab"></em>
+                      <em class="ddp-icon-type-ab"  *ngIf="data.type === 'STRING' || data.type === 'USER_DEFINED' || data.type === 'TEXT'"></em>
+                      <em class="ddp-icon-type-local" *ngIf="data.type === 'LNG' || data.type === 'LNT'"></em>
+                      <em class="ddp-icon-type-calen" *ngIf="data.type === 'TIMESTAMP'"></em>
+                      <em class="ddp-icon-type-sharp" *ngIf="data.type === 'LONG' || data.type === 'INTEGER' || data.type === 'DOUBLE' || data.type === 'CALCULATED'"></em>
+                      <em class="ddp-icon-type-tf" *ngIf="data.type === 'BOOLEAN'"></em>
+                      <em class="ddp-icon-type-array" *ngIf="data.type === 'ARRAY'"></em>
+                      <em class="ddp-icon-type-map" *ngIf="data.type === 'MAP'"></em>
                       <span class="ddp-data-column">{{data.name}}</span>
                     </div>
                   </td>
@@ -131,7 +143,13 @@
                             'ddp-box-column' : 'LACK' !== field.unionType,
                             'ddp-disabled' : 'CORRECT' !== field.unionType
                           }" >
-                      <em *ngIf="''!==field.name && 'NONE' !== field.unionType" class="ddp-icon-type-ab"></em>
+                      <em class="ddp-icon-type-ab"  *ngIf="field.type === 'STRING' || field.type === 'USER_DEFINED' || field.type === 'TEXT'"></em>
+                      <em class="ddp-icon-type-local" *ngIf="field.type === 'LNG' || field.type === 'LNT'"></em>
+                      <em class="ddp-icon-type-calen" *ngIf="field.type === 'TIMESTAMP'"></em>
+                      <em class="ddp-icon-type-sharp" *ngIf="field.type === 'LONG' || field.type === 'INTEGER' || field.type === 'DOUBLE' || field.type === 'CALCULATED'"></em>
+                      <em class="ddp-icon-type-tf" *ngIf="field.type === 'BOOLEAN'"></em>
+                      <em class="ddp-icon-type-array" *ngIf="field.type === 'ARRAY'"></em>
+                      <em class="ddp-icon-type-map" *ngIf="field.type === 'MAP'"></em>
                       <span class="ddp-data-column">{{field.name}}</span>
                     </div>
                   </td>

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/rule-union-popup/rule-union-popup.component.html
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/rule-union-popup/rule-union-popup.component.html
@@ -54,13 +54,7 @@
             <ul class="ddp-list-union" *ngFor="let colInfo of resultFields; let i = index">
               <li [ngClass]="{'ddp-selected':editResultColumnName == colInfo.name}">
                 <div class="ddp-box-column" >
-                  <em class="ddp-icon-type-ab"  *ngIf="colInfo.type === 'STRING' || colInfo.type === 'USER_DEFINED' || colInfo.type === 'TEXT'"></em>
-                  <em class="ddp-icon-type-local" *ngIf="colInfo.type === 'LNG' || colInfo.type === 'LNT'"></em>
-                  <em class="ddp-icon-type-calen" *ngIf="colInfo.type === 'TIMESTAMP'"></em>
-                  <em class="ddp-icon-type-sharp" *ngIf="colInfo.type === 'LONG' || colInfo.type === 'INTEGER' || colInfo.type === 'DOUBLE' || colInfo.type === 'CALCULATED'"></em>
-                  <em class="ddp-icon-type-tf" *ngIf="colInfo.type === 'BOOLEAN'"></em>
-                  <em class="ddp-icon-type-array" *ngIf="colInfo.type === 'ARRAY'"></em>
-                  <em class="ddp-icon-type-map" *ngIf="colInfo.type === 'MAP'"></em>
+                  <em [ngClass]="getIconType(colInfo.type)"></em>
                   <span class="ddp-data-column">{{colInfo.name}}</span>
                 </div>
               </li>
@@ -102,13 +96,7 @@
                 <tr *ngFor="let data of masterDataset.gridData.fields">
                   <td>
                     <div class="ddp-box-column">
-                      <em class="ddp-icon-type-ab"  *ngIf="data.type === 'STRING' || data.type === 'USER_DEFINED' || data.type === 'TEXT'"></em>
-                      <em class="ddp-icon-type-local" *ngIf="data.type === 'LNG' || data.type === 'LNT'"></em>
-                      <em class="ddp-icon-type-calen" *ngIf="data.type === 'TIMESTAMP'"></em>
-                      <em class="ddp-icon-type-sharp" *ngIf="data.type === 'LONG' || data.type === 'INTEGER' || data.type === 'DOUBLE' || data.type === 'CALCULATED'"></em>
-                      <em class="ddp-icon-type-tf" *ngIf="data.type === 'BOOLEAN'"></em>
-                      <em class="ddp-icon-type-array" *ngIf="data.type === 'ARRAY'"></em>
-                      <em class="ddp-icon-type-map" *ngIf="data.type === 'MAP'"></em>
+                      <em [ngClass]="getIconType(data.type)"></em>
                       <span class="ddp-data-column">{{data.name}}</span>
                     </div>
                   </td>
@@ -143,13 +131,7 @@
                             'ddp-box-column' : 'LACK' !== field.unionType,
                             'ddp-disabled' : 'CORRECT' !== field.unionType
                           }" >
-                      <em class="ddp-icon-type-ab"  *ngIf="field.type === 'STRING' || field.type === 'USER_DEFINED' || field.type === 'TEXT'"></em>
-                      <em class="ddp-icon-type-local" *ngIf="field.type === 'LNG' || field.type === 'LNT'"></em>
-                      <em class="ddp-icon-type-calen" *ngIf="field.type === 'TIMESTAMP'"></em>
-                      <em class="ddp-icon-type-sharp" *ngIf="field.type === 'LONG' || field.type === 'INTEGER' || field.type === 'DOUBLE' || field.type === 'CALCULATED'"></em>
-                      <em class="ddp-icon-type-tf" *ngIf="field.type === 'BOOLEAN'"></em>
-                      <em class="ddp-icon-type-array" *ngIf="field.type === 'ARRAY'"></em>
-                      <em class="ddp-icon-type-map" *ngIf="field.type === 'MAP'"></em>
+                      <em [ngClass]="getIconType(field.type)"></em>
                       <span class="ddp-data-column">{{field.name}}</span>
                     </div>
                   </td>

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/rule-union-popup/rule-union-popup.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/rule-union-popup/rule-union-popup.component.ts
@@ -221,6 +221,42 @@ export class RuleUnionPopupComponent extends AbstractPopupComponent implements O
       === fieldList.filter(item => item.unionType === 'INCORRECT').length );
   } // function - getClassFieldRow
 
+  public getIconType(type: string) {
+    var className = 'ddp-icon-type-';
+    switch(type) {
+      case 'STRING':
+      case 'USER_DEFINED':
+      case 'TEXT':
+        className = className + 'ab';
+        break;
+      case 'LNG':
+      case 'LNT':
+        className = className + 'local';
+        break;
+      case 'TIMESTAMP':
+        className = className + 'calen';
+        break;
+      case 'LONG':
+      case 'INTEGER':
+      case 'DOUBLE':
+        className = className + 'sharp';
+        break;
+      case 'BOOLEAN':
+        className = className + 'tf';
+        break;
+      case 'ARRAY':
+        className = className + 'array';
+        break;
+      case 'MAP':
+        className = className + 'map';
+        break;
+      default:
+        className = className + 'ab';
+        break;
+    }
+    return className;
+  }
+
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
   | Protected Method
   |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/

--- a/discovery-frontend/src/assets/css/metatron/page.css
+++ b/discovery-frontend/src/assets/css/metatron/page.css
@@ -6417,6 +6417,11 @@ ul.ddp-list-detail li .ddp-wrap-detailinfo .ddp-data-history .ddp-data-success {
 .ddp-wrap-union-list ul.ddp-list-union li .ddp-box-column {position:relative; padding:0 25px 0 51px; border-radius:2px; border:1px solid #d0d1d8; cursor: pointer;}
 .ddp-wrap-union-list ul.ddp-list-union li .ddp-box-column:hover {border:1px solid #b7b9c2;}
 .ddp-wrap-union-list ul.ddp-list-union li .ddp-box-column em.ddp-icon-type-ab {position:absolute; top:50%; left:17px;}
+.ddp-wrap-union-list ul.ddp-list-union li .ddp-box-column em.ddp-icon-type-calen {position:absolute; top:50%; left:17px;}
+.ddp-wrap-union-list ul.ddp-list-union li .ddp-box-column em.ddp-icon-type-sharp {position:absolute; top:50%; left:17px;}
+.ddp-wrap-union-list ul.ddp-list-union li .ddp-box-column em.ddp-icon-type-float {position:absolute; top:50%; left:17px;}
+.ddp-wrap-union-list ul.ddp-list-union li .ddp-box-column em.ddp-icon-type-array {position:absolute; top:50%; left:17px;}
+.ddp-wrap-union-list ul.ddp-list-union li .ddp-box-column em.ddp-icon-type-map {position:absolute; top:50%; left:17px;}
 .ddp-wrap-union-list ul.ddp-list-union li .ddp-box-column input.ddp-input-column {display:none; width:100%; padding:6px 0; color:#4b515b; font-size:12px; border:none; box-sizing:border-box;}
 .ddp-wrap-union-list ul.ddp-list-union li .ddp-box-column span.ddp-data-column {display:block; width:100%; padding:6px 0; color:#4b515b; font-size:12px; white-space:nowrap; text-overflow:ellipsis; overflow:hidden; word-wrap:normal;}
 


### PR DESCRIPTION
### Description
in the popup of adding union rule,
the type icon should be shown as their own type

**Related Issue** : 
[#2063 ](https://github.com/metatron-app/metatron-discovery/issues/2063)

### How Has This Been Tested?
1. add an union rule in the page of dataflow details
2. union some datasets have fields which are not string type.
3. make sure the correct type of icons are displayed

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
