### PR TITLE
#2745 When you create a new map view widget, 'Custom Color range' does not reset

### DIFF
--- a/discovery-frontend/src/app/common/component/chart/type/map-chart/map-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/map-chart/map-chart.component.ts
@@ -2575,8 +2575,10 @@ export class MapChartComponent extends BaseChart implements AfterViewInit {
 
       // init custom user color setting
       if (!isAnalysisUse) {
-        layer.color.ranges = undefined;
-        layer.color['settingUseFl'] = false;
+        if(_.isUndefined(layer.color.settingUseFl) || layer.color.settingUseFl == false) {
+          layer.color.ranges = undefined;
+          layer.color['settingUseFl'] = false;
+        }
       }
 
       ///////////////////////////
@@ -2650,7 +2652,9 @@ export class MapChartComponent extends BaseChart implements AfterViewInit {
           (this.data.length > 1 ? dataIndex = this.data.length - 1 : dataIndex = 0);
           layer.color.ranges = ColorOptionConverter.setMapMeasureColorRange(uiOption, this.data[dataIndex], this.getColorList(layer), index, shelf);
         } else {
-          layer.color.ranges = ColorOptionConverter.setMapMeasureColorRange(uiOption, this.data[index], this.getColorList(layer), index, shelf);
+          if(_.isUndefined(layer.color.settingUseFl) || layer.color.settingUseFl == false) {
+            layer.color.ranges = ColorOptionConverter.setMapMeasureColorRange(uiOption, this.data[index], this.getColorList(layer), index, shelf);
+          }
         }
       }
       ///////////////////////////
@@ -2899,7 +2903,7 @@ export class MapChartComponent extends BaseChart implements AfterViewInit {
     } else {
       colorList = ChartColorList[layer.color.schema];
     }
-    return colorList;
+    return _.cloneDeep(colorList);
   }
 
   /**

--- a/discovery-frontend/src/app/page/chart-style/map/map-layer-option.component.ts
+++ b/discovery-frontend/src/app/page/chart-style/map/map-layer-option.component.ts
@@ -200,10 +200,16 @@ export class MapLayerOptionComponent extends BaseOptionComponent implements Afte
       layer.symbolOutline = (<UISymbolLayer>cloneLayer).outline;
       layer['symbolPointRadiusFrom'] = (<UISymbolLayer>cloneLayer)['pointRadiusFrom'];
       layer['symbolPointRadiusTo'] = (<UISymbolLayer>cloneLayer)['pointRadiusTo'];
+      layer.color['symbolSettingUseFl'] = (<UISymbolLayer>cloneLayer).color.settingUseFl;
+      layer.color['symbolRanges'] = (<UISymbolLayer>cloneLayer).color.ranges;
+      layer.color['symbolChangeRange'] = (<UISymbolLayer>cloneLayer).color.changeRange;
     } else if (MapLayerType.TILE === preLayerType) {
       layer.tileRadius = cloneLayer.tileRadius;
       layer.color.tileSchema = cloneLayer.color.schema;
       layer.color.tranTransparency = cloneLayer.color.transparency;
+      layer.color['tileSettingUseFl'] = (<UISymbolLayer>cloneLayer).color.settingUseFl;
+      layer.color['tileRanges'] = (<UISymbolLayer>cloneLayer).color.ranges;
+      layer.color['tileChangeRange'] = (<UISymbolLayer>cloneLayer).color.changeRange;
     } else if (MapLayerType.POLYGON === preLayerType) {
       layer.color.polygonSchema = cloneLayer.color.schema;
       layer.color.tranTransparency = cloneLayer.color.transparency;
@@ -212,6 +218,9 @@ export class MapLayerOptionComponent extends BaseOptionComponent implements Afte
       layer.color.clusterTransparency = cloneLayer.color.transparency;
       layer.clusterPointType = (<UISymbolLayer>cloneLayer).symbol;
       layer.clusterOutline = (<UISymbolLayer>cloneLayer).outline;
+      layer.color['clusterSettingUseFl'] = (<UISymbolLayer>cloneLayer).color.settingUseFl;
+      layer.color['clusterRanges'] = (<UISymbolLayer>cloneLayer).color.ranges;
+      layer.color['clusterChangeRange'] = (<UISymbolLayer>cloneLayer).color.changeRange;
     }
 
     delete this.uiOption.layers[layerIndex].noneColor;
@@ -280,6 +289,10 @@ export class MapLayerOptionComponent extends BaseOptionComponent implements Afte
       (<UISymbolLayer>layer).outline = layer.symbolOutline;
       (<UISymbolLayer>layer)['pointRadiusFrom'] = layer['symbolPointRadiusFrom'];
       (<UISymbolLayer>layer)['pointRadiusTo'] = layer['symbolPointRadiusTo'];
+      (<UISymbolLayer>layer).color.settingUseFl = layer.color['symbolSettingUseFl'];
+      (<UISymbolLayer>layer).color.ranges = layer.color['symbolRanges'];
+      (<UISymbolLayer>layer).color.changeRange = layer.color['symbolChangeRange'];
+      this.rangesViewList = this.setRangeViewByDecimal(layer.color.ranges);
 
       // remove measure aggregation type in shelf
       this.removeAggregationType();
@@ -300,6 +313,11 @@ export class MapLayerOptionComponent extends BaseOptionComponent implements Afte
       }
       (<UISymbolLayer>layer).outline = layer.clusterOutline;
 
+      layer.color.settingUseFl = layer.color['clusterSettingUseFl'];
+      layer.color.ranges = layer.color['clusterRanges'];
+      layer.color.changeRange = layer.color['clusterChangeRange'];
+      this.rangesViewList = this.setRangeViewByDecimal(layer.color.ranges);
+
       // remove measure aggregation type in shelf
       this.removeAggregationType();
 
@@ -314,6 +332,11 @@ export class MapLayerOptionComponent extends BaseOptionComponent implements Afte
         layer.tileRadius = 20;
       }
       layer['radius'] = layer.tileRadius;
+      layer.color.settingUseFl = layer.color['tileSettingUseFl'];
+      layer.color.ranges = layer.color['tileRanges'];
+      layer.color.changeRange = layer.color['tileChangeRange'];
+
+      this.rangesViewList = this.setRangeViewByDecimal(layer.color.ranges);
 
       // if( isNullOrUndefined(this.uiOption.layers[this.index]['coverage']) ) {
       //   this.uiOption.layers[this.index]['coverage'] = 0.9;


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Custom Color range 가 초기화 되지 않는 문제를 해결 하였습니다.
추가로 맵뷰 옵션에서 각 Layer 타입별 Custom Color range 를 설정하고 Layer 타입을 변경하는 경우에도 유지되도록 수정했습니다.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#2745 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
