### PR TITLE
F#2640 unify charset detecting code

### DIFF
--- a/discovery-frontend/src/app/meta-data-management/lineage/service/lineage.service.ts
+++ b/discovery-frontend/src/app/meta-data-management/lineage/service/lineage.service.ts
@@ -64,6 +64,10 @@ export class LineageService extends AbstractService {
     return this.post(this.URL_LINEAGE + `/edge_list`, params);
   }
 
+  public getLineageFile(params: object): Promise<any> {
+    return this.post(this.URL_LINEAGE + `/lineage_file`, params);
+  }
+
   /**
    * 코드테이블 목록 조회
    * @param {Object} params

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepProperties.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepProperties.java
@@ -14,9 +14,10 @@
 
 package app.metatron.discovery.domain.dataprep;
 
-import app.metatron.discovery.domain.dataprep.exceptions.PrepErrorCodes;
-import app.metatron.discovery.domain.dataprep.exceptions.PrepException;
-import app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey;
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_HADOOP_NOT_CONFIGURED;
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_STAGING_BASE_DIR_NOT_CONFIGURED;
+import static app.metatron.discovery.domain.dataprep.util.PrepUtil.configError;
+
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
@@ -79,24 +80,21 @@ public class PrepProperties {
 
   public String getHadoopConfDir(boolean mandatory) {
     if (mandatory && hadoopConfDir == null) {
-      throw PrepException.create(PrepErrorCodes.PREP_INVALID_CONFIG_CODE,
-              PrepMessageKey.MSG_DP_ALERT_HADOOP_NOT_CONFIGURED, "Hadoop not configured");
+      throw configError(MSG_DP_ALERT_HADOOP_NOT_CONFIGURED, "Hadoop not configured");
     }
     return hadoopConfDir;
   }
 
   public String getStagingBaseDir(boolean mandatory) {
     if (mandatory && stagingBaseDir == null) {
-      throw PrepException.create(PrepErrorCodes.PREP_INVALID_CONFIG_CODE,
-              PrepMessageKey.MSG_DP_ALERT_STAGING_BASE_DIR_NOT_CONFIGURED, "StagingDir not configured");
+      throw configError(MSG_DP_ALERT_STAGING_BASE_DIR_NOT_CONFIGURED, "StagingBaseDir not configured");
     }
     return stagingBaseDir;
   }
 
   public String getS3BaseDir(boolean mandatory) {
     if (mandatory && s3BaseDir == null) {
-      throw PrepException.create(PrepErrorCodes.PREP_INVALID_CONFIG_CODE,
-              PrepMessageKey.MSG_DP_ALERT_STAGING_BASE_DIR_NOT_CONFIGURED, "S3Dir not configured");
+      throw configError(MSG_DP_ALERT_STAGING_BASE_DIR_NOT_CONFIGURED, "S3Dir not configured");
     }
     return s3BaseDir;
   }
@@ -426,8 +424,7 @@ public class PrepProperties {
   }
 
   public void setLocalBaseDir(String localBaseDir) {
-    if (null != localBaseDir && 1 < localBaseDir.length() && true == localBaseDir
-            .endsWith(File.separator)) {
+    if (localBaseDir != null && localBaseDir.length() > 1 && localBaseDir.endsWith(File.separator)) {
       this.localBaseDir = localBaseDir.substring(0, localBaseDir.length());
     } else {
       this.localBaseDir = localBaseDir;
@@ -435,8 +432,7 @@ public class PrepProperties {
   }
 
   public void setStagingBaseDir(String stagingBaseDir) {
-    if (null != stagingBaseDir && 1 < stagingBaseDir.length() && true == stagingBaseDir
-            .endsWith(File.separator)) {
+    if (stagingBaseDir != null && stagingBaseDir.length() > 1 && stagingBaseDir.endsWith(File.separator)) {
       this.stagingBaseDir = stagingBaseDir.substring(0, stagingBaseDir.length());
     } else {
       this.stagingBaseDir = stagingBaseDir;
@@ -444,7 +440,7 @@ public class PrepProperties {
   }
 
   public void setS3BaseDir(String s3BaseDir) {
-    if (null != s3BaseDir && 1 < s3BaseDir.length() && true == s3BaseDir.endsWith(File.separator)) {
+    if (s3BaseDir != null && s3BaseDir.length() > 1 && s3BaseDir.endsWith(File.separator)) {
       this.s3BaseDir = s3BaseDir.substring(0, s3BaseDir.length());
     } else {
       this.s3BaseDir = s3BaseDir;

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/file/PrepCsvUtil.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/file/PrepCsvUtil.java
@@ -1,13 +1,13 @@
 package app.metatron.discovery.domain.dataprep.file;
 
 import static app.metatron.discovery.domain.dataprep.PrepProperties.HADOOP_CONF_DIR;
-import static app.metatron.discovery.domain.dataprep.util.PrepUtil.datasetError;
-import static app.metatron.discovery.domain.dataprep.util.PrepUtil.snapshotError;
 import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_FAILED_TO_PARSE_CSV;
 import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_FAILED_TO_WRITE_CSV;
 import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_MALFORMED_DELIMITER;
 import static app.metatron.discovery.domain.dataprep.file.PrepFileUtil.getReader;
 import static app.metatron.discovery.domain.dataprep.file.PrepFileUtil.getWriter;
+import static app.metatron.discovery.domain.dataprep.util.PrepUtil.datasetError;
+import static app.metatron.discovery.domain.dataprep.util.PrepUtil.snapshotError;
 
 import app.metatron.discovery.domain.dataprep.exceptions.PrepErrorCodes;
 import app.metatron.discovery.domain.dataprep.exceptions.PrepException;

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/file/PrepFileUtil.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/file/PrepFileUtil.java
@@ -1,36 +1,8 @@
 package app.metatron.discovery.domain.dataprep.file;
 
-import static app.metatron.discovery.domain.dataprep.PrepProperties.HADOOP_CONF_DIR;
-import static app.metatron.discovery.domain.dataprep.PrepUtil.configError;
-import static app.metatron.discovery.domain.dataprep.PrepUtil.snapshotError;
-import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_CANNOT_GET_HDFS_FILE_SYSTEM;
-import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_CANNOT_READ_FROM_LOCAL_PATH;
-import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_CANNOT_WRITE_TO_HDFS_PATH;
-import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_CANNOT_WRITE_TO_LOCAL_PATH;
-import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_MALFORMED_URI_SYNTAX;
-import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_REQUIRED_PROPERTY_MISSING;
-import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_UNSUPPORTED_URI_SCHEME;
-
-import app.metatron.discovery.domain.dataprep.exceptions.PrepErrorCodes;
-import app.metatron.discovery.domain.dataprep.exceptions.PrepException;
-import app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey;
 import com.ibm.icu.text.CharsetDetector;
 import com.ibm.icu.text.CharsetMatch;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.Reader;
-import java.io.UnsupportedEncodingException;
-import java.io.Writer;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.nio.charset.Charset;
+
 import org.apache.commons.io.ByteOrderMark;
 import org.apache.commons.io.input.BOMInputStream;
 import org.apache.hadoop.conf.Configuration;
@@ -41,6 +13,26 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.Charset;
+
+import app.metatron.discovery.domain.dataprep.exceptions.PrepErrorCodes;
+import app.metatron.discovery.domain.dataprep.exceptions.PrepException;
+import app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey;
+
+import static app.metatron.discovery.domain.dataprep.PrepProperties.HADOOP_CONF_DIR;
+import static app.metatron.discovery.domain.dataprep.PrepUtil.configError;
+import static app.metatron.discovery.domain.dataprep.PrepUtil.snapshotError;
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_CANNOT_GET_HDFS_FILE_SYSTEM;
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_CANNOT_READ_FROM_LOCAL_PATH;
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_CANNOT_WRITE_TO_HDFS_PATH;
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_CANNOT_WRITE_TO_LOCAL_PATH;
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_MALFORMED_URI_SYNTAX;
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_REQUIRED_PROPERTY_MISSING;
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_UNSUPPORTED_URI_SCHEME;
 
 public class PrepFileUtil {
 
@@ -87,7 +79,7 @@ public class PrepFileUtil {
     InputStreamReader reader;
 
     try {
-      reader = new InputStreamReader(is, charset);
+      reader = new InputStreamReader(new BOMInputStream(is), charset);
     } catch (IOException e) {
       e.printStackTrace();
       throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_FAILED_TO_READ_CSV,

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/file/PrepFileUtil.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/file/PrepFileUtil.java
@@ -1,9 +1,37 @@
 package app.metatron.discovery.domain.dataprep.file;
 
+import static app.metatron.discovery.domain.dataprep.PrepProperties.HADOOP_CONF_DIR;
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_CANNOT_GET_HDFS_FILE_SYSTEM;
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_CANNOT_READ_FROM_HDFS_PATH;
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_CANNOT_READ_FROM_LOCAL_PATH;
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_CANNOT_WRITE_TO_HDFS_PATH;
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_CANNOT_WRITE_TO_LOCAL_PATH;
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_FAILED_TO_READ_CSV;
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_MALFORMED_URI_SYNTAX;
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_REQUIRED_PROPERTY_MISSING;
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_UNSUPPORTED_CHARSET;
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_UNSUPPORTED_URI_SCHEME;
+import static app.metatron.discovery.domain.dataprep.util.PrepUtil.configError;
+import static app.metatron.discovery.domain.dataprep.util.PrepUtil.datasetError;
+import static app.metatron.discovery.domain.dataprep.util.PrepUtil.snapshotError;
+
 import com.ibm.icu.text.CharsetDetector;
 import com.ibm.icu.text.CharsetMatch;
-
-import org.apache.commons.io.ByteOrderMark;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Reader;
+import java.io.UnsupportedEncodingException;
+import java.io.Writer;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.Charset;
 import org.apache.commons.io.input.BOMInputStream;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.ContentSummary;
@@ -14,66 +42,9 @@ import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.nio.charset.Charset;
-
-import app.metatron.discovery.domain.dataprep.exceptions.PrepErrorCodes;
-import app.metatron.discovery.domain.dataprep.exceptions.PrepException;
-import app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey;
-
-import static app.metatron.discovery.domain.dataprep.PrepProperties.HADOOP_CONF_DIR;
-import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_CANNOT_GET_HDFS_FILE_SYSTEM;
-import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_CANNOT_READ_FROM_LOCAL_PATH;
-import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_CANNOT_WRITE_TO_HDFS_PATH;
-import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_CANNOT_WRITE_TO_LOCAL_PATH;
-import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_MALFORMED_URI_SYNTAX;
-import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_REQUIRED_PROPERTY_MISSING;
-import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_UNSUPPORTED_URI_SCHEME;
-import static app.metatron.discovery.domain.dataprep.util.PrepUtil.configError;
-import static app.metatron.discovery.domain.dataprep.util.PrepUtil.snapshotError;
-
 public class PrepFileUtil {
 
   private static Logger LOGGER = LoggerFactory.getLogger(PrepFileUtil.class);
-
-  // All the code that used to call this function have been changed to use PrepCsvUtil.parse()
-  // Only LineageEdegController.java:file_upload() uses this.
-  // After change that code to use PrepCsvUtil.parse(), delete this function.
-  // In addition, PrepCsvUtil.parse() will be modified a little to use CommonCsvProcess.loadStream()
-  public static InputStreamReader getReaderAfterDetectingCharset(InputStream is, String strUri) {
-    InputStreamReader reader;
-    String charset = null;
-
-    BOMInputStream bis = new BOMInputStream(is, false, ByteOrderMark.UTF_8, ByteOrderMark.UTF_16LE,
-            ByteOrderMark.UTF_16BE, ByteOrderMark.UTF_32LE, ByteOrderMark.UTF_32BE);
-
-    try {
-      if (bis.hasBOM() == false || bis.hasBOM(ByteOrderMark.UTF_8)) {
-        charset = "UTF-8";
-      } else if (bis.hasBOM(ByteOrderMark.UTF_16LE) || bis.hasBOM(ByteOrderMark.UTF_16BE)) {
-        charset = "UTF-16";
-      } else if (bis.hasBOM(ByteOrderMark.UTF_32LE) || bis.hasBOM(ByteOrderMark.UTF_32BE)) {
-        charset = "UTF-32";
-      }
-
-      reader = new InputStreamReader(bis, charset);
-    } catch (UnsupportedEncodingException e) {
-      e.printStackTrace();
-      throw PrepException
-              .create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_UNSUPPORTED_CHARSET, charset);
-    } catch (NullPointerException e) {
-      e.printStackTrace();
-      throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_UNKNOWN_BOM);
-    } catch (IOException e) {
-      e.printStackTrace();
-      throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_FAILED_TO_READ_CSV,
-              String.format("%s (charset: %s)", strUri, charset));
-    }
-
-    return reader;
-  }
 
   private static InputStreamReader getReaderWithCharset(InputStream is, String strUri, String charset) {
     InputStreamReader reader;
@@ -82,8 +53,7 @@ public class PrepFileUtil {
       reader = new InputStreamReader(new BOMInputStream(is), charset);
     } catch (IOException e) {
       e.printStackTrace();
-      throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_FAILED_TO_READ_CSV,
-              String.format("%s (charset: %s)", strUri, charset));
+      throw datasetError(MSG_DP_ALERT_FAILED_TO_READ_CSV, String.format("%s (charset: %s)", strUri, charset));
     }
 
     return reader;
@@ -108,14 +78,12 @@ public class PrepFileUtil {
       String charset = match.getName();
 
       if (!Charset.isSupported(charset)) {
-        throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE,
-                PrepMessageKey.MSG_DP_ALERT_UNSUPPORTED_CHARSET, charset);
+        throw datasetError(MSG_DP_ALERT_UNSUPPORTED_CHARSET, charset);
       }
 
       return charset;
     } catch (IOException e) {
-      throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE,
-              PrepMessageKey.MSG_DP_ALERT_FAILED_TO_READ_CSV, strUri);
+      throw datasetError(MSG_DP_ALERT_FAILED_TO_READ_CSV, strUri);
     }
 
   }
@@ -129,15 +97,13 @@ public class PrepFileUtil {
       uri = new URI(strUri);
     } catch (URISyntaxException e) {
       e.printStackTrace();
-      throw PrepException
-              .create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, MSG_DP_ALERT_MALFORMED_URI_SYNTAX, strUri);
+      throw datasetError(MSG_DP_ALERT_MALFORMED_URI_SYNTAX, strUri);
     }
 
     switch (uri.getScheme()) {
       case "hdfs":
         if (conf == null) {
-          throw PrepException.create(PrepErrorCodes.PREP_INVALID_CONFIG_CODE,
-                  MSG_DP_ALERT_REQUIRED_PROPERTY_MISSING, HADOOP_CONF_DIR);
+          throw configError(MSG_DP_ALERT_REQUIRED_PROPERTY_MISSING, HADOOP_CONF_DIR);
         }
         Path path = new Path(uri);
 
@@ -146,8 +112,7 @@ public class PrepFileUtil {
           hdfsFs = FileSystem.get(conf);
         } catch (IOException e) {
           e.printStackTrace();
-          throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE,
-                  MSG_DP_ALERT_CANNOT_GET_HDFS_FILE_SYSTEM, strUri);
+          throw datasetError(MSG_DP_ALERT_CANNOT_GET_HDFS_FILE_SYSTEM, strUri);
         }
 
         FSDataInputStream his;
@@ -162,8 +127,7 @@ public class PrepFileUtil {
           dhis = hdfsFs.open(path);
         } catch (IOException e) {
           e.printStackTrace();
-          throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE,
-                  PrepMessageKey.MSG_DP_ALERT_CANNOT_READ_FROM_HDFS_PATH, strUri);
+          throw datasetError(MSG_DP_ALERT_CANNOT_READ_FROM_HDFS_PATH, strUri);
         }
 
         charset = detectingCharset(dhis, strUri);
@@ -183,8 +147,7 @@ public class PrepFileUtil {
           dfis = new FileInputStream(file);
         } catch (FileNotFoundException e) {
           e.printStackTrace();
-          throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE,
-                  MSG_DP_ALERT_CANNOT_READ_FROM_LOCAL_PATH, strUri);
+          throw datasetError(MSG_DP_ALERT_CANNOT_READ_FROM_LOCAL_PATH, strUri);
         }
 
         charset = detectingCharset(dfis, strUri);
@@ -192,9 +155,7 @@ public class PrepFileUtil {
         break;
 
       default:
-        throw PrepException
-                .create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, MSG_DP_ALERT_UNSUPPORTED_URI_SCHEME,
-                        strUri);
+        throw datasetError(MSG_DP_ALERT_UNSUPPORTED_URI_SCHEME, strUri);
     }
 
     return reader;
@@ -209,8 +170,7 @@ public class PrepFileUtil {
       writer = new OutputStreamWriter(os, charset);
     } catch (UnsupportedEncodingException e) {
       e.printStackTrace();
-      throw PrepException
-              .create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_UNSUPPORTED_CHARSET, charset);
+      throw datasetError(MSG_DP_ALERT_UNSUPPORTED_CHARSET, charset);
     }
 
     return writer;

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/lineage/LineageEdgeController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/lineage/LineageEdgeController.java
@@ -17,9 +17,6 @@ package app.metatron.discovery.domain.mdm.lineage;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVParser;
-import org.apache.commons.csv.CSVRecord;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -44,8 +41,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.net.URI;
 import java.util.Iterator;
 import java.util.List;
@@ -57,8 +52,6 @@ import app.metatron.discovery.domain.mdm.Metadata;
 import app.metatron.discovery.domain.mdm.MetadataErrorCodes;
 import app.metatron.discovery.domain.mdm.MetadataRepository;
 import app.metatron.discovery.domain.mdm.lineage.LineageMap.ALIGNMENT;
-
-import static app.metatron.discovery.domain.dataprep.file.PrepFileUtil.getReaderAfterDetectingCharset;
 
 @RequestMapping(value = "/metadatas/lineages")
 @RepositoryRestController
@@ -287,57 +280,6 @@ public class LineageEdgeController {
     }
 
     return ResponseEntity.ok().body(gridResponses);
-  }
-
-  // will be removed
-  @RequestMapping(value = "/file_upload_orig", method = RequestMethod.POST, produces = "application/json")
-  public @ResponseBody ResponseEntity<?> file_upload_orig(
-      @RequestPart("file") MultipartFile file
-  ) {
-    Map<String, Object> response = Maps.newHashMap();
-    List<String> header = Lists.newArrayList();
-    List<Map<String,Object>> rows = Lists.newArrayList();
-    try {
-      InputStream is = file.getInputStream();
-      InputStreamReader isr = getReaderAfterDetectingCharset(is,null);
-
-      CSVParser parser = CSVParser.parse(isr, CSVFormat.DEFAULT.withDelimiter(',').withEscape('\\'));
-
-      Iterator<CSVRecord> iter = parser.iterator();
-
-      if (iter.hasNext()) {
-        CSVRecord csvRow = iter.next();
-        int colCnt = csvRow.size();
-        for (int i = 0; i < colCnt; i++) {
-          header.add(i, csvRow.get(i));
-        }
-
-        while (true) {
-          if (!iter.hasNext()) {
-            break;
-          }
-
-          csvRow = iter.next();
-          colCnt = csvRow.size();
-          Map<String,Object> row = Maps.newHashMap();
-          for (int i = 0; i < colCnt; i++) {
-            row.put(header.get(i), csvRow.get(i) );
-          }
-          rows.add(row);
-        }
-      }
-
-      response.put("header",header);
-      response.put("rows",rows);
-    } catch (IOException e) {
-      LOGGER.error("file_upload POST(): caught an exception: ", e);
-    } catch (IllegalStateException e) {
-      LOGGER.error("file_upload POST(): caught an exception: ", e);
-    } catch (Exception e) {
-      LOGGER.error("file_upload POST(): caught an exception: ", e);
-    }
-
-    return ResponseEntity.ok().body(response);
   }
 
   @RequestMapping(value = "/edges/{edgeId}", method = RequestMethod.DELETE, produces = "application/json", consumes = "application/json")

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/dataprep/csv/ApacheCommonsCsvInputTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/dataprep/csv/ApacheCommonsCsvInputTest.java
@@ -3,8 +3,8 @@ package app.metatron.discovery.domain.dataprep.csv;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import app.metatron.discovery.domain.dataprep.file.PrepParseResult;
 import app.metatron.discovery.domain.dataprep.file.PrepCsvUtil;
+import app.metatron.discovery.domain.dataprep.file.PrepParseResult;
 import app.metatron.discovery.domain.dataprep.teddy.DataFrame;
 import org.junit.Test;
 

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/dataprep/csv/ApacheCommonsCsvIntegrationTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/dataprep/csv/ApacheCommonsCsvIntegrationTest.java
@@ -14,7 +14,6 @@
 
 package app.metatron.discovery.domain.dataprep.csv;
 
-import static app.metatron.discovery.domain.dataprep.file.PrepFileUtil.getReaderAfterDetectingCharset;
 import static org.junit.Assert.assertNull;
 
 import app.metatron.discovery.AbstractRestIntegrationTest;
@@ -24,14 +23,13 @@ import app.metatron.discovery.domain.dataprep.exceptions.PrepErrorCodes;
 import app.metatron.discovery.domain.dataprep.exceptions.PrepException;
 import app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey;
 import app.metatron.discovery.domain.dataprep.file.PrepCsvUtil;
+import app.metatron.discovery.domain.dataprep.file.PrepFileUtil;
 import app.metatron.discovery.domain.dataprep.file.PrepParseResult;
 import app.metatron.discovery.domain.dataprep.teddy.DataFrame;
 import com.facebook.presto.jdbc.internal.jackson.core.JsonProcessingException;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStreamReader;
+import java.io.Reader;
 import java.net.URI;
 import java.net.URISyntaxException;
 import org.apache.hadoop.conf.Configuration;
@@ -75,41 +73,19 @@ public class ApacheCommonsCsvIntegrationTest extends AbstractRestIntegrationTest
     String strHdfsUri = String.format("%s/test_output/%s", prepProperties.getStagingBaseDir(true), localRelPath);
     FSDataOutputStream hos;
     FileSystem hdfsFs;
-    URI uri;
-    File file;
-    FileInputStream fis;
-    InputStreamReader reader;
+    Reader reader;
+
+    PrepParseResult result = new PrepParseResult();
+    reader = PrepFileUtil.getReader(strLocalUri, null, false, result);
 
     try {
-      uri = new URI(strLocalUri);
-      file = new File(uri);
-      fis = new FileInputStream(file);
-      reader = getReaderAfterDetectingCharset(fis, strLocalUri);
-    } catch (FileNotFoundException e) {
-      e.printStackTrace();
-      throw PrepException
-              .create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_FILE_NOT_FOUND, strLocalUri);
-    } catch (URISyntaxException e) {
-      e.printStackTrace();
-      throw PrepException
-              .create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_MALFORMED_URI_SYNTAX,
-                      strHdfsUri);
-    } catch (IOException e) {
-      e.printStackTrace();
-      throw PrepException
-              .create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_CANNOT_READ_FROM_LOCAL_PATH,
-                      strHdfsUri);
-    }
-
-    try {
-      uri = new URI(strHdfsUri);
+      URI uri = new URI(strHdfsUri);
       Path path = new Path(uri);
       hdfsFs = FileSystem.get(getHadoopConf());
       hos = hdfsFs.create(path);
 
       org.apache.commons.io.IOUtils.copy(reader, hos);
 
-      fis.close();
       hos.close();
       reader.close();
     } catch (URISyntaxException e) {

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/dataprep/csv/ApacheCommonsCsvOutputTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/dataprep/csv/ApacheCommonsCsvOutputTest.java
@@ -1,9 +1,6 @@
 package app.metatron.discovery.domain.dataprep.csv;
 
-import static app.metatron.discovery.domain.dataprep.PrepProperties.HADOOP_CONF_DIR;
-import static app.metatron.discovery.domain.dataprep.util.PrepUtil.datasetError;
-import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_UNSUPPORTED_URI_SCHEME;
-import static app.metatron.discovery.domain.dataprep.file.PrepFileUtil.getReaderAfterDetectingCharset;
+import static app.metatron.discovery.domain.dataprep.file.PrepFileUtil.getReader;
 
 import app.metatron.discovery.domain.dataprep.exceptions.PrepErrorCodes;
 import app.metatron.discovery.domain.dataprep.exceptions.PrepException;
@@ -13,23 +10,15 @@ import app.metatron.discovery.domain.dataprep.file.PrepParseResult;
 import app.metatron.discovery.domain.dataprep.teddy.DataFrame;
 import app.metatron.discovery.domain.dataprep.teddy.Row;
 import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Reader;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FSDataInputStream;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.junit.Test;
 
 public class ApacheCommonsCsvOutputTest {
@@ -42,7 +31,6 @@ public class ApacheCommonsCsvOutputTest {
   public static String buildStrUrlFromResourceDir(String relpath) {
     return String.format("file://%s/src/test/resources/%s", System.getProperty("user.dir"), relpath);
   }
-
 
   @Test
   public void test_basic_output() {
@@ -81,30 +69,6 @@ public class ApacheCommonsCsvOutputTest {
     }
   }
 
-  /**
-   * @param df DataFrame to write out
-   * @param strUri URI as String (to be java.net.URI)
-   * @param colNames If not null (for FILE snapshots), print as a header.
-   *
-   * colNames is null for StagingDB snapshots.
-   */
-  private void writeCsv(DataFrame df, String strUri, List<String> colNames) {
-    FileWriter writer = null;
-    CSVPrinter printer = null;
-
-    //    try {
-    //      writer = new FileWriter(buildPathToTestOutputDir("ApacheCommonsCsvInputTest.csv"), false);    // append = false
-    //    } catch (IOException e) {
-    //      e.printStackTrace();
-    //    }
-
-    //    try {
-    //      printer = new CSVPrinter(writer, CSVFormat.RFC4180);
-    //    } catch (IOException e) {
-    //      e.printStackTrace();
-    //    }
-  }
-
   private void useCSVPrinter(DataFrame df, String strUri, Configuration conf) {
     CSVPrinter printer = PrepCsvUtil.getPrinter(strUri, conf);
     String errmsg = null;
@@ -135,65 +99,8 @@ public class ApacheCommonsCsvOutputTest {
   }
 
   private void cat(String strUri, Configuration conf) {
-    Reader reader;
-    URI uri;
-
-    try {
-      uri = new URI(strUri);
-    } catch (URISyntaxException e) {
-      e.printStackTrace();
-      throw PrepException
-              .create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_MALFORMED_URI_SYNTAX, strUri);
-    }
-
-    switch (uri.getScheme()) {
-      case "hdfs":
-        if (conf == null) {
-          throw PrepException.create(PrepErrorCodes.PREP_INVALID_CONFIG_CODE,
-                  PrepMessageKey.MSG_DP_ALERT_REQUIRED_PROPERTY_MISSING, HADOOP_CONF_DIR);
-        }
-        Path path = new Path(uri);
-
-        FileSystem hdfsFs;
-        try {
-          hdfsFs = FileSystem.get(conf);
-        } catch (IOException e) {
-          e.printStackTrace();
-          throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE,
-                  PrepMessageKey.MSG_DP_ALERT_CANNOT_GET_HDFS_FILE_SYSTEM, strUri);
-        }
-
-        FSDataInputStream his;
-        try {
-          his = hdfsFs.open(path);
-        } catch (IOException e) {
-          e.printStackTrace();
-          throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE,
-                  PrepMessageKey.MSG_DP_ALERT_CANNOT_READ_FROM_HDFS_PATH, strUri);
-        }
-
-        reader = getReaderAfterDetectingCharset(his, strUri);
-        break;
-
-      case "file":
-        File file = new File(uri);
-
-        FileInputStream fis;
-        try {
-          fis = new FileInputStream(file);
-        } catch (FileNotFoundException e) {
-          e.printStackTrace();
-          throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE,
-                  PrepMessageKey.MSG_DP_ALERT_CANNOT_READ_FROM_LOCAL_PATH, strUri);
-        }
-
-        reader = getReaderAfterDetectingCharset(fis, strUri);
-        break;
-
-      default:
-        throw datasetError(MSG_DP_ALERT_UNSUPPORTED_URI_SCHEME, strUri);
-    }
-
+    PrepParseResult result = new PrepParseResult();
+    Reader reader = getReader(strUri, conf, false, result);
     BufferedReader br = new BufferedReader(reader);
 
     try {


### PR DESCRIPTION
### Description
There are many different charset-detecting-codes in dataprep. (also in metatron-discovery)
I unified that codes within dataprep.
Originally, I was going to unify all different codes in whole metatron-discovery.
But recently, we made a plan to integrate @dataprep & @datasource, that makes the unification to be meaningless.

**Related Issue** : https://github.com/metatron-app/metatron-discovery/issues/2640

### How Has This Been Tested?
Import the files attached at https://github.com/metatron-app/metatron-discovery/issues/2640.

#### Need additional checks?
Yes, please.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
