### PR TITLE
add missing spec in dashboard's configuration

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/datasource/DataSource.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/datasource/DataSource.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import java.io.Serializable;
 
+import app.metatron.discovery.domain.datasource.DataSource.ConnectionType;
+
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
     include = JsonTypeInfo.As.PROPERTY,
     property = "type",
@@ -37,6 +39,16 @@ public abstract class DataSource implements Serializable {
    * 임시 데이터 소스 여부
    */
   Boolean temporary;
+
+  ConnectionType connType;
+
+  String engineName;
+
+  String id;
+
+  String uiDescription;
+
+  String temporaryId;
 
   /**
    * Biz. Logic 용 객체(스펙과 관련 없음)
@@ -66,6 +78,46 @@ public abstract class DataSource implements Serializable {
 
   public void setTemporary(Boolean temporary) {
     this.temporary = temporary;
+  }
+
+  public ConnectionType getConnType() {
+    return connType;
+  }
+
+  public void setConnType(ConnectionType connType) {
+    this.connType = connType;
+  }
+
+  public String getEngineName() {
+    return engineName;
+  }
+
+  public void setEngineName(String engineName) {
+    this.engineName = engineName;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getUiDescription() {
+    return uiDescription;
+  }
+
+  public void setUiDescription(String uiDescription) {
+    this.uiDescription = uiDescription;
+  }
+
+  public String getTemporaryId() {
+    return temporaryId;
+  }
+
+  public void setTemporaryId(String temporaryId) {
+    this.temporaryId = temporaryId;
   }
 
   public app.metatron.discovery.domain.datasource.DataSource getMetaDataSource() {


### PR DESCRIPTION
### Description
An error occurs when cloning a dashboard created using a linked datasource.
So add the missing configuration spec

**Related Issue** : 

### How Has This Been Tested?
1. Create dashboard with linked-type Datasource.
2. Clone the dashboard without error.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
