### PR TITLE
#2844 blank grid on multiple rename page

### DIFF
--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/multiple-rename-popup.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/multiple-rename-popup.component.ts
@@ -923,45 +923,11 @@ export class MultipleRenamePopupComponent extends AbstractComponent implements O
       if ('TIMESTAMP' === type) {
         // 단일 데이터에 대한 타임 스템프 처리
         strFormatVal = this._setTimeStampFormat(value, colDescs.timestampStyle);
-      } else if ('ARRAY' === type) {
-        // 배열 형식내 각 항목별 타임 스템프 처리
-        const arrColDescs = colDescs.arrColDesc ? colDescs.arrColDesc : {};
-        strFormatVal = JSON.stringify(
-          value.map((item: any, idx: number) => {
-            const colDesc = arrColDescs[idx] ? arrColDescs[idx] : {};
-            if ('TIMESTAMP' === colDesc['type']) {
-              return this._setTimeStampFormat(item, colDesc['timestampStyle']);
-            } else {
-              // 재귀 호출 부분
-              const tempResult: string = this._setFieldFormatter(item, colDesc['type'], colDesc);
-              // array, map 타임의 경우 stringify가 중복 적용되기에 parse 처리 해줌
-              return ('ARRAY' === colDesc['type'] || 'MAP' === colDesc['type']) ? JSON.parse(tempResult) : tempResult;
-            }
-          })
-        );
-      } else if ('MAP' === type) {
-        // 구조체내 각 항목별 타임 스템프 처리
-        const mapColDescs = colDescs.mapColDesc ? colDescs.mapColDesc : {};
-        let newMapValue = {};
-        for (let key in value) {
-          if (value.hasOwnProperty(key)) {
-            const colDesc = mapColDescs.hasOwnProperty(key) ? mapColDescs[key] : {};
-            if ('TIMESTAMP' === colDesc['type']) {
-              newMapValue[key] = this._setTimeStampFormat(value[key], colDesc['timestampStyle']);
-            } else {
-              // 재귀 호출 부분
-              const tempResult: string = this._setFieldFormatter(value[key], colDesc['type'], colDesc);
-              // array, map 타임의 경우 stringify가 중복 적용되기에 parse 처리 해줌
-              newMapValue[key]
-                = ('ARRAY' === colDesc['type'] || 'MAP' === colDesc['type']) ? JSON.parse(tempResult) : tempResult;
-            }
-          }
-        }
-        strFormatVal = JSON.stringify(newMapValue);
       } else {
         strFormatVal = <string>value;
       }
     } else {
+      // array and map are regarded as string
       strFormatVal = <string>value;
     }
 


### PR DESCRIPTION
### Description
multiply rename column popup shows blank grid

**Related Issue** : 
[2844](https://github.com/metatron-app/metatron-discovery/issues/2844)

### How Has This Been Tested?
1. make a dataset has MAP type column
2. go to the edit rule page of the dataflow details
3. add a rule for rename
4. select the multiply rename
5. the grid of the popup should be shown well



### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
