### PR TITLE
#2873 extract as nulls when not found instead of empty strings

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DfExtract.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DfExtract.java
@@ -188,7 +188,7 @@ public class DfExtract extends DataFrame {
                 String newColData = targetStr.substring(matcher.start(), matcher.end());
                 newRow.add(extractedColNameList.get(prevDf.getColName(colno)).get(i), newColData);
               } else {
-                newRow.add(extractedColNameList.get(prevDf.getColName(colno)).get(i), "");
+                newRow.add(extractedColNameList.get(prevDf.getColName(colno)).get(i), null);
               }
             }
           } else {
@@ -221,7 +221,7 @@ public class DfExtract extends DataFrame {
                 String newColData = targetStr.substring(matcher.start(), matcher.end());
                 newRow.add(extractedColNameList.get(prevDf.getColName(colno)).get(i), newColData);
               } else {
-                newRow.add(extractedColNameList.get(prevDf.getColName(colno)).get(i), "");
+                newRow.add(extractedColNameList.get(prevDf.getColName(colno)).get(i), null);
               }
             }
           } else {


### PR DESCRIPTION
### Description
Create null values instead of empty strings, when the pattern is not found.

**Related Issue** : https://github.com/metatron-app/metatron-discovery/issues/2873

### How Has This Been Tested?
Ran locally.
Refer to the issue.

#### Need additional checks?
No, thanks.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
