### PR TITLE
The open target of the lnb menu supports "new tab" and "frame" types

### DIFF
--- a/discovery-frontend/src/app/common/domain/extension.ts
+++ b/discovery-frontend/src/app/common/domain/extension.ts
@@ -18,4 +18,7 @@ export class Extension {
   public level: number;
   public permissions: string[];
   public subContents:{ [key: string]: string };
+  public openTarget: string;
+  public route: string;
+  public subMenus: Extension[];
 }

--- a/discovery-frontend/src/app/external/external-page.component.ts
+++ b/discovery-frontend/src/app/external/external-page.component.ts
@@ -106,19 +106,28 @@ export class ExternalPageComponent extends AbstractComponent implements OnInit, 
     const arrUrl:string[] = this._url.split('_');
     if( 0 < CommonService.extensions.length ) {
       const menuItem = CommonService.extensions.filter( item => ( item.parent === arrUrl[0] && item.name === arrUrl[1] ) )[0];
-      this._openExternalView(menuItem.subContents[arrUrl[2]]);
+      this._openExternalView(this._getRouteUrl(menuItem, arrUrl[2]));
       this.loadingHide();
     } else {
       this.commonService.getExtensions('lnb').then( items => {
         if( items && 0 < items.length ) {
           const exts:Extension[] = items;
           const menuItem = exts.filter( item => ( item.parent === arrUrl[0] && item.name === arrUrl[1] ) )[0];
-          this._openExternalView(menuItem.subContents[arrUrl[2]]);
+          this._openExternalView(this._getRouteUrl(menuItem, arrUrl[2]));
           this.loadingHide();
         }
       });
     }
   } // function - _loadMenu
+
+  private _getRouteUrl(menuItem: Extension, name: string):string{
+    if (menuItem.subContents != undefined) {
+      return menuItem.subContents[name];
+    } else if (menuItem.subMenus != undefined) {
+      const subMenuItem = menuItem.subMenus.filter( item => item.name == name)[0];
+      return subMenuItem.route;
+    }
+  }
 
   /**
    * Open external view in iframe

--- a/discovery-frontend/src/app/layout/layout/component/lnb/lnb.component.html
+++ b/discovery-frontend/src/app/layout/layout/component/lnb/lnb.component.html
@@ -250,9 +250,16 @@
                   <em class="ddp-icon-dot"></em> {{item.name}}
                 </a>
                 <ul class="ddp-list-sublnb-2depth">
-                  <li *ngFor="let subKey of ObjectKeys(item.subContents)">
-                    <a href="javascript:" (click)="moveExtension(item, subKey)">{{subKey}}</a>
-                  </li>
+                  <ng-container *ngIf="item.subContents != undefined">
+                    <li *ngFor="let subKey of ObjectKeys(item.subContents)" >
+                      <a href="javascript:" (click)="moveExtension(item, subKey)">{{subKey}}</a>
+                    </li>
+                  </ng-container>
+                  <ng-container *ngIf="item.subMenus != undefined">
+                    <li *ngFor="let subMenuItem of item.subMenus">
+                      <a href="javascript:" (click)="moveExtensionFromSubMenu(subMenuItem, item)">{{subMenuItem.name}}</a>
+                    </li>
+                  </ng-container>
                 </ul>
               </li>
             </ng-container>

--- a/discovery-frontend/src/app/layout/layout/component/lnb/lnb.component.ts
+++ b/discovery-frontend/src/app/layout/layout/component/lnb/lnb.component.ts
@@ -643,11 +643,27 @@ export class LNBComponent extends AbstractComponent implements OnInit, OnDestroy
     }
   } // function - move
 
-  public moveExtension(ext: Extension, subKey) {
+  public moveExtension(ext: Extension, subKey: string) {
     if (ext.subContents[subKey].startsWith('http')) {
       this.move('external/' + ext.parent + '_' + ext.name + '_' + subKey);
     } else {
       this.move(ext.subContents[subKey]);
+    }
+  }
+
+  public moveExtensionFromSubMenu(ext: Extension, parent: Extension) {
+    if(ext.openTarget != undefined && ext.route != undefined){
+      switch (ext.openTarget) {
+        case 'frame' :
+          this.move('external/' + parent.parent + '_' + parent.name + '_' + ext.name);
+          break;
+        case 'blank' :
+          window.open(ext.route, '_blank')
+          break;
+        default :
+          this.move(ext.subContents[ext.name]);
+          break;
+      }
     }
   }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/extension/ExtensionProperties.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/extension/ExtensionProperties.java
@@ -66,6 +66,11 @@ public class ExtensionProperties {
     String parent;
     Integer level;
     List<String> permissions;
+    List<Lnb> subMenus;
+    String openTarget = "frame";
+    String route;
+
+    /* deprectaed */
     Map<String, String> subContents;
 
     public Lnb() {
@@ -111,6 +116,30 @@ public class ExtensionProperties {
 
     public void setSubContents(Map<String, String> subContents) {
       this.subContents = subContents;
+    }
+
+    public String getOpenTarget() {
+      return openTarget;
+    }
+
+    public void setOpenTarget(String openTarget) {
+      this.openTarget = openTarget;
+    }
+
+    public List<Lnb> getSubMenus() {
+      return subMenus;
+    }
+
+    public void setSubMenus(List<Lnb> subMenus) {
+      this.subMenus = subMenus;
+    }
+
+    public String getRoute() {
+      return route;
+    }
+
+    public void setRoute(String route) {
+      this.route = route;
     }
   }
 }


### PR DESCRIPTION
### Description
The open target of the lnb menu supports "new tab" and "frame" types.

**Related Issue** : #3155


### How Has This Been Tested?
1. modify application.yaml
```
  extensions:
    lnb:
      - name: Extensions
        parent: management
        level: 2
        subMenus:
          - name: Open New Tab menu
            parent: Extensions
            route: https://metatron.app
            openTarget: blank
          - name: Open in iFrame menu
            parent: Extensions
            route: https://metatron.app
            openTarget: frame
```
2. Click on the LNB menu to see if both openTarget types "iframe" and "new tab" work well.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
