### PR TITLE
#2230 Too much space in dataset swap pop-up

### DIFF
--- a/discovery-frontend/src/app/data-preparation/component/dataset-summary.component.html
+++ b/discovery-frontend/src/app/data-preparation/component/dataset-summary.component.html
@@ -33,8 +33,8 @@
       </tr>
       </tbody>
     </table>
-    <div class="ddp-wrap-datapreview">
-      <div class="ddp-box-preview" *ngIf="clearGrid">
+    <div class="ddp-wrap-datapreview" style="padding-bottom: 0;">
+      <div *ngIf="clearGrid" class="ddp-box-preview" >
         <div class="ddp-ui-empty" >
           {{'msg.dp.ui.no.preview' | translate}}
         </div>

--- a/discovery-frontend/src/app/data-preparation/component/dataset-summary.component.ts
+++ b/discovery-frontend/src/app/data-preparation/component/dataset-summary.component.ts
@@ -116,14 +116,14 @@ export class DatasetSummaryComponent extends AbstractComponent implements OnInit
 
         if (data) {
           this.dataset = data;
+          this.changeDetect.detectChanges();
+          this._setDsInformationList(this.dataset);
           if (data.gridResponse) {
             this.clearGrid = false;
             this._setGridData(data.gridResponse);
           } else {
             this.clearGrid = true;
           }
-          this.changeDetect.detectChanges();
-          this._setDsInformationList(this.dataset);
 
           this.clearExistingTimeout();
           // FIXME : Used recursive instead of interval. Which is better?
@@ -216,6 +216,9 @@ export class DatasetSummaryComponent extends AbstractComponent implements OnInit
    * @param data
    * */
   private _updateGrid(data: any) {
+
+    const $gridContainer = this.$element.find( '.ddp-box-preview' );
+    $gridContainer.css( { 'height' : $(window).height() - ( 300 + 26 * this.dsInformationList.length ), 'margin-bottom' : '-20px' } );
 
     const maxDataLen: any = {};
     let fields: Field[] = data.fields;


### PR DESCRIPTION
### Description
Too many spaces in the preview area of the dataset for dataset.

**Related Issue** : #2230 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
1. On the dataflow screen, select a dataset.
2. Press the dataset substitution button to display the substitution popup.
3. Click dataset to see a preview.
4. Confirm that the preview is displayed without spaces.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
