### PR TITLE
fn fix union typo

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepRuleChecker.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepRuleChecker.java
@@ -524,6 +524,8 @@ public class PrepRuleChecker {
       case "window":
         checkWindow((Window) rule);
         break;
+      case "union":
+        break;
       default:
         LOGGER.error("confirmRuleStringForException(): ruleName is wrong - " + rule.getName());
         throw PrepException.create(PrepErrorCodes.PREP_TRANSFORM_ERROR_CODE,


### PR DESCRIPTION
### Description
When I use union rule, "rule is known" error comes out.
I added the missing case statement for union.

**Related Issue** : None

### How Has This Been Tested?
1. Import and wrangle 
[sales_2011_01.txt](https://github.com/metatron-app/metatron-discovery/files/3749032/sales_2011_01.txt)
[sales_2011_02.txt](https://github.com/metatron-app/metatron-discovery/files/3749033/sales_2011_02.txt)
[sales_2011_03.txt](https://github.com/metatron-app/metatron-discovery/files/3749034/sales_2011_03.txt)
2. Create a dataflow that includes these datasets.
3. Select sales_2001_01.txt W.DS and click Edit.
4. Select union rule in the left-bottom pull-down, add other datasets.
5. Click "Union" --> No error, then passed.

#### Need additional checks?
Yes, please.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
This is a critical and urgent bug-fix.