### PR TITLE
#2962 stop to use fileFormat

### DIFF
--- a/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-name.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-name.component.ts
@@ -735,6 +735,7 @@ export class CreateDatasetNameComponent extends AbstractPopupComponent implement
     params.storedUri = file.storedUri;
     params.manualColumnCount = file.manualColumnCount;
 
+    /*willberemoved
     const filenameBeforeUpload = file.filenameBeforeUpload.toLowerCase();
     if( filenameBeforeUpload.endsWith("xls") || filenameBeforeUpload.endsWith("xlsx") ) {
 
@@ -749,6 +750,7 @@ export class CreateDatasetNameComponent extends AbstractPopupComponent implement
       params.fileFormat = "JSON";
 
     }
+    */
 
     return params
   }

--- a/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-name.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-name.component.ts
@@ -735,23 +735,6 @@ export class CreateDatasetNameComponent extends AbstractPopupComponent implement
     params.storedUri = file.storedUri;
     params.manualColumnCount = file.manualColumnCount;
 
-    /*willberemoved
-    const filenameBeforeUpload = file.filenameBeforeUpload.toLowerCase();
-    if( filenameBeforeUpload.endsWith("xls") || filenameBeforeUpload.endsWith("xlsx") ) {
-
-      params.fileFormat = "EXCEL";
-
-    } else if(filenameBeforeUpload.endsWith("csv") || filenameBeforeUpload.endsWith("txt") ) {
-
-      params.fileFormat = "CSV";
-
-    } else if(filenameBeforeUpload.endsWith("json") ) {
-
-      params.fileFormat = "JSON";
-
-    }
-    */
-
     return params
   }
 

--- a/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-selectfile.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataset/create-dataset/create-dataset-selectfile.component.ts
@@ -715,16 +715,17 @@ export class CreateDatasetSelectfileComponent extends AbstractPopupComponent imp
         datasetFile.filenameBeforeUpload = this.upFiles[i].name;
         datasetFile.storedUri = this.upFiles[i].storedUri;
         datasetFile.storageType = this._getStorageType(this.fileLocation);
-        datasetFile.fileFormat = this._getFileFormat(this.upFiles[i].fileExtension);
+        let fileFormat = this._getFileFormat(this.upFiles[i].fileExtension);
+        datasetFile.fileFormat = fileFormat;
 
         // Delimiter is , when fileFormat is csv or excel or txt
         const formatWithCommaDel = ['CSV','EXCEL', 'TXT'];
-        if(-1 !== formatWithCommaDel.indexOf(datasetFile.fileFormat.toString())) {
+        if(-1 !== formatWithCommaDel.indexOf(fileFormat.toString())) {
           datasetFile.delimiter = ',';
         }
 
         const quoteCharWithCommaDel = ['CSV', 'TXT'];
-        if(-1 !== quoteCharWithCommaDel.indexOf(datasetFile.fileFormat.toString())) {
+        if(-1 !== quoteCharWithCommaDel.indexOf(fileFormat.toString())) {
           datasetFile.quoteChar = '\"';
         }
 

--- a/discovery-frontend/src/app/data-preparation/dataset/dataset-detail.component.ts
+++ b/discovery-frontend/src/app/data-preparation/dataset/dataset-detail.component.ts
@@ -612,11 +612,13 @@ export class DatasetDetailComponent extends AbstractComponent implements OnInit,
       (this.dataset.dsType === DsType.IMPORTED && this.dataset.importType === ImportType.URI)
     ) {
 
-      if (this.dataset.fileFormat.toString().toLowerCase() === 'excel') {
+      let ext = this.prepCommonUtil.getFileFormatWithExtension( this.dataset.filenameBeforeUpload );
+
+      if (ext.toString().toLowerCase() === 'excel') {
         fileFormat = 'csv';
         downloadFileName = this.dataset.dsName + '.csv';
       } else {
-        fileFormat = this.dataset.fileFormat.toString().toLowerCase();
+        fileFormat = ext.toString().toLowerCase();
         downloadFileName = this.dataset.filenameBeforeUpload;
       }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetFileService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetFileService.java
@@ -15,64 +15,12 @@
 package app.metatron.discovery.domain.dataprep;
 
 
-import static app.metatron.discovery.domain.dataprep.PrepProperties.HADOOP_CONF_DIR;
-import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_CANNOT_GET_HDFS_FILE_SYSTEM;
-import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_CANNOT_READ_FROM_HDFS_PATH;
-import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_CANNOT_READ_FROM_LOCAL_PATH;
-import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_CANNOT_WRITE_TO_LOCAL_PATH;
-import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_FILE_FORMAT_WRONG;
-import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_HADOOP_HDFS_FAILED_TO_CONNECT;
-import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_MALFORMED_URI_SYNTAX;
-import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_REQUIRED_PROPERTY_MISSING;
-import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_UNKOWN_ERROR;
-import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_UNSUPPORTED_URI_SCHEME;
-import static app.metatron.discovery.domain.dataprep.util.PrepUtil.configError;
-import static app.metatron.discovery.domain.dataprep.util.PrepUtil.dataflowError;
-import static app.metatron.discovery.domain.dataprep.util.PrepUtil.datasetError;
-
-import app.metatron.discovery.domain.dataprep.entity.PrDataset;
-import app.metatron.discovery.domain.dataprep.entity.PrUploadFile;
-import app.metatron.discovery.domain.dataprep.exceptions.PrepErrorCodes;
-import app.metatron.discovery.domain.dataprep.exceptions.PrepException;
-import app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey;
-import app.metatron.discovery.domain.dataprep.file.PrepCsvUtil;
-import app.metatron.discovery.domain.dataprep.file.PrepJsonUtil;
-import app.metatron.discovery.domain.dataprep.repository.PrDatasetRepository;
-import app.metatron.discovery.domain.dataprep.teddy.DataFrame;
-import app.metatron.discovery.domain.dataprep.teddy.DataFrameService;
-import app.metatron.discovery.domain.dataprep.teddy.exceptions.TeddyException;
-import app.metatron.discovery.domain.dataprep.transform.TeddyImpl;
-import app.metatron.discovery.domain.dataprep.util.PrepUtil;
-import app.metatron.discovery.domain.storage.StorageProperties;
-import app.metatron.discovery.util.ExcelProcessor;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+
 import com.monitorjbl.xlsx.StreamingReader;
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
-import java.net.ConnectException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
-import java.nio.channels.FileLock;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
+
 import org.apache.commons.io.FilenameUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -90,6 +38,44 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.io.*;
+import java.net.ConnectException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import app.metatron.discovery.domain.dataprep.entity.PrDataset;
+import app.metatron.discovery.domain.dataprep.entity.PrUploadFile;
+import app.metatron.discovery.domain.dataprep.exceptions.PrepErrorCodes;
+import app.metatron.discovery.domain.dataprep.exceptions.PrepException;
+import app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey;
+import app.metatron.discovery.domain.dataprep.file.PrepCsvUtil;
+import app.metatron.discovery.domain.dataprep.file.PrepJsonUtil;
+import app.metatron.discovery.domain.dataprep.repository.PrDatasetRepository;
+import app.metatron.discovery.domain.dataprep.teddy.DataFrame;
+import app.metatron.discovery.domain.dataprep.teddy.DataFrameService;
+import app.metatron.discovery.domain.dataprep.teddy.exceptions.TeddyException;
+import app.metatron.discovery.domain.dataprep.transform.TeddyImpl;
+import app.metatron.discovery.domain.dataprep.util.PrepUtil;
+import app.metatron.discovery.domain.storage.StorageProperties;
+import app.metatron.discovery.util.ExcelProcessor;
+
+import static app.metatron.discovery.domain.dataprep.PrepProperties.HADOOP_CONF_DIR;
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.*;
+import static app.metatron.discovery.domain.dataprep.util.PrepUtil.configError;
+import static app.metatron.discovery.domain.dataprep.util.PrepUtil.dataflowError;
+import static app.metatron.discovery.domain.dataprep.util.PrepUtil.datasetError;
 
 @Service
 public class PrepDatasetFileService {
@@ -265,6 +251,29 @@ public class PrepDatasetFileService {
 
     String pathStr = fileDatasetUploadLocalPath + File.separator + filename;
     return pathStr;
+  }
+
+  public String getFileFormat(PrDataset dataset) {
+    String fileFormat = "CSV";
+    String extension = FilenameUtils.getExtension(dataset.getFilenameBeforeUpload()).toLowerCase();
+    if(extension!=null) {
+      switch (extension) {
+        case "csv":
+          fileFormat = "CSV";
+          break;
+        case "txt":
+          fileFormat = "TXT";
+          break;
+        case "json":
+          fileFormat = "JSON";
+          break;
+        case "xls":
+        case "xlsx":
+          fileFormat = "EXCEL";
+          break;
+      }
+    }
+    return fileFormat;
   }
 
   private List<String[]> getGridFromExcel(Sheet sheet, int limitRows, Integer columnCount) {

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetFileService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepDatasetFileService.java
@@ -15,12 +15,64 @@
 package app.metatron.discovery.domain.dataprep;
 
 
+import static app.metatron.discovery.domain.dataprep.PrepProperties.HADOOP_CONF_DIR;
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_CANNOT_GET_HDFS_FILE_SYSTEM;
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_CANNOT_READ_FROM_HDFS_PATH;
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_CANNOT_READ_FROM_LOCAL_PATH;
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_CANNOT_WRITE_TO_LOCAL_PATH;
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_FILE_FORMAT_WRONG;
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_HADOOP_HDFS_FAILED_TO_CONNECT;
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_MALFORMED_URI_SYNTAX;
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_REQUIRED_PROPERTY_MISSING;
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_UNKOWN_ERROR;
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_UNSUPPORTED_URI_SCHEME;
+import static app.metatron.discovery.domain.dataprep.util.PrepUtil.configError;
+import static app.metatron.discovery.domain.dataprep.util.PrepUtil.dataflowError;
+import static app.metatron.discovery.domain.dataprep.util.PrepUtil.datasetError;
+
+import app.metatron.discovery.domain.dataprep.entity.PrDataset;
+import app.metatron.discovery.domain.dataprep.entity.PrUploadFile;
+import app.metatron.discovery.domain.dataprep.exceptions.PrepErrorCodes;
+import app.metatron.discovery.domain.dataprep.exceptions.PrepException;
+import app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey;
+import app.metatron.discovery.domain.dataprep.file.PrepCsvUtil;
+import app.metatron.discovery.domain.dataprep.file.PrepJsonUtil;
+import app.metatron.discovery.domain.dataprep.repository.PrDatasetRepository;
+import app.metatron.discovery.domain.dataprep.teddy.DataFrame;
+import app.metatron.discovery.domain.dataprep.teddy.DataFrameService;
+import app.metatron.discovery.domain.dataprep.teddy.exceptions.TeddyException;
+import app.metatron.discovery.domain.dataprep.transform.TeddyImpl;
+import app.metatron.discovery.domain.dataprep.util.PrepUtil;
+import app.metatron.discovery.domain.storage.StorageProperties;
+import app.metatron.discovery.util.ExcelProcessor;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-
 import com.monitorjbl.xlsx.StreamingReader;
-
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.net.ConnectException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -38,44 +90,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.io.*;
-import java.net.ConnectException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
-import java.nio.channels.FileLock;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-
-import app.metatron.discovery.domain.dataprep.entity.PrDataset;
-import app.metatron.discovery.domain.dataprep.entity.PrUploadFile;
-import app.metatron.discovery.domain.dataprep.exceptions.PrepErrorCodes;
-import app.metatron.discovery.domain.dataprep.exceptions.PrepException;
-import app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey;
-import app.metatron.discovery.domain.dataprep.file.PrepCsvUtil;
-import app.metatron.discovery.domain.dataprep.file.PrepJsonUtil;
-import app.metatron.discovery.domain.dataprep.repository.PrDatasetRepository;
-import app.metatron.discovery.domain.dataprep.teddy.DataFrame;
-import app.metatron.discovery.domain.dataprep.teddy.DataFrameService;
-import app.metatron.discovery.domain.dataprep.teddy.exceptions.TeddyException;
-import app.metatron.discovery.domain.dataprep.transform.TeddyImpl;
-import app.metatron.discovery.domain.dataprep.util.PrepUtil;
-import app.metatron.discovery.domain.storage.StorageProperties;
-import app.metatron.discovery.util.ExcelProcessor;
-
-import static app.metatron.discovery.domain.dataprep.PrepProperties.HADOOP_CONF_DIR;
-import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.*;
-import static app.metatron.discovery.domain.dataprep.util.PrepUtil.configError;
-import static app.metatron.discovery.domain.dataprep.util.PrepUtil.dataflowError;
-import static app.metatron.discovery.domain.dataprep.util.PrepUtil.datasetError;
 
 @Service
 public class PrepDatasetFileService {
@@ -123,8 +137,7 @@ public class PrepDatasetFileService {
           case "xlsx":
           case "xls":
             assert false : "Excel files are treated as CSV";
-            throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE,
-                    MSG_DP_ALERT_UNKOWN_ERROR, "Excel files should have converted as CSV");
+            throw datasetError(MSG_DP_ALERT_UNKOWN_ERROR, "Excel files should have converted as CSV");
           case "json":
             Configuration hadoopConf = PrepUtil.getHadoopConf(prepProperties.getHadoopConfDir(false));
             result = PrepJsonUtil.countJson(storedUri, limitRows, hadoopConf);
@@ -179,16 +192,14 @@ public class PrepDatasetFileService {
       uri = new URI(dirUri);
     } catch (URISyntaxException e) {
       e.printStackTrace();
-      throw PrepException
-              .create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, MSG_DP_ALERT_MALFORMED_URI_SYNTAX, dirUri);
+      throw datasetError(MSG_DP_ALERT_MALFORMED_URI_SYNTAX, dirUri);
     }
 
     switch (uri.getScheme()) {
       case "hdfs":
         Configuration conf = PrepUtil.getHadoopConf(prepProperties.getHadoopConfDir(true));
         if (conf == null) {
-          throw PrepException.create(PrepErrorCodes.PREP_INVALID_CONFIG_CODE,
-                  MSG_DP_ALERT_REQUIRED_PROPERTY_MISSING, HADOOP_CONF_DIR);
+          throw configError(MSG_DP_ALERT_REQUIRED_PROPERTY_MISSING, HADOOP_CONF_DIR);
         }
         Path path = new Path(uri);
 
@@ -201,8 +212,7 @@ public class PrepDatasetFileService {
           hdfsFs.close();
         } catch (IOException e) {
           e.printStackTrace();
-          throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE,
-                  MSG_DP_ALERT_CANNOT_GET_HDFS_FILE_SYSTEM, dirUri);
+          throw datasetError(MSG_DP_ALERT_CANNOT_GET_HDFS_FILE_SYSTEM, dirUri);
         }
         break;
 
@@ -214,9 +224,7 @@ public class PrepDatasetFileService {
         break;
 
       default:
-        throw PrepException
-                .create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, MSG_DP_ALERT_UNSUPPORTED_URI_SCHEME,
-                        dirUri);
+        throw datasetError(MSG_DP_ALERT_UNSUPPORTED_URI_SCHEME, dirUri);
     }
   }
 
@@ -251,29 +259,6 @@ public class PrepDatasetFileService {
 
     String pathStr = fileDatasetUploadLocalPath + File.separator + filename;
     return pathStr;
-  }
-
-  public String getFileFormat(PrDataset dataset) {
-    String fileFormat = "CSV";
-    String extension = FilenameUtils.getExtension(dataset.getFilenameBeforeUpload()).toLowerCase();
-    if(extension!=null) {
-      switch (extension) {
-        case "csv":
-          fileFormat = "CSV";
-          break;
-        case "txt":
-          fileFormat = "TXT";
-          break;
-        case "json":
-          fileFormat = "JSON";
-          break;
-        case "xls":
-        case "xlsx":
-          fileFormat = "EXCEL";
-          break;
-      }
-    }
-    return fileFormat;
   }
 
   private List<String[]> getGridFromExcel(Sheet sheet, int limitRows, Integer columnCount) {
@@ -340,7 +325,7 @@ public class PrepDatasetFileService {
     List<DataFrame> gridResponses = Lists.newArrayList();
     Workbook workbook;
 
-    URI uri = null;
+    URI uri;
     try {
       uri = new URI(storedUri);
     } catch (URISyntaxException e) {
@@ -348,7 +333,7 @@ public class PrepDatasetFileService {
       throw datasetError(MSG_DP_ALERT_MALFORMED_URI_SYNTAX, storedUri);
     }
 
-    InputStream is = null;
+    InputStream is;
     switch (uri.getScheme()) {
       case "hdfs":
         Configuration conf = PrepUtil.getHadoopConf(prepProperties.getHadoopConfDir(true));
@@ -441,9 +426,8 @@ public class PrepDatasetFileService {
     return responseMap;
   }
 
-  private Map<String, Object> getResponseMapFromCsv(String storedUri, int limitRows,
-                                                    String delimiterCol, String quoteChar,
-                                                    Integer columnCount, boolean autoTyping) throws TeddyException {
+  private Map<String, Object> getResponseMapFromCsv(String storedUri, int limitRows, String delimiterCol,
+          String quoteChar, Integer columnCount, boolean autoTyping) throws TeddyException {
     Map<String, Object> responseMap = Maps.newHashMap();
     List<DataFrame> gridResponses = Lists.newArrayList();
     Configuration hadoopConf = PrepUtil.getHadoopConf(prepProperties.getHadoopConfDir(false));
@@ -468,8 +452,7 @@ public class PrepDatasetFileService {
   }
 
   public void checkStoredUri(String storedUri) {
-
-    URI uri = null;
+    URI uri;
     try {
       uri = new URI(storedUri);
     } catch (URISyntaxException e) {
@@ -492,24 +475,8 @@ public class PrepDatasetFileService {
 
   }
 
-  /*
-   * Response contains:
-   *   success    FIXME: do not use   -> 200 or 500
-   *   message    FIXME: do not use   -> error message in the exception
-   *   sheets     List<String> sheet names    (Excel only)
-   *   grid[]
-   *     headers  FIXME: do not use   -> empty[] (CSV, Excel) or null (JSON)
-   *     field[]  FIXME: only name & type is needed
-   *       column name
-   *       column type
-   *       is dimension?
-   *       column#
-   *     data     List<Map<String, String>
-   *     totalRows    FIXME: is this needed?
-   *     sheetName    (Excel only)
-   *   totalBytes     FIXME: is this needed?
-   */
-  public Map<String, Object> makeFileGrid(String storedUri, Integer size, String delimiterCol, String quoteChar, Integer columnCount,
+  public Map<String, Object> makeFileGrid(String storedUri, Integer size, String delimiterCol, String quoteChar,
+          Integer columnCount,
           boolean autoTyping) {
 
     Map<String, Object> responseMap;

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepPreviewLineService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepPreviewLineService.java
@@ -60,7 +60,7 @@ public class PrepPreviewLineService {
   Integer limit;
 
   PrepPreviewLineService() {
-    this.limit = 200;
+    limit = 200;
   }
 
   private String getPreviewPath() {
@@ -82,11 +82,11 @@ public class PrepPreviewLineService {
   }
 
   public int putPreviewLines(String dsId, DataFrame gridResponse) {
-    int size = 0;
+    int size;
 
     LOGGER.trace("putPreviewLines(): start");
-    PrDataset dataset = this.datasetRepository.findRealOne(this.datasetRepository.findOne(dsId));
-    assert (dataset != null);
+    PrDataset dataset = datasetRepository.findRealOne(datasetRepository.findOne(dsId));
+    assert dataset != null;
 
     DataFrame previewGrid = new DataFrame();
     previewGrid.colCnt = gridResponse.colCnt;
@@ -101,8 +101,8 @@ public class PrepPreviewLineService {
     previewGrid.ruleString = gridResponse.ruleString;
 
     size = gridResponse.rows.size();
-    if (this.limit < size) {
-      previewGrid.rows = gridResponse.rows.subList(0, this.limit);
+    if (limit < size) {
+      previewGrid.rows = gridResponse.rows.subList(0, limit);
     } else {
       previewGrid.rows = gridResponse.rows;
     }
@@ -125,16 +125,16 @@ public class PrepPreviewLineService {
     DataFrame dataFrame;
 
     try {
-      PrDataset dataset = this.datasetRepository.findRealOne(this.datasetRepository.findOne(dsId));
+      PrDataset dataset = datasetRepository.findRealOne(datasetRepository.findOne(dsId));
       assert (dataset != null);
 
       ObjectMapper mapper = GlobalObjectMapper.getDefaultMapper();
       String filepath = getPreviewPath() + File.separator + dataset.getDsId() + ".df";
       File theFile = new File(filepath);
-      if (true == theFile.exists()) {
+      if (theFile.exists()) {
         dataFrame = mapper.readValue(theFile, DataFrame.class);
       } else {
-        dataFrame = this.remakePreviewLines(dsId);
+        dataFrame = savePreviewLines(dsId);
       }
       assert dataFrame != null;
 
@@ -159,7 +159,7 @@ public class PrepPreviewLineService {
         colIdx++;
       }
 
-      if (0 < colNos.size()) {
+      if (colNos.size() > 0) {
         for (Row row : dataFrame.rows) {
           for (Integer colNo : colNos) {
             Object jodaTime = row.get(colNo);
@@ -183,18 +183,18 @@ public class PrepPreviewLineService {
     return dataFrame;
   }
 
-  public DataFrame remakePreviewLines(String dsId) throws IOException, SQLException, TeddyException {
+  public DataFrame savePreviewLines(String dsId) throws IOException, SQLException, TeddyException {
     DataFrame dataFrame = null;
 
-    PrDataset dataset = this.datasetRepository.findRealOne(this.datasetRepository.findOne(dsId));
+    PrDataset dataset = datasetRepository.findRealOne(datasetRepository.findOne(dsId));
     assert (dataset != null);
 
     switch (dataset.getDsType()) {
       case IMPORTED:
-        dataFrame = this.datasetService.getImportedPreview(dataset);
+        dataFrame = datasetService.getImportedPreview(dataset);
         break;
       case WRANGLED:
-        PrepTransformResponse transformResponse = this.transformService.fetch(dsId, null);
+        PrepTransformResponse transformResponse = transformService.fetch(dsId, null);
         dataFrame = transformResponse.getGridResponse();
         break;
     }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/entity/PrDataset.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/entity/PrDataset.java
@@ -81,7 +81,6 @@ public class PrDataset extends AbstractHistoryEntity {
     }
   }
 
-  /*willberemoved
   @JsonFormat(shape = JsonFormat.Shape.OBJECT)
   public enum FILE_FORMAT {
     CSV,
@@ -93,7 +92,6 @@ public class PrDataset extends AbstractHistoryEntity {
       return name();
     }
   }
-  */
 
   @JsonFormat(shape = JsonFormat.Shape.OBJECT)
   public enum RS_TYPE {
@@ -234,11 +232,9 @@ public class PrDataset extends AbstractHistoryEntity {
   @Column(name = "sheet_name")
   private String sheetName;
 
-  /*willberemoved
   @Column(name = "file_format")
   @Enumerated(EnumType.STRING)
   private PrDataset.FILE_FORMAT fileFormat;
-  */
 
   @Column(name = "delimiter")
   private String delimiter;
@@ -560,7 +556,6 @@ public class PrDataset extends AbstractHistoryEntity {
     this.sheetName = sheetName;
   }
 
-  /*willberemoved
   public FILE_FORMAT getFileFormat() {
     return fileFormat;
   }
@@ -568,7 +563,6 @@ public class PrDataset extends AbstractHistoryEntity {
   public void setFileFormat(FILE_FORMAT fileFormat) {
     this.fileFormat = fileFormat;
   }
-  */
 
   public String getDelimiter() {
     return delimiter;

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/entity/PrDataset.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/entity/PrDataset.java
@@ -14,25 +14,32 @@
 
 package app.metatron.discovery.domain.dataprep.entity;
 
+import app.metatron.discovery.domain.AbstractHistoryEntity;
+import app.metatron.discovery.domain.dataprep.teddy.DataFrame;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
-
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.ManyToMany;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+import javax.validation.constraints.Size;
 import org.hibernate.annotations.GenericGenerator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.persistence.*;
-import javax.validation.constraints.Size;
-
-import app.metatron.discovery.domain.AbstractHistoryEntity;
-import app.metatron.discovery.domain.dataprep.teddy.DataFrame;
 
 @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
 @Entity
@@ -557,10 +564,12 @@ public class PrDataset extends AbstractHistoryEntity {
   }
 
   public FILE_FORMAT getFileFormat() {
+    LOGGER.error("fileFormat is deprecated.");
     return fileFormat;
   }
 
   public void setFileFormat(FILE_FORMAT fileFormat) {
+    LOGGER.error("fileFormat is deprecated.");
     this.fileFormat = fileFormat;
   }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/entity/PrDataset.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/entity/PrDataset.java
@@ -81,6 +81,7 @@ public class PrDataset extends AbstractHistoryEntity {
     }
   }
 
+  /*willberemoved
   @JsonFormat(shape = JsonFormat.Shape.OBJECT)
   public enum FILE_FORMAT {
     CSV,
@@ -92,6 +93,7 @@ public class PrDataset extends AbstractHistoryEntity {
       return name();
     }
   }
+  */
 
   @JsonFormat(shape = JsonFormat.Shape.OBJECT)
   public enum RS_TYPE {
@@ -232,9 +234,11 @@ public class PrDataset extends AbstractHistoryEntity {
   @Column(name = "sheet_name")
   private String sheetName;
 
+  /*willberemoved
   @Column(name = "file_format")
   @Enumerated(EnumType.STRING)
   private PrDataset.FILE_FORMAT fileFormat;
+  */
 
   @Column(name = "delimiter")
   private String delimiter;
@@ -556,6 +560,7 @@ public class PrDataset extends AbstractHistoryEntity {
     this.sheetName = sheetName;
   }
 
+  /*willberemoved
   public FILE_FORMAT getFileFormat() {
     return fileFormat;
   }
@@ -563,6 +568,7 @@ public class PrDataset extends AbstractHistoryEntity {
   public void setFileFormat(FILE_FORMAT fileFormat) {
     this.fileFormat = fileFormat;
   }
+  */
 
   public String getDelimiter() {
     return delimiter;

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/entity/PrDatasetProjections.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/entity/PrDatasetProjections.java
@@ -94,7 +94,9 @@ public class PrDatasetProjections {
 
     String getSheetName();
 
+    /*willberemoved
     PrDataset.FILE_FORMAT getFileFormat();
+    */
 
     String getDelimiter();
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/entity/PrDatasetProjections.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/entity/PrDatasetProjections.java
@@ -94,10 +94,6 @@ public class PrDatasetProjections {
 
     String getSheetName();
 
-    /*willberemoved
-    PrDataset.FILE_FORMAT getFileFormat();
-    */
-
     String getDelimiter();
 
     Integer getManualColumnCount();

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/service/PrDatasetService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/service/PrDatasetService.java
@@ -14,22 +14,11 @@
 
 package app.metatron.discovery.domain.dataprep.service;
 
-import com.google.common.collect.Lists;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import org.hibernate.Hibernate;
-import org.hibernate.proxy.HibernateProxy;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.io.IOException;
-import java.sql.SQLException;
-import java.util.List;
-import java.util.Map;
+import static app.metatron.discovery.domain.dataprep.entity.PrDataset.IMPORT_TYPE.UPLOAD;
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_FILE_KEY_MISSING;
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey.MSG_DP_ALERT_IMPORT_TYPE_IS_WRONG;
+import static app.metatron.discovery.domain.dataprep.util.PrepUtil.datasetError;
+import static org.apache.commons.io.FilenameUtils.getExtension;
 
 import app.metatron.discovery.common.GlobalObjectMapper;
 import app.metatron.discovery.domain.dataconnection.DataConnection;
@@ -39,11 +28,22 @@ import app.metatron.discovery.domain.dataprep.PrepDatasetFileService;
 import app.metatron.discovery.domain.dataprep.PrepDatasetStagingDbService;
 import app.metatron.discovery.domain.dataprep.PrepPreviewLineService;
 import app.metatron.discovery.domain.dataprep.entity.PrDataset;
-import app.metatron.discovery.domain.dataprep.exceptions.PrepErrorCodes;
 import app.metatron.discovery.domain.dataprep.exceptions.PrepException;
-import app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey;
 import app.metatron.discovery.domain.dataprep.teddy.DataFrame;
 import app.metatron.discovery.domain.dataprep.teddy.exceptions.TeddyException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+import org.hibernate.Hibernate;
+import org.hibernate.proxy.HibernateProxy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional
@@ -55,7 +55,7 @@ public class PrDatasetService {
   PrepPreviewLineService previewLineService;
 
   @Autowired
-  private PrepDatasetFileService datasetFilePreviewService;
+  private PrepDatasetFileService prepDatasetFileService;
 
   @Autowired
   private PrepDatasetStagingDbService datasetStagingDbPreviewService;
@@ -75,75 +75,43 @@ public class PrDatasetService {
 
     assert dataset.getDsType() == PrDataset.DS_TYPE.IMPORTED : dataset.getDsType();
 
-    PrDataset.IMPORT_TYPE importType = dataset.getImportType();
-    if (importType == PrDataset.IMPORT_TYPE.UPLOAD || importType == PrDataset.IMPORT_TYPE.URI) {
-      dataFrame = this.datasetFilePreviewService.getPreviewLinesFromFileForDataFrame(dataset, this.filePreviewSize);
-    } else if (importType == PrDataset.IMPORT_TYPE.DATABASE) {
-      dataFrame = this.datasetJdbcPreviewService.getPreviewLinesFromJdbcForDataFrame(dataset, this.jdbcPreviewSize);
-    } else if (importType == PrDataset.IMPORT_TYPE.STAGING_DB) {
-      dataFrame = this.datasetStagingDbPreviewService
-              .getPreviewLinesFromStagedbForDataFrame(dataset, this.hivePreviewSize);
-    } else {
-      throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE,
-              PrepMessageKey.MSG_DP_ALERT_IMPORT_TYPE_IS_WRONG, importType.toString());
+    switch (dataset.getImportType()) {
+      case UPLOAD:
+      case URI:
+        dataFrame = prepDatasetFileService.getPreviewLinesFromFileForDataFrame(dataset, filePreviewSize);
+        break;
+      case DATABASE:
+        dataFrame = datasetJdbcPreviewService.getPreviewLinesFromJdbcForDataFrame(dataset, jdbcPreviewSize);
+        break;
+      case STAGING_DB:
+        dataFrame = datasetStagingDbPreviewService.getPreviewLinesFromStagedbForDataFrame(dataset, hivePreviewSize);
+        break;
+      default:
+        throw datasetError(MSG_DP_ALERT_IMPORT_TYPE_IS_WRONG, dataset.getImportType().name());
     }
 
     return dataFrame;
-  }
-
-  // This function is only for imported datasets!
-  public void savePreview(PrDataset dataset) throws Exception {
-    DataFrame dataFrame = null;
-
-    assert dataset.getDsType() == PrDataset.DS_TYPE.IMPORTED : dataset.getDsType();
-
-    PrDataset.IMPORT_TYPE importType = dataset.getImportType();
-    if (importType == PrDataset.IMPORT_TYPE.UPLOAD || importType == PrDataset.IMPORT_TYPE.URI) {
-      dataFrame = this.datasetFilePreviewService.getPreviewLinesFromFileForDataFrame(dataset, this.filePreviewSize);
-    } else if (importType == PrDataset.IMPORT_TYPE.DATABASE) {
-      dataFrame = this.datasetJdbcPreviewService.getPreviewLinesFromJdbcForDataFrame(dataset, this.jdbcPreviewSize);
-    } else if (importType == PrDataset.IMPORT_TYPE.STAGING_DB) {
-      dataFrame = this.datasetStagingDbPreviewService
-              .getPreviewLinesFromStagedbForDataFrame(dataset, this.hivePreviewSize);
-    } else {
-      throw PrepException
-              .create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_IMPORT_TYPE_IS_WRONG,
-                      importType.name());
-    }
-
-    if (dataFrame != null) {
-      int size = this.previewLineService.putPreviewLines(dataset.getDsId(), dataFrame);
-    }
   }
 
   public void changeFileFormatToCsv(PrDataset dataset) throws Exception {
     String storedUri = dataset.getStoredUri();
     String sheetName = dataset.getSheetName();
     String delimiter = dataset.getDelimiter();
+    String csvStrUri;
 
     if (storedUri == null) {
-      throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_FILE_KEY_MISSING,
-              String.format("dsName=%s fileFormat=%s storedUri=%s", dataset.getDsName(),
-                      this.datasetFilePreviewService.getFileFormat(dataset), storedUri));
+      throw datasetError(MSG_DP_ALERT_FILE_KEY_MISSING, "dsName=" + dataset.getDsName());
     }
 
-    String csvStrUri = null;
-    if ( this.datasetFilePreviewService.getFileFormat(dataset).equals("EXCEL") ) {
-      Integer columnCount = dataset.getManualColumnCount();
-
-      PrDataset.IMPORT_TYPE importType = dataset.getImportType();
-      if (importType == PrDataset.IMPORT_TYPE.UPLOAD) {
-        csvStrUri = this.datasetFilePreviewService.moveExcelToCsv(storedUri, sheetName, delimiter);
+    if (getExtension(storedUri).equals("xls") || getExtension(storedUri).equals("xlsx")) {
+      if (dataset.getImportType() == UPLOAD) {
+        csvStrUri = prepDatasetFileService.moveExcelToCsv(storedUri, sheetName, delimiter);
       } else {
-        csvStrUri = this.datasetFilePreviewService.getPathLocalBase(dataset.getDsId() + ".csv");
-        csvStrUri = this.datasetFilePreviewService.moveExcelToCsv(csvStrUri, storedUri, sheetName, delimiter);
+        csvStrUri = prepDatasetFileService.getPathLocalBase(dataset.getDsId() + ".csv");
+        csvStrUri = prepDatasetFileService.moveExcelToCsv(csvStrUri, storedUri, sheetName, delimiter);
       }
-    }
-    if (csvStrUri != null) {
       dataset.setStoredUri(csvStrUri);
     }
-
-    return;
   }
 
   public DataConnection findRealDataConnection(DataConnection lazyOne) {
@@ -160,8 +128,8 @@ public class PrDatasetService {
 
   public void setConnectionInfo(PrDataset dataset) throws PrepException {
     String dcId = dataset.getDcId();
-    if (null != dcId) {
-      DataConnection dataConnection = findRealDataConnection(this.dataConnectionRepository.getOne(dcId));
+    if (dcId != null) {
+      DataConnection dataConnection = findRealDataConnection(dataConnectionRepository.getOne(dcId));
 
       dataset.setDcName(dataConnection.getName());
       dataset.setDcDesc(dataConnection.getDescription());
@@ -212,11 +180,11 @@ public class PrDatasetService {
     ObjectMapper objectMapper = GlobalObjectMapper.getDefaultMapper();
     Map<String, Object> mapDataset = objectMapper.convertValue(patchDataset, Map.class);
     for (String key : mapDataset.keySet()) {
-      if (false == ignoreKeys.contains(key)) {
+      if (!ignoreKeys.contains(key)) {
         continue;
       }
 
-      if (false == allowKeys.contains(key)) {
+      if (!allowKeys.contains(key)) {
         LOGGER.debug("'" + key + "' of pr-dataset is an attribute to which patch is not applied");
       }
     }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/service/PrDatasetService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/service/PrDatasetService.java
@@ -14,6 +14,23 @@
 
 package app.metatron.discovery.domain.dataprep.service;
 
+import com.google.common.collect.Lists;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.hibernate.Hibernate;
+import org.hibernate.proxy.HibernateProxy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+
 import app.metatron.discovery.common.GlobalObjectMapper;
 import app.metatron.discovery.domain.dataconnection.DataConnection;
 import app.metatron.discovery.domain.dataconnection.DataConnectionRepository;
@@ -27,19 +44,6 @@ import app.metatron.discovery.domain.dataprep.exceptions.PrepException;
 import app.metatron.discovery.domain.dataprep.exceptions.PrepMessageKey;
 import app.metatron.discovery.domain.dataprep.teddy.DataFrame;
 import app.metatron.discovery.domain.dataprep.teddy.exceptions.TeddyException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Lists;
-import java.io.IOException;
-import java.sql.SQLException;
-import java.util.List;
-import java.util.Map;
-import org.hibernate.Hibernate;
-import org.hibernate.proxy.HibernateProxy;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional
@@ -120,11 +124,11 @@ public class PrDatasetService {
     if (storedUri == null) {
       throw PrepException.create(PrepErrorCodes.PREP_DATASET_ERROR_CODE, PrepMessageKey.MSG_DP_ALERT_FILE_KEY_MISSING,
               String.format("dsName=%s fileFormat=%s storedUri=%s", dataset.getDsName(),
-                      dataset.getFileFormat(), storedUri));
+                      this.datasetFilePreviewService.getFileFormat(dataset), storedUri));
     }
 
     String csvStrUri = null;
-    if (dataset.getFileFormat() == PrDataset.FILE_FORMAT.EXCEL) {
+    if ( this.datasetFilePreviewService.getFileFormat(dataset).equals("EXCEL") ) {
       Integer columnCount = dataset.getManualColumnCount();
 
       PrDataset.IMPORT_TYPE importType = dataset.getImportType();

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/TeddyImpl.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/transform/TeddyImpl.java
@@ -14,29 +14,7 @@
 
 package app.metatron.discovery.domain.dataprep.transform;
 
-import com.facebook.presto.jdbc.internal.guava.collect.Maps;
-import com.facebook.presto.jdbc.internal.joda.time.DateTime;
-import com.facebook.presto.jdbc.internal.joda.time.format.DateTimeFormat;
-import com.facebook.presto.jdbc.internal.joda.time.format.DateTimeFormatter;
-
-import org.apache.commons.io.FilenameUtils;
-import org.apache.hadoop.conf.Configuration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
-
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
+import static app.metatron.discovery.domain.dataprep.exceptions.PrepErrorCodes.PREP_TEDDY_ERROR_CODE;
 
 import app.metatron.discovery.domain.dataconnection.DataConnection;
 import app.metatron.discovery.domain.dataconnection.DataConnectionHelper;
@@ -56,8 +34,27 @@ import app.metatron.discovery.domain.dataprep.util.PrepUtil;
 import app.metatron.discovery.domain.storage.StorageProperties;
 import app.metatron.discovery.domain.storage.StorageProperties.StageDBConnection;
 import app.metatron.discovery.extension.dataconnection.jdbc.accessor.JdbcAccessor;
-
-import static app.metatron.discovery.domain.dataprep.exceptions.PrepErrorCodes.PREP_TEDDY_ERROR_CODE;
+import com.facebook.presto.jdbc.internal.guava.collect.Maps;
+import com.facebook.presto.jdbc.internal.joda.time.DateTime;
+import com.facebook.presto.jdbc.internal.joda.time.format.DateTimeFormat;
+import com.facebook.presto.jdbc.internal.joda.time.format.DateTimeFormatter;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 @Component
 public class TeddyImpl {
@@ -276,7 +273,7 @@ public class TeddyImpl {
 
   public DataFrame loadFileDataset(String dsId, String strUri, String delimiter, String quoteChar,
           Integer columnCount, String dsName) {
-    DataFrame df = new DataFrame(dsName);   // join, union등에서 dataset 이름을 제공하기위해 dsName 추가
+    DataFrame df = new DataFrame(dsName);   // to provide dataset name in join, union
     Configuration hadoopConf = PrepUtil.getHadoopConf(prepProperties.getHadoopConfDir(false));
     int samplingRows = prepProperties.getSamplingLimitRows();
 


### PR DESCRIPTION
### Description
the fileFormat field in PrDataset will be removed
that information is not needed because we can see the file format by uri

**Related Issue** : 
[2962](https://github.com/metatron-app/metatron-discovery/issues/2962)

### How Has This Been Tested?
create datasets from files of various formats
the fileFormat field must not be used

#### Need additional checks?
PrDataset is JPA entity.
the table should be changed.
make sure that ALTER TABLE is done well

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
