### PR TITLE
#2878 a failure of any rule makes the editor freeze

### DIFF
--- a/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/edit-rule-grid.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataflow/dataflow-detail/component/edit-dataflow-rule/edit-rule-grid/edit-rule-grid.component.ts
@@ -299,8 +299,7 @@ export class EditRuleGridComponent extends AbstractComponent implements OnInit, 
 
     }).catch((error) => {
       this.loadingHide();
-      let prep_error = this.dataprepExceptionHandler(error);
-      PreparationAlert.output(prep_error, this.translateService.instant(prep_error.message));
+      return { error: error };
     });
 
   } // function - init


### PR DESCRIPTION
### Description
a failure of any rule makes the editor freeze

the apply action is using Promise's then-catch-then chain.
the catch routine was already returned with error
so the then routine does not know what is the error

now the catch routine was changed to pass the error. 

**Related Issue** : 
[2878](https://github.com/metatron-app/metatron-discovery/issues/2878)

### How Has This Been Tested?
1. go to the edit rule page of any dataflow
2. apply a rule with wrong condition to be failed on server process. ex) apply 'replace' rule with a LONG type column. server will reply with error message.
3. make sure that an error occurs
4. apply any rule again.

if the add button works well. it is ok

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
