### PR TITLE
Fix null value representation in ORC files

### DIFF
--- a/discovery-frontend/src/app/data-preparation/data-snapshot/data-snapshot-detail.component.ts
+++ b/discovery-frontend/src/app/data-preparation/data-snapshot/data-snapshot-detail.component.ts
@@ -133,7 +133,7 @@ export class DataSnapshotDetailComponent extends AbstractComponent implements On
 
   // Grid 에서 필요한 parameter
   public offset: number = 0;
-  public target: number = 10000;
+  public target: number = 1000;
 
 
   // % 계산

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/etl/TeddyOrcWriter.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/etl/TeddyOrcWriter.java
@@ -125,17 +125,30 @@ public class TeddyOrcWriter {
 
   // TODO: distinguish MISMATCHED, MISSING, VALID
   private boolean setBatch(int pos, ColumnVector colVector, ColumnType colType, ColumnDescription colDesc, Object obj) {
-    //null check
     if (obj == null) {
-      return false;
+      if (colVector.noNulls) {
+        colVector.noNulls = false;
+        for (int i = 0; i < pos; i++) {
+          colVector.isNull[i] = false;
+        }
+      }
+      colVector.isNull[pos] = true;
+      return true;
+    }
+
+    if (!colVector.noNulls) {
+      colVector.isNull[pos] = false;
     }
 
     switch (colType) {
       case STRING:
+        String str;
         if (!(obj instanceof String)) {
-          return false;
+          str = obj.toString();
+        } else {
+          str = (String) obj;
         }
-        byte[] bytes = toBytes((String) obj);
+        byte[] bytes = toBytes(str);
         ((BytesColumnVector) colVector).setVal(pos, bytes, 0, bytes.length);
         break;
       case LONG:

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/service/PrSnapshotService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/service/PrSnapshotService.java
@@ -464,6 +464,8 @@ public class PrSnapshotService {
   }
 
   public Map<String, Object> getContents(String ssId, Integer offset, Integer target) {
+    LOGGER.debug("getContents(): ssId={} offset={} target={}", ssId, offset, target);
+
     Map<String, Object> responseMap = new HashMap();
     try {
       PrSnapshot snapshot = this.snapshotRepository.findOne(ssId);
@@ -509,17 +511,17 @@ public class PrSnapshotService {
             gridResponse = new DataFrame();
           } else {
             int rowSize = gridResponse.rows.size();
-            int lastIdx = offset + target - 1;
-            if (lastIdx >= 0 && offset < rowSize) {
-              if (rowSize <= lastIdx) {
-                lastIdx = rowSize;
-              }
-              gridResponse.rows = gridResponse.rows.subList(offset, lastIdx);
+            LOGGER.debug("getContents(): rowSize={} offset={} size={}", rowSize, offset, size);
+            if (size >= 0 && offset < rowSize) {
+              LOGGER.debug("getContents(): subList(): rowSize={} offset={}", rowSize, offset);
+              gridResponse.rows = gridResponse.rows.subList(offset, Math.min(offset + size, gridResponse.rows.size()));
+              LOGGER.debug("getContents(): subList(): end");
             } else {
               gridResponse.rows.clear();
             }
           }
           Integer gridRowSize = gridResponse.rows.size();
+          LOGGER.debug("getContents(): responseMap: offset={} size={}", offset + gridRowSize, gridRowSize);
           responseMap.put("offset", offset + gridRowSize);
           responseMap.put("size", gridRowSize);
           responseMap.put("gridResponse", gridResponse);
@@ -546,6 +548,7 @@ public class PrSnapshotService {
       throw PrepException.create(PrepErrorCodes.PREP_SNAPSHOT_ERROR_CODE, e);
     }
 
+    LOGGER.debug("getContents(): end");
     return responseMap;
   }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DfDerive.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DfDerive.java
@@ -51,6 +51,9 @@ public class DfDerive extends DataFrame {
 
     //Decide new column's type.(And check identifiers that occurs in rule string.)
     ColumnType newColType = decideType(expr);
+    if (newColType == ColumnType.UNKNOWN) {   // We cannot process UNKNOWN type in Histogram.
+      newColType = ColumnType.STRING;
+    }
 
     if (ruleColumns.size() == 0) {             // identifier가 없거나 2개 이상인 경우, 제일 끝으로 붙인다.
       newColPos = getColCnt();

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DfSet.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DfSet.java
@@ -85,7 +85,8 @@ public class DfSet extends DataFrame {
       if (replacedColExprs.containsKey(colno)) {
         // Column type can be changed according to the result values.
         // This is the same behavior to Apache Spark.
-        addColumn(prevDf.getColName(colno), prevDf.decideType_internal(replacedColExprs.get(colno)));
+        ColumnType newType = prevDf.decideType_internal(replacedColExprs.get(colno));
+        addColumn(prevDf.getColName(colno), newType == ColumnType.UNKNOWN ? prevDf.getColType(colno) : newType);
       } else {
         addColumn(prevDf.getColName(colno), prevDf.getColDesc(colno));
       }


### PR DESCRIPTION
### Description
When I first implemented the ORC writer code, I decided to skip null or mismatched values in ORC files because they made some troubles.
Now, we need appropriate representations of them.

1. Null values are stored as nulls.
2. For string type columns, the non-null values are stored as their toString() values.
3. For non-string type columns, it's impossible to store mismatched values usually. Rows that have any of this kind of mismatched values are skipped. We can check this with skippedLines.

**Related Issue** : https://github.com/metatron-app/metatron-discovery/issues/2752

### How Has This Been Tested?
1. Import & wrangle 
[s5k_1.csv.txt](https://github.com/metatron-app/metatron-discovery/files/3766125/s5k_1.csv.txt)
2. Select set command.
3. Put null as expression, column9 < 2 as condition. Then click "Add"
4. Click "Snapshot"
5. If you see (null)-contained rows, then passed.

#### Need additional checks?
Yes, please.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
