### PR TITLE
#2760 fill condition automatically using histogram bar selection

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformRuleService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformRuleService.java
@@ -525,6 +525,9 @@ public class PrepTransformRuleService {
         break;
       case "set":
         shortRuleString = String.format(FMTSTR_SET, mapStrExp.get("col").toColList(), mapStrExp.get("value"));
+        if(mapStrExp.containsKey("row")==true) {
+          shortRuleString = shortRuleString + " (with cond)";
+        }
         break;
       case "settype":
         shortRuleString = String.format(FMTSTR_SETTYPE, mapStrExp.get("col").toColList(), mapStrExp.get("type"));


### PR DESCRIPTION
### Description
Adding a set rule while the bar is pressed should complete the condition automatically

![image](https://user-images.githubusercontent.com/42264835/67460657-88034400-f676-11e9-81a4-e7efdb1bcdb5.png)

**Related Issue** : 
[2760](https://github.com/metatron-app/metatron-discovery/issues/2760)

### How Has This Been Tested?
1. go to the page of editing rules of dataset
2. select some values of histogram bar
3. click [edit]-[set] in context menu
4. add the rule with a value which you want to set

Make sure the rule is added correctly

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
