### PR TITLE
#2686 postgresql sql syntax error

### DIFF
--- a/discovery-frontend/src/app/workbench/workbench.component.ts
+++ b/discovery-frontend/src/app/workbench/workbench.component.ts
@@ -2465,6 +2465,8 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
     //H2, HIVE, ORACLE, TIBERO, MYSQL, MSSQL, PRESTO, FILE, POSTGRESQL, GENERAL;
     if (this.mimeType == 'HIVE' || this.mimeType == 'PRESTO' || this.mimeType == 'GENERAL') {
       this.editor.setModeOptions('text/x-hive');
+    } else if ( this.mimeType == 'POSTGRESQL' ) {
+      this.editor.setModeOptions('text/x-pgsql');
     } else {
       this.editor.setModeOptions('text/x-mysql');
     }

--- a/discovery-frontend/src/app/workbench/workbench.component.ts
+++ b/discovery-frontend/src/app/workbench/workbench.component.ts
@@ -1023,7 +1023,7 @@ export class WorkbenchComponent extends AbstractComponent implements OnInit, OnD
             .then(() => {
 
               let queryStrArr: string[]
-                = runningQuery.replace(/--.*/gmi, '').split(';').filter(item => !/^\s*$/.test(item));
+                = runningQuery.replace(/--.*/gmi, '').replace(/#.*/gmi, '').split(';').filter(item => !/^\s*$/.test(item));
 
               if (0 === queryStrArr.length) {
                 Alert.warning(this.translateService.instant('msg.bench.alert.execute.query'));


### PR DESCRIPTION
### Description
postgresql sql syntax error.
The comment in postgresql is '--', not '#'.
And there is an error when executing sql statements with '#'.
Even if the response is returned, it does not proceed to the next sql run.

**Related Issue** : #2686 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
1. Go to workbench(postgresql).
2. write some sql.
```
select 1;
```
3. input comment shortcut (Ctrl + /)
4. Check that it is created as follows:
```
-- select 1;
```

#### Need additional checks?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
