### PR TITLE
#3040 use engineName parameter for user-defined validation

### DIFF
--- a/discovery-frontend/src/app/dashboard/component/custom-field/custom-field.component.ts
+++ b/discovery-frontend/src/app/dashboard/component/custom-field/custom-field.component.ts
@@ -27,7 +27,7 @@ import {
 } from '@angular/core';
 import {DashboardService} from '../../service/dashboard.service';
 import {CommonCode} from '../../../domain/code/common-code';
-import {ConnectionType, Field, FieldRole} from '../../../domain/datasource/datasource';
+import {Field, FieldRole} from '../../../domain/datasource/datasource';
 import {AbstractComponent} from '../../../common/component/abstract.component';
 import {Alert} from '../../../common/util/alert.util';
 import {BoardDataSource} from '../../../domain/dashboard/dashboard';
@@ -614,7 +614,7 @@ export class CustomFieldComponent extends AbstractComponent implements OnInit, O
       expr = StringUtil.trim(expr);
 
       const cloneDs:BoardDataSource = _.cloneDeep( this.dataSource );
-      if( ConnectionType.LINK.toString() === cloneDs.connType && !isNullOrUndefined(cloneDs.engineName) ) {
+      if( !isNullOrUndefined(cloneDs.engineName) ) {
         cloneDs.name = cloneDs.engineName;
       }
       const param = { expr, dataSource: DashboardUtil.convertBoardDataSourceSpecToServer(cloneDs) };


### PR DESCRIPTION
### Description
Use enigneName parameter regardless of connection type.

**Related Issue** : #3040 


### How Has This Been Tested?
1. Create Chart with Data Source of Korean Name
2. Create user defined column
3. Click "Validation check"
4. Validation check success

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
