### PR TITLE
#3049 In case of real-time dashboard, cache should not used

### DIFF
--- a/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
+++ b/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
@@ -1589,25 +1589,28 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
         //   data.columns[0].value.push(Math.floor((Math.random() * 12) - 9));
         // }
 
-        const colSize = data.columns.length;
-        for(let colIdx = 0; colIdx < colSize; ++colIdx){
-          let colData = data.columns[colIdx].value;
-          let newData = data.rows.map((rowItem, idx) => {
-            return {
-              row: rowItem,
-              col: colData[idx]
-            };
-          }).sort((a, b) => {
-            return moment(a.row).isBefore(moment(b.row));
-          });
-          newData.forEach(newItem => {
-            if (!this.resultData.data.rows.some(row => row === newItem.row)) {
-              this.resultData.data.rows.push(newItem.row);
-              this.resultData.data.columns[colIdx].value.push(newItem.col);
+        const columnSize = data.columns.length;
+        let newData = data.rows.map((rowItem, rowIndex) => {
+          let columnValues = [];
+          for(let columnIdx = 0; columnIdx < columnSize; ++columnIdx){
+            let columnValue = data.columns[columnIdx].value;
+            columnValues.push(columnValue[rowIndex]);
+          }
+          return {
+            row: rowItem,
+            col: columnValues
+          };
+        }).sort((a, b) => {
+          return moment(a.row).isBefore(moment(b.row));
+        });
+        newData.forEach(newItem => {
+          if (!this.resultData.data.rows.some(row => row === newItem.row)) {
+            this.resultData.data.rows.push(newItem.row);
+            for(let columnIdx = 0; columnIdx < columnSize; ++columnIdx){
+              this.resultData.data.columns[columnIdx].value.push(newItem.col[columnIdx]);
             }
-          });
-        }
-        // console.info( '>>>>>>', newData );
+          }
+        });
       } else {
         this.resultData = {
           data,

--- a/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
+++ b/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
@@ -74,7 +74,6 @@ import {Pivot} from "../../../domain/workbook/configurations/pivot";
 import {MapChartComponent} from '../../../common/component/chart/type/map-chart/map-chart.component';
 import {Shelf, ShelfLayers} from "../../../domain/workbook/configurations/shelf/shelf";
 import {CommonConstant} from "../../../common/constant/common.constant";
-import {clone} from "@turf/turf";
 
 declare let $;
 declare let moment;
@@ -1577,8 +1576,9 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
     this._currentSelectionFilters = currentSelectionFilters;
     this._currentSelectionFilterString = JSON.stringify(currentSelectionFilters);
     this._currentGlobalFilterString = JSON.stringify(globalFilters);
+    const disableCache: boolean = this.isRealTimeWidget;
 
-    this.datasourceService.searchQuery(cloneQuery).then((data) => {
+    this.datasourceService.searchQuery(cloneQuery, disableCache).then((data) => {
 
       if (this.resultData && this.isRealTimeWidget && cloneQuery.pivot.columns.some(item => 'TIMESTAMP' === item.subRole)) {
 

--- a/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
+++ b/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
@@ -1589,21 +1589,24 @@ export class PageWidgetComponent extends AbstractWidgetComponent implements OnIn
         //   data.columns[0].value.push(Math.floor((Math.random() * 12) - 9));
         // }
 
-        let colData = data.columns[0].value;
-        let newData = data.rows.map((rowItem, idx) => {
-          return {
-            row: rowItem,
-            col: colData[idx]
-          };
-        }).sort((a, b) => {
-          return moment(a.row).isBefore(moment(b.row));
-        });
-        newData.forEach(newItem => {
-          if (!this.resultData.data.rows.some(row => row === newItem.row)) {
-            this.resultData.data.rows.push(newItem.row);
-            this.resultData.data.columns[0].value.push(newItem.col);
-          }
-        });
+        const colSize = data.columns.length;
+        for(let colIdx = 0; colIdx < colSize; ++colIdx){
+          let colData = data.columns[colIdx].value;
+          let newData = data.rows.map((rowItem, idx) => {
+            return {
+              row: rowItem,
+              col: colData[idx]
+            };
+          }).sort((a, b) => {
+            return moment(a.row).isBefore(moment(b.row));
+          });
+          newData.forEach(newItem => {
+            if (!this.resultData.data.rows.some(row => row === newItem.row)) {
+              this.resultData.data.rows.push(newItem.row);
+              this.resultData.data.columns[colIdx].value.push(newItem.col);
+            }
+          });
+        }
         // console.info( '>>>>>>', newData );
       } else {
         this.resultData = {

--- a/discovery-frontend/src/app/datasource/service/datasource.service.ts
+++ b/discovery-frontend/src/app/datasource/service/datasource.service.ts
@@ -134,14 +134,14 @@ export class DatasourceService extends AbstractService {
    * @param {SearchQueryRequest} query
    * @returns {Promise<any>}
    */
-  public searchQuery(query: SearchQueryRequest): Promise<any> {
+  public searchQuery(query: SearchQueryRequest, disableCache?: boolean): Promise<any> {
     // let params: any = {type:'spatial_bbox', field:'cell_point', lowerCorner: '129.444 38.444', upperCorner: '129.888 38.999', dataSource: 'cei_m1_b'};
     // let params: any = {type:'spatial_bbox', field:'cell_point', lowerCorner: '38.444 129.444', upperCorner: '38.999 129.888', dataSource: 'cei_m1_b'};
 
     // query.filters.push(params);
     let stringifyQuery = JSON.stringify(query);
     let historyItem = this._searchHistory.find(history => history.query === stringifyQuery);
-    if (historyItem) {
+    if (!disableCache && historyItem) {
       return new Promise((resolve, reject) => {
         resolve(historyItem.result);
       });


### PR DESCRIPTION
### Description
Real-time dashboard should use queried data, not cached data when chart drawing.

**Related Issue** : #3049 


### How Has This Been Tested?
1. Create real-time dashboard.
2. turn on "Data sync" in dashboard edit.
3. turn on "Data sync" in widget tool bar.
4. should re-draw the chart every interval.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
