### PR TITLE
Use maxFetchSize on JDBC. Set auto_commit=false for PostgreSQL

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/connector/PostgresqlJdbcConnector.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/connector/PostgresqlJdbcConnector.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.metatron.discovery.domain.dataconnection.connector;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Properties;
+
+/**
+ * Postgresql Jdbc Connector.
+ * setFetchSize() is not working in autoCommit mode with PostgresSQL JDBC driver.
+ * so set default value of autoCommit mode to false.
+ * https://jdbc.postgresql.org/documentation/83/query.html#query-with-cursor
+ */
+@Component
+public class PostgresqlJdbcConnector extends CachedUserJdbcConnector {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PostgresqlJdbcConnector.class);
+
+  @Override
+  public Connection getConnection(String connectionUrl, Properties properties, String driverClassName) {
+    Connection connection = super.getConnection(connectionUrl, properties, driverClassName);
+    try{
+      connection.setAutoCommit(false);
+    } catch (SQLException e){
+      LOGGER.error(e.getMessage(), e);
+    }
+    return connection;
+  }
+}

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/PostgresqlDialect.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/PostgresqlDialect.java
@@ -100,7 +100,7 @@ public class PostgresqlDialect implements JdbcDialect {
 
   @Override
   public String getConnectorClass(JdbcConnectInformation connectInfo) {
-    return null;
+    return "app.metatron.discovery.domain.dataconnection.connector.PostgresqlJdbcConnector";
   }
 
   @Override

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepProperties.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepProperties.java
@@ -37,6 +37,7 @@ public class PrepProperties {
   public static final String SAMPLING_CORES = "polaris.dataprep.sampling.cores";
   public static final String SAMPLING_TIMEOUT = "polaris.dataprep.sampling.timeout";
   public static final String SAMPLING_LIMIT_ROWS = "polaris.dataprep.sampling.limitRows";
+  public static final String SAMPLING_MAX_FETCH_SIZE = "polaris.dataprep.sampling.maxFetchSize";
   public static final String SAMPLING_AUTO_TYPING = "polaris.dataprep.sampling.autoTyping";
 
   public static final String STAGEDB_HOSTNAME = "polaris.storage.stagedb.hostname";
@@ -48,6 +49,7 @@ public class PrepProperties {
   public static final String ETL_CORES = "polaris.dataprep.etl.cores";
   public static final String ETL_TIMEOUT = "polaris.dataprep.etl.timeout";
   public static final String ETL_LIMIT_ROWS = "polaris.dataprep.etl.limitRows";
+  public static final String ETL_MAX_FETCH_SIZE = "polaris.dataprep.etl.maxFetchSize";
   public static final String ETL_JVM_OPTIONS = "polaris.dataprep.etl.jvmOptions";
   public static final String ETL_EXPLICIT_GC = "polaris.dataprep.etl.explicitGC";
 
@@ -112,6 +114,10 @@ public class PrepProperties {
     return sampling.getLimitRows();
   }
 
+  public Integer getSamplingMaxFetchSize() {
+    return sampling.getMaxFetchSize();
+  }
+
   public Boolean getSamplingAutoTyping() {
     return sampling.getAutoTyping();
   }
@@ -126,6 +132,10 @@ public class PrepProperties {
 
   public Integer getEtlLimitRows() {
     return etl.getLimitRows();
+  }
+
+  public Integer getEtlMaxFetchSize() {
+    return etl.getMaxFetchSize();
   }
 
   public String getEtlJvmOptions() {
@@ -182,6 +192,7 @@ public class PrepProperties {
     map.put(ETL_CORES, getEtlCores());
     map.put(ETL_TIMEOUT, getEtlTimeout());
     map.put(ETL_LIMIT_ROWS, getEtlLimitRows());
+    map.put(ETL_MAX_FETCH_SIZE, getEtlMaxFetchSize());
     map.put(ETL_JVM_OPTIONS, getEtlJvmOptions());
     map.put(ETL_EXPLICIT_GC, getEtlExplicitGC());
     map.put(ETL_SPARK_PORT, getEtlSparkPort());
@@ -210,6 +221,7 @@ public class PrepProperties {
     public Integer cores;
     public Integer timeout;
     public Integer limitRows;
+    public Integer maxFetchSize;
     public Boolean autoTyping;
 
     public SamplingInfo() {
@@ -236,6 +248,13 @@ public class PrepProperties {
       return limitRows;
     }
 
+    public Integer getMaxFetchSize() {
+      if (maxFetchSize == null) {
+        maxFetchSize = 1000;
+      }
+      return maxFetchSize;
+    }
+
     public boolean getAutoTyping() {
       if (autoTyping == null) {
         autoTyping = true;
@@ -255,14 +274,18 @@ public class PrepProperties {
       this.limitRows = limitRows;
     }
 
+    public void setMaxFetchSize(Integer maxFetchSize) {
+      this.maxFetchSize = maxFetchSize;
+    }
+
     public void setAutoTyping(Boolean autoTyping) {
       this.autoTyping = autoTyping;
     }
 
     @Override
     public String toString() {
-      return String.format("SamplingInfo{cores=%d timeout=%d limitRows=%d autoTyping=%b}",
-              cores, timeout, limitRows, autoTyping);
+      return String.format("SamplingInfo{cores=%d timeout=%d limitRows=%d maxFetchSize=%d autoTyping=%b}",
+              cores, timeout, limitRows, maxFetchSize, autoTyping);
     }
   }
 
@@ -343,6 +366,7 @@ public class PrepProperties {
     public Integer cores;
     public Integer timeout;
     public Integer limitRows;
+    public Integer maxFetchSize;
     public String jvmOptions;
     public Boolean explicitGC;
     public SparkInfo spark;
@@ -372,6 +396,13 @@ public class PrepProperties {
         limitRows = 100 * 10000;  // being conservative
       }
       return limitRows;
+    }
+
+    public Integer getMaxFetchSize() {
+      if (maxFetchSize == null) {
+        maxFetchSize = 1000;
+      }
+      return maxFetchSize;
     }
 
     public String getJvmOptions() {
@@ -404,6 +435,10 @@ public class PrepProperties {
       this.limitRows = limitRows;
     }
 
+    public void setMaxFetchSize(Integer maxFetchSize) {
+      this.maxFetchSize = maxFetchSize;
+    }
+
     public void setJvmOptions(String jvmOptions) {
       this.jvmOptions = jvmOptions;
     }
@@ -418,8 +453,8 @@ public class PrepProperties {
 
     @Override
     public String toString() {
-      return String.format("EtlInfo{cores=%d timeout=%d jvmOptions=%s explicitGC=%b}",
-              cores, timeout, jvmOptions, explicitGC);
+      return String.format("EtlInfo{cores=%d timeout=%d limitRows=%d maxFetchSize=%d jvmOptions=%s explicitGC=%b}",
+              cores, timeout, limitRows, maxFetchSize, jvmOptions, explicitGC);
     }
   }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/etl/TeddyDatabaseService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/etl/TeddyDatabaseService.java
@@ -1,6 +1,7 @@
 package app.metatron.discovery.domain.dataprep.etl;
 
 import static app.metatron.discovery.domain.dataprep.PrepProperties.ETL_LIMIT_ROWS;
+import static app.metatron.discovery.domain.dataprep.PrepProperties.ETL_MAX_FETCH_SIZE;
 
 import app.metatron.discovery.domain.dataconnection.DataConnection;
 import app.metatron.discovery.domain.dataconnection.DataConnectionHelper;
@@ -23,14 +24,17 @@ public class TeddyDatabaseService {
   private static Logger LOGGER = LoggerFactory.getLogger(TeddyExecutor.class);
 
   private Integer limitRows = null;
+  private Integer maxFetchSize = null;
 
   public void setPrepPropertiesInfo(Map<String, Object> prepPropertiesInfo) {
     limitRows = (Integer) prepPropertiesInfo.get(ETL_LIMIT_ROWS);
+    maxFetchSize = (Integer) prepPropertiesInfo.get(ETL_MAX_FETCH_SIZE);
   }
 
   public DataFrame loadDatabaseTable(String dsId, String sql, DbInfo db)
           throws SQLException, ClassNotFoundException, TeddyException {
     Statement stmt = getJdbcStatement(db.implementor, db.connectUri, db.username, db.password);
+    stmt.setFetchSize(maxFetchSize);
     DataFrame df = new DataFrame();
 
     LOGGER.info(
@@ -60,6 +64,7 @@ public class TeddyDatabaseService {
       }
       Connection conn = DriverManager.getConnection(connectUri, jdbcDataConnection.getUsername(),
               jdbcDataConnection.getPassword());
+      conn.setAutoCommit(false);
       return conn.createStatement();
     } catch (ClassNotFoundException e) {
       LOGGER.error(String

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/etl/TeddyExecutor.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/etl/TeddyExecutor.java
@@ -16,6 +16,7 @@ package app.metatron.discovery.domain.dataprep.etl;
 
 import static app.metatron.discovery.domain.dataprep.PrepProperties.ETL_CORES;
 import static app.metatron.discovery.domain.dataprep.PrepProperties.ETL_LIMIT_ROWS;
+import static app.metatron.discovery.domain.dataprep.PrepProperties.ETL_MAX_FETCH_SIZE;
 import static app.metatron.discovery.domain.dataprep.PrepProperties.ETL_TIMEOUT;
 import static app.metatron.discovery.domain.dataprep.entity.PrSnapshot.STATUS.CANCELED;
 import static app.metatron.discovery.domain.dataprep.entity.PrSnapshot.STATUS.FAILED;
@@ -91,6 +92,7 @@ public class TeddyExecutor {
   public Integer timeout;
   public Integer cores;
   public Integer limitRows;
+  public Integer maxFetchSize;
 
   Map<String, String> replaceMap = new HashMap(); // origTeddyDsId -> newFullDsId
   Map<String, String> reverseMap = new HashMap(); // newFullDsId -> origTeddyDsId
@@ -101,6 +103,7 @@ public class TeddyExecutor {
     cores = (Integer) prepPropertiesInfo.get(ETL_CORES);
     timeout = (Integer) prepPropertiesInfo.get(ETL_TIMEOUT);
     limitRows = (Integer) prepPropertiesInfo.get(ETL_LIMIT_ROWS);
+    maxFetchSize = (Integer) prepPropertiesInfo.get(ETL_MAX_FETCH_SIZE);
   }
 
   private void putStackTraceIntoCustomField(String ssId, Exception e) {

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/etl/TeddyStagingDbService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/etl/TeddyStagingDbService.java
@@ -1,6 +1,7 @@
 package app.metatron.discovery.domain.dataprep.etl;
 
 import static app.metatron.discovery.domain.dataprep.PrepProperties.ETL_LIMIT_ROWS;
+import static app.metatron.discovery.domain.dataprep.PrepProperties.ETL_MAX_FETCH_SIZE;
 import static app.metatron.discovery.domain.dataprep.PrepProperties.HADOOP_CONF_DIR;
 import static app.metatron.discovery.domain.dataprep.PrepProperties.STAGEDB_HOSTNAME;
 import static app.metatron.discovery.domain.dataprep.PrepProperties.STAGEDB_METASTORE_URI;
@@ -62,6 +63,7 @@ public class TeddyStagingDbService {
   private String hadoopConfDir;
   private Configuration hadoopConf = null;
   private Integer limitRows = null;
+  private Integer maxFetchSize = null;
 
   String hiveHostname;
   Integer hivePort;
@@ -72,6 +74,7 @@ public class TeddyStagingDbService {
   public void setPrepPropertiesInfo(Map<String, Object> prepPropertiesInfo) {
     hadoopConfDir = (String) prepPropertiesInfo.get(HADOOP_CONF_DIR);
     limitRows = (Integer) prepPropertiesInfo.get(ETL_LIMIT_ROWS);
+    maxFetchSize = (Integer) prepPropertiesInfo.get(ETL_MAX_FETCH_SIZE);
 
     hiveHostname = (String) prepPropertiesInfo.get(STAGEDB_HOSTNAME);
     hivePort = (Integer) prepPropertiesInfo.get(STAGEDB_PORT);
@@ -244,7 +247,9 @@ public class TeddyStagingDbService {
     Connection conn;
     try {
       conn = jdbcDataAccessor.getConnection();
+      conn.setAutoCommit(false);
       stmt = conn.createStatement();
+      stmt.setFetchSize(maxFetchSize);
     } catch (SQLException e) {
       LOGGER.error(String.format("getHiveStatement(): SQLException occurred: connStr=%s username=%s password=%s",
               jdbcDataAccessor.getDialect().getConnectUrl(hiveConn), hiveConn.getUsername(), hiveConn.getPassword()),
@@ -364,6 +369,7 @@ public class TeddyStagingDbService {
     LOGGER.debug(String.format("loadHiveTable(): dsId=%s sql=%s", dsId, sql));
 
     Statement stmt = getHiveStatement();
+    stmt.setFetchSize(maxFetchSize);
     DataFrame df = new DataFrame();
 
     df.setByJDBC(stmt, sql, limitRows);

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/etl/TeddyStagingDbService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/etl/TeddyStagingDbService.java
@@ -247,7 +247,6 @@ public class TeddyStagingDbService {
     Connection conn;
     try {
       conn = jdbcDataAccessor.getConnection();
-      conn.setAutoCommit(false);
       stmt = conn.createStatement();
       stmt.setFetchSize(maxFetchSize);
     } catch (SQLException e) {

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/TeddyImpl.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/TeddyImpl.java
@@ -320,7 +320,9 @@ public class TeddyImpl {
 
     try {
       conn = jdbcDataAccessor.getConnection();
+      conn.setAutoCommit(false);
       stmt = conn.createStatement();
+      stmt.setFetchSize(prepProperties.getSamplingMaxFetchSize());
     } catch (SQLException e) {
       e.printStackTrace();
       throw PrepException.create(PREP_TEDDY_ERROR_CODE, e);
@@ -346,7 +348,9 @@ public class TeddyImpl {
 
     try {
       conn = jdbcDataAccessor.getConnection();
+      conn.setAutoCommit(false);
       stmt = conn.createStatement();
+      stmt.setFetchSize(prepProperties.getSamplingMaxFetchSize());
     } catch (SQLException e) {
       e.printStackTrace();
     }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/TeddyImpl.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/TeddyImpl.java
@@ -320,7 +320,6 @@ public class TeddyImpl {
 
     try {
       conn = jdbcDataAccessor.getConnection();
-      conn.setAutoCommit(false);
       stmt = conn.createStatement();
       stmt.setFetchSize(prepProperties.getSamplingMaxFetchSize());
     } catch (SQLException e) {
@@ -348,7 +347,6 @@ public class TeddyImpl {
 
     try {
       conn = jdbcDataAccessor.getConnection();
-      conn.setAutoCommit(false);
       stmt = conn.createStatement();
       stmt.setFetchSize(prepProperties.getSamplingMaxFetchSize());
     } catch (SQLException e) {


### PR DESCRIPTION
### Description
When I create a dataset based on PostgreSQL, I got an OOM.
I found out that it was because of JDBC fetch count.
And I knew that PostgreSQL JDBC ignores the fetch count when auto_commit is true.

I gave a property polaris.dataprep.sampling.maxFetchSize and polaris.dataprep.etl.maxFetchSize.
The default values are 1000 both.
And I set auto_commit as false for all JDBC connections in dataprep.

### How Has This Been Tested?
Generate a dataset against a table that has more than 1m rows.

#### Need additional checks?
No, it's troublesome.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
I guess Workbench code also needs to care of this issue.