### PR TITLE
#2659 change Hibernate fetchType to LAZY -> EAGER for @OneToOne relation

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/Metadata.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/Metadata.java
@@ -73,7 +73,7 @@ public class Metadata extends AbstractHistoryEntity implements MetatronDomain<St
   @Enumerated(EnumType.STRING)
   private SourceType sourceType;
 
-  @OneToOne(fetch = FetchType.LAZY, cascade = {CascadeType.ALL})
+  @OneToOne(fetch = FetchType.EAGER, cascade = {CascadeType.ALL})
   @JoinColumn(name = "source_id", referencedColumnName = "id")
   private MetadataSource source;
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/MetadataController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/MetadataController.java
@@ -405,6 +405,10 @@ public class MetadataController {
       }
     }
 
+    //add popularity and tags
+    metadataService.findTags(metadatas);
+    metadataService.findPopularities(metadatas);
+
     Page<Metadata> metadataPage = new PageImpl<Metadata>(metadatas, pageable, metadataPopularityList.getTotalElements());
     Page<Metadata> metadataResourced = ProjectionUtils.toPageResource(projectionFactory,
             metadataProjections.getProjectionByName("forListView"),


### PR DESCRIPTION
### Description
1. Hibernate error occurs when editing metadata description
So change Hibernate fetchType to LAZY -> EAGER for @OneToOne relation
<img width="1248" alt="metatron_Discovery" src="https://user-images.githubusercontent.com/3770446/67269826-624d3200-f4f2-11e9-9c8b-a3a4e3c00cff.png">

2. No popularity displayed on Exploration Main banner
So add popularity and tags in popurality api.
![metatron_Discovery_및_metatron_Discovery](https://user-images.githubusercontent.com/3770446/67269947-9fb1bf80-f4f2-11e9-8ad8-3ed170fb3d0c.png)

**Related Issue** : #2659 


### How Has This Been Tested?
1. Management > Metadata > Detail > Change description without error.
2. Exploration > Data > See popularity bar.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
