### PR TITLE
#fix paging of the dataflow list on return from the dataflow detail page

### DIFF
--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/dataflow-detail2.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/dataflow-detail2.component.ts
@@ -246,7 +246,9 @@ export class DataflowDetail2Component extends AbstractPopupComponent {
    * 뒤로가기
    * */
   public close() {
-    this.router.navigate(['/management/datapreparation/dataflow']);
+    this.router.navigate(['/management/datapreparation/dataflow'],
+      {queryParams: {backFromDetail:true}}
+    );
   }
 
   // 다른 데이터 플로우로 이동

--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow.component.ts
@@ -97,6 +97,12 @@ export class DataflowComponent extends AbstractComponent implements OnInit, OnDe
 
         if (!_.isEmpty(params)) {
 
+          if (!isNullOrUndefined(params['backFromDetail'])) {
+            if( params['backFromDetail']==='true' ) {
+              params = this.dataflowService.getParamsForDataflowList();
+            }
+          }
+
           if (!isNullOrUndefined(params['size'])) {
             this.page.size = params['size'];
           }
@@ -160,6 +166,8 @@ export class DataflowComponent extends AbstractComponent implements OnInit, OnDe
    * @param dfId
    */
   public goToDfDetail(dfId) {
+    const params = this._getDfParams();
+    this.dataflowService.setParamsForDataflowList(params);
     this.router.navigate(
       ['/management/datapreparation/dataflow',dfId])
       .then();

--- a/discovery-frontend/src/app/data-preparation/dataflow/service/dataflow.service.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/service/dataflow.service.ts
@@ -30,11 +30,21 @@ import {SnapShotCreateDomain} from "../../component/create-snapshot-popup.compon
 @Injectable()
 export class DataflowService extends AbstractService {
 
+  private dataflowListParams: any = null;
+
   constructor(protected injector: Injector,
               private popupService: PopupService,
               public translateService: TranslateService
   ) {
     super(injector);
+  }
+
+  public getParamsForDataflowList() {
+    return this.dataflowListParams?this.dataflowListParams:{};
+  }
+
+  public setParamsForDataflowList(params: any) {
+    this.dataflowListParams = params;
   }
 
   // 데이터 플로우 목록 조회


### PR DESCRIPTION
### Description
when you come back to the dataflow list page from the dataflow detail page
always the first page is shown

![3 4 1-rc3-01](https://user-images.githubusercontent.com/42264835/68735116-fd33ba80-061f-11ea-85dd-748878f18e92.gif)

### How Has This Been Tested?
1. go to the dataflow list
2. load the next page
3. go to any detail page
4. back to the list page
make sure it's the list you saw earlier

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
