### PR TITLE
fix engine monitoring trivial error

### DIFF
--- a/discovery-frontend/src/app/dashboard/component/custom-field/custom-field.component.html
+++ b/discovery-frontend/src/app/dashboard/component/custom-field/custom-field.component.html
@@ -206,7 +206,7 @@
                     | baseFilter : ['commonValue', calFuncSearchText]"
                           (mouseenter)="setCalculationDesciption(calFunction, true)"
                           (mouseleave)="setCalculationDesciption(null, false)">
-                        <a href="javascript:">
+                        <a href="javascript:"(click)="clickFunction($event);selectedCalculationFunction(calFunction)">
                           {{calFunction.commonValue}}
                           <em class="ddp-icon-plus ddp-cursor" (click)="selectedCalculationFunction(calFunction); selectFunction(calFunction)"></em>
                         </a>

--- a/discovery-frontend/src/app/dashboard/component/custom-field/custom-field.component.ts
+++ b/discovery-frontend/src/app/dashboard/component/custom-field/custom-field.component.ts
@@ -768,6 +768,14 @@ export class CustomFieldComponent extends AbstractComponent implements OnInit, O
 
   }
 
+  public clickFunction($event) {
+    const $targetElm = $( $event.target ).parent();
+
+    $targetElm.parent().parent().parent().find('li').removeClass( 'ddp-selected' );
+    $targetElm.addClass( 'ddp-selected' );
+
+  }
+
   public checkCategory(calFunction:any[]): string {
     return calFunction.filter(item=> item['commonValue'].toLowerCase().indexOf(this.calFuncSearchText.toLowerCase()) !== -1).length > 0 ? 'block' : 'none';
   }

--- a/discovery-frontend/src/app/domain/engine-monitoring/engine.ts
+++ b/discovery-frontend/src/app/domain/engine-monitoring/engine.ts
@@ -17,6 +17,7 @@ import {PageResult} from '../common/page';
 export namespace Engine {
 
   export enum NodeType {
+    ALL = 'ALL',
     BROKER = 'broker',
     COORDINATOR = 'coordinator',
     HISTORICAL = 'historical',

--- a/discovery-frontend/src/app/engine-monitoring/component/druid-cluster-information/druid-cluster-information.component.html
+++ b/discovery-frontend/src/app/engine-monitoring/component/druid-cluster-information/druid-cluster-information.component.html
@@ -51,7 +51,7 @@
     <div class="ddp-wrap-tab-contents">
       <div class="ddp-ui-tab-contents">
         <div class="ddp-wrap-informaiton">
-          <div class="ddp-ui-detail ddp-clear ">
+          <div class="ddp-ui-detail ddp-clear" *ngIf="selectTab === 'common'">
             <!-- col -->
             <div class="ddp-col-12">
               <div class="ddp-ui-title">

--- a/discovery-frontend/src/app/engine-monitoring/ingestion/component/supervisor/supervisor.component.html
+++ b/discovery-frontend/src/app/engine-monitoring/ingestion/component/supervisor/supervisor.component.html
@@ -14,7 +14,7 @@
 <!-- top filtering -->
 <div class="ddp-wrap-top-filtering">
   <!-- filter search -->
-  <div class="ddp-filter-search type-dataname ">
+  <div class="ddp-filter-search ddp-fright">
     <div class="ddp-form-filter-search">
       <component-input
         [autoFocus]="false"
@@ -24,6 +24,8 @@
         (changeValue)="onChangedSearchKeyword($event)">
       </component-input>
     </div>
+    <!-- form -->
+    <a href="javascript:" class="ddp-btn-selection" (click)="reloadPage(true)">{{'msg.comm.btn.search' | translate}}</a>
   </div>
   <!-- //filter search -->
 

--- a/discovery-frontend/src/app/engine-monitoring/ingestion/component/supervisor/supervisor.component.ts
+++ b/discovery-frontend/src/app/engine-monitoring/ingestion/component/supervisor/supervisor.component.ts
@@ -25,7 +25,8 @@ declare let moment: any;
 @Component({
   selector: 'ingestion-supervisor',
   templateUrl: './supervisor.component.html',
-  styles: ['.ddp-wrap-top-filtering .ddp-filter-search.type-dataname .ddp-form-filter-search {width: 100%;}']
+  styles: ['.ddp-wrap-top-filtering .ddp-filter-search.type-dataname .ddp-form-filter-search {width: 100%;}'
+          ,'.ddp-wrap-top-filtering .ddp-filter-search .ddp-form-filter-search {width: 280px;}']
 })
 export class SupervisorComponent extends AbstractComponent implements OnInit, OnDestroy, AfterViewInit {
 

--- a/discovery-frontend/src/app/engine-monitoring/ingestion/component/task/task.component.ts
+++ b/discovery-frontend/src/app/engine-monitoring/ingestion/component/task/task.component.ts
@@ -36,7 +36,7 @@ declare let moment: any;
 @Component({
   selector: 'ingestion-task',
   templateUrl: './task.component.html',
-  styles: ['.ddp-wrap-top-filtering .ddp-filter-search .ddp-form-filter-search {width: 250px;}']
+  styles: ['.ddp-wrap-top-filtering .ddp-filter-search .ddp-form-filter-search {width: 280px;}']
 })
 export class TaskComponent extends AbstractComponent implements OnInit, OnDestroy, AfterViewInit {
 

--- a/discovery-frontend/src/app/engine-monitoring/ingestion/component/worker/worker.component.ts
+++ b/discovery-frontend/src/app/engine-monitoring/ingestion/component/worker/worker.component.ts
@@ -35,7 +35,7 @@ declare let moment: any;
 @Component({
   selector: 'ingestion-worker',
   templateUrl: './worker.component.html',
-  styles: ['.ddp-wrap-top-filtering .ddp-filter-search .ddp-form-filter-search {width: 250px;}']
+  styles: ['.ddp-wrap-top-filtering .ddp-filter-search .ddp-form-filter-search {width: 280px;}']
 })
 export class WorkerComponent extends AbstractComponent implements OnInit, OnDestroy, AfterViewInit {
 

--- a/discovery-frontend/src/app/engine-monitoring/overview/component/graph.component.ts
+++ b/discovery-frontend/src/app/engine-monitoring/overview/component/graph.component.ts
@@ -189,10 +189,10 @@ export class GraphComponent extends AbstractComponent implements OnInit, OnDestr
         },
         grid: [
           {
-            top: 0,
-            bottom: 0,
-            left: 0,
-            right: 0
+            top: 3,
+            bottom: 10,
+            left: 20,
+            right: 20
           }
         ],
         xAxis: [
@@ -226,7 +226,7 @@ export class GraphComponent extends AbstractComponent implements OnInit, OnDestr
                 color: '#72d9a7'
               }
             },
-            smooth: true
+            smooth: false
           }
         ]
       };
@@ -265,10 +265,10 @@ export class GraphComponent extends AbstractComponent implements OnInit, OnDestr
         },
         grid: [
           {
-            top: 0,
-            bottom: 0,
-            left: 0,
-            right: 0
+            top: 3,
+            bottom: 10,
+            left: 20,
+            right: 20
           }
         ],
         xAxis: [
@@ -302,7 +302,7 @@ export class GraphComponent extends AbstractComponent implements OnInit, OnDestr
                 color: '#2eaaaf'
               }
             },
-            smooth: true
+            smooth: false
           }
         ]
       };

--- a/discovery-frontend/src/app/engine-monitoring/overview/component/node-information.component.ts
+++ b/discovery-frontend/src/app/engine-monitoring/overview/component/node-information.component.ts
@@ -16,6 +16,7 @@ import {
   AfterViewInit,
   Component,
   ElementRef,
+  HostListener,
   Injector,
   OnDestroy,
   OnInit,
@@ -42,7 +43,10 @@ export class NodeInformationComponent extends AbstractPopupComponent implements 
   public monitoring: Engine.Monitoring = new Engine.Monitoring();
 
   @ViewChild('gcCount') private _gcCountChartElmRef: ElementRef;
-  @ViewChild('memory') private _memoryChartElmRef: ElementRef;s
+  @ViewChild('memory') private _memoryChartElmRef: ElementRef;
+
+  private _gcCountChart: any;
+  private _memoryChart: any;
 
   constructor(protected elementRef: ElementRef,
               protected injector: Injector,
@@ -60,6 +64,20 @@ export class NodeInformationComponent extends AbstractPopupComponent implements 
 
   public ngOnDestroy() {
     super.ngOnDestroy();
+  }
+
+  /**
+   * Window resize
+   * @param event
+   */
+  @HostListener('window:resize', ['$event'])
+  public onResize(event) {
+    if (!_.isNil(this._gcCountChart)) {
+      this._gcCountChart.resize();
+    }
+    if (!_.isNil(this._memoryChart)) {
+      this._memoryChart.resize();
+    }
   }
 
   public show(monitoring: Engine.Monitoring) {
@@ -159,8 +177,10 @@ export class NodeInformationComponent extends AbstractPopupComponent implements 
           }
         ]
       };
-      const chartobj = echarts.init(this._gcCountChartElmRef.nativeElement, 'exntu');
-      chartobj.setOption(chartOps, false);
+      if (_.isNil(this._gcCountChart)) {
+        this._gcCountChart = echarts.init(this._gcCountChartElmRef.nativeElement, 'exntu');
+      }
+      this._gcCountChart.setOption(chartOps, false);
     });
   }
 
@@ -248,8 +268,10 @@ export class NodeInformationComponent extends AbstractPopupComponent implements 
           return params[0].axisValue + '<br/>' + params[0].marker + params[0].seriesName + ' : ' + CommonUtil.formatBytes(params[0].data, 2)
             + '<br/>' + params[1].marker + params[1].seriesName + ' : ' + CommonUtil.formatBytes(params[1].data, 2);
         });
-        const chartobj = echarts.init(this._memoryChartElmRef.nativeElement, 'exntu');
-        chartobj.setOption(chartOps, false);
+        if (_.isNil(this._memoryChart)) {
+          this._memoryChart = echarts.init(this._memoryChartElmRef.nativeElement, 'exntu');
+        }
+        this._memoryChart.setOption(chartOps, false);
       });
     });
   }

--- a/discovery-frontend/src/app/engine-monitoring/overview/overview.component.html
+++ b/discovery-frontend/src/app/engine-monitoring/overview/overview.component.html
@@ -26,32 +26,38 @@
 
   <div class="ddp-box-type ddp-type-server">
     <div class="ddp-wrap-status-value ddp-clear">
-      <div class="ddp-ui-status-value">
-        <div class="ddp-label-status" [ngClass]="[getTypeStatusClass(clusterStatus.broker)]">
+      <div class="ddp-ui-status-value type-all" (click)="searchByNodeType(MONITORING_NODETYPE.ALL);">
+        <!-- 선택시 type-selected 추가 -->
+        <div class="ddp-label-status type-all" [class.type-selected]="selectedNodeType === MONITORING_NODETYPE.ALL">
+          All
+        </div>
+      </div>
+      <div class="ddp-ui-status-value" (click)="searchByNodeType(MONITORING_NODETYPE.BROKER);">
+        <div class="ddp-label-status" [ngClass]="[getTypeStatusClass(clusterStatus.broker)]" [class.type-selected]="selectedNodeType === MONITORING_NODETYPE.BROKER">
           Broker
           <em [ngClass]="[getIconStatusClass(clusterStatus.broker)]"></em>
         </div>
       </div>
-      <div class="ddp-ui-status-value">
-        <div class="ddp-label-status" [ngClass]="[getTypeStatusClass(clusterStatus.coordinator)]">
+      <div class="ddp-ui-status-value" (click)="searchByNodeType(MONITORING_NODETYPE.COORDINATOR);">
+        <div class="ddp-label-status" [ngClass]="[getTypeStatusClass(clusterStatus.coordinator)]" [class.type-selected]="selectedNodeType === MONITORING_NODETYPE.COORDINATOR">
           Coordinator
           <em [ngClass]="[getIconStatusClass(clusterStatus.coordinator)]"></em>
         </div>
       </div>
-      <div class="ddp-ui-status-value">
-        <div class="ddp-label-status" [ngClass]="[getTypeStatusClass(clusterStatus.historical)]">
+      <div class="ddp-ui-status-value" (click)="searchByNodeType(MONITORING_NODETYPE.HISTORICAL);">
+        <div class="ddp-label-status" [ngClass]="[getTypeStatusClass(clusterStatus.historical)]" [class.type-selected]="selectedNodeType === MONITORING_NODETYPE.HISTORICAL">
           Historical
           <em [ngClass]="[getIconStatusClass(clusterStatus.historical)]"></em>
         </div>
       </div>
-      <div class="ddp-ui-status-value">
-        <div class="ddp-label-status" [ngClass]="[getTypeStatusClass(clusterStatus.overlord)]">
+      <div class="ddp-ui-status-value" (click)="searchByNodeType(MONITORING_NODETYPE.OVERLORD);">
+        <div class="ddp-label-status" [ngClass]="[getTypeStatusClass(clusterStatus.overlord)]" [class.type-selected]="selectedNodeType === MONITORING_NODETYPE.OVERLORD">
           Overlord
           <em [ngClass]="[getIconStatusClass(clusterStatus.overlord)]"></em>
         </div>
       </div>
-      <div class="ddp-ui-status-value">
-        <div class="ddp-label-status" [ngClass]="[getTypeStatusClass(clusterStatus.middleManager)]">
+      <div class="ddp-ui-status-value" (click)="searchByNodeType(MONITORING_NODETYPE.MIDDLE_MANAGER);">
+        <div class="ddp-label-status" [ngClass]="[getTypeStatusClass(clusterStatus.middleManager)]" [class.type-selected]="selectedNodeType === MONITORING_NODETYPE.MIDDLE_MANAGER">
           Middle Manager
           <em [ngClass]="[getIconStatusClass(clusterStatus.middleManager)]"></em>
         </div>
@@ -97,12 +103,12 @@
     <!-- // Search & Filter -->
 
     <div class="ddp-box-detail">
-      <ng-container *ngIf="monitorings | tableSort:tableSortProperty:tableSortDirection | tableFilter:{'hostname': keyword, 'status': selectedMonitoringStatus} as filteredItems">
+      <ng-container *ngIf="monitorings | tableSort:tableSortProperty:tableSortDirection | tableFilter:{'hostname': keyword, 'status': selectedMonitoringStatus, 'type': selectedNodeType} as filteredItems">
         <div class="ddp-data-source-none" *ngIf="filteredItems.length == 0">
           No data
         </div>
         <div class="ddp-grid-detail" *ngIf="selectedViewMode === VIEW_MODE.CARD && filteredItems.length > 0">
-          <div class="ddp-grid-box" *ngFor="let monitoring of filteredItems" [ngClass]="{'type-error' : !monitoring.status}">
+          <div class="ddp-grid-box ddp-cursor" *ngFor="let monitoring of filteredItems" [ngClass]="{'type-error' : !monitoring.status}" title="{{ 'msg.engine.monotoring.overview.server.name' | translate }} : {{monitoring.hostname}}" (click)="showNodeInformationModal(monitoring);">
             {{ convertTypeLabel(monitoring.type).substring(0, 1) }}
           </div>
         </div>
@@ -113,15 +119,21 @@
             <col width="33%">
           </colgroup>
           <thead>
-          <tr (click)="clickHostameHeaderColumn('hostname')">
-            <th>
+          <tr>
+            <th (click)="sortTable('hostname')">
               {{ 'msg.engine.monotoring.overview.server.name' | translate }}
-              <em [class.ddp-icon-array-default2]="tableSortDirection === TABLE_SORT_DIRECTION.NONE"
-                  [class.ddp-icon-array-asc2]="tableSortDirection === TABLE_SORT_DIRECTION.DESC"
-                  [class.ddp-icon-array-des2]="tableSortDirection === TABLE_SORT_DIRECTION.ASC">
+              <em [class.ddp-icon-array-default2]="tableSortProperty != 'hostname' || tableSortDirection === TABLE_SORT_DIRECTION.NONE"
+                  [class.ddp-icon-array-asc2]="tableSortProperty === 'hostname' && tableSortDirection === TABLE_SORT_DIRECTION.DESC"
+                  [class.ddp-icon-array-des2]="tableSortProperty === 'hostname' && tableSortDirection === TABLE_SORT_DIRECTION.ASC">
               </em>
             </th>
-            <th>{{ 'msg.engine.monotoring.overview.node.name' | translate }}</th>
+            <th (click)="sortTable('type')">
+              {{ 'msg.engine.monotoring.overview.node.name' | translate }}
+              <em [class.ddp-icon-array-default2]="tableSortProperty != 'type' || tableSortDirection === TABLE_SORT_DIRECTION.NONE"
+                  [class.ddp-icon-array-asc2]="tableSortProperty === 'type' && tableSortDirection === TABLE_SORT_DIRECTION.DESC"
+                  [class.ddp-icon-array-des2]="tableSortProperty === 'type' && tableSortDirection === TABLE_SORT_DIRECTION.ASC">
+              </em>
+            </th>
             <th>{{ 'msg.engine.monotoring.overview.status' | translate }}</th>
           </tr>
           </thead>

--- a/discovery-frontend/src/app/engine-monitoring/overview/overview.component.ts
+++ b/discovery-frontend/src/app/engine-monitoring/overview/overview.component.ts
@@ -48,9 +48,11 @@ export class OverviewComponent extends AbstractComponent implements OnInit, OnDe
 
   public keyword: string = '';
   public selectedMonitoringStatus: Engine.MonitoringStatus = Engine.MonitoringStatus.ALL;
+  public selectedNodeType: Engine.NodeType = Engine.NodeType.ALL;
   public tableSortProperty: string = '';
   public tableSortDirection: Engine.TableSortDirection = this.TABLE_SORT_DIRECTION.NONE;
 
+  public readonly MONITORING_NODETYPE = Engine.NodeType;
   public readonly VIEW_MODE = Engine.ViewMode;
   public selectedViewMode: Engine.ViewMode = this.VIEW_MODE.GRID;
   public selectedDuration: string = '1DAY';
@@ -91,6 +93,7 @@ export class OverviewComponent extends AbstractComponent implements OnInit, OnDe
           this._initTableSortDirection();
           this._changeKeyword(decodeURIComponent(_.get(params, 'keyword', '')));
           this._changeStatus(_.get(params, 'status', Engine.MonitoringStatus.ALL));
+          this._changeNodeType(_.get(params, 'type', Engine.NodeType.ALL));
           this._changeDuration(_.get(params, 'duration', '1DAY'));
         }));
 
@@ -138,10 +141,7 @@ export class OverviewComponent extends AbstractComponent implements OnInit, OnDe
     this.pageResult.size = 5000;
   }
 
-  /**
-   * Cllck hostname column
-   */
-  public clickHostameHeaderColumn(column: string) {
+  public sortTable(column: string) {
 
     if (this.tableSortProperty == column) {
       this.tableSortDirection = this.tableSortDirection == this.TABLE_SORT_DIRECTION.DESC
@@ -229,6 +229,7 @@ export class OverviewComponent extends AbstractComponent implements OnInit, OnDe
         queryParams: {
           keyword: encodeURIComponent(keyword),
           status: this.selectedMonitoringStatus,
+          type: this.selectedNodeType,
           duration: this.selectedDuration
         }
       })
@@ -242,6 +243,21 @@ export class OverviewComponent extends AbstractComponent implements OnInit, OnDe
         queryParams: {
           keyword: encodeURIComponent(this.keyword),
           status: status,
+          type: this.selectedNodeType,
+          duration: this.selectedDuration
+        }
+      })
+  }
+
+  public searchByNodeType(nodeType: Engine.NodeType) {
+    this.router.navigate([
+        this.ENGINE_MONITORING_OVERVIEW_ROUTER_URL
+      ],
+      {
+        queryParams: {
+          keyword: encodeURIComponent(this.keyword),
+          status: this.selectedMonitoringStatus,
+          type: nodeType,
           duration: this.selectedDuration
         }
       })
@@ -258,6 +274,7 @@ export class OverviewComponent extends AbstractComponent implements OnInit, OnDe
           queryParams: {
             keyword: encodeURIComponent(this.keyword),
             status: this.selectedMonitoringStatus,
+            type: this.selectedNodeType,
             duration: duration
           }
         })
@@ -265,16 +282,18 @@ export class OverviewComponent extends AbstractComponent implements OnInit, OnDe
   }
 
   public changeViewMode(viewMode: Engine.ViewMode) {
-
     if (_.isNil(viewMode)) {
       return;
     }
-
     if (this.selectedViewMode === viewMode) {
       return;
     }
-
     this.selectedViewMode = viewMode;
+
+    setTimeout(() => {
+      this._graphComponent.onResize(event);
+    }, 300);
+
   }
 
   private _changeTab(contentType: Engine.ContentType) {
@@ -283,10 +302,26 @@ export class OverviewComponent extends AbstractComponent implements OnInit, OnDe
 
   private _changeKeyword(keyword: string) {
     this.keyword = keyword;
+
+    setTimeout(() => {
+      this._graphComponent.onResize(event);
+    }, 300);
   }
 
   private _changeStatus(status: Engine.MonitoringStatus) {
     this.selectedMonitoringStatus = status;
+
+    setTimeout(() => {
+      this._graphComponent.onResize(event);
+    }, 300);
+  }
+
+  private _changeNodeType(nodeType: Engine.NodeType) {
+    this.selectedNodeType = nodeType;
+
+    setTimeout(() => {
+      this._graphComponent.onResize(event);
+    }, 300);
   }
 
   private _changeDuration(duration: string) {

--- a/discovery-frontend/src/app/engine-monitoring/overview/pipe/table-filter.pipe.ts
+++ b/discovery-frontend/src/app/engine-monitoring/overview/pipe/table-filter.pipe.ts
@@ -25,19 +25,40 @@ export class TableFilterPipe implements PipeTransform {
       return items;
     }
 
+    if (filter[ 'status' ] === 'ALL' && filter[ 'hostname' ] === '' && filter[ 'type' ] === 'ALL') {
+      return items;
+    }
+
     if (filter[ 'status' ] === 'ALL') {
       if (filter[ 'hostname' ] === '') {
-        return items;
+        return items.filter(monitoring => monitoring.type === filter[ 'type' ]);
+      } else {
+        return items.filter(monitoring => monitoring.hostname.indexOf(filter[ 'hostname' ]) > -1)
+          .filter(monitoring => monitoring.type === filter[ 'type' ]);
       }
-      return items.filter(monitoring => monitoring.hostname.indexOf(filter[ 'hostname' ]) > -1);
     }
 
     if (filter[ 'hostname' ] === '') {
-      return items.filter(monitoring => monitoring.status === (filter[ 'status' ] === 'OK'));
+      if (filter[ 'status' ] === 'ALL') {
+        return items.filter(monitoring => monitoring.type === filter[ 'type' ]);
+      } else {
+        return items.filter(monitoring => monitoring.status === (filter[ 'status' ] === 'OK'))
+          .filter(monitoring => monitoring.type === filter[ 'type' ]);
+      }
+    }
+
+    if (filter[ 'type' ] === '') {
+      if (filter[ 'hostname' ] === '') {
+        return items.filter(monitoring => monitoring.status === (filter[ 'status' ] === 'OK'))
+      } else {
+        return items.filter(monitoring => monitoring.hostname.indexOf(filter[ 'hostname' ]) > -1)
+          .filter(monitoring => monitoring.status === (filter[ 'status' ] === 'OK'))
+      }
     }
 
     return items
       .filter(monitoring => monitoring.hostname.indexOf(filter[ 'hostname' ]) > -1)
-      .filter(monitoring => monitoring.status === (filter[ 'status' ] === 'OK'));
+      .filter(monitoring => monitoring.status === (filter[ 'status' ] === 'OK'))
+      .filter(monitoring => monitoring.type === filter[ 'type' ]);
   }
 }

--- a/discovery-frontend/src/app/workspace/workspace.component.html
+++ b/discovery-frontend/src/app/workspace/workspace.component.html
@@ -367,7 +367,7 @@
         <!-- notebook -->
         <div class="ddp-box-bottom" *ngIf="book.type === 'notebook'">
           <div class="ddp-wrap-data">
-            <span class="ddp-data-name" title="{{book.connector}}" *ngIf="book.contents.connectorType === 'jupyter' || book.contents.connectorType === 'zeppelin'">
+            <span class="ddp-data-name" *ngIf="book.contents.connectorType === 'jupyter' || book.contents.connectorType === 'zeppelin'">
                 <em [ngClass]="{'ddp-icon-lang-jupyter' : book.contents.connectorType === 'jupyter', 'ddp-icon-lang-zeppelin' : book.contents.connectorType === 'zeppelin'}"></em>
                 <div class="ddp-txt-name">
                   <!-- error -->
@@ -381,7 +381,7 @@
                     <!-- //tooltip -->
                   </div>
                   <!-- //error -->
-                  <span class="ddp-txt-name-in">{{book.connector}}</span>
+                  <span class="ddp-txt-name-in" title="{{book.connector}}">{{book.connector}}</span>
                 </div>
             </span>
             <span class="ddp-data-name ddp-data-lang-r" title="{{'msg.nbook.ui.r' | translate}}" *ngIf="book.kernelType === 'R'">

--- a/discovery-frontend/src/app/workspace/workspace.component.html
+++ b/discovery-frontend/src/app/workspace/workspace.component.html
@@ -285,7 +285,6 @@
       <!-- box -->
       <!-- checkbox 선택시 ddp-selected 추가 -->
       <div class="ddp-box-block"
-           [title]="book.name"
            *ngFor="let book of (getList()
            | baseFilter:['type', 'folder', true]
            | baseFilter:['type', selectedContentFilter.key]
@@ -315,7 +314,7 @@
         <!-- //top -->
         <!-- box contents -->
         <div class="ddp-ui-box-contents">
-          <span class="ddp-data-name" [ngClass]="{'ddp-data-line2' : book.type != 'notebook'}">{{book.name}}</span>
+          <span class="ddp-data-name" [ngClass]="{'ddp-data-line2' : book.type != 'notebook'}" [title]="book.name">{{book.name}}</span>
           <span class="ddp-data-date">{{'msg.comm.ui.list.last' | translate}} <span class="ddp-data-ago">{{book.modifiedTime | amLocale:getLanguage() | amTimeAgo}}</span></span>
         </div>
         <!-- //box contents -->
@@ -558,7 +557,7 @@
 
           <!-- Name -->
           <div class="ddp-wrap-name">
-            <span class="ddp-data-name" [class.ddp-data-new]="book.createdTime | moment: 'isNew'">
+            <span class="ddp-data-name" [class.ddp-data-new]="book.createdTime | moment: 'isNew'" [title]="book.name">
               {{book.name}}
               <em class="ddp-icon-new" *ngIf="book.createdTime | moment: 'isNew'">{{'msg.common.ui.new' | translate}}</em>
             </span>


### PR DESCRIPTION
### Description
The overview area is visible only in the common tab of the Druid configuration.
Filter node type  for overview of engine monitoring
Modify workspace Notebook Connector tooltip
Maintain focus when you click a function in a custom field

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Go to engine monitoring 
   - Click druid configuration in the top right corner of the screen
   - Check the Overview area is visible only on the common tab.
2. Go to engine monitoring
   - Check if filtering is performed by node type in the center of the screen.
3. Go to workspace
   - Check the Notebook Connector tooltip
4. Go to workbook and create or edit Chart.
   - Move to create custom-filed view.
   - Click a function and check the function you click is in focus and the help is displayed in the help area.
   - When focusing out of the function list area, make sure that the help area is maintained.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
