### PR TITLE
fix initial oauth client details

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/config/OAuth2ServerConfig.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/config/OAuth2ServerConfig.java
@@ -300,17 +300,7 @@ public class OAuth2ServerConfig {
 
       // @formatter:off
 			builder
-          .jdbcClientDetailsService(jdbcClientDetailsService())
-            .withClient("polaris_client")
-              .authorizedGrantTypes("authorization_code", "implicit", "password", "refresh_token", "client_credentials")
-              .authorities("ROLE_CLIENT")
-              .scopes("read", "write")
-              .secret("polaris")
-          .and()
-            .withClient("polaris_trusted").secret("secret")
-              .authorities("ROLE_TRUSTED_CLIENT")
-              .authorizedGrantTypes("client_credentials", "implicit", "password", "authorization_code", "refresh_token")
-              .scopes("read", "write", "trust");
+          .jdbcClientDetailsService(jdbcClientDetailsService());
 			// @formatter:on
 
       clients.setBuilder(builder);

--- a/discovery-server/src/main/resources/db/changelog/discovery.changelog-3.4.0.xml
+++ b/discovery-server/src/main/resources/db/changelog/discovery.changelog-3.4.0.xml
@@ -48,4 +48,26 @@
             <column name="next_val" value="1" />
         </insert>
     </changeSet>
+    <changeSet author="minhyun2" id="1587338284530-0">
+        <preConditions onFail="MARK_RAN">
+            <and>
+                <tableExists tableName="oauth_client_details" />
+                <tableIsEmpty tableName="oauth_client_details" />
+            </and>
+        </preConditions>
+        <insert tableName="oauth_client_details">
+            <column name="client_id" value="polaris_client" />
+            <column name="client_secret" value="polaris" />
+            <column name="authorized_grant_types" value="authorization_code,implicit,password,refresh_token,client_credentials" />
+            <column name="authorities" value="ROLE_CLIENT" />
+            <column name="scope" value="read,write" />
+        </insert>
+        <insert tableName="oauth_client_details">
+            <column name="client_id" value="polaris_trusted" />
+            <column name="client_secret" value="secret" />
+            <column name="authorized_grant_types" value="client_credentials,implicit,password,authorization_code,refresh_token" />
+            <column name="authorities" value="ROLE_TRUSTED_CLIENT" />
+            <column name="scope" value="read,write,trust" />
+        </insert>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
If you change the row of the initial client_id (polaris_trusted, polaris_client) in the oauth_client_details table and restart the server, the changed values ​​are initialized.
Therefore, liquibase manages the initial data.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Empty the data in the oauth_client_details table.
2. After the server is started, check if the initial data is inserted in the oauth_client_details table.
3. Modify the initial client_id (polaris_trusted, polaris_client) row in the oauth_client_details table.
4. After restarting the server, verify that there are no changes to the data in the oauth_client_details table.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
