### PR TITLE
fix code table, column dictionary, chart color setting css error

### DIFF
--- a/discovery-frontend/src/app/meta-data-management/code-table/code-table.component.html
+++ b/discovery-frontend/src/app/meta-data-management/code-table/code-table.component.html
@@ -23,6 +23,8 @@
         [defaultType]="defaultDate?.type"
         [dateType]="false"
         [roundSecond]="true"
+        [startPlaceholder]="'msg.storage.ui.criterion.time.past' | translate"
+        [endPlaceholder]="'msg.storage.ui.criterion.time.current' | translate"
         (changeDate)="onChangeData($event)"
         [title]="'msg.metadata.ui.codetable.created.date' | translate"
       ></component-period>
@@ -81,7 +83,7 @@
     <tbody>
     <tr *ngFor="let codeTable of codeTableList" (click)="onClickDetailCodeTable(codeTable.id)">
       <td>
-        {{codeTable.name}}
+        <span class="ddp-txt-long">{{codeTable.name}}</span>
       </td>
       <td>
         <span class="ddp-txt-long">{{codeTable.description}}</span>

--- a/discovery-frontend/src/assets/css/metatron/component/component.form.css
+++ b/discovery-frontend/src/assets/css/metatron/component/component.form.css
@@ -382,6 +382,7 @@ ul.ddp-list-value li.ddp-data-none {background:none; color:#b7b9c3;}
 
 /* table code */
 .ddp-box-layout4 .ddp-data-code {padding:14px 15px 20px 15px; max-height:250px; overflow:auto; box-sizing:border-box;}
+.ddp-box-layout4 .ddp-data-title +.ddp-data-code {padding-top:0; white-space:normal;}
 .ddp-box-layout4 .ddp-data-title +.ddp-data-code {padding-top:0;}
 .ddp-box-layout4 .ddp-table-code {width:100%;}
 .ddp-box-layout4 .ddp-data-code.ddp-size {max-height:initial; overflow:inherit;}

--- a/discovery-frontend/src/assets/css/metatron/page.css
+++ b/discovery-frontend/src/assets/css/metatron/page.css
@@ -4597,8 +4597,8 @@ em.ddp-icon-line-curve,.ddp-list-express em.ddp-icon-cross
 .ddp-wrap-colorby-button button[class*="ddp-btn-color"] {width:100%; background-size:100% 100% !important;}
 
 button[class*="ddp-btn-color-series"],
-button[class*="ddp-btn-color-"]{display:inline-block; position:relative; width:235px; height:25px;cursor: pointer;}
-button[class*="ddp-btn-color2-series"] {display:inline-block; position:relative; width:235px; height:25px; cursor: pointer;}
+button[class*="ddp-btn-color-"]{display:inline-block; position:relative; width:100%; height:25px;cursor: pointer;}
+button[class*="ddp-btn-color2-series"] {display:inline-block; position:relative; width:100%; height:25px; cursor: pointer;}
 button[class*="ddp-btn-color"].ddp-selected:before {display:inline-block; content:''; position:absolute; top:0; left:0; right:0; bottom:0; border-radius:4px; border:3px solid #4b515b; z-index:10; overflow:hidden;}
 button[class*="ddp-btn-color"].ddp-selected:after {display:inline-block; content:''; position:absolute; top:3px; left:3px; right:3px; bottom:3px; border-radius:2px; border:1px solid #fff;}
 button.ddp-btn-color-series1.ddp-type {background:url(../../images/img_color_01_type.png) no-repeat;}
@@ -9669,7 +9669,8 @@ table.ddp-table-type2 tbody tr td .ddp-pop-select .ddp-table-pop tr:nth-child(od
 table.ddp-table-type2 tbody tr td .ddp-pop-select .ddp-txt-link {font-weight:bold;}
 table.ddp-table-type2 tbody tr td .ddp-pop-select.ddp-selected .ddp-txt-link {text-decoration:underline;}
 table.ddp-table-type2 tbody tr td .ddp-pop-select.ddp-selected .ddp-txt-link.type-underline-none {text-decoration:none;}
-table.ddp-table-type2 tbody tr td .ddp-pop-select .ddp-box-layout4.type-dictionary {width:300px; max-height:300px; overflow:auto;}
+table.ddp-table-type2 tbody tr td .ddp-pop-select .ddp-box-layout4.type-dictionary {width:300px; overflow:auto; white-space:normal;}
+table.ddp-table-type2 tbody tr td .ddp-pop-select .ddp-box-layout4.type-dictionary .ddp-data-title {white-space:nowrap; text-overflow:ellipsis; overflow:hidden;}
 table.ddp-table-type2 tbody tr td .ddp-box-hover {display:inline-block;}
 table.ddp-table-type2 tbody tr td .ddp-box-hover a {display:inline-block; position:relative; color:#4b525b; font-size:12px; text-decoration:underline; font-style:italic;}
 table.ddp-table-type2 tbody tr td .ddp-box-hover .ddp-box-layout4 {display:none; position:absolute; right:0; top:30px;}

--- a/discovery-frontend/src/assets/css/theme_dark/component/component.form.css
+++ b/discovery-frontend/src/assets/css/theme_dark/component/component.form.css
@@ -1669,7 +1669,7 @@
 }
 
 .theme-dark .ddp-box-layout4 .ddp-data-title + .ddp-data-code {
-    padding-top: 0;
+  padding-top: 0; white-space:normal;
 }
 
 .theme-dark .ddp-box-layout4 .ddp-table-code {

--- a/discovery-frontend/src/assets/css/theme_dark/metatron/page.css
+++ b/discovery-frontend/src/assets/css/theme_dark/metatron/page.css
@@ -21204,7 +21204,7 @@
 .theme-dark button[class*="ddp-btn-color-"] {
     display: inline-block;
     position: relative;
-    width: 235px;
+    width: 100%;
     height: 25px;
     cursor: pointer;
 }
@@ -21212,7 +21212,7 @@
 .theme-dark button[class*="ddp-btn-color2-series"] {
     display: inline-block;
     position: relative;
-    width: 235px;
+    width: 100%;
     height: 25px;
     cursor: pointer;
 }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
fix column dictionary layer, chart color setting align, code table title ellipsis

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Exploration -> data -> click metadata -> column tab
hover column dictionary has long description and title. -> Check scroll is not showing
2. Explore -> metadata -> code table tab -> Check title shows properly with ellipsis
3. Workspace -> workbook -> edit dashboard -> choose one chart -> color setting tab -> choose measure -> click color template icon -> check each color template's width aligned properly
#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
