### PR TITLE
#2795 Read less bytes to get charset. Reduce size of preview grid.

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/file/PrepCsvUtil.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/file/PrepCsvUtil.java
@@ -38,6 +38,8 @@ public class PrepCsvUtil {
 
   private static void readCsv(CSVParser parser, int limitRows, Integer manualColCnt, boolean header, boolean onlyCount,
           PrepParseResult result) {
+    LOGGER.debug("readCsv(): limitRows={} header={} onlyCount={}", limitRows, header, onlyCount);
+
     Iterator<CSVRecord> iter = parser.iterator();
     Integer colCnt = manualColCnt != null ? manualColCnt : null;
 
@@ -92,6 +94,7 @@ public class PrepCsvUtil {
         break;
       }
     }
+    LOGGER.debug("readCsv(): limitRows={} header={} onlyCount={}", limitRows, header, onlyCount);
   }
 
   private static char getUnescapedDelimiter(String strDelim) {
@@ -123,7 +126,7 @@ public class PrepCsvUtil {
           Configuration conf, boolean header, boolean onlyCount) {
     PrepParseResult result = new PrepParseResult();
 
-    LOGGER.debug("PrepCsvUtil.parse(): strUri={} strDelim={} conf={}", strUri, strDelim, conf);
+    LOGGER.debug("PrepCsvUtil.parse(): strUri={} strDelim={} limitRows={} conf={}", strUri, strDelim, limitRows, conf);
 
     Reader reader = getReader(strUri, conf, onlyCount, result);
 
@@ -131,6 +134,7 @@ public class PrepCsvUtil {
     CSVParser parser;
     try {
       // \", "" both become " by default
+      LOGGER.debug("Call CSVParser.parse(): strDelim={}", delim);
       parser = CSVParser.parse(reader, CSVFormat.DEFAULT.withDelimiter(delim).withEscape('\\'));
     } catch (IOException e) {
       e.printStackTrace();
@@ -139,6 +143,7 @@ public class PrepCsvUtil {
 
     readCsv(parser, limitRows, manualColCnt, header, onlyCount, result);
 
+    LOGGER.debug("PrepCsvUtil.parse(): end");
     return result;
   }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/file/PrepFileUtil.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/file/PrepFileUtil.java
@@ -67,7 +67,7 @@ public class PrepFileUtil {
     CharsetMatch match;
 
     try {
-      byte[] byteData = new byte[is.available()];
+      byte[] byteData = new byte[1000];
       is.read(byteData);
       is.close();
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/service/PrDatasetController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/service/PrDatasetController.java
@@ -295,7 +295,7 @@ public class PrDatasetController {
   @ResponseBody
   ResponseEntity<?> fileGrid(
           @RequestParam(value = "storedUri", required = false) String storedUri,
-          @RequestParam(value = "resultSize", required = false, defaultValue = "250") Integer size,
+          @RequestParam(value = "resultSize", required = false, defaultValue = "50") Integer size,
           @RequestParam(value = "delimiterRow", required = false, defaultValue = "\n") String delimiterRow,
           @RequestParam(value = "delimiterCol", required = false, defaultValue = ",") String delimiterCol,
           @RequestParam(value = "manualColumnCount", required = false) Integer manualColumnCount,

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/service/PrDatasetService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/service/PrDatasetService.java
@@ -62,7 +62,7 @@ public class PrDatasetService {
   @Autowired
   private DataConnectionRepository dataConnectionRepository;
 
-  private String filePreviewSize = "2000";
+  private String filePreviewSize = "50";
   private String hivePreviewSize = "50";
   private String jdbcPreviewSize = "50";
 


### PR DESCRIPTION
### Description
We used to read such a lot of bytes to decide the right charsets. Just 1000 is OK.
In addition, I reduced the preview size of file uploaded datasets.
It was too slow for me. If any problem afterward, then I'll fix it again.

**Related Issue** : #2795 

### How Has This Been Tested?
Ran locally.

#### Need additional checks?
No, thanks.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
