### PR TITLE
#2997 Workbench schema information Data tab query error

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/HiveDialect.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/dialect/HiveDialect.java
@@ -438,4 +438,8 @@ public class HiveDialect implements JdbcDialect {
     if(StringUtils.isEmpty(metastorePassword)) return false;
     return true;
   }
+
+  public String getNoneStrictMode() {
+    return "set hive.mapred.mode=nonstrict";
+  }
 }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcConnectionService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcConnectionService.java
@@ -299,6 +299,10 @@ public class JdbcConnectionService {
       if (limit > 0)
         stmt.setMaxRows(limit);
 
+      if(dialect instanceof HiveDialect) {
+        stmt.execute(((HiveDialect)dialect).getNoneStrictMode());
+      }
+
       rs = stmt.executeQuery(query);
 
       queryResultSet = getJdbcQueryResult(rs, dialect, extractColumnName);


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
워크벤치 스키마 브라우저 같은 사용자가 쿼리를 제어할 수 없는 부분에 한하여 커넥션에 `hive.mapred.mode=nonstrict`를 추가로 실행하도록 수정 하였습니다.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#2997

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Hive 서버에 아래와 같이 설정 후 파티션 컬럼이 포함된 테이블을 만들고 스키마 브라우저에서 'Data' 탭에 데이터가 정상적으로 보여지는지 확인 했습니다.
```xml
<!-- hive-site.xml -->
<!-- ... -->
<property>
    <name>hive.mapred.mode</name>
    <description>The mode in which the hive operations are being performed. 
     In strict mode, some risky queries are not allowed to run. They include:
       Cartesian Product.
       No partition being picked up for a query.
       Comparing bigints and strings.
       Comparing bigints and doubles.
       Orderby without limit.</description>
    <value>strict</value>
  </property>
```

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
