### PR TITLE
#2722 'Size by', 'Radius Range' values are not kept when setting layer in map view chart

### DIFF
--- a/discovery-frontend/src/app/common/component/chart/type/map-chart/map-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/map-chart/map-chart.component.ts
@@ -64,6 +64,7 @@ import {UIPolygonLayer} from '../../option/ui-option/map/ui-polygon-layer';
 import {UITileLayer} from '../../option/ui-option/map/ui-tile-layer';
 import {ColorOptionConverter} from '../../option/converter/color-option-converter';
 import {CommonConstant} from "../../../../constant/common.constant";
+import {StringUtil} from "../../../../util/string.util";
 
 declare let ol;
 
@@ -2712,7 +2713,9 @@ export class MapChartComponent extends BaseChart implements AfterViewInit {
         ///////////////////////////
         else if (isMeasure) {
           symbolLayer.size.by = MapBy.MEASURE;
-          symbolLayer.size.column = uiOption.fieldMeasureList[0]['name'];
+          if(StringUtil.isEmpty(symbolLayer.size.column) || symbolLayer.size.column === "NONE") {
+            symbolLayer.size.column = uiOption.fieldMeasureList[0]['name'];
+          }
         }
       }
       ////////////////////////////////////////////////////////

--- a/discovery-frontend/src/app/page/chart-style/map/map-layer-option.component.ts
+++ b/discovery-frontend/src/app/page/chart-style/map/map-layer-option.component.ts
@@ -198,6 +198,8 @@ export class MapLayerOptionComponent extends BaseOptionComponent implements Afte
       layer.color.symbolTransparency = cloneLayer.color.transparency;
       layer.symbolPointType = (<UISymbolLayer>cloneLayer).symbol;
       layer.symbolOutline = (<UISymbolLayer>cloneLayer).outline;
+      layer['symbolPointRadiusFrom'] = (<UISymbolLayer>cloneLayer)['pointRadiusFrom'];
+      layer['symbolPointRadiusTo'] = (<UISymbolLayer>cloneLayer)['pointRadiusTo'];
     } else if (MapLayerType.TILE === preLayerType) {
       layer.tileRadius = cloneLayer.tileRadius;
       layer.color.tileSchema = cloneLayer.color.schema;
@@ -276,6 +278,8 @@ export class MapLayerOptionComponent extends BaseOptionComponent implements Afte
         layer.symbolOutline = null;
       }
       (<UISymbolLayer>layer).outline = layer.symbolOutline;
+      (<UISymbolLayer>layer)['pointRadiusFrom'] = layer['symbolPointRadiusFrom'];
+      (<UISymbolLayer>layer)['pointRadiusTo'] = layer['symbolPointRadiusTo'];
 
       // remove measure aggregation type in shelf
       this.removeAggregationType();


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
맵뷰에서 Layer Setting에 'Size by', 'Radius Range' 설정 후 값이 유지 되도록 수정 했습니다.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#2722 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
