### PR TITLE
fix error for regex filtering mode in advance filter 

### DIFF
--- a/discovery-frontend/src/app/dashboard/filters/inclusion-filter/configure-filters-inclusion.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/inclusion-filter/configure-filters-inclusion.component.ts
@@ -491,6 +491,7 @@ export class ConfigureFiltersInclusionComponent extends AbstractFilterPopupCompo
     this.resetRegExpr(this.regExpr);
     this.resetCondition(this.condition);
     this.resetLimitation(this.limitation);
+    this.candidateWithValidation();
   } // function resetAll
 
   /**
@@ -514,6 +515,7 @@ export class ConfigureFiltersInclusionComponent extends AbstractFilterPopupCompo
     this._limitation = _.cloneDeep( this.limitation );
     this.targetFilter.preFilters = [this._wildcard, this._regExpr, this._condition, this._limitation];
     this.datasourceService.getCandidateForFilter(this.targetFilter, this._board, [], this._targetField).then(result => {
+      this._candidateList = this._candidateList.filter(item => item.isDefinedValue);  // initialize list
       this._setCandidateResult(result, this.targetFilter, this._targetField);
       this.safelyDetectChanges();
       this.loadingHide();
@@ -603,6 +605,7 @@ export class ConfigureFiltersInclusionComponent extends AbstractFilterPopupCompo
       this.currentPage = 1;
       this.lastPage = 1;
       this.totalCount = 0;
+      this.safelyDetectChanges();
     }
     if (this._candidateList && 0 < this._candidateList.length) {
 
@@ -893,8 +896,6 @@ export class ConfigureFiltersInclusionComponent extends AbstractFilterPopupCompo
         );
     }
 
-
-
     // 목록 설정
     this._candidateList =
       this._candidateList.concat(
@@ -911,7 +912,6 @@ export class ConfigureFiltersInclusionComponent extends AbstractFilterPopupCompo
             .filter(item => -1 === this._candidateList.findIndex(can => can.name === item.name))
         );
     }
-
 
     // 목록에 선택값이 없을 경우 선택값 추가
     if (this.selectedValues && 0 < this.selectedValues.length) {

--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/AbstractQueryBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/AbstractQueryBuilder.java
@@ -42,42 +42,13 @@
 
 package app.metatron.discovery.query.druid;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-
-import org.apache.commons.collections.MapUtils;
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
 import app.metatron.discovery.common.CommonLocalVariable;
 import app.metatron.discovery.common.datasource.LogicalType;
 import app.metatron.discovery.domain.datasource.QueryHistoryTeller;
 import app.metatron.discovery.domain.datasource.data.QueryTimeExcetpion;
-import app.metatron.discovery.domain.datasource.data.forward.CsvResultForward;
-import app.metatron.discovery.domain.datasource.data.forward.ExcelResultForward;
-import app.metatron.discovery.domain.datasource.data.forward.JsonResultForward;
-import app.metatron.discovery.domain.datasource.data.forward.OrcResultForward;
-import app.metatron.discovery.domain.datasource.data.forward.ParquetResultForward;
-import app.metatron.discovery.domain.datasource.data.forward.ResultForward;
-import app.metatron.discovery.domain.workbook.configurations.datasource.DataSource;
-import app.metatron.discovery.domain.workbook.configurations.datasource.DefaultDataSource;
-import app.metatron.discovery.domain.workbook.configurations.datasource.JoinMapping;
-import app.metatron.discovery.domain.workbook.configurations.datasource.MappingDataSource;
-import app.metatron.discovery.domain.workbook.configurations.datasource.MultiDataSource;
-import app.metatron.discovery.domain.workbook.configurations.field.ExpressionField;
-import app.metatron.discovery.domain.workbook.configurations.field.Field;
-import app.metatron.discovery.domain.workbook.configurations.field.MapField;
-import app.metatron.discovery.domain.workbook.configurations.field.MeasureField;
-import app.metatron.discovery.domain.workbook.configurations.field.UserDefinedField;
+import app.metatron.discovery.domain.datasource.data.forward.*;
+import app.metatron.discovery.domain.workbook.configurations.datasource.*;
+import app.metatron.discovery.domain.workbook.configurations.field.*;
 import app.metatron.discovery.domain.workbook.configurations.filter.BoundFilter;
 import app.metatron.discovery.domain.workbook.configurations.filter.*;
 import app.metatron.discovery.domain.workbook.configurations.format.ContinuousTimeFormat;
@@ -107,15 +78,21 @@ import app.metatron.discovery.query.druid.virtualcolumns.VirtualColumn;
 import app.metatron.discovery.query.polaris.ComputationalField;
 import app.metatron.discovery.util.PolarisUtils;
 import app.metatron.discovery.util.TimeUnits;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.*;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static app.metatron.discovery.domain.datasource.DataSourceErrorCodes.CONFUSING_FIELD_CODE;
 import static app.metatron.discovery.domain.datasource.Field.FieldRole.DIMENSION;
 import static app.metatron.discovery.domain.datasource.Field.FieldRole.TIMESTAMP;
-import static app.metatron.discovery.domain.datasource.data.forward.ResultForward.ForwardType.CSV;
-import static app.metatron.discovery.domain.datasource.data.forward.ResultForward.ForwardType.EXCEL;
-import static app.metatron.discovery.domain.datasource.data.forward.ResultForward.ForwardType.JSON;
-import static app.metatron.discovery.domain.datasource.data.forward.ResultForward.ForwardType.NONE;
-import static app.metatron.discovery.domain.datasource.data.forward.ResultForward.ForwardType.PARQUET;
+import static app.metatron.discovery.domain.datasource.data.forward.ResultForward.ForwardType.*;
 import static app.metatron.discovery.domain.workbook.configurations.field.Field.FIELD_NAMESPACE_SEP;
 
 /**
@@ -575,6 +552,12 @@ public abstract class AbstractQueryBuilder {
 
         filter.addField(new RegExpFilter(fieldName, PolarisUtils.convertSqlLikeToRegex(likeFilter.getExpr(), false)));
 
+      } else if (reqFilter instanceof RegExprFilter) {
+
+        RegExprFilter regExprFilter = (RegExprFilter) reqFilter;
+
+        filter.addField(new RegExpFilter(fieldName, regExprFilter.getExpr()));
+
       } else if (reqFilter instanceof IntervalFilter) {
 
         IntervalFilter intervalFilter = (IntervalFilter) reqFilter;
@@ -598,7 +581,7 @@ public abstract class AbstractQueryBuilder {
           for (String interval : curIntervals) {
             String[] splitedInterval = StringUtils.split(interval, "/");
             String expr = String.format("(timestamp(%s, format='%s') >= timestamp('%s') && (timestamp(%s, format='%s') <= timestamp('%s')",
-                                        engineColumnName, datasourceField.getTimeFormat(), splitedInterval[0], engineColumnName, datasourceField.getFormat(), splitedInterval[1]);
+                    engineColumnName, datasourceField.getTimeFormat(), splitedInterval[0], engineColumnName, datasourceField.getFormat(), splitedInterval[1]);
 
             orFilter.addField(new MathFilter(expr));
           }
@@ -620,16 +603,16 @@ public abstract class AbstractQueryBuilder {
           field = "__time";
         } else {
           DateTimeMillisFunc millisFunc = new DateTimeMillisFunc(engineColumnName,
-                                                                 datasourceField.getTimeFormat(),
-                                                                 null, null);
+                  datasourceField.getTimeFormat(),
+                  null, null);
           field = millisFunc.toExpression();
         }
 
         TimeFieldFormat timeFormat = (TimeFieldFormat) timestampFilter.getTimeFormat();
         TimeFormatFunc timeFormatFunc = new TimeFormatFunc(field,
-                                                           timeFormat.getFormat(),
-                                                           timeFormat.selectTimezone(),
-                                                           timeFormat.getLocale());
+                timeFormat.getFormat(),
+                timeFormat.selectTimezone(),
+                timeFormat.getLocale());
 
         InFunc inFunc = new InFunc(timeFormatFunc.toExpression(), timestampFilter.getSelectedTimestamps());
 


### PR DESCRIPTION
### Description
Fix not working regex filtering mode in advance filter.

**Related Issue** : #2698

### How Has This Been Tested?
1. Create a dashboard that is linked to an existing sales data source.
2. Create chart widget within the dashboard.
3. Create a user-defined column named "test" with the following expression in the created chart edit screen. ex. `CONCAT( [State] , [City] )`
4. Add the "test" column filter you created in the left filter panel.
5. Click the Add option on the right of the added filter and click the "edit" button. and then You can see the filter details screen.
6. Select the advanced filter and select "Matcher"> "Regular expression" mode to specify an arbitrary regular expression. ex `A.*`
![image](https://user-images.githubusercontent.com/822255/66983978-c50a8c00-f0f4-11e9-85bc-ea5619292014.png)

7. check that the filtering items are displayed accordingly.

#### Need additional checks?
- In addition to the regular expression mode in the advanced filter, the remaining filter functions need to be checked.
- Requires druid engine update(#2719) associated with this issue.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
