### PR TITLE
Bug-fix on unnest. Implement auto-typing by value

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DataFrame.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/DataFrame.java
@@ -289,7 +289,7 @@ public class DataFrame implements Serializable, Transformable {
     return colDescs.get(colno).getType();
   }
 
-  private void setColType(int colno, ColumnType colType) {
+  public void setColType(int colno, ColumnType colType) {
     colDescs.get(colno).setType(colType);
   }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/TeddyUtil.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/teddy/TeddyUtil.java
@@ -99,13 +99,20 @@ public class TeddyUtil {
     return colNames;
   }
 
+  private static String strip(String str) {
+    return str.substring(1, str.length() - 1);
+  }
+
   public static List<String> getStringList(Expression expr) {
     List<String> colNames = new ArrayList<>();
 
     if (expr instanceof StringExpr) {
-      colNames.add(expr.toString());
+      colNames.add(((StringExpr) expr).getEscapedValue());
     } else if (expr instanceof ArrayExpr) {
-      colNames = ((ArrayExpr) expr).getValue();
+      List<String> quotedStrs = ((ArrayExpr) expr).getValue();
+      for (String str : quotedStrs) {
+        colNames.add(strip(str));
+      }
     }
     return colNames;
   }

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/dataprep/teddy/DataFrameTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/dataprep/teddy/DataFrameTest.java
@@ -321,7 +321,7 @@ public class DataFrameTest extends TeddyTest {
     store = prepare_store(store);
     store.show();
 
-    String ruleString = "join leftSelectCol: cdate,pcode1,pcode2,pcode3,pcode4,customer_id,detail_store_code rightSelectCol: detail_store_code,customer_id condition: detail_store_code=detail_store_code joinType: 'inner' dataset2: '88888888-4444-4444-4444-121212121212'";
+    String ruleString = "join leftSelectCol: cdate,pcode1,pcode2,pcode3,pcode4,customer_id,code_sum rightSelectCol: detail_store_code,customer_id condition: code_sum=detail_store_code joinType: 'inner' dataset2: '88888888-4444-4444-4444-121212121212'";
     ArrayList<DataFrame> slaveDFs = new ArrayList<>(Arrays.asList(store));
 
     DataFrame newDf = apply_rule(contract, ruleString, slaveDFs);
@@ -424,7 +424,7 @@ public class DataFrameTest extends TeddyTest {
     contract = prepare_contract(contract);
     contract.show();
 
-    String ruleString = "aggregate value: min(detail_store_code), max(detail_store_code) group: pcode1, pcode2";
+    String ruleString = "aggregate value: min(code_sum), max(code_sum) group: pcode1, pcode2";
 
     DataFrame newDf = apply_rule(contract, ruleString);
     newDf.show();
@@ -463,13 +463,7 @@ public class DataFrameTest extends TeddyTest {
     contract = prepare_contract(contract);
     contract.show();
 
-    String ruleString = "settype col: detail_store_code type: long";
-
-    DataFrame newDf = apply_rule(contract, ruleString);
-
-    ruleString = "sort order: detail_store_code type: 'desc'";
-
-    newDf = apply_rule(newDf, ruleString);
+    DataFrame newDf = apply_rule(contract, "sort order: code_sum type: 'desc'");
     newDf.show(100);
   }
 
@@ -480,7 +474,7 @@ public class DataFrameTest extends TeddyTest {
     contract = prepare_contract(contract);
     contract.show();
 
-    String ruleString = "pivot col: pcode1, pcode2 value: sum(detail_store_code), count() group: pcode3, pcode4";
+    String ruleString = "pivot col: pcode1, pcode2 value: sum(code_sum), count() group: pcode3, pcode4";
 
     DataFrame newDf = apply_rule(contract, ruleString);
     newDf.show();
@@ -493,7 +487,7 @@ public class DataFrameTest extends TeddyTest {
     contract = prepare_contract(contract);
     contract.show();
 
-    String ruleString = "pivot col: pcode1, pcode2 value: avg(detail_store_code) group: pcode3, pcode4";
+    String ruleString = "pivot col: pcode1, pcode2 value: avg(code_sum) group: pcode3, pcode4";
 
     DataFrame newDf = apply_rule(contract, ruleString);
     newDf.show(100);
@@ -506,11 +500,11 @@ public class DataFrameTest extends TeddyTest {
     contract = prepare_contract(contract);
     contract.show();
 
-    String ruleString = "pivot col: pcode1 value: sum(detail_store_code) group: pcode3, pcode4";
+    String ruleString = "pivot col: pcode1 value: sum(code_sum) group: pcode3, pcode4";
 
     DataFrame newDf = apply_rule(contract, ruleString);
 
-    ruleString = "unpivot col: sum_detail_store_code_1, sum_detail_store_code_2, sum_detail_store_code_3, sum_detail_store_code_4 groupEvery: 1";
+    ruleString = "unpivot col: sum_code_sum_1, sum_code_sum_2, sum_code_sum_3, sum_code_sum_4 groupEvery: 1";
 
     newDf = apply_rule(newDf, ruleString);
 
@@ -524,11 +518,11 @@ public class DataFrameTest extends TeddyTest {
     contract = prepare_contract(contract);
     contract.show();
 
-    String ruleString = "pivot col: pcode1 value: sum(detail_store_code) group: pcode3, pcode4";
+    String ruleString = "pivot col: pcode1 value: sum(code_sum) group: pcode3, pcode4";
 
     DataFrame newDf = apply_rule(contract, ruleString);
 
-    ruleString = "unpivot col: sum_detail_store_code_1, sum_detail_store_code_2, sum_detail_store_code_3, sum_detail_store_code_4 groupEvery: 4";
+    ruleString = "unpivot col: sum_code_sum_1, sum_code_sum_2, sum_code_sum_3, sum_code_sum_4 groupEvery: 4";
 
     newDf = apply_rule(newDf, ruleString);
 

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/dataprep/teddy/SplitMergeTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/dataprep/teddy/SplitMergeTest.java
@@ -28,6 +28,7 @@ public class SplitMergeTest extends TeddyTest {
     loadGridCsv("contract", "teddy/contract.csv");
     loadGridCsv("sample", "teddy/sample.csv");
     loadGridCsv("sample_split", "teddy/sample_split.csv");
+    loadGridCsv("contract", "teddy/contract.csv");
   }
 
   private DataFrame prepare_sample_split() throws IOException, TeddyException {
@@ -199,4 +200,22 @@ public class SplitMergeTest extends TeddyTest {
     assertEquals("borghini", newDf2.rows.get(4).get("split_name2"));
   }
 
+  @Test
+  public void test_merge_null() throws IOException, TeddyException {
+    String[][] strGrid = new String[][]{
+            {"Nortel Networks", "T7316 \"E Nt8 B27\""},
+            {"SM", "TSP800", "TSP847IIU", "Receipt Printer"},
+            {"SM", "\"TSP100", "TSP143LAN", "Receipt\" Printer"},
+            {null, null, null},
+            {}
+    };
+    DataFrame df = createByGrid(strGrid, new String[]{"manufacturer", "model1", "model2", "etc"});
+
+    df = apply_rule(df, "merge col: manufacturer, model1, model2, etc with: ',' as 'altogether'");
+    assertRow(df.rows.get(0), new Object[]{"Nortel Networks,T7316 \"E Nt8 B27\""});
+    assertRow(df.rows.get(1), new Object[]{"SM,TSP800,TSP847IIU,Receipt Printer"});
+    assertRow(df.rows.get(2), new Object[]{"SM,\"TSP100,TSP143LAN,Receipt\" Printer"});
+    assertRow(df.rows.get(3), new Object[]{""});
+    assertRow(df.rows.get(4), new Object[]{""});
+  }
 }

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/dataprep/teddy/TeddyTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/dataprep/teddy/TeddyTest.java
@@ -167,7 +167,7 @@ public class TeddyTest {
     ruleStrings.add("settype col: pcode2 type: long");
     ruleStrings.add("settype col: pcode3 type: long");
     ruleStrings.add("settype col: pcode4 type: long");
-    ruleStrings.add("settype col: detail_store_code type: long");
+    ruleStrings.add("derive value: pcode3 + pcode2 + pcode3 + pcode4 as: 'code_sum'");
 
     return apply_rules(contract, ruleStrings);
   }


### PR DESCRIPTION
### Description
I've added more check code into unnest test cases.
Some bugs are found and to solve this, I had to implement auto-typing by column value.
When unnesting the JSON string in Map (Object) or Array type, according to the type of value expressions, the result type chages no matter what types they had before.
For unnest, deciding the type is very simple and obvious, but for other rules, there're some considerations. I'll apply auto-typing by value with extra care, later.

**Related Issue** : #2896 

### How Has This Been Tested?
Ran all test cases in dataprep.
Tested with a file that contains a very complex json column: [nmas_sensor_short.csv.txt](https://github.com/metatron-app/metatron-discovery/files/3874082/nmas_sensor_short.csv.txt)
 

#### Need additional checks?
Yes, thank you.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
