### PR TITLE
#2695 Dashboard widget 'save table as file' screen error in dark theme

### DIFF
--- a/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
+++ b/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
@@ -81,7 +81,7 @@ declare let $;
   selector: 'page-widget',
   templateUrl: 'page-widget.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  styles: ['.ddp-pop-preview { position: fixed; width: 700px; height: 500px; top: 50%; left: 50%; margin-left: -350px; margin-top: -250px;}']
+  styles: ['.ddp-pop-preview { position: fixed; width: 700px; height: 500px; top: 50% !important; left: 50% !important; margin-left: -350px; margin-top: -250px;}']
 })
 export class PageWidgetComponent extends AbstractWidgetComponent implements OnInit, OnDestroy {
 


### PR DESCRIPTION
### Description
When using the dark theme, a blank screen appears only when clicking 'save table as file' in the dashboard widget.

**Related Issue** : #2695 

### How Has This Been Tested?
1. Create a dashboard.
2. Create a chart and place it on the dashboard.
3. After saving the dashboard, press the Save File button to see if the preview popup is displayed normally.

#### Need additional checks?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
