### PR TITLE
#2756 remove initial profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,13 +113,11 @@ export METATRON_DB_TYPE=mysql
 ```
 
 #### Run Metatron Discovery
-Initialize and run with the following command.
-<pre><code>$ bin/metatron.sh --init start</code></pre>
-> :warning: Cautions! `--init` option initialize whole data.  
-> Add this argument only the first time or when you want to reset your development environment.
+Run with the following command.
+<pre><code>$ bin/metatron.sh start</code></pre>
 
 Running options are provided as well.
-<pre><code>$ bin/metatron.sh [--config=directory] [--init] [--management] [--debug=port] {start|stop|restart|status}</code></pre>
+<pre><code>$ bin/metatron.sh [--config=directory] [--management] [--debug=port] {start|stop|restart|status}</code></pre>
 To access Metatron Discovery, go to [http://localhost:8180](http://localhost:8180). (The default admin user account is provided as Username: admin, PW: admin.)
 
 ### Using REST API

--- a/discovery-distribution/bin/metatron.sh
+++ b/discovery-distribution/bin/metatron.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 USAGE="-e Usage: metatron.sh\n\t
-        [--config=directory] [--init] [--management] [--debug=port] {start|stop|restart|status}"
+        [--config=directory] [--management] [--debug=port] {start|stop|restart|status}"
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -14,9 +14,6 @@ while [ $# -gt 0 ]; do
       else
         export METATRON_CONF_DIR="${conf_dir}"
       fi
-      ;;
-    --init)
-      METATRON_INIT_MODE=",initial"
       ;;
     --management)
       METATRON_MGMT_MODE=",management"
@@ -89,7 +86,7 @@ else
 fi
 
 
-METATRON_APP_PROFILE="${METATRON_DB_TYPE}-default-db,logging-console-debug,scheduling${METATRON_MGMT_MODE}${METATRON_PREP_MODE}${METATRON_EXTRA_PROFILE}${METATRON_INIT_MODE}"
+METATRON_APP_PROFILE="${METATRON_DB_TYPE}-default-db,logging-console-debug,scheduling${METATRON_MGMT_MODE}${METATRON_PREP_MODE}${METATRON_EXTRA_PROFILE}
 METATRON_OPTION="--loader.system=true --spring.config.location=classpath:application.yaml${METATRON_CONF_FILE}"
 METATRON_OPTION="${METATRON_OPTION} --spring.profiles.active=${METATRON_APP_PROFILE}"
 

--- a/discovery-server/src/main/resources/application.yaml
+++ b/discovery-server/src/main/resources/application.yaml
@@ -233,18 +233,18 @@ polaris:
 #      exposedHeaders: "*"
 #      allowCredentials: false
 #      maxAge: 3600
----
-spring:
-  profiles: initial
-  datasource:
-    initialize: true
-  jpa:
-    properties:
-      hibernate:
-        hbm2ddl:
-          auto: create
-          import_files: /scripts/default.sql,/scripts/default_expressions.sql,/scripts/default_datasource_ingestion_options.sql
-          import_files_sql_extractor: org.hibernate.tool.hbm2ddl.MultipleLinesSqlCommandExtractor
+#---
+#spring:
+#  profiles: initial
+#  datasource:
+#    initialize: true
+#  jpa:
+#    properties:
+#      hibernate:
+#        hbm2ddl:
+#          auto: create
+#          import_files: /scripts/default.sql,/scripts/default_expressions.sql,/scripts/default_datasource_ingestion_options.sql
+#          import_files_sql_extractor: org.hibernate.tool.hbm2ddl.MultipleLinesSqlCommandExtractor
 ---
 spring:
   profiles: local


### PR DESCRIPTION
### Description
Since initial-changelog xml is created for users who run the metatron-discovery application for the first time, delete the initial profile to initialize the development environment.
Also delete the contents of init profile in READEME.md.

Users must initialize the database manually for initialization.

**Related Issue** : #2756 


### How Has This Been Tested?
run below command without initialization and error.
```
$ bin/metatron.sh --init
```

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
