### PR TITLE
#3045 decrypt password in welcome email

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/user/UserController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/user/UserController.java
@@ -329,9 +329,13 @@ public class UserController {
 
     // mail 전송을 수행하지 않고 패스워드를 지정하지 않은 경우 시스템에서 비번 생성
     if (!user.getPassMailer() || StringUtils.isEmpty(user.getPassword())) {
-      String encodedPassword = passwordEncoder.encode(PolarisUtils.createTemporaryPassword(8));
-      user.setPassword(encodedPassword);
+      user.setPassword(PolarisUtils.createTemporaryPassword(8));
     }
+
+    //encode password
+    String decryptedPassword = user.getPassword();
+    String encodedPassword = passwordEncoder.encode(user.getPassword());
+    user.setPassword(encodedPassword);
 
     user.setStatus(User.Status.ACTIVATED);
 
@@ -353,7 +357,7 @@ public class UserController {
     userRepository.save(user);
 
     if (!user.getPassMailer()) {
-      mailer.sendSignUpApprovedMail(user, true, user.getPassword());
+      mailer.sendSignUpApprovedMail(user, true, decryptedPassword);
     }
 
     Map<String, Object> responseMap = Maps.newHashMap();


### PR DESCRIPTION
### Description
changed to use plain text password for sending welcome mail

**Related Issue** : #3045 

### How Has This Been Tested?
1. turn on "bcrypt-encoder" in application.yaml
2. Go to Administration > User > Members
3. Click on 'Create member'
4. Create user with email address.
5. Check email inbox.
6. See the plain password in the welcome email.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
