### PR TITLE
#2293 cannot close preview result

### DIFF
--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/rule-join-popup/rule-join-popup.component.html
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/rule-join-popup/rule-join-popup.component.html
@@ -417,7 +417,7 @@
         </div>
 
 
-        <div class="ddp-btn-bottom">
+        <div class="ddp-btn-bottom" *ngIf="!isShowPreview">
           <a href="javascript:" class="ddp-btn-solid2" (click)="previewJoinResult()"
              [style.display]="isShowPreview ? 'none':'inline-block'"
              [ngClass]="{'ddp-disabled':leftSelCols.length === 0 || rightSelCols.length === 0 || selectedJoinType === '' || joinList.length === 0}">


### PR DESCRIPTION
### Description
the padding of the show result button screened the close result button

**Related Issue** : 
[2293](https://github.com/metatron-app/metatron-discovery/issues/2293)

### How Has This Been Tested?
test the issue of 2293
on join popup, click show and close repeatedly 
the close button should be clicked every time

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
