### PR TITLE
#2728 In the workbench created with a druid connection, if you use Hangul in the conditional statement when querying the druid, there is no query result

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/QueryEditorService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/QueryEditorService.java
@@ -14,6 +14,8 @@
 
 package app.metatron.discovery.domain.workbench;
 
+import app.metatron.discovery.domain.workbench.util.AvaticaQueryEncoder;
+import org.apache.calcite.avatica.AvaticaStatement;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hive.jdbc.HiveStatement;
 import org.joda.time.DateTime;
@@ -380,6 +382,11 @@ public class QueryEditorService {
           queryResult = createMessageResult("OK", query, QueryResult.QueryResultStatus.SUCCESS);
         }
       } else {
+        if(stmt instanceof AvaticaStatement) {
+          // #2728 조건문에 한글이 포함할 수 있으므로 인코딩
+          query = AvaticaQueryEncoder.encode(query);
+        }
+
         if(stmt.execute(query)){
           sendWebSocketMessage(WorkbenchWebSocketController.WorkbenchWebSocketCommand.GET_RESULTSET, queryIndex,
                   queryEditorId, workbenchId, webSocketId);

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/util/AvaticaQueryEncoder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/util/AvaticaQueryEncoder.java
@@ -1,0 +1,42 @@
+package app.metatron.discovery.domain.workbench.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AvaticaQueryEncoder {
+  private static Logger LOGGER = LoggerFactory.getLogger(AvaticaQueryEncoder.class);
+
+  public static String encode(final String query) {
+    try {
+      char[] chars = query.toCharArray();
+      List<Integer> output = new ArrayList<>();
+      for (int i = 0; i < chars.length; i++) {
+        int c = Character.codePointAt(chars, i);
+        if (c < 0x7F) {
+          output.add(c);
+        } else if (c < 0x7FF) {
+          output.add(0xC0 + (c >> 6));
+          output.add(0x80 + (c & 0x3F));
+        } else if (c < 0xFFFF) {
+          output.add(0xE0 + (c >> 12));
+          output.add(0x80 + ((c >> 6) & 0x3F));
+          output.add(0x80 + (c & 0x3F));
+        } else if (c < 0x10FFFF) {
+          output.add(0xF0 + (c >> 18));
+          output.add(0x80 + ((c >> 6) & 0x3F));
+          output.add(0x80 + ((c >> 12) & 0x3F));
+          output.add(0x80 + (c & 0x3F));
+        }
+      }
+      int[] codePoints = output.stream().mapToInt(i -> i).toArray();
+      return new String(codePoints, 0, codePoints.length);
+    } catch(Exception e) {
+      LOGGER.error("error query encoding", e);
+      return query;
+    }
+  }
+
+}


### PR DESCRIPTION
### Description
문제는 Avatica JDBC에서 쿼리에 한글이 포함되면 깨집니다.
![image](https://user-images.githubusercontent.com/16472109/67059157-e02bd900-f192-11e9-9efd-8c8fda44a24f.png)

Avatica JDBC 연결 URL 옵션으로 해결하려 했으나 관련 값을 찾지 못 했습니다.
https://calcite.apache.org/avatica/docs/client_reference.html

그래서 한글이 깨지지 않게 직접 인코딩 했습니다.

다른 방법으로 해결 가능하다면 PR 닫겠습니다.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#2728 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Druid 커넥션 워크벤치에서 한글이 포함된 데이터소스를 대상으로 쿼리하여 정상적으로 반환되는 것을 확인 했습니다.
![image](https://user-images.githubusercontent.com/16472109/67059286-5fb9a800-f193-11e9-8a6a-1be4276847b1.png)


#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
