### PR TITLE
#2921 Timestamp filter not applied when downloading chart original data

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/widget/WidgetController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/widget/WidgetController.java
@@ -190,10 +190,7 @@ public class WidgetController {
 
     BoardConfiguration boardConfiguration = GlobalObjectMapper.readValue(widget.getDashBoard().getConfiguration(), BoardConfiguration.class);
     if(CollectionUtils.isNotEmpty(filters)) {
-      if(boardConfiguration.getFilters() == null) {
-        boardConfiguration.setFilters(new ArrayList<>());
-      }
-      boardConfiguration.getFilters().addAll(filters);
+      boardConfiguration.setFilters(filters);
     }
 
     Object result = engineQueryService.search(getQueryRequestFromConfig(
@@ -337,10 +334,7 @@ public class WidgetController {
 
     BoardConfiguration boardConfiguration = GlobalObjectMapper.readValue(widget.getDashBoard().getConfiguration(), BoardConfiguration.class);
     if(CollectionUtils.isNotEmpty(filters)) {
-      if(boardConfiguration.getFilters() == null) {
-        boardConfiguration.setFilters(new ArrayList<>());
-      }
-      boardConfiguration.getFilters().addAll(filters);
+      boardConfiguration.setFilters(filters);
     }
 
     SearchQueryRequest searchQuery = getQueryRequestFromConfig(


### PR DESCRIPTION
### Description
ㅌ날짜 필터 사용 하여 특정 날짜만 조회한 경우 차트에는 반영 되나 차트 데이터 보기에는 반영되지 않는 오류를 수정 했습니다.

**Related Issue** : <!--- Please link to the issue here. -->
#2921 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. 차트 필터를 추가하여 차트를 만들었습니다.
![image](https://user-images.githubusercontent.com/16472109/70026307-c596ad80-15e2-11ea-86d7-148909d05851.png)
2. 날짜 필터를 대시보드에 추가하고 특정 기간을 조회하였습니다.
3. 차트에 나타나는 데이터와 데이터 다운로드에 나타나는 데이터가 일치하는 것을 확인 했습니다.
![image](https://user-images.githubusercontent.com/16472109/70026368-f37bf200-15e2-11ea-8795-733497b99c9f.png)

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
