### PR TITLE
Change liquibase initial script

### DIFF
--- a/discovery-server/src/main/resources/db/changelog/discovery.changelog-initial.xml
+++ b/discovery-server/src/main/resources/db/changelog/discovery.changelog-initial.xml
@@ -68,7 +68,7 @@
             </not>
         </preConditions>
         <createTable tableName="REVINFO">
-            <column name="id" type="${bigint.type}" autoIncrement="true">
+            <column name="id" type="${bigint.type}">
                 <constraints primaryKey="true" />
             </column>
             <column name="timestamp" type="${bigint.type}" />
@@ -3851,5 +3851,13 @@
             </not>
         </preConditions>
         <addForeignKeyConstraint baseColumnNames="book_id" baseTableName="queryeditor" constraintName="FKxo9cgi0sqay1s92b1d6mxare" deferrable="false" initiallyDeferred="false" onDelete="RESTRICT" onUpdate="RESTRICT" referencedColumnNames="id" referencedTableName="book_workbench" validate="true" />
+    </changeSet>
+    <changeSet author="initial (generated)" id="1571037633789-225">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="REVINFO" />
+            </not>
+        </preConditions>
+        <addAutoIncrement tableName="REVINFO" columnName="id" columnDataType="${bigint.type}" />
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
We've changed a middle section in the liquibase's initial script.
But it occurred an error such as : 
`
liquibase.exception.validationfailedexception : 1 change sets check sum
`

We have to record a new changeSet sequentially at the end of the liquibase file.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
N/A
But it occurred during integrated testing.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
tested In my local mysql,
and deployed to integrated test environment (mysql too)

#### Need additional checks?
please check this strategy is correct @ufoscw @kyungtaak  

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
