### PR TITLE
Adjust filtering start/end timestamp when specifying relative filter

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/format/TimeFieldFormat.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/format/TimeFieldFormat.java
@@ -14,18 +14,16 @@
 
 package app.metatron.discovery.domain.workbook.configurations.format;
 
+import app.metatron.discovery.common.exception.BadRequestException;
+import app.metatron.discovery.domain.engine.EngineQueryProperties;
+import app.metatron.discovery.util.EnumUtils;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
 import java.util.Locale;
-
-import app.metatron.discovery.common.exception.BadRequestException;
-import app.metatron.discovery.domain.engine.EngineQueryProperties;
-import app.metatron.discovery.util.EnumUtils;
 
 public abstract class TimeFieldFormat {
 
@@ -284,6 +282,53 @@ public abstract class TimeFieldFormat {
 
       return dateTime;
     }
+
+    public DateTime resetDateTimeByUnit(DateTime dateTime) {
+
+      switch (this) {
+        case YEAR:
+          return dateTime.withMonthOfYear(1).withDayOfMonth(1).withTime(0, 0, 0, 0);
+        case MONTH:
+          return dateTime.withDayOfMonth(1).withTime(0, 0, 0, 0);
+        case WEEK:
+          return dateTime.withDayOfWeek(1).withTime(0, 0, 0, 0);
+        case DAY:
+          return dateTime.withTime(0, 0, 0, 0);
+        case HOUR:
+          return dateTime.withMinuteOfHour(0).withSecondOfMinute(0).withMillisOfSecond(0);
+        case MINUTE:
+          return dateTime.withSecondOfMinute(0).withMillisOfSecond(0);
+        case SECOND:
+          return dateTime.withMillisOfSecond(0);
+      }
+
+      return dateTime;
+
+    }
+
+    public DateTime maxDateTimeByUnit(DateTime dateTime) {
+
+      switch (this) {
+        case YEAR:
+          return dateTime.withMonthOfYear(12).withDayOfMonth(31).withTime(23, 59, 59, 999);
+        case MONTH:
+          return dateTime.dayOfMonth().withMaximumValue().millisOfDay().withMaximumValue();
+        case WEEK:
+          return dateTime.dayOfWeek().withMaximumValue().millisOfDay().withMaximumValue();
+        case DAY:
+          return dateTime.millisOfDay().withMaximumValue();
+        case HOUR:
+          return dateTime.withMinuteOfHour(59).withSecondOfMinute(59).withMillisOfSecond(999);
+        case MINUTE:
+          return dateTime.withSecondOfMinute(59).withMillisOfSecond(999);
+        case SECOND:
+          return dateTime.withMillisOfSecond(999);
+      }
+
+      return dateTime;
+
+    }
+
   }
 
   public enum ByTimeUnit {

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/workbook/configurations/filter/TimeRelativeFilterTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/workbook/configurations/filter/TimeRelativeFilterTest.java
@@ -14,12 +14,11 @@
 
 package app.metatron.discovery.domain.workbook.configurations.filter;
 
-import org.junit.Before;
-import org.junit.Test;
-
 import app.metatron.discovery.common.GlobalObjectMapper;
 import app.metatron.discovery.domain.datasource.Field;
 import app.metatron.discovery.domain.workbook.configurations.format.CustomDateTimeFormat;
+import org.junit.Before;
+import org.junit.Test;
 
 public class TimeRelativeFilterTest {
 
@@ -51,13 +50,13 @@ public class TimeRelativeFilterTest {
   public void getEngineIntervals() {
 
     TimeRelativeFilter timeRelativeFilter = new TimeRelativeFilter("test field",
-                                                                   "ref",
-                                                                   "HOUR",
-                                                                   null,
-                                                                   "previous",
-                                                                   5,
-                                                                   "Asia/Seoul",
-                                                                   "ko"
+            "ref",
+            "DAY",
+            null,
+            "current",
+            5,
+            "Asia/Seoul",
+            "ko"
     );
 
     System.out.println(timeRelativeFilter.getEngineIntervals(dataSourceField));

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/workbook/configurations/format/TimeFieldFormatTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/workbook/configurations/format/TimeFieldFormatTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specic language governing permissions and
+ * limitations under the License.
+ */
+
+package app.metatron.discovery.domain.workbook.configurations.format;
+
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TimeFieldFormatTest {
+
+  @Test
+  public void resetDateTimeByUnit() {
+
+    DateTime currentTime = DateTime.now();
+
+    //    System.out.println(TimeFieldFormat.TimeUnit.YEAR.resetDateTimeByUnit(currentTime));
+    //    System.out.println(TimeFieldFormat.TimeUnit.MONTH.resetDateTimeByUnit(currentTime));
+    //    System.out.println(TimeFieldFormat.TimeUnit.WEEK.resetDateTimeByUnit(currentTime));
+    //    System.out.println(TimeFieldFormat.TimeUnit.DAY.resetDateTimeByUnit(currentTime));
+    //    System.out.println(TimeFieldFormat.TimeUnit.HOUR.resetDateTimeByUnit(currentTime));
+    //    System.out.println(TimeFieldFormat.TimeUnit.MINUTE.resetDateTimeByUnit(currentTime));
+    //    System.out.println(TimeFieldFormat.TimeUnit.SECOND.resetDateTimeByUnit(currentTime));
+
+    assertEquals(1, TimeFieldFormat.TimeUnit.YEAR.resetDateTimeByUnit(currentTime).getMonthOfYear());
+    assertEquals(1, TimeFieldFormat.TimeUnit.MONTH.resetDateTimeByUnit(currentTime).getDayOfMonth());
+    assertEquals(1, TimeFieldFormat.TimeUnit.WEEK.resetDateTimeByUnit(currentTime).getDayOfWeek());
+    assertEquals(0, TimeFieldFormat.TimeUnit.DAY.resetDateTimeByUnit(currentTime).getHourOfDay());
+    assertEquals(0, TimeFieldFormat.TimeUnit.HOUR.resetDateTimeByUnit(currentTime).getMinuteOfHour());
+    assertEquals(0, TimeFieldFormat.TimeUnit.MINUTE.resetDateTimeByUnit(currentTime).getSecondOfMinute());
+    assertEquals(0, TimeFieldFormat.TimeUnit.SECOND.resetDateTimeByUnit(currentTime).getMillisOfSecond());
+
+  }
+
+  @Test
+  public void maxDateTimeByUnit() {
+
+    DateTime currentTime = DateTime.now();
+
+    //    System.out.println(TimeFieldFormat.TimeUnit.YEAR.maxDateTimeByUnit(currentTime));
+    //    System.out.println(TimeFieldFormat.TimeUnit.MONTH.maxDateTimeByUnit(currentTime));
+    //    System.out.println(TimeFieldFormat.TimeUnit.WEEK.maxDateTimeByUnit(currentTime));
+    //    System.out.println(TimeFieldFormat.TimeUnit.DAY.maxDateTimeByUnit(currentTime));
+    //    System.out.println(TimeFieldFormat.TimeUnit.HOUR.maxDateTimeByUnit(currentTime));
+    //    System.out.println(TimeFieldFormat.TimeUnit.MINUTE.maxDateTimeByUnit(currentTime));
+    //    System.out.println(TimeFieldFormat.TimeUnit.SECOND.maxDateTimeByUnit(currentTime));
+
+    assertEquals(12, TimeFieldFormat.TimeUnit.YEAR.maxDateTimeByUnit(currentTime).getMonthOfYear());
+    assertEquals(currentTime.dayOfMonth().withMaximumValue().getDayOfMonth(),
+            TimeFieldFormat.TimeUnit.MONTH.maxDateTimeByUnit(currentTime).getDayOfMonth());
+    assertEquals(currentTime.dayOfWeek().withMaximumValue().getDayOfWeek(),
+            TimeFieldFormat.TimeUnit.WEEK.maxDateTimeByUnit(currentTime).getDayOfWeek());
+    assertEquals(23, TimeFieldFormat.TimeUnit.DAY.maxDateTimeByUnit(currentTime).getHourOfDay());
+    assertEquals(59, TimeFieldFormat.TimeUnit.HOUR.maxDateTimeByUnit(currentTime).getMinuteOfHour());
+    assertEquals(59, TimeFieldFormat.TimeUnit.MINUTE.maxDateTimeByUnit(currentTime).getSecondOfMinute());
+    assertEquals(999, TimeFieldFormat.TimeUnit.SECOND.maxDateTimeByUnit(currentTime).getMillisOfSecond());
+
+  }
+
+}


### PR DESCRIPTION
### Description
When the relative filter is processed in the system, the time filter is configured by setting the unit lower time value to 0.

**Related Issue** : #3099 

### How Has This Been Tested?

You can check with the built-in "Sales" data source.

1. Create a text table in the dashboard that you linked to the "Sales" data source.
2. Place "Category" in the column area, "OrderDate" with the "Month" granularity in the row area, and "Sales" in the Aggregation.
3. Confirm that the result value of the relative mode and the absolute mode is the same as below

![image](https://user-images.githubusercontent.com/822255/75867161-82e6aa80-5e49-11ea-9a34-453950dbb2c2.png)
![image](https://user-images.githubusercontent.com/822255/75867216-998d0180-5e49-11ea-839b-0b83dcd51738.png)


#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
