### PR TITLE
open the dashboard/workbench with a tab in Exploration

### DIFF
--- a/discovery-frontend/src/app/explore-data/explore-data/component/explore-data-user-card.component.ts
+++ b/discovery-frontend/src/app/explore-data/explore-data/component/explore-data-user-card.component.ts
@@ -24,11 +24,9 @@ export class ExploreDataUserCardComponent extends AbstractComponent {
       return;
     }
 
-    const popupX = (window.screen.width / 2) - (1200 / 2);
-    const popupY = (window.screen.height / 2) - (900 / 2);
     const popUrl = `workbench/${this.topUser.workbench.id}`;
-
-    window.open(popUrl, '', 'status=no, height=700, width=1200, left=' + popupX + ', top=' + popupY + ', screenX=' + popupX + ', screenY= ' + popupY);
+    //open in new tab
+    window.open(popUrl, '_blank');
   }
 
   onClickDashBoardName(hasPermission: boolean) {
@@ -36,10 +34,8 @@ export class ExploreDataUserCardComponent extends AbstractComponent {
       return;
     }
 
-    const popupX = (window.screen.width / 2) - (1200 / 2);
-    const popupY = (window.screen.height / 2) - (900 / 2);
     const popUrl = `workbook/${this.topUser.workbook.id}/${this.topUser.dashboard.id}`;
-
-    window.open(popUrl, '', 'status=no, height=700, width=1200, left=' + popupX + ', top=' + popupY + ', screenX=' + popupX + ', screenY= ' + popupY);
+    //open in new tab
+    window.open(popUrl, '_blank');
   }
 }

--- a/discovery-frontend/src/app/explore-data/explore-data/popup/metadata-overview.component.ts
+++ b/discovery-frontend/src/app/explore-data/explore-data/popup/metadata-overview.component.ts
@@ -83,12 +83,9 @@ export class MetadataOverviewComponent extends AbstractComponent implements OnIn
       return
     }
 
-    const popupX = (window.screen.width / 2) - (1200 / 2);
-    const popupY = (window.screen.height / 2) - (900 / 2);
     const popUrl = `workbook/${recentlyUsedDashboard.workbook.id}/${recentlyUsedDashboard.id}`;
-    //
-    window.open(popUrl, '', 'status=no, height=700, width=1200, left=' + popupX + ', top=' + popupY + ', screenX=' + popupX + ', screenY= ' + popupY);
-    //
+    //open in new tab
+    window.open(popUrl, '_blank');
   }
 
   /**


### PR DESCRIPTION
### Description
Open the dashboard/workbench with a tab(not popup) in Exploration.
<img width="1673" alt="metatron_Discovery" src="https://user-images.githubusercontent.com/3770446/66182632-dbeebe80-e6b0-11e9-9049-d46b798d834e.png">

**Related Issue** : 

### How Has This Been Tested?
1. goto Exploration > Detail View
2. Click Workbench or Dashboard link
3. Look at the new tab, not the popup.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
