### PR TITLE
#2821 Hive personal database improvement

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/common/HivePersonalDatasource.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/common/HivePersonalDatasource.java
@@ -1,0 +1,71 @@
+package app.metatron.discovery.common;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.Serializable;
+
+public class HivePersonalDatasource implements Serializable {
+  private String datasourceName;
+  private String hdfsConfPath;
+  private String adminName;
+  private String adminPassword;
+  private String personalDatabasePrefix;
+
+  public HivePersonalDatasource() {
+  }
+
+  public HivePersonalDatasource(String datasourceName, String hdfsConfPath, String adminName, String adminPassword, String personalDatabasePrefix) {
+    this.datasourceName = datasourceName;
+    this.hdfsConfPath = hdfsConfPath;
+    this.adminName = adminName;
+    this.adminPassword = adminPassword;
+    this.personalDatabasePrefix = personalDatabasePrefix;
+  }
+
+  public String getDatasourceName() {
+    return datasourceName;
+  }
+
+  public void setDatasourceName(String datasourceName) {
+    this.datasourceName = datasourceName;
+  }
+
+  public String getHdfsConfPath() {
+    return hdfsConfPath;
+  }
+
+  public void setHdfsConfPath(String hdfsConfPath) {
+    this.hdfsConfPath = hdfsConfPath;
+  }
+
+  public String getAdminName() {
+    return adminName;
+  }
+
+  public void setAdminName(String adminName) {
+    this.adminName = adminName;
+  }
+
+  public String getAdminPassword() {
+    return adminPassword;
+  }
+
+  public void setAdminPassword(String adminPassword) {
+    this.adminPassword = adminPassword;
+  }
+
+  public String getPersonalDatabasePrefix() {
+    return personalDatabasePrefix;
+  }
+
+  public void setPersonalDatabasePrefix(String personalDatabasePrefix) {
+    this.personalDatabasePrefix = personalDatabasePrefix;
+  }
+
+  public boolean isValidate() {
+    return StringUtils.isNotEmpty(this.hdfsConfPath)
+      && StringUtils.isNotEmpty(this.adminName)
+      && StringUtils.isNotEmpty(this.adminPassword)
+      && StringUtils.isNotEmpty(this.personalDatabasePrefix);
+  }
+}

--- a/discovery-server/src/main/java/app/metatron/discovery/common/MetatronProperties.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/common/MetatronProperties.java
@@ -19,8 +19,10 @@ import com.google.common.collect.Maps;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -31,39 +33,41 @@ import java.util.Map;
 @ConfigurationProperties(prefix = "polaris")
 public class MetatronProperties {
 
-    private final Map<String, Object> format = Maps.newHashMap();
+  private final Map<String, Object> format = Maps.newHashMap();
 
-    private final Mail mail = new Mail();
+  private final Mail mail = new Mail();
 
-    private final List<Cors> cors = Lists.newArrayList();
+  private final List<Cors> cors = Lists.newArrayList();
 
-    private Integer csvMaxCharsPerColumn = 1024 * 30;
+  private Integer csvMaxCharsPerColumn = 1024 * 30;
 
-    public Map<String, Object> getFormat() {
-        return format;
+  private List<HivePersonalDatasource> hivePersonalDatasources = new ArrayList<>();
+
+  public Map<String, Object> getFormat() {
+    return format;
+  }
+
+  public Mail getMail() {
+    return mail;
+  }
+
+  public List<Cors> getCors() {
+    return cors;
+  }
+
+  public List<String> getTimeFormats() {
+
+    List<String> formats = Lists.newArrayList();
+    if (!format.containsKey("datetimes")) {
+      return formats;
     }
 
-    public Mail getMail() {
-        return mail;
-    }
+    // 결과는 key 가 리스트 인덱스, value 가 값임, { "0": "yyyy-MM-dd", ...}
+    Object result = format.get("datetimes");
+    formats.addAll(((Map) result).values());
 
-    public List<Cors> getCors() {
-        return cors;
-    }
-
-    public List<String> getTimeFormats() {
-
-        List<String> formats = Lists.newArrayList();
-        if (!format.containsKey("datetimes")) {
-            return formats;
-        }
-
-        // 결과는 key 가 리스트 인덱스, value 가 값임, { "0": "yyyy-MM-dd", ...}
-        Object result = format.get("datetimes");
-        formats.addAll(((Map) result).values());
-
-        return formats;
-    }
+    return formats;
+  }
 
   public Integer getCsvMaxCharsPerColumn() {
     return csvMaxCharsPerColumn;
@@ -73,132 +77,140 @@ public class MetatronProperties {
     this.csvMaxCharsPerColumn = csvMaxCharsPerColumn;
   }
 
+  public List<HivePersonalDatasource> getHivePersonalDatasources() {
+    return hivePersonalDatasources;
+  }
+
+  public void setHivePersonalDatasources(List<HivePersonalDatasource> hivePersonalDatasources) {
+    this.hivePersonalDatasources = hivePersonalDatasources;
+  }
+
   public static class Mail {
 
-        private String from = "admin@metatron.com";
+    private String from = "admin@metatron.com";
 
-        private String admin = "admin@metatron.com";
+    private String admin = "admin@metatron.com";
 
-        private String baseUrl = "";
+    private String baseUrl = "";
 
-        public String getFrom() {
-            return from;
-        }
-
-        public void setFrom(String from) {
-            this.from = from;
-        }
-
-        public String getBaseUrl() {
-            return baseUrl;
-        }
-
-        public void setBaseUrl(String baseUrl) {
-            this.baseUrl = baseUrl;
-        }
-
-        public String getAdmin() {
-            return admin;
-        }
-
-        public void setAdmin(String admin) {
-            this.admin = admin;
-        }
+    public String getFrom() {
+      return from;
     }
 
-    public static class Cors {
-
-        private String mapping;
-
-        private String allowedOrigins = "*";
-
-        private String allowedMethods = "GET,HEAD,POST";
-
-        private String allowedHeaders = "*";
-
-        private String exposedHeaders;
-
-        private Boolean allowCredentials = false;
-
-        private Integer maxAge = 3600;
-
-        public Cors() {
-        }
-
-        public List<String> getAllowOriginList() {
-           return Lists.newArrayList(StringUtils.split(allowedOrigins, ","));
-        }
-
-        public List<String> getAllowedMethodList() {
-            return Lists.newArrayList(StringUtils.split(allowedMethods, ","));
-        }
-
-        public List<String> getAllowedHeadersList() {
-            return Lists.newArrayList(StringUtils.split(allowedHeaders, ","));
-        }
-
-        public List<String> getExposedHeadersList() {
-            if(exposedHeaders == null) {
-                return null;
-            }
-            return Lists.newArrayList(StringUtils.split(exposedHeaders, ","));
-        }
-
-        public String getMapping() {
-            return mapping;
-        }
-
-        public void setMapping(String mapping) {
-            this.mapping = mapping;
-        }
-
-        public String getAllowedOrigins() {
-            return allowedOrigins;
-        }
-
-        public void setAllowedOrigins(String allowedOrigins) {
-            this.allowedOrigins = allowedOrigins;
-        }
-
-        public String getAllowedMethods() {
-            return allowedMethods;
-        }
-
-        public void setAllowedMethods(String allowedMethods) {
-            this.allowedMethods = allowedMethods;
-        }
-
-        public String getAllowedHeaders() {
-            return allowedHeaders;
-        }
-
-        public void setAllowedHeaders(String allowedHeaders) {
-            this.allowedHeaders = allowedHeaders;
-        }
-
-        public String getExposedHeaders() {
-            return exposedHeaders;
-        }
-
-        public void setExposedHeaders(String exposedHeaders) {
-            this.exposedHeaders = exposedHeaders;
-        }
-
-        public Boolean getAllowCredentials() {
-            return allowCredentials;
-        }
-
-        public void setAllowCredentials(Boolean allowCredentials) {
-            this.allowCredentials = allowCredentials;
-        }
-
-        public Integer getMaxAge() {
-            return maxAge;
-        }
-
-        public void setMaxAge(Integer maxAge) {
-            this.maxAge = maxAge;
-        }
+    public void setFrom(String from) {
+      this.from = from;
     }
+
+    public String getBaseUrl() {
+      return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+      this.baseUrl = baseUrl;
+    }
+
+    public String getAdmin() {
+      return admin;
+    }
+
+    public void setAdmin(String admin) {
+      this.admin = admin;
+    }
+  }
+
+  public static class Cors {
+
+    private String mapping;
+
+    private String allowedOrigins = "*";
+
+    private String allowedMethods = "GET,HEAD,POST";
+
+    private String allowedHeaders = "*";
+
+    private String exposedHeaders;
+
+    private Boolean allowCredentials = false;
+
+    private Integer maxAge = 3600;
+
+    public Cors() {
+    }
+
+    public List<String> getAllowOriginList() {
+      return Lists.newArrayList(StringUtils.split(allowedOrigins, ","));
+    }
+
+    public List<String> getAllowedMethodList() {
+      return Lists.newArrayList(StringUtils.split(allowedMethods, ","));
+    }
+
+    public List<String> getAllowedHeadersList() {
+      return Lists.newArrayList(StringUtils.split(allowedHeaders, ","));
+    }
+
+    public List<String> getExposedHeadersList() {
+      if(exposedHeaders == null) {
+        return null;
+      }
+      return Lists.newArrayList(StringUtils.split(exposedHeaders, ","));
+    }
+
+    public String getMapping() {
+      return mapping;
+    }
+
+    public void setMapping(String mapping) {
+      this.mapping = mapping;
+    }
+
+    public String getAllowedOrigins() {
+      return allowedOrigins;
+    }
+
+    public void setAllowedOrigins(String allowedOrigins) {
+      this.allowedOrigins = allowedOrigins;
+    }
+
+    public String getAllowedMethods() {
+      return allowedMethods;
+    }
+
+    public void setAllowedMethods(String allowedMethods) {
+      this.allowedMethods = allowedMethods;
+    }
+
+    public String getAllowedHeaders() {
+      return allowedHeaders;
+    }
+
+    public void setAllowedHeaders(String allowedHeaders) {
+      this.allowedHeaders = allowedHeaders;
+    }
+
+    public String getExposedHeaders() {
+      return exposedHeaders;
+    }
+
+    public void setExposedHeaders(String exposedHeaders) {
+      this.exposedHeaders = exposedHeaders;
+    }
+
+    public Boolean getAllowCredentials() {
+      return allowCredentials;
+    }
+
+    public void setAllowCredentials(Boolean allowCredentials) {
+      this.allowCredentials = allowCredentials;
+    }
+
+    public Integer getMaxAge() {
+      return maxAge;
+    }
+
+    public void setMaxAge(Integer maxAge) {
+      this.maxAge = maxAge;
+    }
+  }
 
 }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/HiveDialect.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/HiveDialect.java
@@ -46,10 +46,7 @@ public class HiveDialect implements JdbcDialect {
 
   private static final String KERBEROS_PRINCIPAL_PATTERN = "principal=(.+)@(.[^;,\\n\\r\\t]+)";
 
-  public static final String PROPERTY_KEY_ADMIN_NAME = METATRON_PROPERTY_PREFIX + "hive.admin.name";
-  public static final String PROPERTY_KEY_ADMIN_PASSWORD = METATRON_PROPERTY_PREFIX + "hive.admin.password";
-  public static final String PROPERTY_KEY_PERSONAL_DATABASE_PREFIX = METATRON_PROPERTY_PREFIX + "personal.database.prefix";
-  public static final String PROPERTY_KEY_HDFS_CONF_PATH = METATRON_PROPERTY_PREFIX + "hdfs.conf.path";
+  public static final String PROPERTY_KEY_PERSONAL_DATASOURCE_NAME = METATRON_PROPERTY_PREFIX + "hive.personal.datasource.name";
 
   public static final String PROPERTY_KEY_METASTORE_HOST = METATRON_PROPERTY_PREFIX + "metastore.host";
   public static final String PROPERTY_KEY_METASTORE_PORT = METATRON_PROPERTY_PREFIX + "metastore.port";
@@ -388,10 +385,7 @@ public class HiveDialect implements JdbcDialect {
     if(MapUtils.isEmpty(connectionProperties)) {
       return false;
     } else {
-      if(StringUtils.isNotEmpty(connectionProperties.get(PROPERTY_KEY_ADMIN_NAME)) &&
-          StringUtils.isNotEmpty(connectionProperties.get(PROPERTY_KEY_ADMIN_PASSWORD)) &&
-          StringUtils.isNotEmpty(connectionProperties.get(PROPERTY_KEY_PERSONAL_DATABASE_PREFIX)) &&
-          StringUtils.isNotEmpty(connectionProperties.get(PROPERTY_KEY_HDFS_CONF_PATH))) {
+      if(StringUtils.isNotEmpty(connectionProperties.get(PROPERTY_KEY_PERSONAL_DATASOURCE_NAME))) {
         return true;
       } else {
         return false;

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/hive/DataTableHiveRepository.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/hive/DataTableHiveRepository.java
@@ -14,6 +14,7 @@
 
 package app.metatron.discovery.domain.workbench.hive;
 
+import app.metatron.discovery.common.HivePersonalDatasource;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -35,11 +36,11 @@ import app.metatron.discovery.domain.dataconnection.dialect.HiveDialect;
 @Repository
 public class DataTableHiveRepository {
 
-  public String saveToHdfs(DataConnection hiveConnection, Path path, DataTable dataTable) {
-    final String hiveAdminUser = hiveConnection.getPropertiesMap().get(HiveDialect.PROPERTY_KEY_ADMIN_NAME);
+  public String saveToHdfs(HivePersonalDatasource hivePersonalDataSource, Path path, DataTable dataTable) {
+    final String hiveAdminUser = hivePersonalDataSource.getAdminName();
     FileSystem fs = null;
     try {
-      fs = getFileSystem(hiveConnection.getPropertiesMap().get(HiveDialect.PROPERTY_KEY_HDFS_CONF_PATH), hiveAdminUser);
+      fs = getFileSystem(hivePersonalDataSource.getHdfsConfPath(), hiveAdminUser);
       if (!fs.exists(path)) {
         try {
           fs.mkdirs(path);

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/util/WorkbenchDataSource.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/util/WorkbenchDataSource.java
@@ -155,9 +155,9 @@ public class WorkbenchDataSource {
     return primaryConnection;
   }
 
-  public Connection getSecondaryConnection() {
+  public Connection getSecondaryConnection(String username, String password) {
     if(secondaryConnection == null){
-      secondaryConnection = createSecondaryConnection();
+      secondaryConnection = createSecondaryConnection(username, password);
     }
     return secondaryConnection;
   }
@@ -200,14 +200,14 @@ public class WorkbenchDataSource {
     return getCloseSuppressingConnectionProxy(originalPrimaryConnection);
   }
 
-  private Connection createSecondaryConnection(){
+  private Connection createSecondaryConnection(String username, String password){
     JdbcDialect jdbcDialect = DataConnectionHelper.lookupDialect(connectionInfo);
 
-    Map<String, String> propMap = connectionInfo.getPropertiesMap();
-    String hiveAdminUserName = propMap.get(HiveDialect.PROPERTY_KEY_ADMIN_NAME);
-    String hiveAdminUserPassword = propMap.get(HiveDialect.PROPERTY_KEY_ADMIN_PASSWORD);
+//    Map<String, String> propMap = connectionInfo.getPropertiesMap();
+//    String hiveAdminUserName = propMap.get(HiveDialect.PROPERTY_KEY_ADMIN_NAME);
+//    String hiveAdminUserPassword = propMap.get(HiveDialect.PROPERTY_KEY_ADMIN_PASSWORD);
 
-    originalSecondaryConnection = jdbcConnector.getConnection(connectionInfo, jdbcDialect, connectionInfo.getDatabase(), true, hiveAdminUserName, hiveAdminUserPassword);
+    originalSecondaryConnection = jdbcConnector.getConnection(connectionInfo, jdbcDialect, connectionInfo.getDatabase(), true, username, password);
     return getCloseSuppressingConnectionProxy(originalSecondaryConnection);
   }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/util/ApplicationContextProvider.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/util/ApplicationContextProvider.java
@@ -1,0 +1,20 @@
+package app.metatron.discovery.util;
+
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ApplicationContextProvider implements ApplicationContextAware {
+  private static ApplicationContext context;
+
+  @Override
+  public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+    context = applicationContext;
+  }
+
+  public static ApplicationContext getApplicationContext() {
+    return context;
+  }
+}

--- a/discovery-server/src/test/java/app/metatron/discovery/TestLocalHdfs.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/TestLocalHdfs.java
@@ -27,9 +27,7 @@ public class TestLocalHdfs {
   final static String localHdfsSuperUser = "yooyoungmo";
   final Configuration configuration;
 
-  public TestLocalHdfs() {
-    String hdfsConfLocalPath = Paths.get("src/test/hdfs-conf").toAbsolutePath().toString();
-
+  public TestLocalHdfs(String hdfsConfLocalPath) {
     Configuration conf = new Configuration();
     conf.addResource(new Path(String.format("%s/core-site.xml", hdfsConfLocalPath)));
     conf.addResource(new Path(String.format("%s/hdfs-site.xml", hdfsConfLocalPath)));

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/workbench/hive/DataTableHiveRepositoryTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/workbench/hive/DataTableHiveRepositoryTest.java
@@ -13,6 +13,7 @@
  */
 package app.metatron.discovery.domain.workbench.hive;
 
+import app.metatron.discovery.common.HivePersonalDatasource;
 import org.apache.hadoop.fs.Path;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 
 public class DataTableHiveRepositoryTest {
-  final TestLocalHdfs testLocalHdfs = new TestLocalHdfs();
+  final TestLocalHdfs testLocalHdfs = new TestLocalHdfs("/tmp/hdfs-conf");
 
   @Before
   public void setUp() throws IOException, InterruptedException {
@@ -41,8 +42,6 @@ public class DataTableHiveRepositoryTest {
   @Test
   public void saveToHdfs() throws IOException, InterruptedException {
     // given
-    DataConnection hiveConnection = getHiveConnection();
-
     List<String> fields = Arrays.asList("records.year", "records.temperature", "records.quality");
 
     List<Map<String, Object>> records = new ArrayList<>();
@@ -61,26 +60,11 @@ public class DataTableHiveRepositoryTest {
 
     // when
     final DataTableHiveRepository dataTableHiveRepository = new DataTableHiveRepository();
-    String filePath = dataTableHiveRepository.saveToHdfs(hiveConnection, new Path("/tmp/metatron/test"), dataTable);
+
+    HivePersonalDatasource hivePersonalDatasource = new HivePersonalDatasource("ds1", "/tmp/hdfs-conf", "hive_admin", "1111", "private");
+    String filePath = dataTableHiveRepository.saveToHdfs(hivePersonalDatasource, new Path("/tmp/metatron/test"), dataTable);
 
     // then
     assertThat(testLocalHdfs.exists(new Path(filePath))).isTrue();
   }
-
-  private DataConnection getHiveConnection() {
-    DataConnection hiveConnection = new DataConnection("HIVE");
-    hiveConnection.setUsername("read_only");
-    hiveConnection.setPassword("1111");
-    hiveConnection.setHostname("localhost");
-    hiveConnection.setPort(10000);
-    hiveConnection.setProperties("{" +
-        "  \"metatron.hdfs.conf.path\": \"/tmp/hdfs-conf\"," +
-        "  \"metatron.hive.admin.name\": \"hive_admin\"," +
-        "  \"metatron.hive.admin.password\": \"1111\"," +
-        "  \"metatron.personal.database.prefix\": \"private\"" +
-        "}");
-
-    return hiveConnection;
-  }
-
 }

--- a/discovery-server/src/test/resources/sql/workbench.sql
+++ b/discovery-server/src/test/resources/sql/workbench.sql
@@ -1,10 +1,10 @@
 
-INSERT INTO DATACONNECTION(DC_IMPLEMENTOR, ID, CREATED_BY, CREATED_TIME, MODIFIED_BY, MODIFIED_TIME, VERSION, DC_DESC, DC_HOSTNAME, DC_NAME, DC_OPTIONS, DC_PASSWORD, DC_PORT, DC_TYPE, DC_URL, DC_USERNAME, DC_DATABASE, PATH, DC_CATALOG, DC_SID, REMOVEFIRSTROW, DC_PROPERTIES) VALUES
-('STAGE', 'stage-hive-connection-for-test', 'polaris', now(), 'polaris', now(), 0, NULL, 'localhost', 'hive-local', NULL, 'hive', 10000, 'JDBC', NULL, 'hive', NULL, NULL, NULL, NULL, NULL, NULL),
-('HIVE', 'hive-local', 'polaris', now(), 'polaris', now(), 0, NULL, 'localhost', 'hive-local', NULL, 'hive', 10000, 'JDBC', NULL, 'hive', NULL, NULL, NULL, NULL, NULL, NULL),
-('MYSQL', 'mysql-local', 'polaris', now(), 'polaris', now(), 0, NULL, 'localhost', 'mysql-local', NULL, 'polaris', 3306, 'JDBC', NULL, 'polaris', NULL, NULL, NULL, NULL, NULL, NULL),
-('PRESTO', 'presto-local', 'polaris', now(), 'polaris', now(), 0, NULL, 'localhost', 'presto-local', NULL, 'hive', 8080, 'JDBC', NULL, 'hive', NULL, NULL, 'hive', NULL, NULL, NULL),
-('HIVE', 'hive-local-enable-save-as-hive-table', 'polaris', now(), 'polaris', now(), 0, NULL, 'localhost', 'hive-local-enable-save-as-hive-table', NULL, 'hive', 10000, 'JDBC', NULL, 'hive', NULL, NULL, NULL, NULL, NULL, '{"metatron.hive.admin.name":"hive_admin","metatron.hive.admin.password":"1111","metatron.personal.database.prefix":"private","metatron.hdfs.conf.path":"/tmp/hdfs-conf"}');
+INSERT INTO DATACONNECTION(DC_IMPLEMENTOR, ID, CREATED_BY, CREATED_TIME, MODIFIED_BY, MODIFIED_TIME, VERSION, DC_DESC, DC_HOSTNAME, DC_NAME, DC_OPTIONS, DC_PASSWORD, DC_PORT, DC_TYPE, DC_URL, DC_USERNAME, DC_DATABASE, DC_CATALOG, DC_SID, DC_PROPERTIES) VALUES
+('STAGE', 'stage-hive-connection-for-test', 'polaris', now(), 'polaris', now(), 0, NULL, 'localhost', 'hive-local', NULL, 'hive', 10000, 'JDBC', NULL, 'hive', NULL, NULL, NULL, NULL),
+('HIVE', 'hive-local', 'polaris', now(), 'polaris', now(), 0, NULL, 'localhost', 'hive-local', NULL, 'hive', 10000, 'JDBC', NULL, 'hive', NULL, NULL, NULL, NULL),
+('MYSQL', 'mysql-local', 'polaris', now(), 'polaris', now(), 0, NULL, 'localhost', 'mysql-local', NULL, 'polaris', 3306, 'JDBC', NULL, 'polaris', NULL, NULL, NULL, NULL),
+('PRESTO', 'presto-local', 'polaris', now(), 'polaris', now(), 0, NULL, 'localhost', 'presto-local', NULL, 'hive', 8080, 'JDBC', NULL, 'hive', NULL, 'hive', NULL, NULL),
+('HIVE', 'hive-local-enable-save-as-hive-table', 'polaris', now(), 'polaris', now(), 0, NULL, 'localhost', 'hive-local-enable-save-as-hive-table', NULL, 'hive', 10000, 'JDBC', NULL, 'hive', NULL, NULL, NULL, '{"metatron.hive.personal.datasource.name":"ds1"}');
 
 INSERT INTO book (type,id, created_by, created_time, modified_by, modified_time,version,book_desc,book_favorite,book_folder_id,book_name,book_tag,ws_id) VALUES
 ('workbench','workbench-01','admin',NOW(),'admin',NOW(),1.0,'',FALSE,'','TEST-Workbench-01','','ws-00'),


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->

**Related Issue** : <!--- Please link to the issue here. -->
#2821 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
메타트론 application.yaml에 Hive아래 내용을 추가하고 
```yaml
polaris:
 // ...
  hive-personal-datasources:
    -
      datasource-name: ds1
      hdfs-conf-path: /test1/hdfs-conf
      admin-name: admin
      admin-password: 1111
      personal-database-prefix: private
    -
      datasource-name: ds2
      hdfs-conf-path: /test2/hdfs-conf
      admin-name: admin
      admin-password: qwer
      personal-database-prefix: pv
```
추가로 Hive connection을 만들고 커스텀 프로퍼티 `metatron.hive.personal.datasource.name` 에 `ds1` 을 입력하여 기존과 동일하게 동작하는 것을 확인하였습니다.
![image](https://user-images.githubusercontent.com/16472109/68273249-3fea1580-00a9-11ea-84f4-1413e5645f69.png)

#### Need additional checks?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
