### PR TITLE
Table chart broken issue and original format display issue in original view

### DIFF
--- a/discovery-frontend/angular.json
+++ b/discovery-frontend/angular.json
@@ -68,7 +68,7 @@
               "src/lib/moment/moment-timezone-with-data.min.js",
               "src/lib/dom-to-image/dom-to-image.js",
               "src/lib/rome/rome.standalone.js",
-              "src/lib/pivot-grid/pivot.grid.min.js",
+              "src/lib/pivot-grid/pivot.grid.js",
               "src/lib/caret/jquery.caret.min.js",
               "src/lib/tui/markdown-it.js",
               "src/lib/tui//tui-code-snippet.js",

--- a/discovery-frontend/src/app/common/component/chart/type/grid-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/grid-chart.component.ts
@@ -316,7 +316,6 @@ export class GridChartComponent extends BaseChart implements OnInit, OnDestroy, 
     let rows: any = this.fieldInfo.rows.map((name) => {
       return {name};
     });
-    console.info( this.pivot.aggregations );
     let aggregations: any;
     if( this.pivot && this.pivot.aggregations && 0 < this.pivot.aggregations.length ) {
       aggregations = this.pivot.aggregations.map((pivot) => {

--- a/discovery-frontend/src/app/common/component/chart/type/grid-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/grid-chart.component.ts
@@ -316,9 +316,21 @@ export class GridChartComponent extends BaseChart implements OnInit, OnDestroy, 
     let rows: any = this.fieldInfo.rows.map((name) => {
       return {name};
     });
-    let aggregations: any = this.fieldInfo.aggs.map((name) => {
-      return {name, digits: 2};
-    });
+    console.info( this.pivot.aggregations );
+    let aggregations: any;
+    if( this.pivot && this.pivot.aggregations && 0 < this.pivot.aggregations.length ) {
+      aggregations = this.pivot.aggregations.map((pivot) => {
+        if( pivot.field && pivot.field.logicalType ) {
+          return {name : pivot.name, digits: 2, type : pivot.field.logicalType };
+        } else {
+          return {name : pivot.name, digits: 2 };
+        }
+      });
+    } else {
+      aggregations = this.fieldInfo.aggs.map((name) => {
+        return {name, digits: 2};
+      });
+    }
 
     // 원본보기데이터 초기화
     this.originData = [];
@@ -368,6 +380,12 @@ export class GridChartComponent extends BaseChart implements OnInit, OnDestroy, 
       rows = [{"name": "&nbsp;"}];
       originAggregations = [{name: "VALUE"}];
 
+      this.pivot.aggregations.map((pivot) => {
+        if( pivot.field && pivot.field.logicalType ) {
+          ( originAggregations[0].type ) || ( originAggregations[0].type = {} );
+          originAggregations[0].type[ pivot.name ] = pivot.field.logicalType;
+        }
+      });
       aggregations = originAggregations;
 
       // 원본보기 데이터에 설정

--- a/discovery-frontend/src/app/page/chart-style/common-option.component.ts
+++ b/discovery-frontend/src/app/page/chart-style/common-option.component.ts
@@ -942,7 +942,12 @@ export class CommonOptionComponent extends BaseOptionComponent {
       (<UIGridChart>this.uiOption).measureLayout = UIOrient.VERTICAL;
       (<UIGridChart>this.uiOption).contentStyle = (<UIGridChart>this.uiOption).contentStyle ? (<UIGridChart>this.uiOption).contentStyle : {};
       (<UIGridChart>this.uiOption).contentStyle.showHeader = false;
+    } else {
+      if( 'origin' === (<UIGridChart>this.uiOption).valueFormat.type ) {
+        (<UIGridChart>this.uiOption).valueFormat.type = 'number';
+      }
     }
+
 
     this.uiOption['dataType'] = dataType;
     this.update({type: EventType.GRID_ORIGINAL});

--- a/discovery-frontend/src/app/page/chart-style/format-option.component.html
+++ b/discovery-frontend/src/app/page/chart-style/format-option.component.html
@@ -19,7 +19,8 @@
   </div>
   <div class="ddp-wrap-downmenu">
     <!-- box down -->
-    <div format-item class="ddp-box-down" #commonFormat (changeFormat)="onChange($event)" [format]="format">
+    <div format-item class="ddp-box-down" #commonFormat (changeFormat)="onChange($event)"
+         [format]="format" [uiOption]="uiOption">
     </div>
     <!-- //box down -->
   </div>

--- a/discovery-frontend/src/app/page/chart-style/format-option.component.ts
+++ b/discovery-frontend/src/app/page/chart-style/format-option.component.ts
@@ -139,12 +139,16 @@ export class FormatOptionComponent extends BaseOptionComponent implements OnInit
       }
     }
 
+    console.info( '>>>>>> format', format );
+
     // 공통적용 포맷
     this.format = format;
   }
 
   @Input('uiOption')
   public set setUiOption(uiOption: UIOption) {
+
+    console.info( '>>>>>> uiOption', uiOption );
 
     // Set
     this.uiOption = uiOption;

--- a/discovery-frontend/src/app/page/chart-style/format-option.component.ts
+++ b/discovery-frontend/src/app/page/chart-style/format-option.component.ts
@@ -139,16 +139,12 @@ export class FormatOptionComponent extends BaseOptionComponent implements OnInit
       }
     }
 
-    console.info( '>>>>>> format', format );
-
     // 공통적용 포맷
     this.format = format;
   }
 
   @Input('uiOption')
   public set setUiOption(uiOption: UIOption) {
-
-    console.info( '>>>>>> uiOption', uiOption );
 
     // Set
     this.uiOption = uiOption;

--- a/discovery-frontend/src/app/page/chart-style/format/format-item.component.html
+++ b/discovery-frontend/src/app/page/chart-style/format/format-item.component.html
@@ -44,7 +44,7 @@
 
   <!-- 숫자일때 -->
   <!-- divide2 -->
-  <div class="ddp-divide2" *ngIf="selectedType['value'] != 'currency'">
+  <div class="ddp-divide2" *ngIf="selectedType['value'] != 'currency'" [class.ddp-disabled]="selectedType?.value == 'origin'">
     <div class="ddp-list-label">{{'msg.page.th.decimal.place' | translate}}</div>
     <!-- number -->
     <div class="ddp-input-number">

--- a/discovery-frontend/src/app/page/chart-style/format/format-item.component.ts
+++ b/discovery-frontend/src/app/page/chart-style/format/format-item.component.ts
@@ -13,17 +13,31 @@
  */
 
 import {
-  Component, ElementRef, Injector, OnDestroy, OnInit, Input, ViewChild, Output,
-  EventEmitter
+  Component,
+  ElementRef,
+  EventEmitter,
+  Injector,
+  Input,
+  OnDestroy,
+  OnInit,
+  Output,
+  ViewChild
 } from '@angular/core';
 import {AbstractComponent} from "../../../common/component/abstract.component";
 import {SelectComponent} from "../../../common/component/select/select.component";
 import {Format} from "../../../domain/workbook/configurations/format";
-import { Field as AbstractField } from '../../../domain/workbook/configurations/field/field';
-import {UIFormatSymbolPosition, UIFormatNumericAliasType} from '../../../common/component/chart/option/define/common';
-import { FormatOptionConverter } from '../../../common/component/chart/option/converter/format-option-converter';
+import {Field as AbstractField} from '../../../domain/workbook/configurations/field/field';
+import {
+  ChartType,
+  GridViewType,
+  UIFormatNumericAliasType,
+  UIFormatSymbolPosition
+} from '../../../common/component/chart/option/define/common';
+import {FormatOptionConverter} from '../../../common/component/chart/option/converter/format-option-converter';
 import {CustomSymbol} from "../../../common/component/chart/option/ui-option/ui-format";
-import { OptionGenerator } from '../../../common/component/chart/option/util/option-generator';
+import {OptionGenerator} from '../../../common/component/chart/option/util/option-generator';
+import {UIOption} from "../../../common/component/chart/option/ui-option";
+import {UIGridChart} from "../../../common/component/chart/option/ui-option/ui-grid-chart";
 import UI = OptionGenerator.UI;
 
 @Component({
@@ -44,6 +58,14 @@ export class FormatItemComponent extends AbstractComponent implements OnInit, On
   @ViewChild('numericAliasListSelect')
   private numericAliasListComp: SelectComponent;
 
+  // 타입 목록
+  private _orgTypeList: Object[] = [
+    {name: this.translateService.instant('msg.page.li.num'), value: 'number'},
+    {name: this.translateService.instant('msg.page.li.currency'), value: 'currency'},
+    {name: this.translateService.instant('msg.page.li.percent'), value: 'percent'},
+    {name: this.translateService.instant('msg.page.li.exponent'), value: 'exponent10'}
+  ];
+
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Protected Variables
    |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
@@ -59,6 +81,8 @@ export class FormatItemComponent extends AbstractComponent implements OnInit, On
   // 필드
   @Input()
   public field: AbstractField;
+
+  public uiOption: UIOption;
 
   // 포맷정보
   public format: Format;
@@ -123,6 +147,14 @@ export class FormatItemComponent extends AbstractComponent implements OnInit, On
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Getter & Setter
    |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
+  @Input('uiOption')
+  public set setUiOption(uiOption : UIOption) {
+    this.uiOption = uiOption;
+    this.typeList = JSON.parse(JSON.stringify(this._orgTypeList));
+    if( uiOption.type === ChartType.GRID && (uiOption as UIGridChart).dataType === GridViewType.MASTER ) {
+      this.typeList.push({name: this.translateService.instant('msg.page.li.origin'), value: 'origin'});
+    }
+  }
 
   @Input('format')
   public set setFormat(format: Format) {
@@ -211,8 +243,8 @@ export class FormatItemComponent extends AbstractComponent implements OnInit, On
   // 생성자
   constructor(protected elementRef: ElementRef,
               protected injector: Injector) {
-
     super(elementRef, injector);
+    this.typeList = JSON.parse(JSON.stringify(this._orgTypeList));
   }
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/discovery-frontend/src/assets/i18n/en.json
+++ b/discovery-frontend/src/assets/i18n/en.json
@@ -3442,6 +3442,7 @@
   "msg.page.li.line" : "Line",
   "msg.page.li.bar" : "Bar",
   "msg.page.th.exponential.form" : "Exponential form",
+  "msg.page.li.origin" : "Origin",
   "msg.page.li.num" : "Number",
   "msg.page.li.currency" : "Currency",
   "msg.page.li.percent" : "Percent",

--- a/discovery-frontend/src/assets/i18n/ko.json
+++ b/discovery-frontend/src/assets/i18n/ko.json
@@ -3419,6 +3419,7 @@
   "msg.page.li.line": "라인",
   "msg.page.li.bar": "바",
   "msg.page.th.exponential.form": "지수",
+  "msg.page.li.origin" : "원본",
   "msg.page.li.num": "숫자",
   "msg.page.li.currency": "통화",
   "msg.page.li.percent": "퍼센트",

--- a/discovery-frontend/src/assets/i18n/zh.json
+++ b/discovery-frontend/src/assets/i18n/zh.json
@@ -2571,6 +2571,7 @@
   "msg.page.li.line": "线",
   "msg.page.li.bar": "条形",
   "msg.page.th.exponential.form": "指数",
+  "msg.page.li.origin" : "Origin",
   "msg.page.li.num": "数字",
   "msg.page.li.currency": "货币",
   "msg.page.li.percent": "百分比",

--- a/discovery-frontend/src/lib/pivot-grid/pivot.grid.js
+++ b/discovery-frontend/src/lib/pivot-grid/pivot.grid.js
@@ -28083,9 +28083,6 @@ var pivot =
 	                        var xItem = _this2._xItems[xii];
 	                        var propertyName = _this2._settings.xProperties[_xpi].name;
 	                        var value = common.format(xItem[propertyName], _this2._settings.xProperties[_xpi].digits);
-	                        if (prevValue === value) {
-	                            return "continue";
-	                        }
 	                        columnAttributes = {};
 
 	                        // Add Property by eltriny
@@ -28107,6 +28104,10 @@ var pivot =
 	                            columnAttributes["data-parent-vals"] = arrVals.join("||");
 	                        }
 	                        // #20161229-01 : 축 선택 시 상위 축 정보 포함 제공 - End
+
+                          if (prevValue === value) {
+                            return "continue";
+                          }
 
 	                        columnStyles = {};
 	                        columnStyles["height"] = cellHeight + "px";
@@ -28158,7 +28159,7 @@ var pivot =
 	                        html.push("</div>");
 
 	                        // 프로퍼티 이름 갱신 ( 중복된 프러퍼티를 생성하지 않기 위해 )
-	                        prevValue = value;
+	                        prevValue = columnAttributes["data-parent-vals"];
 	                    };
 
 	                    for (var xii = range.left; xii <= range.right; xii++) {
@@ -28900,9 +28901,6 @@ var pivot =
 	                        var xItem = _this3._xItems[xii];
 	                        var propertyName = _this3._settings.xProperties[_xpi2].name;
 	                        var value = common.format(xItem[propertyName], _this3._settings.xProperties[_xpi2].digits);
-	                        if (prevValue === value) {
-	                            return "continue";
-	                        }
 	                        columnAttributes = {};
 
 	                        // Add Property by eltriny
@@ -28927,6 +28925,10 @@ var pivot =
 	                            columnAttributes["data-parent-vals"] = arrVals.join("||");
 	                        }
 	                        // #20161229-01 : 축 선택 시 상위 축 정보 포함 제공 - End
+
+                          if (prevValue === value) {
+                            return "continue";
+                          }
 
 	                        columnStyles = {};
 	                        columnStyles["height"] = cellHeight + "px";
@@ -28978,7 +28980,7 @@ var pivot =
 	                        html.push("</div>");
 
 	                        // 프로퍼티 이름 갱신 ( 중복된 프러퍼티를 생성하지 않기 위해 )
-	                        prevValue = value;
+	                        prevValue = columnAttributes["data-parent-vals"];
 	                    };
 
 	                    for (var xii = range.left; xii <= range.right; xii++) {


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
1. Boundaries broken when there is no data in the chart
2. In the grid original view, the number is displayed according to the original type of the field. 

**Related Issue** : METATRON-3057 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
====== Metatron-3057 ====== 
1. Create a data source using sample data with empty data.
2. After creating the dashboard, create a grid chart using fields with empty data.
3. Check if the display is normal without cracking.
========================
1. Create a grid chart and change to the original view.
2. After changing the original view, under Number Format, verify that the original format exists and select the original format.
3. Check that the number is displayed according to the field type.

#### Need additional checks?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
