### PR TITLE
#2753 checking the status of snapshot is repeated

### DIFF
--- a/discovery-frontend/src/app/data-preparation/data-snapshot/data-snapshot-detail.component.ts
+++ b/discovery-frontend/src/app/data-preparation/data-snapshot/data-snapshot-detail.component.ts
@@ -158,6 +158,9 @@ export class DataSnapshotDetailComponent extends AbstractComponent implements On
   public sSInformationList: {label : String, value : string, isFileUri?: boolean}[] = [];
 
   public ssType = SsType;
+
+  public callbackIndex = null;
+
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Constructor
    |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
@@ -184,6 +187,9 @@ export class DataSnapshotDetailComponent extends AbstractComponent implements On
     super.ngOnDestroy();
     $('body').removeClass('body-hidden');
 
+    if(this.callbackIndex) {
+      clearTimeout(this.callbackIndex);
+    }
   }
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
@@ -530,8 +536,10 @@ export class DataSnapshotDetailComponent extends AbstractComponent implements On
           } else {
             this.progressbarWidth = '100%';
           }
+
           // Whenever received response at the status of preparing, it requests snapshot data
-          setTimeout(() => {
+          this.callbackIndex = setTimeout(() => {
+            this.callbackIndex = null;
             this.getSnapshot();
           }, 2000)
 

--- a/discovery-frontend/src/app/data-preparation/data-snapshot/data-snapshot-detail.component.ts
+++ b/discovery-frontend/src/app/data-preparation/data-snapshot/data-snapshot-detail.component.ts
@@ -223,6 +223,11 @@ export class DataSnapshotDetailComponent extends AbstractComponent implements On
    * Close snapshot popup
    */
   public close() {
+
+    if(this.callbackIndex) {
+      clearTimeout(this.callbackIndex);
+    }
+    
     this.isShow = false;
     $('body').removeClass('body-hidden');
     this.snapshotDetailCloseEvent.emit();


### PR DESCRIPTION
### Description
if you out of the snapshot screen
checking status should stop

**Related Issue** : 
[2753](https://github.com/metatron-app/metatron-discovery/issues/2753)

### How Has This Been Tested?
When the status of a snapshot is PREPARING, go to the snapshot detail page  
And out of the page
API call should stop

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
