### PR TITLE
#2966 dataset cache out per every 3 hours

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/config/SchedulingConfig.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/config/SchedulingConfig.java
@@ -14,6 +14,7 @@
 
 package app.metatron.discovery.config;
 
+import app.metatron.discovery.domain.scheduling.dataprep.DatasetCacheOutJob;
 import org.quartz.spi.JobFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -92,7 +93,8 @@ public class SchedulingConfig {
                                        tempCSVFileCleanJob().getObject(),
                                        timeoutWorkbenchConnectionCloseJob().getObject(),
                                        engineMonitoringJob().getObject(),
-                                       engineMonitoringSetter().getObject());
+                                       engineMonitoringSetter().getObject(),
+                                       datasetCacheOutJob().getObject());
     schedulerFactoryBean.setTriggers(dataSourceCheckTrigger().getObject(),
                                      dataSourceIngestionCheckTrigger().getObject(),
                                      dataSourceSizeCheckTrigger().getObject(),
@@ -102,7 +104,8 @@ public class SchedulingConfig {
                                      tempCSVFileCleanTrigger().getObject(),
                                      timeoutWorkbenchConnectionCloseTrigger().getObject(),
                                      engineMonitoringTrigger().getObject(),
-                                     engineMonitoringSetterTrigger().getObject());
+                                     engineMonitoringSetterTrigger().getObject(),
+                                     datasetCacheOutTrigger().getObject());
 
     return schedulerFactoryBean;
   }
@@ -392,4 +395,33 @@ public class SchedulingConfig {
     return jobDetailFactory;
   }
 
+  /**
+   * Cache-out idle wrangled datasets.
+   *
+   * @return
+   */
+  @Bean
+  public JobDetailFactoryBean datasetCacheOutJob() {
+    JobDetailFactoryBean jobDetailFactory = new JobDetailFactoryBean();
+    jobDetailFactory.setName("dataset-cache-out");
+    jobDetailFactory.setGroup(JOB_GROUP_CLEANER);
+    jobDetailFactory.setJobClass(DatasetCacheOutJob.class);
+    jobDetailFactory.setDurability(true);
+    return jobDetailFactory;
+  }
+
+  /**
+   * Every 3 hours
+   *
+   * @return
+   */
+  @Bean
+  public CronTriggerFactoryBean datasetCacheOutTrigger() {
+    CronTriggerFactoryBean triggerFactory = new CronTriggerFactoryBean();
+    triggerFactory.setJobDetail(datasetCacheOutJob().getObject());
+    triggerFactory.setName("dataset-cache-out-trigger");
+    triggerFactory.setGroup(JOB_GROUP_CLEANER);
+    triggerFactory.setCronExpression("0 0 0/3 1/1 * ? *");
+    return triggerFactory;
+  }
 }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepProperties.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataprep/PrepProperties.java
@@ -122,6 +122,14 @@ public class PrepProperties {
     return sampling.getAutoTyping();
   }
 
+  public Integer getSamplingCacheSize() {
+    return sampling.getCacheSize();
+  }
+
+  public Integer getSamplingIdleTime() {
+    return sampling.getIdleTime();
+  }
+
   public Integer getEtlCores() {
     return etl.getCores();
   }
@@ -223,6 +231,8 @@ public class PrepProperties {
     public Integer limitRows;
     public Integer maxFetchSize;
     public Boolean autoTyping;
+    public Integer cacheSize;
+    public Integer idleTime;
 
     public SamplingInfo() {
     }
@@ -262,6 +272,20 @@ public class PrepProperties {
       return autoTyping;
     }
 
+    public Integer getCacheSize() {
+      if (cacheSize == null) {
+        cacheSize = 2;
+      }
+      return cacheSize;
+    }
+
+    public Integer getIdleTime() {
+      if (idleTime == null) {
+        idleTime = 3 * 3600;
+      }
+      return idleTime;
+    }
+
     public void setCores(Integer cores) {
       this.cores = cores;
     }
@@ -280,6 +304,14 @@ public class PrepProperties {
 
     public void setAutoTyping(Boolean autoTyping) {
       this.autoTyping = autoTyping;
+    }
+
+    public void setCacheSize(Integer cacheSize) {
+      this.cacheSize = cacheSize;
+    }
+
+    public void setIdleTime(Integer idleTime) {
+      this.idleTime = idleTime;
     }
 
     @Override

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/scheduling/dataprep/DatasetCacheOutJob.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/scheduling/dataprep/DatasetCacheOutJob.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.metatron.discovery.domain.scheduling.dataprep;
+
+import app.metatron.discovery.domain.dataprep.PrepProperties;
+import app.metatron.discovery.domain.dataprep.transform.PrepTransformService;
+import app.metatron.discovery.domain.dataprep.transform.TeddyImpl;
+import app.metatron.discovery.domain.engine.EngineProperties;
+import app.metatron.discovery.domain.workbench.WorkbenchProperties;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.joda.time.DateTime;
+import org.joda.time.Duration;
+import org.joda.time.Period;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.quartz.QuartzJobBean;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Transactional(readOnly = true, isolation = Isolation.READ_UNCOMMITTED)
+public class DatasetCacheOutJob extends QuartzJobBean {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DatasetCacheOutJob.class);
+
+  @Autowired
+  TeddyImpl teddyImpl;
+
+  public DatasetCacheOutJob() {
+  }
+
+  @Override
+  public void executeInternal(JobExecutionContext jobExecutionContext) throws JobExecutionException {
+
+    LOGGER.info("## Start batch job for checking idle wrangled datasets.");
+    teddyImpl.datasetCacheOut();
+  }
+}


### PR DESCRIPTION
### Description
Old W.DS will be cache-out'ed according to the configuration.
polaris.dataprep.sampling.cacheSize -> How many W.DS should be keep.
polaris.dataprep.sampling.idleTime -> Although it's the oldest, if it had been used recently, it's excepted.

**Related Issue** : #2966 


### How Has This Been Tested?
Ran locally.

#### Need additional checks?
No, thanks.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
