### PR TITLE
#2734 'Custom Color Range' values are not kept when setting layer in map view chart.

### DIFF
--- a/discovery-frontend/src/app/common/component/chart/type/map-chart/map-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/map-chart/map-chart.component.ts
@@ -3154,7 +3154,6 @@ export class MapChartComponent extends BaseChart implements AfterViewInit {
               layer.color.ranges = ColorOptionConverter.setMapMeasureColorRange(this.getUiMapOption(), this.data[idx], colorList, idx, shelf, rangeList);
             }
           }
-          layer.color.changeRange = true;
         }
       });
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
사용자가 입력한 맵뷰 color range 값이 유지 되도록 변경 하였습니다.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#2734 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
