### PR TITLE
#2821 Hive personal database improvement

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/common/ConnectionConfigProperties.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/common/ConnectionConfigProperties.java
@@ -1,0 +1,25 @@
+package app.metatron.discovery.common;
+
+import com.google.common.collect.Maps;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+@ConfigurationProperties(prefix = "polaris.connection")
+public class ConnectionConfigProperties {
+  private Map<String, Map<String, String>> propertyGroup = Maps.newHashMap();
+
+  public Map<String, Map<String, String>> getPropertyGroup() {
+    return propertyGroup;
+  }
+
+  public void setPropertyGroup(Map<String, Map<String, String>> propertyGroup) {
+    this.propertyGroup = propertyGroup;
+  }
+
+  public Map<String, String> findPropertyGroupByName(String name) {
+    return propertyGroup.getOrDefault(name, Maps.newHashMap());
+  }
+}

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/accessor/HiveDataAccessor.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/accessor/HiveDataAccessor.java
@@ -14,29 +14,27 @@
 
 package app.metatron.discovery.domain.dataconnection.accessor;
 
+import app.metatron.discovery.common.ConnectionConfigProperties;
+import app.metatron.discovery.common.datasource.DataType;
+import app.metatron.discovery.domain.dataconnection.dialect.HiveDialect;
+import app.metatron.discovery.domain.datasource.Field;
+import app.metatron.discovery.domain.datasource.connection.jdbc.HiveTableInformation;
+import app.metatron.discovery.domain.workbench.hive.HiveNamingRule;
+import app.metatron.discovery.domain.workbench.hive.HivePersonalDatasource;
+import app.metatron.discovery.extension.dataconnection.jdbc.JdbcConnectInformation;
+import app.metatron.discovery.extension.dataconnection.jdbc.accessor.AbstractJdbcDataAccessor;
+import app.metatron.discovery.extension.dataconnection.jdbc.exception.JdbcDataConnectionErrorCodes;
+import app.metatron.discovery.extension.dataconnection.jdbc.exception.JdbcDataConnectionException;
+import app.metatron.discovery.util.ApplicationContextProvider;
+import app.metatron.discovery.util.AuthUtils;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.pf4j.Extension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
-
-import app.metatron.discovery.common.datasource.DataType;
-import app.metatron.discovery.domain.dataconnection.dialect.HiveDialect;
-import app.metatron.discovery.domain.datasource.Field;
-import app.metatron.discovery.domain.datasource.connection.jdbc.HiveTableInformation;
-import app.metatron.discovery.domain.workbench.hive.HiveNamingRule;
-import app.metatron.discovery.extension.dataconnection.jdbc.JdbcConnectInformation;
-import app.metatron.discovery.extension.dataconnection.jdbc.accessor.AbstractJdbcDataAccessor;
-import app.metatron.discovery.extension.dataconnection.jdbc.exception.JdbcDataConnectionErrorCodes;
-import app.metatron.discovery.extension.dataconnection.jdbc.exception.JdbcDataConnectionException;
-import app.metatron.discovery.util.AuthUtils;
 
 import static java.util.stream.Collectors.toList;
 
@@ -52,14 +50,13 @@ public class HiveDataAccessor extends AbstractJdbcDataAccessor {
     Map<String, Object> databaseMap = super.getDatabases(catalog, schemaPattern, pageSize, pageNumber);
 
     List<String> databaseNames = (List) databaseMap.get("databases");
-    //filter personal database
+
     String loginUserId = AuthUtils.getAuthUserName();
     if(StringUtils.isNotEmpty(loginUserId)
         && HiveDialect.isSupportSaveAsHiveTable(connectionInfo)) {
+      //filter personal database
       databaseNames
-          = filterOtherPersonalDatabases(databaseNames,
-                                         connectionInfo.getPropertiesMap().get(HiveDialect.PROPERTY_KEY_PERSONAL_DATABASE_PREFIX),
-                                         HiveNamingRule.replaceNotAllowedCharacters(loginUserId));
+          = filterOtherPersonalDatabases(databaseNames, loginUserId);
     }
 
     int databaseCount = databaseNames.size();
@@ -268,12 +265,17 @@ public class HiveDataAccessor extends AbstractJdbcDataAccessor {
     return super.getColumns(schemaPattern, schemaPattern, tableNamePattern, columnNamePattern);
   }
 
-  private List<String> filterOtherPersonalDatabases(List<String> databases, String personalDatabasePrefix, String loginUserId) {
-    final String personalDatabase = String.format("%s_%s", personalDatabasePrefix, loginUserId);
+  private List<String> filterOtherPersonalDatabases(List<String> databases, String loginUserId) {
+    HivePersonalDatasource hivePersonalDataSource = findHivePersonalDataSource();
+    if(hivePersonalDataSource.isValidate() == false) {
+      return databases;
+    }
+
+    final String personalDatabase = String.format("%s_%s", hivePersonalDataSource.getPersonalDatabasePrefix(), HiveNamingRule.replaceNotAllowedCharacters(loginUserId));
 
     if(CollectionUtils.isNotEmpty(databases)) {
       return databases.stream().filter(database -> {
-        if (database.startsWith(personalDatabasePrefix + "_")) {
+        if (database.startsWith(hivePersonalDataSource.getPersonalDatabasePrefix() + "_")) {
           if (database.equalsIgnoreCase(personalDatabase)) {
             return true;
           } else {
@@ -286,5 +288,11 @@ public class HiveDataAccessor extends AbstractJdbcDataAccessor {
     } else {
       return Collections.emptyList();
     }
+  }
+
+  private HivePersonalDatasource findHivePersonalDataSource() {
+    ConnectionConfigProperties connectionConfigProperties = ApplicationContextProvider.getApplicationContext().getBean(ConnectionConfigProperties.class);
+    Map<String, String> findProperties = connectionConfigProperties.findPropertyGroupByName(connectionInfo.getPropertiesMap().get(HiveDialect.PROPERTY_KEY_PROPERTY_GROUP_NAME));
+    return new HivePersonalDatasource(findProperties);
   }
 }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/HiveDialect.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/HiveDialect.java
@@ -14,8 +14,13 @@
 
 package app.metatron.discovery.domain.dataconnection.dialect;
 
+import app.metatron.discovery.common.ConnectionConfigProperties;
+import app.metatron.discovery.common.MetatronProperties;
+import app.metatron.discovery.domain.workbench.hive.HivePersonalDatasource;
+import app.metatron.discovery.util.ApplicationContextProvider;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
@@ -46,10 +51,7 @@ public class HiveDialect implements JdbcDialect {
 
   private static final String KERBEROS_PRINCIPAL_PATTERN = "principal=(.+)@(.[^;,\\n\\r\\t]+)";
 
-  public static final String PROPERTY_KEY_ADMIN_NAME = METATRON_PROPERTY_PREFIX + "hive.admin.name";
-  public static final String PROPERTY_KEY_ADMIN_PASSWORD = METATRON_PROPERTY_PREFIX + "hive.admin.password";
-  public static final String PROPERTY_KEY_PERSONAL_DATABASE_PREFIX = METATRON_PROPERTY_PREFIX + "personal.database.prefix";
-  public static final String PROPERTY_KEY_HDFS_CONF_PATH = METATRON_PROPERTY_PREFIX + "hdfs.conf.path";
+  public static final String PROPERTY_KEY_PROPERTY_GROUP_NAME = METATRON_PROPERTY_PREFIX + "property.group.name";
 
   public static final String PROPERTY_KEY_METASTORE_HOST = METATRON_PROPERTY_PREFIX + "metastore.host";
   public static final String PROPERTY_KEY_METASTORE_PORT = METATRON_PROPERTY_PREFIX + "metastore.port";
@@ -388,11 +390,15 @@ public class HiveDialect implements JdbcDialect {
     if(MapUtils.isEmpty(connectionProperties)) {
       return false;
     } else {
-      if(StringUtils.isNotEmpty(connectionProperties.get(PROPERTY_KEY_ADMIN_NAME)) &&
-          StringUtils.isNotEmpty(connectionProperties.get(PROPERTY_KEY_ADMIN_PASSWORD)) &&
-          StringUtils.isNotEmpty(connectionProperties.get(PROPERTY_KEY_PERSONAL_DATABASE_PREFIX)) &&
-          StringUtils.isNotEmpty(connectionProperties.get(PROPERTY_KEY_HDFS_CONF_PATH))) {
-        return true;
+      if(StringUtils.isNotEmpty(connectionProperties.get(PROPERTY_KEY_PROPERTY_GROUP_NAME))) {
+        ConnectionConfigProperties connectionConfigProperties = ApplicationContextProvider.getApplicationContext().getBean(ConnectionConfigProperties.class);
+        Map<String, String> findProperties = connectionConfigProperties.findPropertyGroupByName(connectionProperties.getOrDefault(PROPERTY_KEY_PROPERTY_GROUP_NAME, ""));
+        HivePersonalDatasource hivePersonalDatasource = new HivePersonalDatasource(findProperties);
+        if(hivePersonalDatasource.isValidate()) {
+          return true;
+        } else {
+          return false;
+        }
       } else {
         return false;
       }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/hive/DataTableHiveRepository.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/hive/DataTableHiveRepository.java
@@ -29,17 +29,15 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import app.metatron.discovery.common.exception.MetatronException;
-import app.metatron.discovery.domain.dataconnection.DataConnection;
-import app.metatron.discovery.domain.dataconnection.dialect.HiveDialect;
 
 @Repository
 public class DataTableHiveRepository {
 
-  public String saveToHdfs(DataConnection hiveConnection, Path path, DataTable dataTable) {
-    final String hiveAdminUser = hiveConnection.getPropertiesMap().get(HiveDialect.PROPERTY_KEY_ADMIN_NAME);
+  public String saveToHdfs(HivePersonalDatasource hivePersonalDataSource, Path path, DataTable dataTable) {
+    final String hiveAdminUser = hivePersonalDataSource.getAdminName();
     FileSystem fs = null;
     try {
-      fs = getFileSystem(hiveConnection.getPropertiesMap().get(HiveDialect.PROPERTY_KEY_HDFS_CONF_PATH), hiveAdminUser);
+      fs = getFileSystem(hivePersonalDataSource.getHdfsConfPath(), hiveAdminUser);
       if (!fs.exists(path)) {
         try {
           fs.mkdirs(path);

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/hive/HivePersonalDatasource.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/hive/HivePersonalDatasource.java
@@ -1,0 +1,50 @@
+package app.metatron.discovery.domain.workbench.hive;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.Serializable;
+import java.util.Map;
+
+public class HivePersonalDatasource implements Serializable {
+  private String hdfsConfPath;
+  private String adminName;
+  private String adminPassword;
+  private String personalDatabasePrefix;
+
+  public HivePersonalDatasource(Map<String, String> properties) {
+    this.hdfsConfPath = properties.getOrDefault("hdfs-conf-path", "");
+    this.adminName = properties.getOrDefault("admin-name", "");
+    this.adminPassword = properties.getOrDefault("admin-password", "");
+    this.personalDatabasePrefix = properties.getOrDefault("personal-database-prefix", "");
+  }
+
+  public HivePersonalDatasource(String hdfsConfPath, String adminName, String adminPassword, String personalDatabasePrefix) {
+    this.hdfsConfPath = hdfsConfPath;
+    this.adminName = adminName;
+    this.adminPassword = adminPassword;
+    this.personalDatabasePrefix = personalDatabasePrefix;
+  }
+
+  public String getHdfsConfPath() {
+    return hdfsConfPath;
+  }
+
+  public String getAdminName() {
+    return adminName;
+  }
+
+  public String getAdminPassword() {
+    return adminPassword;
+  }
+
+  public String getPersonalDatabasePrefix() {
+    return personalDatabasePrefix;
+  }
+
+  public boolean isValidate() {
+    return StringUtils.isNotEmpty(this.hdfsConfPath)
+      && StringUtils.isNotEmpty(this.adminName)
+      && StringUtils.isNotEmpty(this.adminPassword)
+      && StringUtils.isNotEmpty(this.personalDatabasePrefix);
+  }
+}

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/hive/WorkbenchHiveService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/hive/WorkbenchHiveService.java
@@ -14,23 +14,7 @@
 
 package app.metatron.discovery.domain.workbench.hive;
 
-import com.google.common.collect.Maps;
-
-import org.apache.hadoop.fs.Path;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
-import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.sql.Connection;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
+import app.metatron.discovery.common.ConnectionConfigProperties;
 import app.metatron.discovery.common.MetatronProperties;
 import app.metatron.discovery.common.exception.BadRequestException;
 import app.metatron.discovery.common.exception.GlobalErrorCodes;
@@ -46,6 +30,22 @@ import app.metatron.discovery.domain.workbench.dto.ImportFile;
 import app.metatron.discovery.domain.workbench.util.WorkbenchDataSource;
 import app.metatron.discovery.domain.workbench.util.WorkbenchDataSourceManager;
 import app.metatron.discovery.util.csv.CsvTemplate;
+import com.google.common.collect.Maps;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 public class WorkbenchHiveService {
@@ -61,6 +61,8 @@ public class WorkbenchHiveService {
   private JdbcConnectionService jdbcConnectionService;
 
   private MetatronProperties metatronProperties;
+
+  private ConnectionConfigProperties connectionConfigProperties;
 
   @Autowired
   public void setWorkbenchProperties(WorkbenchProperties workbenchProperties) {
@@ -82,10 +84,18 @@ public class WorkbenchHiveService {
     this.metatronProperties = metatronProperties;
   }
 
+  @Autowired
+  public void setConnectionConfigProperties(ConnectionConfigProperties connectionConfigProperties) {
+    this.connectionConfigProperties = connectionConfigProperties;
+  }
+
   public void importFileToPersonalDatabase(DataConnection hiveConnection, ImportFile importFile) {
     DataTable dataTable = convertUploadFileToDataTable(importFile);
 
-    String hdfsDataFilePath = dataTableHiveRepository.saveToHdfs(hiveConnection, new Path(workbenchProperties.getTempDataTableHdfsPath()), dataTable);
+    final String hivePersonalDataSourceName = hiveConnection.getPropertiesMap().get(HiveDialect.PROPERTY_KEY_PROPERTY_GROUP_NAME);
+    HivePersonalDatasource hivePersonalDataSource = findHivePersonalDataSourceByName(hivePersonalDataSourceName);
+
+    String hdfsDataFilePath = dataTableHiveRepository.saveToHdfs(hivePersonalDataSource, new Path(workbenchProperties.getTempDataTableHdfsPath()), dataTable);
 
     SavingHiveTable savingHiveTable = new SavingHiveTable();
     savingHiveTable.setTableName(importFile.getTableName());
@@ -93,13 +103,30 @@ public class WorkbenchHiveService {
     savingHiveTable.setHdfsDataFilePath(hdfsDataFilePath);
     savingHiveTable.setWebSocketId(importFile.getWebSocketId());
     savingHiveTable.setLoginUserId(importFile.getLoginUserId());
-    saveAsHiveTableFromHdfsDataTable(hiveConnection, savingHiveTable);
+
+    saveAsHiveTableFromHdfsDataTable(hiveConnection, hivePersonalDataSource, savingHiveTable);
   }
 
-  private void saveAsHiveTableFromHdfsDataTable(DataConnection hiveConnection, SavingHiveTable savingHiveTable) {
-    String saveAsTableScript = generateSaveAsTableScript(hiveConnection, savingHiveTable);
+  private HivePersonalDatasource findHivePersonalDataSourceByName(String dataSourceName) {
+    if(StringUtils.isEmpty(dataSourceName)) {
+      LOGGER.error(String.format("Not found hive personal datasource name : %s", dataSourceName));
+      throw new MetatronException(GlobalErrorCodes.DEFAULT_GLOBAL_ERROR_CODE, "Failed save as hive table.");
+    }
+    Map<String, String> findProperties = connectionConfigProperties.findPropertyGroupByName(dataSourceName);
+    HivePersonalDatasource hivePersonalDatasource = new HivePersonalDatasource(findProperties);
+    if(hivePersonalDatasource.isValidate()) {
+      return hivePersonalDatasource;
+    } else {
+      LOGGER.error(String.format("Invalid hive personal datasource : %s", dataSourceName));
+      throw new MetatronException(GlobalErrorCodes.DEFAULT_GLOBAL_ERROR_CODE, "Failed save as hive table.");
+    }
+  }
+
+  private void saveAsHiveTableFromHdfsDataTable(DataConnection hiveConnection, HivePersonalDatasource hivePersonalDataSource, SavingHiveTable savingHiveTable) {
+    String saveAsTableScript = generateSaveAsTableScript(hivePersonalDataSource, savingHiveTable);
     WorkbenchDataSource dataSourceInfo = workbenchDataSourceManager.findDataSourceInfo(savingHiveTable.getWebSocketId());
-    Connection secondaryConnection = dataSourceInfo.getSecondaryConnection();
+
+    Connection secondaryConnection = dataSourceInfo.getSecondaryConnection(hivePersonalDataSource.getAdminName(), hivePersonalDataSource.getAdminPassword());
 
     List<String> queryList = Arrays.asList(saveAsTableScript.split(";"));
     for (String query : queryList) {
@@ -114,10 +141,10 @@ public class WorkbenchHiveService {
     }
   }
 
-  private String generateSaveAsTableScript(DataConnection hiveConnection, SavingHiveTable savingHiveTable) {
+  private String generateSaveAsTableScript(HivePersonalDatasource hivePersonalDataSource, SavingHiveTable savingHiveTable) {
     StringBuffer script = new StringBuffer();
     // 1. Create Database
-    final String personalDatabaseName = String.format("%s_%s", hiveConnection.getPropertiesMap().get(HiveDialect.PROPERTY_KEY_PERSONAL_DATABASE_PREFIX),
+    final String personalDatabaseName = String.format("%s_%s", hivePersonalDataSource.getPersonalDatabasePrefix(),
         HiveNamingRule.replaceNotAllowedCharacters(savingHiveTable.getLoginUserId()));
     script.append(String.format("CREATE DATABASE IF NOT EXISTS %s;", personalDatabaseName));
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/util/WorkbenchDataSource.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbench/util/WorkbenchDataSource.java
@@ -155,9 +155,9 @@ public class WorkbenchDataSource {
     return primaryConnection;
   }
 
-  public Connection getSecondaryConnection() {
+  public Connection getSecondaryConnection(String username, String password) {
     if(secondaryConnection == null){
-      secondaryConnection = createSecondaryConnection();
+      secondaryConnection = createSecondaryConnection(username, password);
     }
     return secondaryConnection;
   }
@@ -200,14 +200,14 @@ public class WorkbenchDataSource {
     return getCloseSuppressingConnectionProxy(originalPrimaryConnection);
   }
 
-  private Connection createSecondaryConnection(){
+  private Connection createSecondaryConnection(String username, String password){
     JdbcDialect jdbcDialect = DataConnectionHelper.lookupDialect(connectionInfo);
 
-    Map<String, String> propMap = connectionInfo.getPropertiesMap();
-    String hiveAdminUserName = propMap.get(HiveDialect.PROPERTY_KEY_ADMIN_NAME);
-    String hiveAdminUserPassword = propMap.get(HiveDialect.PROPERTY_KEY_ADMIN_PASSWORD);
+//    Map<String, String> propMap = connectionInfo.getPropertiesMap();
+//    String hiveAdminUserName = propMap.get(HiveDialect.PROPERTY_KEY_ADMIN_NAME);
+//    String hiveAdminUserPassword = propMap.get(HiveDialect.PROPERTY_KEY_ADMIN_PASSWORD);
 
-    originalSecondaryConnection = jdbcConnector.getConnection(connectionInfo, jdbcDialect, connectionInfo.getDatabase(), true, hiveAdminUserName, hiveAdminUserPassword);
+    originalSecondaryConnection = jdbcConnector.getConnection(connectionInfo, jdbcDialect, connectionInfo.getDatabase(), true, username, password);
     return getCloseSuppressingConnectionProxy(originalSecondaryConnection);
   }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/util/ApplicationContextProvider.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/util/ApplicationContextProvider.java
@@ -1,0 +1,20 @@
+package app.metatron.discovery.util;
+
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ApplicationContextProvider implements ApplicationContextAware {
+  private static ApplicationContext context;
+
+  @Override
+  public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+    context = applicationContext;
+  }
+
+  public static ApplicationContext getApplicationContext() {
+    return context;
+  }
+}

--- a/discovery-server/src/test/java/app/metatron/discovery/TestLocalHdfs.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/TestLocalHdfs.java
@@ -27,9 +27,7 @@ public class TestLocalHdfs {
   final static String localHdfsSuperUser = "yooyoungmo";
   final Configuration configuration;
 
-  public TestLocalHdfs() {
-    String hdfsConfLocalPath = Paths.get("src/test/hdfs-conf").toAbsolutePath().toString();
-
+  public TestLocalHdfs(String hdfsConfLocalPath) {
     Configuration conf = new Configuration();
     conf.addResource(new Path(String.format("%s/core-site.xml", hdfsConfLocalPath)));
     conf.addResource(new Path(String.format("%s/hdfs-site.xml", hdfsConfLocalPath)));

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/workbench/hive/DataTableHiveRepositoryTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/workbench/hive/DataTableHiveRepositoryTest.java
@@ -25,13 +25,12 @@ import java.util.List;
 import java.util.Map;
 
 import app.metatron.discovery.TestLocalHdfs;
-import app.metatron.discovery.domain.dataconnection.DataConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 
 public class DataTableHiveRepositoryTest {
-  final TestLocalHdfs testLocalHdfs = new TestLocalHdfs();
+  final TestLocalHdfs testLocalHdfs = new TestLocalHdfs("/tmp/hdfs-conf");
 
   @Before
   public void setUp() throws IOException, InterruptedException {
@@ -41,8 +40,6 @@ public class DataTableHiveRepositoryTest {
   @Test
   public void saveToHdfs() throws IOException, InterruptedException {
     // given
-    DataConnection hiveConnection = getHiveConnection();
-
     List<String> fields = Arrays.asList("records.year", "records.temperature", "records.quality");
 
     List<Map<String, Object>> records = new ArrayList<>();
@@ -61,26 +58,11 @@ public class DataTableHiveRepositoryTest {
 
     // when
     final DataTableHiveRepository dataTableHiveRepository = new DataTableHiveRepository();
-    String filePath = dataTableHiveRepository.saveToHdfs(hiveConnection, new Path("/tmp/metatron/test"), dataTable);
+
+    HivePersonalDatasource hivePersonalDatasource = new HivePersonalDatasource("/tmp/hdfs-conf", "hive_admin", "1111", "private");
+    String filePath = dataTableHiveRepository.saveToHdfs(hivePersonalDatasource, new Path("/tmp/metatron/test"), dataTable);
 
     // then
     assertThat(testLocalHdfs.exists(new Path(filePath))).isTrue();
   }
-
-  private DataConnection getHiveConnection() {
-    DataConnection hiveConnection = new DataConnection("HIVE");
-    hiveConnection.setUsername("read_only");
-    hiveConnection.setPassword("1111");
-    hiveConnection.setHostname("localhost");
-    hiveConnection.setPort(10000);
-    hiveConnection.setProperties("{" +
-        "  \"metatron.hdfs.conf.path\": \"/tmp/hdfs-conf\"," +
-        "  \"metatron.hive.admin.name\": \"hive_admin\"," +
-        "  \"metatron.hive.admin.password\": \"1111\"," +
-        "  \"metatron.personal.database.prefix\": \"private\"" +
-        "}");
-
-    return hiveConnection;
-  }
-
 }

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/workbench/hive/WorkbenchHiveServiceTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/workbench/hive/WorkbenchHiveServiceTest.java
@@ -20,7 +20,6 @@ import org.mockito.ArgumentCaptor;
 import java.util.UUID;
 
 import app.metatron.discovery.domain.dataconnection.DataConnection;
-import app.metatron.discovery.domain.dataconnection.dialect.HiveDialect;
 import app.metatron.discovery.domain.datasource.connection.jdbc.JdbcConnectionService;
 import app.metatron.discovery.domain.workbench.WorkbenchProperties;
 import app.metatron.discovery.domain.workbench.dto.ImportCsvFile;
@@ -50,7 +49,9 @@ public class WorkbenchHiveServiceTest {
 
     DataTableHiveRepository mockDataTableHiveRepository = mock(DataTableHiveRepository.class);
     final String savedFilePath = String.format("/tmp/metatron/%s.dat", UUID.randomUUID().toString());
-    when(mockDataTableHiveRepository.saveToHdfs(eq(hiveConnection), anyObject(), anyObject())).thenReturn(savedFilePath);
+
+    HivePersonalDatasource hivePersonalDatasource = new HivePersonalDatasource("/tmp/hdfs-conf", "hive_admin", "1111", "private");
+    when(mockDataTableHiveRepository.saveToHdfs(eq(hivePersonalDatasource), anyObject(), anyObject())).thenReturn(savedFilePath);
     workbenchHiveService.setDataTableHiveRepository(mockDataTableHiveRepository);
 
     JdbcConnectionService mockJdbcConnectionService = mock(JdbcConnectionService.class);
@@ -74,7 +75,7 @@ public class WorkbenchHiveServiceTest {
     // saveToHdfs
     ArgumentCaptor<Path> argPath = ArgumentCaptor.forClass(Path.class);
     ArgumentCaptor<DataTable> argDataTable = ArgumentCaptor.forClass(DataTable.class);
-    verify(mockDataTableHiveRepository).saveToHdfs(eq(hiveConnection), argPath.capture(), argDataTable.capture());
+    verify(mockDataTableHiveRepository).saveToHdfs(eq(hivePersonalDatasource), argPath.capture(), argDataTable.capture());
     assertThat(argPath.getValue().toString()).isEqualTo("/tmp/metatron");
     assertThat(argDataTable.getValue().getFields()).hasSize(5);
     assertThat(argDataTable.getValue().getFields()).contains("time", "order_id", "amount", "product_id", "sale_count");
@@ -88,19 +89,19 @@ public class WorkbenchHiveServiceTest {
     // saveAsHiveTable
     ArgumentCaptor<String> queries = ArgumentCaptor.forClass(String.class);
     verify(mockJdbcConnectionService, times(3)).executeUpdate(eq(hiveConnection),
-        eq(workbenchDataSourceManager.findDataSourceInfo(webSocketId).getSecondaryConnection()),
+        eq(workbenchDataSourceManager.findDataSourceInfo(webSocketId).getSecondaryConnection(hivePersonalDatasource.getAdminName(), hivePersonalDatasource.getAdminPassword())),
         queries.capture());
     assertThat(queries.getAllValues()).hasSize(3);
     assertThat(queries.getAllValues().get(0))
         .isEqualTo(String.format("CREATE DATABASE IF NOT EXISTS %s_%s",
-                                 hiveConnection.getPropertiesMap().get(HiveDialect.PROPERTY_KEY_PERSONAL_DATABASE_PREFIX), metatronUserId));
+            hivePersonalDatasource.getPersonalDatabasePrefix(), metatronUserId));
     assertThat(queries.getAllValues().get(1))
         .isEqualTo(
             String.format("CREATE TABLE %s_%s.%s (`time` STRING, `order_id` STRING, `amount` STRING, `product_id` STRING, `sale_count` STRING) ROW FORMAT DELIMITED FIELDS TERMINATED BY '\\001' LINES TERMINATED BY '\\n'",
-                hiveConnection.getPropertiesMap().get(HiveDialect.PROPERTY_KEY_PERSONAL_DATABASE_PREFIX), metatronUserId, importFile.getTableName()));
+                hivePersonalDatasource.getPersonalDatabasePrefix(), metatronUserId, importFile.getTableName()));
     assertThat(queries.getAllValues().get(2))
         .isEqualTo(String.format("LOAD DATA INPATH '%s' OVERWRITE INTO TABLE %s_%s.%s",
-            savedFilePath, hiveConnection.getPropertiesMap().get(HiveDialect.PROPERTY_KEY_PERSONAL_DATABASE_PREFIX), metatronUserId, importFile.getTableName()));
+            savedFilePath, hivePersonalDatasource.getPersonalDatabasePrefix(), metatronUserId, importFile.getTableName()));
   }
 
   private DataConnection getHiveConnection() {
@@ -110,13 +111,9 @@ public class WorkbenchHiveServiceTest {
     hiveConnection.setHostname("localhost");
     hiveConnection.setPort(10000);
     hiveConnection.setProperties("{" +
-        "  \"metatron.hdfs.conf.path\": \"/tmp/hdfs-conf\"," +
-        "  \"metatron.hive.admin.name\": \"hive_admin\"," +
-        "  \"metatron.hive.admin.password\": \"1111\"," +
-        "  \"metatron.personal.database.prefix\": \"private\"" +
+        "  \"metatron.property.group.name\": \"group1\"" +
         "}");
 
     return hiveConnection;
   }
-
 }

--- a/discovery-server/src/test/resources/sql/workbench.sql
+++ b/discovery-server/src/test/resources/sql/workbench.sql
@@ -1,10 +1,10 @@
 
-INSERT INTO DATACONNECTION(DC_IMPLEMENTOR, ID, CREATED_BY, CREATED_TIME, MODIFIED_BY, MODIFIED_TIME, VERSION, DC_DESC, DC_HOSTNAME, DC_NAME, DC_OPTIONS, DC_PASSWORD, DC_PORT, DC_TYPE, DC_URL, DC_USERNAME, DC_DATABASE, PATH, DC_CATALOG, DC_SID, REMOVEFIRSTROW, DC_PROPERTIES) VALUES
-('STAGE', 'stage-hive-connection-for-test', 'polaris', now(), 'polaris', now(), 0, NULL, 'localhost', 'hive-local', NULL, 'hive', 10000, 'JDBC', NULL, 'hive', NULL, NULL, NULL, NULL, NULL, NULL),
-('HIVE', 'hive-local', 'polaris', now(), 'polaris', now(), 0, NULL, 'localhost', 'hive-local', NULL, 'hive', 10000, 'JDBC', NULL, 'hive', NULL, NULL, NULL, NULL, NULL, NULL),
-('MYSQL', 'mysql-local', 'polaris', now(), 'polaris', now(), 0, NULL, 'localhost', 'mysql-local', NULL, 'polaris', 3306, 'JDBC', NULL, 'polaris', NULL, NULL, NULL, NULL, NULL, NULL),
-('PRESTO', 'presto-local', 'polaris', now(), 'polaris', now(), 0, NULL, 'localhost', 'presto-local', NULL, 'hive', 8080, 'JDBC', NULL, 'hive', NULL, NULL, 'hive', NULL, NULL, NULL),
-('HIVE', 'hive-local-enable-save-as-hive-table', 'polaris', now(), 'polaris', now(), 0, NULL, 'localhost', 'hive-local-enable-save-as-hive-table', NULL, 'hive', 10000, 'JDBC', NULL, 'hive', NULL, NULL, NULL, NULL, NULL, '{"metatron.hive.admin.name":"hive_admin","metatron.hive.admin.password":"1111","metatron.personal.database.prefix":"private","metatron.hdfs.conf.path":"/tmp/hdfs-conf"}');
+INSERT INTO DATACONNECTION(DC_IMPLEMENTOR, ID, CREATED_BY, CREATED_TIME, MODIFIED_BY, MODIFIED_TIME, VERSION, DC_DESC, DC_HOSTNAME, DC_NAME, DC_OPTIONS, DC_PASSWORD, DC_PORT, DC_TYPE, DC_URL, DC_USERNAME, DC_DATABASE, DC_CATALOG, DC_SID, DC_PROPERTIES) VALUES
+('STAGE', 'stage-hive-connection-for-test', 'polaris', now(), 'polaris', now(), 0, NULL, 'localhost', 'hive-local', NULL, 'hive', 10000, 'JDBC', NULL, 'hive', NULL, NULL, NULL, NULL),
+('HIVE', 'hive-local', 'polaris', now(), 'polaris', now(), 0, NULL, 'localhost', 'hive-local', NULL, 'hive', 10000, 'JDBC', NULL, 'hive', NULL, NULL, NULL, NULL),
+('MYSQL', 'mysql-local', 'polaris', now(), 'polaris', now(), 0, NULL, 'localhost', 'mysql-local', NULL, 'polaris', 3306, 'JDBC', NULL, 'polaris', NULL, NULL, NULL, NULL),
+('PRESTO', 'presto-local', 'polaris', now(), 'polaris', now(), 0, NULL, 'localhost', 'presto-local', NULL, 'hive', 8080, 'JDBC', NULL, 'hive', NULL, 'hive', NULL, NULL),
+('HIVE', 'hive-local-enable-save-as-hive-table', 'polaris', now(), 'polaris', now(), 0, NULL, 'localhost', 'hive-local-enable-save-as-hive-table', NULL, 'hive', 10000, 'JDBC', NULL, 'hive', NULL, NULL, NULL, '{"metatron.property.group.name":"group1"}');
 
 INSERT INTO book (type,id, created_by, created_time, modified_by, modified_time,version,book_desc,book_favorite,book_folder_id,book_name,book_tag,ws_id) VALUES
 ('workbench','workbench-01','admin',NOW(),'admin',NOW(),1.0,'',FALSE,'','TEST-Workbench-01','','ws-00'),


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#2821

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1.. 메타트론 application.yaml에 propertyGroup 추가
```yaml
polaris:
  connection:
      property-group:
        group1:
          hdfs-conf-path: /test1/hdfs-conf
          admin-name: admin
          admin-password: 1111
          personal-database-prefix: private
        group2:
          hdfs-conf-path: /test2/hdfs-conf
          admin-name: admin
          admin-password: qwer
          personal-database-prefix: pv
```
2. Hive connection을 만들고 커스텀 프로퍼티 `metatron.property.group.name` 에 group1 을 입력하여 기존과 동일하게 동작하는 것을 확인하였습니다.
![image](https://user-images.githubusercontent.com/16472109/68567582-aea9e300-049c-11ea-8d89-ff8f4691901b.png)

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
