### PR TITLE
#fix there is no margin at the top of dataflow list

### DIFF
--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow.component.html
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow.component.html
@@ -38,7 +38,7 @@
   </div>
   <!-- //top -->
   <div class="ddp-ui-contents-list">
-    <div class="ddp-fileter-option">
+    <div class="ddp-filter-option">
       <div class="ddp-ui-option ddp-clear ddp-optiontype">
         <!-- 검색 -->
         <div class="ddp-form-search ddp-fleft">


### PR DESCRIPTION
### Description
there is no margin at the top of the dataflow list.
fixed it.

![image](https://user-images.githubusercontent.com/42264835/68741403-e184e000-0630-11ea-8c47-b5db6067eea2.png)



### How Has This Been Tested?
go to the dataflow list page and check it


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
