### PR TITLE
fix changeset for hibernate sequence

### DIFF
--- a/discovery-server/src/main/resources/db/changelog/discovery.changelog-3.4.0.xml
+++ b/discovery-server/src/main/resources/db/changelog/discovery.changelog-3.4.0.xml
@@ -29,4 +29,23 @@
             <column name="quote_char" type="${varchar.type}(255)" />
         </addColumn>
     </changeSet>
+    <changeSet author="sohncw" id="1574830584206-0">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <sequenceExists sequenceName="hibernate_sequence"/>
+            </not>
+        </preConditions>
+        <createSequence sequenceName="hibernate_sequence" cycle="false" incrementBy="1" ordered="true" startValue="0"/>
+    </changeSet>
+    <changeSet author="sohncw" id="1574830584206-1">
+        <preConditions onFail="MARK_RAN">
+            <and>
+                <tableExists tableName="hibernate_sequence" />
+                <tableIsEmpty tableName="hibernate_sequence" />
+            </and>
+        </preConditions>
+        <insert tableName="hibernate_sequence">
+            <column name="next_val" value="1" />
+        </insert>
+    </changeSet>
 </databaseChangeLog>

--- a/discovery-server/src/main/resources/db/changelog/discovery.changelog-initial.xml
+++ b/discovery-server/src/main/resources/db/changelog/discovery.changelog-initial.xml
@@ -68,7 +68,7 @@
             </not>
         </preConditions>
         <createTable tableName="REVINFO">
-            <column name="id" type="${bigint.type}">
+            <column name="id" type="${bigint.type}" autoIncrement="true">
                 <constraints primaryKey="true" />
             </column>
             <column name="timestamp" type="${bigint.type}" />


### PR DESCRIPTION
### Description
An error occurs because the hibernate sequence was not created correctly.

There are two fixes.
1. Added create sequence changeset for DBs with sequence support.
2. If there is no initial value of hibernate_sequence table, an error occurs and the initial value is inserted.

**This patch also needs to be applied to 3.4.0-rc3-hotfix.**

**Related Issue** : 

### How Has This Been Tested?
1. Delete existing H2 database if it exists.
2. create metadata (via creating datasorce or from database)
3. Check metadata creation complete without error.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
