### PR TITLE
#2476 show an error when fetch failed by connection

### DIFF
--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/edit-rule-grid.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/edit-rule-grid.component.ts
@@ -299,9 +299,8 @@ export class EditRuleGridComponent extends AbstractComponent implements OnInit, 
 
     }).catch((error) => {
       this.loadingHide();
-      return {
-        error : error
-      };
+      let prep_error = this.dataprepExceptionHandler(error);
+      PreparationAlert.output(prep_error, this.translateService.instant(prep_error.message));
     });
 
   } // function - init


### PR DESCRIPTION
### Description
when a connection doesn't work, the error about fetch failure should be shown

**Related Issue** : 
[2476](https://github.com/metatron-app/metatron-discovery/issues/2476)

### How Has This Been Tested?
1. make a dataset using hive connection
2. turn off the hive
3. run a metatron and edit rule of the dataset
an error message should be shown 

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
