### PR TITLE
#2635 Maintain search result list view in datasource mgmt. after moving to detailed view

### DIFF
--- a/discovery-frontend/angular.json
+++ b/discovery-frontend/angular.json
@@ -49,7 +49,8 @@
               "src/assets/css/lib/golden-layout/goldenlayout-base.css",
               "src/assets/css/lib/golden-layout/goldenlayout-light-theme.css",
               "node_modules/air-datepicker/dist/css/datepicker.css",
-              "src/lib/openlayers/ol.css"
+              "src/lib/openlayers/ol.css",
+              "src/assets/css/metatron.css"
             ],
             "scripts": [
               "node_modules/codemirror/lib/codemirror.js",

--- a/discovery-frontend/src/app/data-storage/component/criterion/criterion-time-radiobox-list.component.ts
+++ b/discovery-frontend/src/app/data-storage/component/criterion/criterion-time-radiobox-list.component.ts
@@ -89,7 +89,7 @@ export class CriterionTimeRadioboxListComponent extends AbstractComponent {
   public ngAfterViewInit() {
     // init
     this._initView();
-    if (this.defaultSelectedItemList.length > 0) {
+    if (this.defaultSelectedItemList) {
       Object.keys(this.defaultSelectedItemList).forEach((key) => {
         if (key === Criteria.KEY_DATETIME_TYPE_SUFFIX) {
           // change selected time type

--- a/discovery-frontend/src/app/data-storage/data-source-list/data-source-list.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/data-source-list.component.ts
@@ -11,15 +11,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, ElementRef, Injector, ViewChild } from '@angular/core';
-import { AbstractComponent } from '../../common/component/abstract.component';
-import { DatasourceService } from '../../datasource/service/datasource.service';
-import { Datasource, SourceType, Status } from '../../domain/datasource/datasource';
-import { Alert } from '../../common/util/alert.util';
-import { Modal } from '../../common/domain/modal';
-import { DeleteModalComponent } from '../../common/component/modal/delete/delete.component';
-import { MomentDatePipe } from '../../common/pipe/moment.date.pipe';
-import { StringUtil } from '../../common/util/string.util';
+import {Component, ElementRef, Injector, ViewChild} from '@angular/core';
+import {AbstractComponent} from '../../common/component/abstract.component';
+import {DatasourceService} from '../../datasource/service/datasource.service';
+import {Datasource, SourceType, Status} from '../../domain/datasource/datasource';
+import {Alert} from '../../common/util/alert.util';
+import {Modal} from '../../common/domain/modal';
+import {DeleteModalComponent} from '../../common/component/modal/delete/delete.component';
+import {MomentDatePipe} from '../../common/pipe/moment.date.pipe';
+import {StringUtil} from '../../common/util/string.util';
 import {ActivatedRoute} from "@angular/router";
 import {CriterionComponent} from "../component/criterion/criterion.component";
 import {Criteria} from "../../domain/datasource/criteria";
@@ -71,37 +71,40 @@ export class DataSourceListComponent extends AbstractComponent {
       .then((result: Criteria.Criterion) => {
         // init criterion list
         this.criterionComponent.initCriterionList(result);
-        this.subscriptions.push(this.activatedRoute.queryParams.subscribe(params => {
-          const paramKeys = Object.keys(params);
-          const isExistSearchParams = paramKeys.length > 0;
-          const searchParams = {};
-          // if exist search param in URL
-          if (isExistSearchParams) {
-            paramKeys.forEach((key) => {
-              if (key === 'size') {
-                this.page.size = params['size'];
-              } else if (key === 'page') {
-                this.page.page = params['page'];
-              } else if (key === 'sort') {
-                const sortParam = params['sort'].split(',');
-                this.selectedContentSort.key = sortParam[0];
-                this.selectedContentSort.sort = sortParam[1];
-              } else if (key === 'containsText') {
-                this.searchKeyword = params['containsText'];
-              } else {
-                searchParams[key] = params[key].split(',');
-              }
-            });
-            // TODO 추후 criterion component로 이동
-            delete searchParams['pseudoParam'];
-            // init criterion search param
-            this.criterionComponent.initSearchParams(searchParams);
-          }
-          // set datasource list
-          this._setDatasourceList();
-        }));
       })
       .catch(error => this.commonExceptionHandler(error));
+
+    this.subscriptions.push(
+      this.activatedRoute.queryParams.subscribe(params => {
+        const paramKeys = Object.keys(params);
+        const isExistSearchParams = paramKeys.length > 0;
+        const searchParams = {};
+        // if exist search param in URL
+        if (isExistSearchParams) {
+          paramKeys.forEach((key) => {
+            if (key === 'size') {
+              this.page.size = params['size'];
+            } else if (key === 'page') {
+              this.page.page = params['page'];
+            } else if (key === 'sort') {
+              const sortParam = params['sort'].split(',');
+              this.selectedContentSort.key = sortParam[0];
+              this.selectedContentSort.sort = sortParam[1];
+            } else if (key === 'containsText') {
+              this.searchKeyword = params['containsText'];
+            } else {
+              searchParams[key] = params[key].split(',');
+            }
+          });
+          // TODO 추후 criterion component로 이동
+          delete searchParams['pseudoParam'];
+          // init criterion search param
+          this.criterionComponent.initSearchParams(searchParams);
+        }
+        // set datasource list
+        this._setDatasourceList();
+      })
+    );
   }
 
   isEmptyList(): boolean {
@@ -137,7 +140,7 @@ export class DataSourceListComponent extends AbstractComponent {
    * @param {string} mode
    */
   public changeMode(mode: string) {
-    this.useUnloadConfirm = ( 'create-data-source' === mode );
+    this.useUnloadConfirm = ('create-data-source' === mode);
     this.mode = mode;
   } // function - changeMode
 
@@ -145,7 +148,7 @@ export class DataSourceListComponent extends AbstractComponent {
    * 데이터소스 생성 완료
    */
   public createComplete(): void {
-    this.changeMode( '' );
+    this.changeMode('');
     // true
     this.reloadPage();
   }
@@ -215,6 +218,7 @@ export class DataSourceListComponent extends AbstractComponent {
    */
   public onClickDatasource(sourceId: string): void {
     // open datasource detail
+    sessionStorage.setItem( 'IS_LOCATION_BACK_DS_LIST', 'TRUE' );
     this.router.navigate(['/management/storage/datasource', sourceId]).then();
   }
 
@@ -335,8 +339,7 @@ export class DataSourceListComponent extends AbstractComponent {
         // 현재 페이지에 아이템이 없다면 전 페이지를 불러온다.
         if (this.page.page > 0 &&
           isNullOrUndefined(result['_embedded']) ||
-          (!isNullOrUndefined(result['_embedded']) && result['_embedded'].datasources.length === 0))
-        {
+          (!isNullOrUndefined(result['_embedded']) && result['_embedded'].datasources.length === 0)) {
           this.page.page = result.page.number - 1;
           this._setDatasourceList();
         }
@@ -360,7 +363,7 @@ export class DataSourceListComponent extends AbstractComponent {
     const params = {
       page: this.page.page,
       size: this.page.size,
-      pseudoParam : (new Date()).getTime(),
+      pseudoParam: (new Date()).getTime(),
       sort: this.selectedContentSort.key + ',' + this.selectedContentSort.sort
     };
     const searchParams = this.criterionComponent.getUrlQueryParams();

--- a/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/detail-data-source.component.ts
+++ b/discovery-frontend/src/app/data-storage/data-source-list/detail-data-source/detail-data-source.component.ts
@@ -44,7 +44,7 @@ import {CreateSourceCompleteData} from "../../service/data-source-create.service
   templateUrl: './detail-data-source.component.html',
   providers: [MomentDatePipe]
 })
-export class DetailDataSourceComponent extends AbstractComponent implements OnInit, OnChanges {
+export class DetailDataSourceComponent extends AbstractComponent implements OnInit {
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
   | Private Variables
@@ -172,7 +172,8 @@ export class DetailDataSourceComponent extends AbstractComponent implements OnIn
                       failResults: {
                         errorCode: history['_embedded'].ingestionHistories[0].errorCode,
                         cause: history['_embedded'].ingestionHistories[0].cause
-                      }};
+                      }
+                    };
                   } else if (history['_embedded'] && !history['_embedded'].ingestionHistories[0].progress) {
                     this.isNotShowProgress = true;
                   } else if (datasource.srcType === SourceType.FILE || datasource.srcType === SourceType.JDBC) {
@@ -206,19 +207,13 @@ export class DetailDataSourceComponent extends AbstractComponent implements OnIn
     });
   }
 
-  // Change
-  public ngOnChanges() {
-
-  }
-
-  // Destory
   public ngOnDestroy() {
-    // Destory
     super.ngOnDestroy();
     // if exist _subscribe
     if (this._subscribe) {
       this._subscribe.unsubscribe();
     }
+    sessionStorage.removeItem('IS_LOCATION_BACK_DS_LIST');
   }
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
@@ -243,7 +238,6 @@ export class DetailDataSourceComponent extends AbstractComponent implements OnIn
       .then(result => this.loadingHide())
       .catch(error => this.commonExceptionHandler(error));
   }
-
 
 
   /**
@@ -326,7 +320,7 @@ export class DetailDataSourceComponent extends AbstractComponent implements OnIn
     if (type === 'published') {
       // 현재 전체공개 됨
       if (this.datasource.published) {
-        modal.name = `'${this.datasource.name}' `+ this.translateService.instant('msg.storage.alert.source.change-selected');
+        modal.name = `'${this.datasource.name}' ` + this.translateService.instant('msg.storage.alert.source.change-selected');
         modal.description = this.translateService.instant('msg.storage.alert.source-publish.description');
         modal.btnName = this.translateService.instant('msg.storage.btn.source.private');
       } else {
@@ -379,7 +373,7 @@ export class DetailDataSourceComponent extends AbstractComponent implements OnIn
    */
   public reIngestionClose(): void {
     this.step = '';
-    this.onChangeMode( this.mode );
+    this.onChangeMode(this.mode);
   }
 
   /**
@@ -398,7 +392,7 @@ export class DetailDataSourceComponent extends AbstractComponent implements OnIn
     }
     this.nameFl = false;
     // update
-    this.updateDatasource({name : this.reName.trim()});
+    this.updateDatasource({name: this.reName.trim()});
   }
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
@@ -413,7 +407,11 @@ export class DetailDataSourceComponent extends AbstractComponent implements OnIn
 
   // 뒤로가기
   public prevDatasourceList(): void {
-    this.router.navigate(['/management/storage/datasource']);
+    if ('TRUE' === sessionStorage.getItem('IS_LOCATION_BACK_DS_LIST')) {
+      this.location.back();
+    } else {
+      this.router.navigate(['/management/storage/datasource']);
+    }
   }
 
   // mode
@@ -529,7 +527,7 @@ export class DetailDataSourceComponent extends AbstractComponent implements OnIn
               // set timestamp column
               this.timestampColumn = field;
               // if column is current time, hide
-              if (field.format &&  field.format.type === FieldFormatType.TEMPORARY_TIME) {
+              if (field.format && field.format.type === FieldFormatType.TEMPORARY_TIME) {
                 list.splice(index, 1);
               }
             }
@@ -568,12 +566,12 @@ export class DetailDataSourceComponent extends AbstractComponent implements OnIn
    */
   private _setProcessIngestion(datasourceId: string): void {
     try {
-      const headers: any = { 'X-AUTH-TOKEN': this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN) };
+      const headers: any = {'X-AUTH-TOKEN': this.cookieService.get(CookieConstant.KEY.LOGIN_TOKEN)};
       // 메세지 수신
-      this._subscribe = CommonConstant.stomp.watch( `/topic/datasources/${datasourceId}/progress` )
+      this._subscribe = CommonConstant.stomp.watch(`/topic/datasources/${datasourceId}/progress`)
         .subscribe((msg: Message) => {
 
-          const data: { progress: number, message: string, results: any } = JSON.parse( msg.body );
+          const data: { progress: number, message: string, results: any } = JSON.parse(msg.body);
 
           console.log('process socket', data);
           // if has history


### PR DESCRIPTION
### Description
When you return to the list from the detail screen, the filter information you selected may not be retained.

**Related Issue** : #2635 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
1. Go to 'LNB > management > data storage > datasource
2. Click on any filtering condition and check list view.
3. Click on any content in searched list and check detail view
4. move to list using back button.
5. In the list screen, verify that filter conditions are maintained.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
