### PR TITLE
#2066 apply timestamp format to file type snapshots

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/etl/SparkExecutor.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/etl/SparkExecutor.java
@@ -39,10 +39,16 @@ public class SparkExecutor {
 
   @Async("prepThreadPoolTaskExecutor")
   public Future<String> run(String[] argv) throws IOException {
+    LOGGER.debug("runSpark(): start");
+
     Map<String, Object> prepPropertiesInfo = GlobalObjectMapper.readValue(argv[0], HashMap.class);
     Map<String, Object> datasetInfo = GlobalObjectMapper.readValue(argv[1], HashMap.class);
     Map<String, Object> snapshotInfo = GlobalObjectMapper.readValue(argv[2], HashMap.class);
     Map<String, Object> callbackInfo = GlobalObjectMapper.readValue(argv[3], HashMap.class);
+
+    String ssName = (String) snapshotInfo.get("ssName");
+    String ssType = (String) snapshotInfo.get("ssType");
+    LOGGER.debug("runSpark(): ssName={} ssType={}" + ssName, ssType);
 
     // Send spark request
     Map<String, Object> args = new HashMap();

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/etl/TeddyExecutor.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/etl/TeddyExecutor.java
@@ -227,7 +227,6 @@ public class TeddyExecutor {
     return false;
   }
 
-  // returns slaveFullDsIds
   void transformRecursive(String ssId, Map<String, Object> dsInfo) throws ClassNotFoundException, SQLException,
           TeddyException, URISyntaxException, TimeoutException, InterruptedException {
     snapshotService.cancelCheck(ssId);

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/etl/TeddyFileService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/etl/TeddyFileService.java
@@ -12,6 +12,7 @@ import app.metatron.discovery.domain.dataprep.file.PrepCsvUtil;
 import app.metatron.discovery.domain.dataprep.file.PrepJsonUtil;
 import app.metatron.discovery.domain.dataprep.file.PrepParseResult;
 import app.metatron.discovery.domain.dataprep.service.PrSnapshotService;
+import app.metatron.discovery.domain.dataprep.teddy.ColumnDescription;
 import app.metatron.discovery.domain.dataprep.teddy.ColumnType;
 import app.metatron.discovery.domain.dataprep.teddy.DataFrame;
 import app.metatron.discovery.domain.dataprep.teddy.Row;
@@ -115,7 +116,14 @@ public class TeddyFileService {
       for (int rowno = 0; rowno < df.rows.size(); snapshotService.cancelCheck(ssId, ++rowno)) {
         Row row = df.rows.get(rowno);
         for (int colno = 0; colno < df.getColCnt(); ++colno) {
-          printer.print(row.get(colno));
+          ColumnDescription colDesc = df.getColDesc(colno);
+          Object obj = row.get(colno);
+
+          if (colDesc.getType() == ColumnType.TIMESTAMP && obj != null) {
+            printer.print(getDateTimeStr(colDesc, obj));
+          } else {
+            printer.print(obj);
+          }
         }
         printer.println();
       }
@@ -136,6 +144,11 @@ public class TeddyFileService {
     return df.rows.size();
   }
 
+  private String getDateTimeStr(ColumnDescription colDesc, Object dt) {
+    String fmt = colDesc.getTimestampStyle();
+    return ((DateTime) dt).toString(fmt, Locale.ENGLISH);
+  }
+
   public int writeJson(String ssId, String strUri, DataFrame df) {
     LOGGER.debug("TeddyExecutor.wirteJSON(): strUri={} hadoopConfDir={}", strUri, hadoopConfDir);
     PrintWriter printWriter = PrepJsonUtil.getPrinter(strUri, hadoopConf);
@@ -148,15 +161,13 @@ public class TeddyFileService {
         Map<String, Object> jsonRow = new LinkedHashMap();
 
         for (int colno = 0; colno < df.getColCnt(); ++colno) {
-          if (df.getColType(colno).equals(ColumnType.TIMESTAMP)) {
-            if (row.get(colno) == null) {
-              jsonRow.put(df.getColName(colno), row.get(colno));
-            } else {
-              jsonRow.put(df.getColName(colno), ((DateTime) row.get(colno))
-                      .toString(df.getColTimestampStyle(colno), Locale.ENGLISH));
-            }
+          ColumnDescription colDesc = df.getColDesc(colno);
+          Object obj = row.get(colno);
+
+          if (colDesc.getType() == ColumnType.TIMESTAMP && obj != null) {
+            jsonRow.put(df.getColName(colno), getDateTimeStr(colDesc, obj));
           } else {
-            jsonRow.put(df.getColName(colno), row.get(colno));
+            jsonRow.put(df.getColName(colno), obj);
           }
         }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
@@ -14,37 +14,13 @@
 
 package app.metatron.discovery.domain.dataprep.transform;
 
-import com.google.common.collect.Maps;
-
-import com.facebook.presto.jdbc.internal.guava.collect.Lists;
-import com.fasterxml.jackson.core.JsonProcessingException;
-
-import org.hibernate.Hibernate;
-import org.hibernate.proxy.HibernateProxy;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.env.Environment;
-import org.springframework.core.env.StandardEnvironment;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import static app.metatron.discovery.domain.dataprep.PrepProperties.STAGEDB_HOSTNAME;
+import static app.metatron.discovery.domain.dataprep.PrepProperties.STAGEDB_METASTORE_URI;
+import static app.metatron.discovery.domain.dataprep.PrepProperties.STAGEDB_PASSWORD;
+import static app.metatron.discovery.domain.dataprep.PrepProperties.STAGEDB_PORT;
+import static app.metatron.discovery.domain.dataprep.PrepProperties.STAGEDB_USERNAME;
+import static app.metatron.discovery.domain.dataprep.entity.PrDataset.DS_TYPE.IMPORTED;
+import static app.metatron.discovery.domain.dataprep.entity.PrDataset.DS_TYPE.WRANGLED;
 
 import app.metatron.discovery.common.GlobalObjectMapper;
 import app.metatron.discovery.domain.dataconnection.DataConnection;
@@ -79,14 +55,34 @@ import app.metatron.discovery.domain.dataprep.teddy.exceptions.IllegalColumnName
 import app.metatron.discovery.domain.dataprep.teddy.exceptions.TeddyException;
 import app.metatron.discovery.domain.storage.StorageProperties;
 import app.metatron.discovery.domain.storage.StorageProperties.StageDBConnection;
-
-import static app.metatron.discovery.domain.dataprep.PrepProperties.STAGEDB_HOSTNAME;
-import static app.metatron.discovery.domain.dataprep.PrepProperties.STAGEDB_METASTORE_URI;
-import static app.metatron.discovery.domain.dataprep.PrepProperties.STAGEDB_PASSWORD;
-import static app.metatron.discovery.domain.dataprep.PrepProperties.STAGEDB_PORT;
-import static app.metatron.discovery.domain.dataprep.PrepProperties.STAGEDB_USERNAME;
-import static app.metatron.discovery.domain.dataprep.entity.PrDataset.DS_TYPE.IMPORTED;
-import static app.metatron.discovery.domain.dataprep.entity.PrDataset.DS_TYPE.WRANGLED;
+import com.facebook.presto.jdbc.internal.guava.collect.Lists;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.collect.Maps;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import org.hibernate.Hibernate;
+import org.hibernate.proxy.HibernateProxy;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class PrepTransformService {
@@ -159,25 +155,10 @@ public class PrepTransformService {
     NOT_USED
   }
 
-  // Properties along the ETL program kinds are gathered into a single JSON properties string.
-  // Currently, the ETL programs kinds are the embedded engine and Apache Spark.
-  private String getJsonPrepPropertiesInfo(String dsId, PrepSnapshotRequestPost requestPost)
-          throws JsonProcessingException, URISyntaxException {
-    PrSnapshot.SS_TYPE ssType = requestPost.getSsType();
-
-    boolean ssHdfs = (ssType == PrSnapshot.SS_TYPE.URI && (new URI(requestPost.getStoredUri())).getScheme()
-            .equals("hdfs"));
-    boolean ssStagingDb = (ssType == PrSnapshot.SS_TYPE.STAGING_DB);
-
-    // check polaris.dataprep.hadoopConfDir
-    if (ssHdfs || ssStagingDb) {
-      prepProperties.getHadoopConfDir(true);
-      prepProperties.getStagingBaseDir(true);
-    }
-
+  private String getJsonPrepPropertiesInfo(PrSnapshot snapshot) throws JsonProcessingException {
     Map<String, Object> mapEveryForEtl = prepProperties.getEveryForEtl();
 
-    // if the value is null, that means storage.stagedb is not in a yaml. NOT using STAGING_DB
+    // Add stage db information from storageProperties
     if (storageProperties != null && storageProperties.getStagedb() != null) {
       StageDBConnection stageDB = storageProperties.getStagedb();
       mapEveryForEtl.put(STAGEDB_HOSTNAME, stageDB.getHostname());
@@ -185,7 +166,7 @@ public class PrepTransformService {
       mapEveryForEtl.put(STAGEDB_USERNAME, stageDB.getUsername());
       mapEveryForEtl.put(STAGEDB_PASSWORD, stageDB.getPassword());
 
-      if (requestPost.getEngine() == ENGINE.SPARK) {
+      if (snapshot.getEngine() == ENGINE.SPARK) {
         mapEveryForEtl.put(STAGEDB_METASTORE_URI, stageDB.getMetastoreUri());
       }
     }
@@ -193,34 +174,38 @@ public class PrepTransformService {
     return GlobalObjectMapper.getDefaultMapper().writeValueAsString(mapEveryForEtl);
   }
 
-  private String getJsonSnapshotInfo(PrepSnapshotRequestPost requestPost, String ssId) throws JsonProcessingException {
+  private String getJsonSnapshotInfo(PrSnapshot snapshot) throws JsonProcessingException {
+    String ssId = snapshot.getSsId();
+
     Map<String, Object> map = new HashMap();
-    PrSnapshot.SS_TYPE ssType = requestPost.getSsType();
-    PrSnapshot.ENGINE engine = requestPost.getEngine();
-    PrSnapshot.APPEND_MODE appendMode = requestPost.getAppendMode();
+    PrSnapshot.SS_TYPE ssType = snapshot.getSsType();
+    PrSnapshot.ENGINE engine = snapshot.getEngine();
+    PrSnapshot.APPEND_MODE appendMode = snapshot.getAppendMode();
 
-    // 공통
+    // Put common properties for every types
     map.put("ssId", ssId);
-    map.put("ssName", requestPost.getSsName());
+    map.put("ssName", snapshot.getSsName());
     map.put("ssType", ssType.name());
+    map.put("launchTime", snapshot.getLaunchTime());
     map.put("engine", engine.name());
-    map.put("hiveFileFormat", requestPost.getHiveFileFormat());
-    map.put("hiveFileCompression", requestPost.getHiveFileCompression());
-    map.put("localBaseDir", prepProperties.getLocalBaseDir());
 
+    // Put specific properties for each type
     switch (ssType) {
       case URI:
-        String storedUri = requestPost.getStoredUri();
+        String storedUri = snapshot.getStoredUri();
         assert storedUri != null;
+        map.put("localBaseDir", prepProperties.getLocalBaseDir());
         map.put("storedUri", storedUri);
         break;
       case STAGING_DB:
-        map.put("partitionColNames", requestPost.getPartitionColNames());
-        map.put("appendMode", appendMode.name());
-        map.put("dbName", requestPost.getDbName());
-        map.put("tblName", requestPost.getTblName());
-
         map.put("stagingBaseDir", prepProperties.getStagingBaseDir(true));
+        map.put("dbName", snapshot.getDbName());
+        map.put("tblName", snapshot.getTblName());
+
+        map.put("hiveFileFormat", snapshot.getHiveFileFormat());
+        map.put("hiveFileCompression", snapshot.getHiveFileCompression());
+        map.put("appendMode", appendMode.name());
+        map.put("partitionColNames", snapshot.getPartitionColNames());
         break;
       default:
         assert false : ssType;
@@ -915,15 +900,38 @@ public class PrepTransformService {
     return GlobalObjectMapper.getDefaultMapper().writeValueAsString(datasetInfo);
   }
 
-  private void runTransformer(String wrangledDsId, PrepSnapshotRequestPost requestPost, String ssId,
-          String authorization) throws Throwable {
+  private void checkHadoopConf(PrSnapshot snapshot) throws URISyntaxException {
+    PrSnapshot.SS_TYPE ssType = snapshot.getSsType();
 
-    String jsonPrepPropertiesInfo = getJsonPrepPropertiesInfo(wrangledDsId, requestPost);
+    switch (ssType) {
+      case URI:
+        if ((new URI(snapshot.getStoredUri())).getScheme().equals("hdfs")) {
+          prepProperties.getHadoopConfDir(true);
+          prepProperties.getStagingBaseDir(true);
+        }
+        break;
+      case STAGING_DB:
+        prepProperties.getHadoopConfDir(true);
+        prepProperties.getStagingBaseDir(true);
+        break;
+      case DATABASE:
+      case DRUID:
+        break;
+    }
+  }
+
+  private void runTransformer(String wrangledDsId, PrSnapshot snapshot, String authorization) throws Throwable {
+
+    LOGGER.debug("runTransformer(): ssName={} engine={}", snapshot.getSsName(), snapshot.getEngine());
+
+    checkHadoopConf(snapshot);
+
+    String jsonPrepPropertiesInfo = getJsonPrepPropertiesInfo(snapshot);
     String jsonDatasetInfo = getJsonDatasetInfo(wrangledDsId);
-    String jsonSnapshotInfo = getJsonSnapshotInfo(requestPost, ssId);
+    String jsonSnapshotInfo = getJsonSnapshotInfo(snapshot);
     String jsonCallbackInfo = getJsonCallbackInfo(authorization);
 
-    switch (requestPost.getEngine()) {
+    switch (snapshot.getEngine()) {
       case EMBEDDED:
         runTeddy(jsonPrepPropertiesInfo, jsonDatasetInfo, jsonSnapshotInfo, jsonCallbackInfo);
         break;
@@ -931,7 +939,7 @@ public class PrepTransformService {
         runSpark(jsonPrepPropertiesInfo, jsonDatasetInfo, jsonSnapshotInfo, jsonCallbackInfo);
         break;
       default:
-        assert false : requestPost.getEngine();
+        assert false : snapshot.getEngine();
     }
   }
 
@@ -1002,8 +1010,7 @@ public class PrepTransformService {
     PrSnapshot.SS_TYPE ssType = requestPost.getSsType();
     String ssName = requestPost.getSsName();
 
-    LOGGER.trace("transform_snapshot(): start: ssType={} ssName={} dsId={} ", ssType, ssName,
-            wrangledDsId);
+    LOGGER.debug("transform_snapshot(): start: ssType={} ssName={} dsId={} ", ssType, ssName, wrangledDsId);
 
     if (ssName == null || ssName.equals("")) {
       throw PrepException.create(PrepErrorCodes.PREP_SNAPSHOT_ERROR_CODE,
@@ -1122,9 +1129,8 @@ public class PrepTransformService {
 
     snapshotRepository.saveAndFlush(snapshot);
 
-    if (requestPost.getSsType() == PrSnapshot.SS_TYPE.URI ||
-            requestPost.getSsType() == PrSnapshot.SS_TYPE.STAGING_DB) {
-      runTransformer(wrangledDsId, requestPost, snapshot.getSsId(), authorization);
+    if (requestPost.getSsType() == PrSnapshot.SS_TYPE.URI || requestPost.getSsType() == PrSnapshot.SS_TYPE.STAGING_DB) {
+      runTransformer(wrangledDsId, snapshot, authorization);
       LOGGER.info("transform_snapshot(): snapshot generation successfully start");
     } else {
       throw new IllegalArgumentException(requestPost.toString());
@@ -1134,7 +1140,7 @@ public class PrepTransformService {
 
     response = new PrepSnapshotResponse(snapshot.getSsId(), snapshot.getSsName());
 
-    LOGGER.trace("transform_snapshot(): end");
+    LOGGER.debug("transform_snapshot(): end");
     return response;
   }
 
@@ -1168,19 +1174,19 @@ public class PrepTransformService {
 
     if (cloningDsName == null) {
       cloningDsName = importedDataset.getDsName().replaceFirst(
-          " \\((EXCEL|CSV|JSON|STAGING|MYSQL|ORACLE|TIBERO|HIVE|POSTGRESQL|MSSQL|PRESTO)\\)$", "");
+              " \\((EXCEL|CSV|JSON|STAGING|MYSQL|ORACLE|TIBERO|HIVE|POSTGRESQL|MSSQL|PRESTO)\\)$", "");
     }
 
     List<String> dsNames = new ArrayList();
     for (PrDataset dataset : dataflow.getDatasets()) {
-      if(dataset.getDsType()!= PrDataset.DS_TYPE.IMPORTED) {
+      if (dataset.getDsType() != PrDataset.DS_TYPE.IMPORTED) {
         dsNames.add(dataset.getDsName());
       }
     }
 
     String newDsName = cloningDsName;
     for (int i = 0; /* NOP */ ; i++) {
-      if(i!=0) {
+      if (i != 0) {
         newDsName = String.format("%s (%d)", cloningDsName, i);
       }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/PrepTransformService.java
@@ -320,10 +320,7 @@ public class PrepTransformService {
             transform(wrangledDsId, OP_TYPE.APPEND, i, ruleString, jsonRuleString, true);
           }
           break;
-        case DATABASE:
-        case STAGING_DB:
-        case DRUID:
-          /* NOP */
+        default:
           break;
       }
     }
@@ -867,7 +864,7 @@ public class PrepTransformService {
             datasetInfo.put("sourceQuery", upstreamDataset.getQueryStmt());
             break;
 
-          case DRUID:
+          default:
             assert false : upstreamDataset.getImportType();
         }
       } else {
@@ -914,8 +911,7 @@ public class PrepTransformService {
         prepProperties.getHadoopConfDir(true);
         prepProperties.getStagingBaseDir(true);
         break;
-      case DATABASE:
-      case DRUID:
+      default:
         break;
     }
   }


### PR DESCRIPTION
### Description
Even though there're timestamp format information when creating a snapshot, we ignored the format for now.
With this PR, timestamp columns will be formatted as expected.

**Related Issue** : #2066 

### How Has This Been Tested?
1. Import & wrangle [s5k_1.csv.txt](https://github.com/metatron-app/metatron-discovery/files/3810115/s5k_1.csv.txt)
2. Set format of column1 with context menu into like "yyyy"
3. Click "Snapshot"
4. Click "Done"
5. Click the new snapshot on right panel.
6. See "2011", "2012", etc.

#### Need additional checks?
Yes, please.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
