### PR TITLE
#2952 Remove unnecessary loading data when switching the view / edit screen on the dashboard

### DIFF
--- a/discovery-frontend/src/app/dashboard/service/dashboard.service.ts
+++ b/discovery-frontend/src/app/dashboard/service/dashboard.service.ts
@@ -33,6 +33,8 @@ declare let async;
 @Injectable()
 export class DashboardService extends AbstractService {
 
+  private _dashboard:Dashboard;
+
   constructor(protected injector: Injector,
               private metadataService: MetadataService) {
     super(injector);
@@ -41,6 +43,14 @@ export class DashboardService extends AbstractService {
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Public Method
    |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
+  public setCurrentDashboard(board:Dashboard) {
+    this._dashboard = board;
+  }
+
+  public getCurrentDashboard() {
+    return this._dashboard;
+  }
+
   /**
    * 데이터소스와 대시보드를 연결한다.
    * @param {string} boardId

--- a/discovery-frontend/src/app/dashboard/update-dashboard.component.ts
+++ b/discovery-frontend/src/app/dashboard/update-dashboard.component.ts
@@ -153,10 +153,6 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
   @Input()
   public dashboards: Dashboard[] = [];
 
-  // 대시보드 선택 진입점
-  @Input('dashboard')
-  public inputDashboard: Dashboard;
-
   @Input()
   public startupCmd: { cmd: string, id?: string, type?: string };
 
@@ -360,19 +356,10 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
     $('body').css( 'overflow', 'hidden' );
   } // function - ngOnInit
 
-  /**
-   * Input 값 변경 체크
-   * @param {SimpleChanges} changes
-   */
-  public ngOnChanges(changes: SimpleChanges) {
-    const boardChanges: SimpleChange = changes.inputDashboard;
-    if (boardChanges && boardChanges.currentValue) {
-      // 초기 설정
-      this.dashboard = boardChanges.currentValue;
-
-      this._initViewPage(this.dashboard.id);
-    }
-  } // function - ngOnChanges
+  public ngAfterViewInit() {
+    super.ngAfterViewInit();
+    this._initViewPage();
+  }
 
   /**
    * 클래스 제거
@@ -1598,18 +1585,18 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
 
   /**
    * 화면 정보 초기화
-   * @param {string} dashboardId
    * @private
    */
-  private _initViewPage(dashboardId: string) {
+  private _initViewPage() {
 
     this.showBoardLoading();
 
     this.useUnloadConfirm = false;
 
+    this.dashboard = this.dashboardService.getCurrentDashboard();
     // 대시보드 설정
-    this.dashboardService.getDashboard(dashboardId).then((boardInfo:Dashboard) => {
-
+    {
+      let boardInfo = this.dashboard;
       boardInfo.workBook = this.workbook;
       // Linked Datasource 인지 그리고 데이터소스가 적재되었는지 여부를 판단함
       const mainDsList: Datasource[] = DashboardUtil.getMainDataSources(boardInfo);
@@ -1655,7 +1642,7 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
       } else {
         this.hideBoardLoading();
       }
-    }).catch(err => this.commonExceptionHandler(err));
+    }
 
   } // function - _initViewPage
 

--- a/discovery-frontend/src/app/workbook/workbook.component.html
+++ b/discovery-frontend/src/app/workbook/workbook.component.html
@@ -517,7 +517,6 @@
 <app-update-dashboard *ngIf="mode == 'UPDATE'"
                       [startupCmd]="updateDashboardStartupCmd"
                       [workbook]="workbook"
-                      [dashboard]="selectedDashboard"
                       [dashboards]="dashboards"
                       (changeMode)="changeMode($event)"
                       (updateComplete)="updateCompleteDashboard($event)"

--- a/discovery-frontend/src/app/workbook/workbook.component.ts
+++ b/discovery-frontend/src/app/workbook/workbook.component.ts
@@ -441,7 +441,7 @@ export class WorkbookComponent extends AbstractComponent implements OnInit, OnDe
 
         // 현재 보고있는 페이지 인 경우
         if (this.selectedDashboard.id === dashboard.id) {
-          this.selectedDashboard = null;
+          this._setSelectedDashboard( null );
         }
 
         this._getWorkbook().then(() => {
@@ -772,7 +772,7 @@ export class WorkbookComponent extends AbstractComponent implements OnInit, OnDe
           }
         }
       } else {
-        this.selectedDashboard = null;
+        this._setSelectedDashboard( null );
       }
 
       // detect changes
@@ -975,7 +975,7 @@ export class WorkbookComponent extends AbstractComponent implements OnInit, OnDe
    */
   public updateCompleteDashboard(dashboard) {
     // 업데이트한 대시보드 선택처리
-    this.selectedDashboard = dashboard;
+    this._setSelectedDashboard( dashboard );
     // 좌측 대시보드 리스트 썸네일 갱신
     this.dashboards.forEach((board) => {
       if (board.id === dashboard.id) {
@@ -1026,7 +1026,7 @@ export class WorkbookComponent extends AbstractComponent implements OnInit, OnDe
     this.tempLoadBoard = dashboard;
     if (this.isInvalidDatasource(dashboard)) {
       if (this._boardComp) {
-        this.selectedDashboard = undefined;
+        this._setSelectedDashboard( undefined );
         this._boardComp.showError(this.translateService.instant('msg.space.ui.dashboard.unauthorized'));
         this._boardComp.hideBoardLoading();
       }
@@ -1039,7 +1039,7 @@ export class WorkbookComponent extends AbstractComponent implements OnInit, OnDe
         this.dashboardService.getDashboard(dashboard.id).then((board: Dashboard) => {
           // save data for selected dashboard
           board.workBook = this.workbook;
-          this.selectedDashboard = board;
+          this._setSelectedDashboard( board );
           this.tempLoadBoard = undefined;
 
           this.scrollToDashboard(board.id); // scroll to item
@@ -1090,7 +1090,7 @@ export class WorkbookComponent extends AbstractComponent implements OnInit, OnDe
       this._boardComp.hideError();
       this.dashboardService.getDashboard(dashboard.id).then((board: Dashboard) => {
         board.workBook = this.workbook;
-        this.selectedDashboard = board;
+        this._setSelectedDashboard( board );
         this.loadingHide(); // 로딩 숨김
         this.changeDetect.detectChanges();    // 변경 갱신
       }).catch(() => {
@@ -1336,4 +1336,9 @@ export class WorkbookComponent extends AbstractComponent implements OnInit, OnDe
 
     this.changeMode('NO_DATA');
   } // function - _initViewPage
+
+  private _setSelectedDashboard(dashboard) {
+    this.selectedDashboard = dashboard;
+    this.dashboardService.setCurrentDashboard( dashboard );
+  }
 }


### PR DESCRIPTION
### Description
Whenever switching between view and edit screens in the dashboard, the data in the widget is loaded newly. The bigger the amount of data loaded in the widget, It's getting the more difficult to switch screens in the dashboard.

**Related Issue** : #2952 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Check one dashboard on the dashboard view.
2. When entering the dashboard edit screen, make sure that you move to the edit screen without loading data on the dashboard.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
