### PR TITLE
fix permission error for engine monitoring

### DIFF
--- a/discovery-frontend/src/app/layout/layout/layout.module.ts
+++ b/discovery-frontend/src/app/layout/layout/layout.module.ts
@@ -73,7 +73,7 @@ const layoutRoutes: Routes = [
       {
         path: 'management/engine-monitoring',
         loadChildren: 'app/engine-monitoring/engine-monitoring.module#EngineMonitoringModule',
-        canActivate: [MetadataManagementGuard]
+        canActivate: [DatasourceManagementGuard]
       },
       {path: 'admin', loadChildren: 'app/admin/admin.module#AdminModule'},
       {path: 'external', loadChildren: 'app/external/external-view.module#ExternalViewModule'},


### PR DESCRIPTION
### Description
Allows users other than SYSTEM MANAGER to access engine monitoring.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Register a user without SYSTEM MANAGER privilege to DATA MANAGER.
2. Confirm the connection to the engine monitoring menu with the user.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
