### PR TITLE
#2893 policies of reading json is changed

### DIFF
--- a/discovery-frontend/src/assets/i18n/en.json
+++ b/discovery-frontend/src/assets/i18n/en.json
@@ -803,6 +803,7 @@
   "msg.dp.alert.failed.to.write.csv": "IOException while writing a CSV file.",
   "msg.dp.alert.failed.to.close.csv": "IOException while closing a CSV file.",
   "msg.dp.alert.failed.to.parse.json": "IOException while parsing a JSON file.",
+  "msg.dp.alert.failed.to.parse.json.for.empty": "Parsed 0 columns. check out your JSON file.",
   "msg.dp.alert.failed.to.delete.snapshot": "IOException while deleting a snapshot",
   "msg.dp.alert.invalid.snapshot.name": "Invalid snapshot name (null or empty)",
   "msg.dp.alert.snapshot.type.not.supported.yet": "Snapshot type not supported",

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/exceptions/PrepMessageKey.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/exceptions/PrepMessageKey.java
@@ -66,6 +66,7 @@ public enum PrepMessageKey {
   MSG_DP_ALERT_FAILED_TO_CLOSE_JSON(                           "msg.dp.alert.failed.to.close.json"),
   MSG_DP_ALERT_FAILED_TO_CLOSE_SQL(                            "msg.dp.alert.failed.to.close.sql"),
   MSG_DP_ALERT_FAILED_TO_PARSE_JSON(                           "msg.dp.alert.failed.to.parse.json"),
+  MSG_DP_ALERT_FAILED_TO_PARSE_JSON_FOR_EMPTY(                 "msg.dp.alert.failed.to.parse.json.for.empty"),
   MSG_DP_ALERT_FAILED_TO_PARSE_SQL(                            "msg.dp.alert.failed.to.parse.sql"),
   MSG_DP_ALERT_FAILED_TO_DELETE_SNAPSHOT(                      "msg.dp.alert.failed.to.delete.snapshot"),
   MSG_DP_ALERT_INVALID_SNAPSHOT_NAME(                          "msg.dp.alert.invalid.snapshot.name"),

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/file/PrepJsonUtil.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/file/PrepJsonUtil.java
@@ -1,16 +1,15 @@
 package app.metatron.discovery.domain.dataprep.file;
 
-import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_FAILED_TO_PARSE_JSON;
-import static app.metatron.discovery.domain.dataprep.file.PrepFileUtil.getWriter;
-import static app.metatron.discovery.domain.dataprep.util.PrepUtil.datasetError;
+import com.google.common.collect.Lists;
 
-import app.metatron.discovery.common.GlobalObjectMapper;
-import app.metatron.discovery.domain.dataprep.exceptions.PrepErrorCodes;
-import app.metatron.discovery.domain.dataprep.exceptions.PrepException;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Lists;
+
+import org.apache.hadoop.conf.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -21,10 +20,17 @@ import java.sql.ResultSetMetaData;
 import java.sql.Types;
 import java.util.HashMap;
 import java.util.Map;
+
 import javax.servlet.ServletOutputStream;
-import org.apache.hadoop.conf.Configuration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import app.metatron.discovery.common.GlobalObjectMapper;
+import app.metatron.discovery.domain.dataprep.exceptions.PrepErrorCodes;
+import app.metatron.discovery.domain.dataprep.exceptions.PrepException;
+
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_FAILED_TO_PARSE_JSON;
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_FAILED_TO_PARSE_JSON_FOR_EMPTY;
+import static app.metatron.discovery.domain.dataprep.file.PrepFileUtil.getWriter;
+import static app.metatron.discovery.domain.dataprep.util.PrepUtil.datasetError;
 
 public class PrepJsonUtil {
 
@@ -40,7 +46,7 @@ public class PrepJsonUtil {
     BufferedReader br = new BufferedReader(reader);
 
     try {
-      result.colNames = Lists.newArrayList();
+      result.colNames = null;
       StringBuffer sb = new StringBuffer();
       while ((line = br.readLine()) != null && result.totalRows < limitRows) {
         Map<String, Object> jsonRow = null;
@@ -60,14 +66,30 @@ public class PrepJsonUtil {
           continue;
         }
 
-        for (String jsonKey : jsonRow.keySet()) {
-          if (result.colNames.contains(jsonKey) == false) {
-            result.colNames.add(jsonKey);
+        if( result.colNames==null ) {
+          result.colNames = Lists.newArrayList();
+          for (String jsonKey : jsonRow.keySet()) {
+            if (result.colNames.contains(jsonKey) == false) {
+              result.colNames.add(jsonKey);
+            }
           }
-        }
 
-        if (colCnt == null) {
-          colCnt = result.colNames.size();
+          if (colCnt == null) {
+            colCnt = result.colNames.size();
+          } else {
+            int createIndex = 0;
+            while(result.colNames.size()<colCnt) {
+              String colName = null;
+              while( colName==null || result.colNames.contains(colName) ) {
+                colName = "column_"+String.valueOf(createIndex++);
+              }
+              result.colNames.add(colName);
+            }
+          }
+
+          if(colCnt==0) {
+            throw datasetError(MSG_DP_ALERT_FAILED_TO_PARSE_JSON_FOR_EMPTY);
+          }
         }
 
         String[] row = new String[colCnt];

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/file/PrepJsonUtil.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/file/PrepJsonUtil.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Lists;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 
 import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
@@ -56,8 +57,17 @@ public class PrepJsonUtil {
           jsonRow = mapper.readValue(sb.toString(), new TypeReference<Map<String, Object>>() {
           });
           sb.delete(0, sb.length());
+        } catch (MismatchedInputException e) {
+          LOGGER.debug("Empty JSON string.", e);
+          sb.delete(0, sb.length());
+          continue;
         } catch (JsonParseException e) {
           LOGGER.debug("Incomplete JSON string.", e);
+          int bracket = sb.indexOf("{");
+          if(bracket<0) {
+            bracket = sb.length();
+          }
+          sb.delete(0, bracket);
           continue;
         }
 


### PR DESCRIPTION
### Description
policies of parsing JSON was changed.
when an object is empty, the object should be passed.
and the list of key name depends on the first line.
if the first line is empty object, throws an exception

**Related Issue** :
[2893](https://github.com/metatron-app/metatron-discovery/issues/2893)

### How Has This Been Tested?
1. upload a JSON file to create a dataset
2. check the preview of the file

make sure that column count is depend on first object
and empty object should be null
if the first object is empty, exception occurs

test files ( change the extension to json. txt means the file is for csv )
[test_col_empty.json.txt](https://github.com/metatron-app/metatron-discovery/files/3873116/test_col_empty.json.txt)
[test_col_1.json.txt](https://github.com/metatron-app/metatron-discovery/files/3873117/test_col_1.json.txt)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
