### PR TITLE
add granularity options - peroid, duration (only Search API)

### DIFF
--- a/discovery-server/src/main/asciidoc/api-datasource-query-guide.adoc
+++ b/discovery-server/src/main/asciidoc/api-datasource-query-guide.adoc
@@ -234,7 +234,9 @@ then the Select statement is performed; otherwise, the GroupBy statement is perf
 |granularity
 |Enum
 |(timestamp) timeserise aggregation unit, "SECOND", "MINUTE", "HOUR", "DAYOFWEEK", "WEEK", "MONTH", "QUARTER", "YEAR"
-|
+|In addition to fixed granularity, duration can be specified.
+ex1. ISO8601 Period format : {"type":"period","period":"P2M","timeZone":"UTC","origin":"2000-01-01T00:00:00.000Z"}
+ex2. Millisecond format : {"type": "duration","duration": "5184000000","origin": "2000-01-01T00:00:00Z"}
 
 |timeUnit
 |Enum

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/data/DataQueryController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/data/DataQueryController.java
@@ -14,40 +14,6 @@
 
 package app.metatron.discovery.domain.datasource.data;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.hibernate.validator.constraints.NotBlank;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.Period;
-import org.joda.time.format.DateTimeFormat;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.rest.webmvc.RepositoryRestController;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-
-import java.io.Serializable;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import javax.validation.constraints.NotNull;
-
 import app.metatron.discovery.common.MatrixResponse;
 import app.metatron.discovery.common.RawJsonString;
 import app.metatron.discovery.common.exception.BadRequestException;
@@ -66,6 +32,36 @@ import app.metatron.discovery.domain.workbook.configurations.filter.TimeListFilt
 import app.metatron.discovery.domain.workbook.configurations.format.TimeFieldFormat;
 import app.metatron.discovery.query.polaris.ComputationalField;
 import app.metatron.discovery.util.EnumUtils;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.hibernate.validator.constraints.NotBlank;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Period;
+import org.joda.time.format.DateTimeFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.rest.webmvc.RepositoryRestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import javax.validation.constraints.NotNull;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static app.metatron.discovery.domain.datasource.DataSource.ConnectionType.LINK;
 import static app.metatron.discovery.query.polaris.ComputationalField.checkComputationalFieldIn;
@@ -132,6 +128,14 @@ public class DataQueryController {
 
       result = response;
     }
+
+    return ResponseEntity.ok(result);
+  }
+
+  @RequestMapping(value = "/datasources/query/sql", method = RequestMethod.POST)
+  public ResponseEntity<?> queryForSql(@RequestBody SqlQueryRequest queryRequest) {
+
+    Object result = engineQueryService.sql(queryRequest);
 
     return ResponseEntity.ok(result);
   }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/data/SqlQueryRequest.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/data/SqlQueryRequest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specic language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specic language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.metatron.discovery.domain.datasource.data;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * Request model for SQL query
+ */
+public class SqlQueryRequest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SqlQueryRequest.class);
+
+  /**
+   * SQL Statement
+   */
+  String query;
+
+  /**
+   * SQL Context
+   */
+  protected Map<String, Object> context;
+
+  public SqlQueryRequest() {
+    // Empty Constructor
+  }
+
+  @JsonCreator
+  public SqlQueryRequest(@JsonProperty("sql") String sql,
+          @JsonProperty("context") Map<String, Object> context) {
+    this.query = sql;
+    this.context = context;
+  }
+
+  public String getQuery() {
+    return query;
+  }
+
+  public Map<String, Object> getContext() {
+    return context;
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this)
+            .append("query", query)
+            .append("context", context)
+            .toString();
+  }
+}

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/engine/DruidEngineRepository.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/engine/DruidEngineRepository.java
@@ -14,8 +14,8 @@
 
 package app.metatron.discovery.domain.engine;
 
+import app.metatron.discovery.domain.datasource.data.QueryTimeExcetpion;
 import com.google.common.collect.Maps;
-
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,14 +26,11 @@ import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.ResponseErrorHandler;
 
+import javax.annotation.PostConstruct;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
-import javax.annotation.PostConstruct;
-
-import app.metatron.discovery.domain.datasource.data.QueryTimeExcetpion;
 
 import static app.metatron.discovery.domain.engine.EngineProperties.*;
 
@@ -79,6 +76,10 @@ public class DruidEngineRepository extends AbstractEngineRepository {
     return call(SEARCH_QUERY, Maps.newHashMap(), spec, clazz);
   }
 
+  public <T> Optional<T> sql(String spec, Class<T> clazz) {
+    return call(SQL_QUERY, Maps.newHashMap(), spec, clazz);
+  }
+
   public <T> Optional<T> health(String url, Class<T> clazz) {
     return callByUrl(url + HEALTH_CHECK, HttpMethod.GET, Maps.newHashMap(), null, clazz);
   }
@@ -87,7 +88,7 @@ public class DruidEngineRepository extends AbstractEngineRepository {
     return callByUrl(url + PROPERTIES_CHECK, HttpMethod.GET, Maps.newHashMap(), null, clazz);
   }
 
-  public Optional<List> getHistoricalNodes(){
+  public Optional<List> getHistoricalNodes() {
     Map paramMap = Maps.newHashMap();
     paramMap.put("simple", null);
     return call(GET_HISTORICAL_NODE, paramMap, List.class);

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/engine/EngineProperties.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/engine/EngineProperties.java
@@ -28,27 +28,25 @@
 
 package app.metatron.discovery.domain.engine;
 
+import app.metatron.discovery.common.fileloader.FileLoaderProperties;
 import com.google.common.collect.Maps;
-
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 
-import java.net.URI;
-import java.util.Map;
-
 import javax.annotation.PostConstruct;
 import javax.validation.constraints.NotNull;
-
-import app.metatron.discovery.common.fileloader.FileLoaderProperties;
+import java.net.URI;
+import java.util.Map;
 
 @Component
 @ConfigurationProperties(prefix = "polaris.engine")
 public class EngineProperties {
 
   public final static String SEARCH_QUERY = "query";
+  public final static String SQL_QUERY = "sql";
   public final static String BULK_LOAD = "load";
   public final static String GET_PROGRESS = "getProgress";
   public final static String GET_LOAD_DATASOURCE = "getLoadDatasourceInfo";

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/engine/QueryService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/engine/QueryService.java
@@ -14,19 +14,18 @@
 
 package app.metatron.discovery.domain.engine;
 
-import app.metatron.discovery.domain.datasource.data.CandidateQueryRequest;
-import app.metatron.discovery.domain.datasource.data.CovarianceQueryRequest;
-import app.metatron.discovery.domain.datasource.data.SearchQueryRequest;
-import app.metatron.discovery.domain.datasource.data.SummaryQueryRequest;
+import app.metatron.discovery.domain.datasource.data.*;
 
 /**
- * Created by kyungtaak on 2016. 9. 22..
+ * Query service interface
  */
 public interface QueryService {
 
   Object preview(SearchQueryRequest request);
 
   Object search(SearchQueryRequest request);
+
+  Object sql(SqlQueryRequest request);
 
   Object candidate(CandidateQueryRequest request);
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/field/MeasureField.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/field/MeasureField.java
@@ -28,21 +28,19 @@
 
 package app.metatron.discovery.domain.workbook.configurations.field;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Maps;
-
+import app.metatron.discovery.domain.workbook.configurations.format.FieldFormat;
+import app.metatron.discovery.util.EnumUtils;
+import app.metatron.discovery.util.PolarisUtils;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Map;
-
-import app.metatron.discovery.domain.workbook.configurations.format.FieldFormat;
-import app.metatron.discovery.util.EnumUtils;
-import app.metatron.discovery.util.PolarisUtils;
 
 import static app.metatron.discovery.domain.workbook.configurations.field.MeasureField.AggregationType.NONE;
 import static app.metatron.discovery.domain.workbook.configurations.field.MeasureField.AggregationType.SUM;
@@ -109,6 +107,14 @@ public class MeasureField extends Field {
           setParamValue("value", Double.parseDouble(parsedMap.get("value")));
         } else {
           setParamValue("value", 0.75); // 기본값 처리
+        }
+        break;
+      case LAST:
+      case FIRST:
+        if (parsedMap.containsKey("includeTimestamp")) {
+          setParamValue("includeTimestamp", BooleanUtils.toBoolean(parsedMap.get("includeTimestamp")));
+        } else {
+          setParamValue("includeTimestamp", false);
         }
         break;
       default:

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/field/TimestampField.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/field/TimestampField.java
@@ -18,6 +18,7 @@ import app.metatron.discovery.common.exception.BadRequestException;
 import app.metatron.discovery.domain.workbook.configurations.format.CustomDateTimeFormat;
 import app.metatron.discovery.domain.workbook.configurations.format.FieldFormat;
 import app.metatron.discovery.domain.workbook.configurations.format.TimeFieldFormat;
+import app.metatron.discovery.query.druid.Granularity;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -30,6 +31,8 @@ import org.apache.commons.lang3.StringUtils;
 @JsonTypeName("timestamp")
 public class TimestampField extends Field {
 
+  Granularity granularity;
+
   FieldFormat format;
 
   public TimestampField() {
@@ -37,12 +40,16 @@ public class TimestampField extends Field {
 
   @JsonCreator
   public TimestampField(
-      @JsonProperty("name") String name,
-      @JsonProperty("alias") String alias,
-      @JsonProperty("ref") String ref,
-      @JsonProperty("format") FieldFormat format) {
+          @JsonProperty("name") String name,
+          @JsonProperty("alias") String alias,
+          @JsonProperty("ref") String ref,
+          @JsonProperty("granularity") Granularity granularity,
+          @JsonProperty("format") FieldFormat format) {
 
     super(name, alias, ref);
+
+    this.granularity = granularity;
+
     if (format != null) {
       if (format instanceof TimeFieldFormat) {
         this.format = format;
@@ -57,11 +64,11 @@ public class TimestampField extends Field {
   }
 
   public TimestampField(String name, String ref) {
-    this(name, null, ref, new CustomDateTimeFormat(TimeFieldFormat.DEFAULT_DATETIME_FORMAT));
+    this(name, null, ref, null, new CustomDateTimeFormat(TimeFieldFormat.DEFAULT_DATETIME_FORMAT));
   }
 
   public TimestampField(String name, String ref, FieldFormat format) {
-    this(name, null, ref, format);
+    this(name, null, ref, null, format);
   }
 
   public void emptyFormat() {
@@ -71,6 +78,10 @@ public class TimestampField extends Field {
   @Override
   public FieldFormat getFormat() {
     return format;
+  }
+
+  public Granularity getGranularity() {
+    return granularity;
   }
 
   @JsonIgnore

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/format/TimeFieldFormat.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/format/TimeFieldFormat.java
@@ -16,6 +16,7 @@ package app.metatron.discovery.domain.workbook.configurations.format;
 
 import app.metatron.discovery.common.exception.BadRequestException;
 import app.metatron.discovery.domain.engine.EngineQueryProperties;
+import app.metatron.discovery.query.druid.granularities.SimpleGranularity;
 import app.metatron.discovery.util.EnumUtils;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.joda.time.DateTime;
@@ -329,6 +330,28 @@ public abstract class TimeFieldFormat {
 
     }
 
+    public SimpleGranularity getGranularity() {
+      switch (this) {
+        case SECOND:
+          return new SimpleGranularity("second");
+        case MINUTE:
+          return new SimpleGranularity("minute");
+        case HOUR:
+          return new SimpleGranularity("hour");
+        case DAY:
+          return new SimpleGranularity("day");
+        case WEEK:
+          return new SimpleGranularity("week");
+        case MONTH:
+          return new SimpleGranularity("month");
+        case QUARTER:
+          return new SimpleGranularity("quarter");
+        case YEAR:
+          return new SimpleGranularity("year");
+        default:
+          return new SimpleGranularity("all");
+      }
+    }
   }
 
   public enum ByTimeUnit {

--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/Granularity.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/Granularity.java
@@ -15,20 +15,27 @@
 package app.metatron.discovery.query.druid;
 
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-
 import app.metatron.discovery.query.druid.granularities.DurationGranularity;
 import app.metatron.discovery.query.druid.granularities.PeriodGranularity;
 import app.metatron.discovery.query.druid.granularities.SimpleGranularity;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
-@JsonTypeInfo(use=JsonTypeInfo.Id.NAME,
-    include= JsonTypeInfo.As.EXTERNAL_PROPERTY, property="type",
-    defaultImpl = SimpleGranularity.class)
+import java.beans.Transient;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "type",
+        defaultImpl = SimpleGranularity.class)
 @JsonSubTypes({
-    @JsonSubTypes.Type(value = SimpleGranularity.class, name = "simple"),
-    @JsonSubTypes.Type(value = DurationGranularity.class, name = "duration"),
-    @JsonSubTypes.Type(value = PeriodGranularity.class, name = "period")
+        @JsonSubTypes.Type(value = SimpleGranularity.class, name = "simple"),
+        @JsonSubTypes.Type(value = DurationGranularity.class, name = "duration"),
+        @JsonSubTypes.Type(value = PeriodGranularity.class, name = "period")
 })
 public interface Granularity {
+
+  @Transient
+  String getAlias();
+
+  void setAlias(String alias);
+
 }

--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/granularities/AbstractGranularity.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/granularities/AbstractGranularity.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specic language governing permissions and
+ * limitations under the License.
+ */
+
+package app.metatron.discovery.query.druid.granularities;
+
+import app.metatron.discovery.query.druid.Granularity;
+
+public abstract class AbstractGranularity implements Granularity {
+
+  public String alias;
+
+  public AbstractGranularity() {
+  }
+
+  @Override
+  public String getAlias() {
+    return alias;
+  }
+
+  @Override
+  public void setAlias(String alias) {
+    this.alias = alias;
+  }
+}

--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/granularities/DurationGranularity.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/granularities/DurationGranularity.java
@@ -14,21 +14,25 @@
 
 package app.metatron.discovery.query.druid.granularities;
 
+import app.metatron.discovery.query.druid.Granularity;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import app.metatron.discovery.query.druid.Granularity;
-
 @JsonTypeName("duration")
-public class DurationGranularity implements Granularity {
+public class DurationGranularity extends AbstractGranularity implements Granularity {
+
   String duration;
+
   String origin;
 
-  public DurationGranularity(){
+  public DurationGranularity() {
     super();
   }
 
-  public DurationGranularity(String duration, String origin){
-    this();
+  @JsonCreator
+  public DurationGranularity(@JsonProperty("duration") String duration,
+          @JsonProperty("origin") String origin) {
     this.duration = duration;
     this.origin = origin;
   }
@@ -37,15 +41,7 @@ public class DurationGranularity implements Granularity {
     return duration;
   }
 
-  public void setDuration(String duration) {
-    this.duration = duration;
-  }
-
   public String getOrigin() {
     return origin;
-  }
-
-  public void setOrigin(String origin) {
-    this.origin = origin;
   }
 }

--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/granularities/PeriodGranularity.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/granularities/PeriodGranularity.java
@@ -14,38 +14,43 @@
 
 package app.metatron.discovery.query.druid.granularities;
 
+import app.metatron.discovery.query.druid.Granularity;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import app.metatron.discovery.query.druid.Granularity;
-
 @JsonTypeName("period")
-public class PeriodGranularity implements Granularity {
+public class PeriodGranularity extends AbstractGranularity implements Granularity {
+
   String period;
+
   String timeZone;
 
-  public PeriodGranularity(){
+  String origin;
+
+  public PeriodGranularity() {
     super();
   }
 
-  public PeriodGranularity(String period, String timeZone){
+  @JsonCreator
+  public PeriodGranularity(@JsonProperty("period") String period,
+          @JsonProperty("timeZone") String timeZone,
+          @JsonProperty("origin") String origin) {
     this();
     this.period = period;
     this.timeZone = timeZone;
+    this.origin = origin;
   }
 
   public String getPeriod() {
     return period;
   }
 
-  public void setPeriod(String period) {
-    this.period = period;
-  }
-
   public String getTimeZone() {
     return timeZone;
   }
 
-  public void setTimeZone(String timeZone) {
-    this.timeZone = timeZone;
+  public String getOrigin() {
+    return origin;
   }
 }

--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/granularities/SimpleGranularity.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/granularities/SimpleGranularity.java
@@ -15,21 +15,20 @@
 package app.metatron.discovery.query.druid.granularities;
 
 
+import app.metatron.discovery.query.druid.Granularity;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import app.metatron.discovery.query.druid.Granularity;
-
 @JsonTypeName("simple")
-public class SimpleGranularity implements Granularity {
+public class SimpleGranularity extends AbstractGranularity implements Granularity {
 
   String value;
 
-  public SimpleGranularity(){
+  public SimpleGranularity() {
   }
 
   @JsonCreator
-  public SimpleGranularity(String value){
+  public SimpleGranularity(String value) {
     this.value = value;
   }
 
@@ -42,7 +41,7 @@ public class SimpleGranularity implements Granularity {
   }
 
   @Override
-  public String toString(){
+  public String toString() {
     return value;
   }
 }

--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/queries/GroupByQueryBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/queries/GroupByQueryBuilder.java
@@ -42,26 +42,6 @@
 
 package app.metatron.discovery.query.druid.queries;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-
-import org.apache.commons.collections.MapUtils;
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import app.metatron.discovery.common.GlobalObjectMapper;
 import app.metatron.discovery.common.datasource.LogicalType;
 import app.metatron.discovery.common.exception.BadRequestException;
@@ -75,48 +55,25 @@ import app.metatron.discovery.domain.workbook.configurations.analysis.Analysis;
 import app.metatron.discovery.domain.workbook.configurations.analysis.GeoSpatialOperation;
 import app.metatron.discovery.domain.workbook.configurations.analysis.PredictionAnalysis;
 import app.metatron.discovery.domain.workbook.configurations.datasource.MappingDataSource;
-import app.metatron.discovery.domain.workbook.configurations.field.DimensionField;
-import app.metatron.discovery.domain.workbook.configurations.field.Field;
-import app.metatron.discovery.domain.workbook.configurations.field.MeasureField;
-import app.metatron.discovery.domain.workbook.configurations.field.TimestampField;
-import app.metatron.discovery.domain.workbook.configurations.field.UserDefinedField;
+import app.metatron.discovery.domain.workbook.configurations.field.*;
 import app.metatron.discovery.domain.workbook.configurations.filter.Filter;
-import app.metatron.discovery.domain.workbook.configurations.filter.LikeFilter;
-import app.metatron.discovery.domain.workbook.configurations.filter.MeasureInequalityFilter;
-import app.metatron.discovery.domain.workbook.configurations.filter.MeasurePositionFilter;
-import app.metatron.discovery.domain.workbook.configurations.filter.RegExprFilter;
-import app.metatron.discovery.domain.workbook.configurations.filter.WildCardFilter;
+import app.metatron.discovery.domain.workbook.configurations.filter.*;
 import app.metatron.discovery.domain.workbook.configurations.format.ContinuousTimeFormat;
 import app.metatron.discovery.domain.workbook.configurations.format.DefaultFormat;
 import app.metatron.discovery.domain.workbook.configurations.format.FieldFormat;
 import app.metatron.discovery.domain.workbook.configurations.format.TimeFieldFormat;
 import app.metatron.discovery.domain.workbook.configurations.widget.shelf.LayerView;
 import app.metatron.discovery.domain.workbook.configurations.widget.shelf.MapViewLayer;
-import app.metatron.discovery.query.druid.AbstractQueryBuilder;
-import app.metatron.discovery.query.druid.Aggregation;
-import app.metatron.discovery.query.druid.Dimension;
-import app.metatron.discovery.query.druid.Granularity;
-import app.metatron.discovery.query.druid.Having;
-import app.metatron.discovery.query.druid.PostAggregation;
-import app.metatron.discovery.query.druid.PostProcessor;
-import app.metatron.discovery.query.druid.Query;
+import app.metatron.discovery.query.druid.*;
 import app.metatron.discovery.query.druid.aggregations.CountAggregation;
 import app.metatron.discovery.query.druid.aggregations.RelayAggregation;
 import app.metatron.discovery.query.druid.dimensions.DefaultDimension;
 import app.metatron.discovery.query.druid.dimensions.ExtractionDimension;
 import app.metatron.discovery.query.druid.extractionfns.ExpressionFunction;
 import app.metatron.discovery.query.druid.filters.AndFilter;
-import app.metatron.discovery.query.druid.funtions.CaseFunc;
-import app.metatron.discovery.query.druid.funtions.CastFunc;
-import app.metatron.discovery.query.druid.funtions.LookupMapFunc;
-import app.metatron.discovery.query.druid.funtions.RunningSumFunc;
-import app.metatron.discovery.query.druid.funtions.TimeFormatFunc;
+import app.metatron.discovery.query.druid.funtions.*;
 import app.metatron.discovery.query.druid.granularities.SimpleGranularity;
-import app.metatron.discovery.query.druid.havings.EqualTo;
-import app.metatron.discovery.query.druid.havings.GreaterThan;
-import app.metatron.discovery.query.druid.havings.GreaterThanOrEqual;
-import app.metatron.discovery.query.druid.havings.LessThan;
-import app.metatron.discovery.query.druid.havings.LessThanOrEqual;
+import app.metatron.discovery.query.druid.havings.*;
 import app.metatron.discovery.query.druid.limits.DefaultLimit;
 import app.metatron.discovery.query.druid.limits.OrderByColumn;
 import app.metatron.discovery.query.druid.limits.PivotWindowingSpec;
@@ -125,15 +82,26 @@ import app.metatron.discovery.query.druid.postaggregations.ExprPostAggregator;
 import app.metatron.discovery.query.druid.postaggregations.MathPostAggregator;
 import app.metatron.discovery.query.druid.postprocessor.PostAggregationProcessor;
 import app.metatron.discovery.query.druid.virtualcolumns.ExprVirtualColumn;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.stream.Collectors;
 
 import static app.metatron.discovery.domain.datasource.data.CandidateQueryRequest.RESULT_VALUE_NAME_PREFIX;
 import static app.metatron.discovery.domain.workbook.configurations.Sort.Direction.ASC;
 import static app.metatron.discovery.domain.workbook.configurations.Sort.Direction.DESC;
 import static app.metatron.discovery.domain.workbook.configurations.field.Field.FIELD_NAMESPACE_SEP;
 import static app.metatron.discovery.domain.workbook.configurations.filter.MeasurePositionFilter.PositionType.BOTTOM;
-import static app.metatron.discovery.domain.workbook.configurations.filter.WildCardFilter.ContainsType.AFTER;
-import static app.metatron.discovery.domain.workbook.configurations.filter.WildCardFilter.ContainsType.BEFORE;
-import static app.metatron.discovery.domain.workbook.configurations.filter.WildCardFilter.ContainsType.BOTH;
+import static app.metatron.discovery.domain.workbook.configurations.filter.WildCardFilter.ContainsType.*;
 import static app.metatron.discovery.query.druid.Query.RESERVED_WORD_COUNT;
 
 /**
@@ -170,11 +138,11 @@ public class GroupByQueryBuilder extends AbstractQueryBuilder {
   private RelayAggregation.RelayType relayType;
 
   private List<String> percentPartitionExprs = Lists.newArrayList(
-      "#_ = " + new RunningSumFunc("_").toExpression(),
-      "concat(_, '" + ChartResultFormat.POSTFIX_PERCENTAGE + "') = "
-          + new CaseFunc("#_ == 0",
-                         0.0,
-                         new CastFunc("_", CastFunc.CastType.DOUBLE).toExpression() + " / #_ * 100").toExpression()
+          "#_ = " + new RunningSumFunc("_").toExpression(),
+          "concat(_, '" + ChartResultFormat.POSTFIX_PERCENTAGE + "') = "
+                  + new CaseFunc("#_ == 0",
+                  0.0,
+                  new CastFunc("_", CastFunc.CastType.DOUBLE).toExpression() + " / #_ * 100").toExpression()
   );
 
   public GroupByQueryBuilder(app.metatron.discovery.domain.workbook.configurations.datasource.DataSource dataSource) {
@@ -257,8 +225,8 @@ public class GroupByQueryBuilder extends AbstractQueryBuilder {
             if (format != null && format instanceof DefaultFormat) {
               // FixMe : replace expression
               dimensions.add(new ExtractionDimension(engineColumnName,
-                                                     aliasName,
-                                                     new ExpressionFunction(((DefaultFormat) format).getFormat(), engineColumnName)));
+                      aliasName,
+                      new ExpressionFunction(((DefaultFormat) format).getFormat(), engineColumnName)));
             } else {
               addDimension(new DefaultDimension(engineColumnName, aliasName));
             }
@@ -302,7 +270,9 @@ public class GroupByQueryBuilder extends AbstractQueryBuilder {
             if (layerView instanceof LayerView.ClusteringLayerView || layerView instanceof LayerView.AbbreviatedView) {
               LayerView.HashLayerView clusteringLayerView = (LayerView.HashLayerView) layerView;
 
-              virtualColumns.put(VC_COLUMN_GEO_COORD, new ExprVirtualColumn(clusteringLayerView.toHashExpression(engineColumnName), VC_COLUMN_GEO_COORD));
+              virtualColumns.put(VC_COLUMN_GEO_COORD,
+                      new ExprVirtualColumn(clusteringLayerView.toHashExpression(engineColumnName),
+                              VC_COLUMN_GEO_COORD));
               dimensions.add(new DefaultDimension(VC_COLUMN_GEO_COORD));
 
               aggregations.addAll(clusteringLayerView.getClusteringAggregations(engineColumnName));
@@ -313,9 +283,11 @@ public class GroupByQueryBuilder extends AbstractQueryBuilder {
             } else if (layerView instanceof LayerView.HashLayerView) {
               LayerView.HashLayerView hashLayerView = (LayerView.HashLayerView) layerView;
 
-              virtualColumns.put(VC_COLUMN_GEO_COORD, new ExprVirtualColumn(hashLayerView.toHashExpression(engineColumnName), VC_COLUMN_GEO_COORD));
+              virtualColumns.put(VC_COLUMN_GEO_COORD,
+                      new ExprVirtualColumn(hashLayerView.toHashExpression(engineColumnName), VC_COLUMN_GEO_COORD));
               dimensions.add(new DefaultDimension(VC_COLUMN_GEO_COORD));
-              postAggregations.add(new ExprPostAggregator(hashLayerView.toWktExpression(VC_COLUMN_GEO_COORD, geoColumnName)));
+              postAggregations
+                      .add(new ExprPostAggregator(hashLayerView.toWktExpression(VC_COLUMN_GEO_COORD, geoColumnName)));
             }
 
             // set geometry
@@ -344,6 +316,17 @@ public class GroupByQueryBuilder extends AbstractQueryBuilder {
             unUsedVirtualColumnName.remove(fieldName);
           } else {
             addAggregationFunction(measureField);
+
+            // Set "includeTimestamp" Option
+            if (measureField.getParamValue("includeTimestamp") != null) {
+              String timestampColumnName = aliasName + ".timestamp";
+              postAggregations.add(new MathPostAggregator(
+                      aliasName + ".timestamp",
+                      "datetime(\"" + aliasName + "\"[0])",
+                      false
+              ));
+              outputColumns.add(timestampColumnName);
+            }
           }
         }
 
@@ -355,6 +338,7 @@ public class GroupByQueryBuilder extends AbstractQueryBuilder {
         TimeFieldFormat originalTimeFormat = (TimeFieldFormat) datasourceField.getFormatObject();
 
         TimestampField timestampField = (TimestampField) field;
+
         TimeFieldFormat timeFormat = (TimeFieldFormat) timestampField.getFormat();
         if (timeFormat == null) {
           timeFormat = originalTimeFormat;
@@ -364,27 +348,35 @@ public class GroupByQueryBuilder extends AbstractQueryBuilder {
           timeFormat.setUTC();
         }
 
-        // set time format using function
-        String innerFieldName = aliasName + Query.POSTFIX_INNER_FIELD;
-        String predefinedFieldName = timestampField.getPredefinedColumn(dataSource instanceof MappingDataSource);
+        // Set Granularity
+        granularity = timestampField.getGranularity();
+        if (granularity != null) {
+          granularity.setAlias(aliasName);
+          sortFormatMap.put(aliasName, "TIMESTAMP");
+          processingInnerTimeField(aliasName, timeFormat);
+        } else {
 
-        TimeFormatFunc timeFormatFunc = new TimeFormatFunc(predefinedFieldName,
-                                                           timeFormat.enableSortField() ? timeFormat.getSortFormat() : timeFormat.getFormat(),
-                                                           timeFormat.selectTimezone(),
-                                                           timeFormat.getLocale());
-        ExprVirtualColumn exprVirtualColumn = new ExprVirtualColumn(timeFormatFunc.toExpression(), innerFieldName);
+          // set time format using function
+          String innerFieldName = aliasName + Query.POSTFIX_INNER_FIELD;
+          String predefinedFieldName = timestampField.getPredefinedColumn(dataSource instanceof MappingDataSource);
 
-        virtualColumns.put(aliasName, exprVirtualColumn);
-        addDimension(new DefaultDimension(innerFieldName, aliasName));
+          TimeFormatFunc timeFormatFunc = new TimeFormatFunc(predefinedFieldName,
+                  timeFormat.enableSortField() ? timeFormat.getSortFormat() : timeFormat.getFormat(),
+                  timeFormat.selectTimezone(),
+                  timeFormat.getLocale());
+          ExprVirtualColumn exprVirtualColumn = new ExprVirtualColumn(timeFormatFunc.toExpression(), innerFieldName);
 
-        // for sorting time format
-        sortFormatMap.put(aliasName, timeFormat.getFormat());
-        convertSortToOriginalFormat(aliasName, timeFormat);
+          virtualColumns.put(aliasName, exprVirtualColumn);
+          addDimension(new DefaultDimension(innerFieldName, aliasName));
+
+          // for sorting time format
+          sortFormatMap.put(aliasName, timeFormat.getFormat());
+          convertSortToOriginalFormat(aliasName, timeFormat);
+        }
 
       }
 
     } // end of for loop
-
 
     // name can't be duplicate
     Set<Dimension> depdupeDimensions = new LinkedHashSet<>(dimensions);
@@ -417,9 +409,6 @@ public class GroupByQueryBuilder extends AbstractQueryBuilder {
     }
     postAggregations = depdupePostAggregations;
 
-    // 기본값 지정
-    granularity = new SimpleGranularity("all");
-
     return this;
   }
 
@@ -433,7 +422,8 @@ public class GroupByQueryBuilder extends AbstractQueryBuilder {
     if (relayType == null) {
       dimensions.add(dimension);
     } else {
-      aggregations.add(new RelayAggregation(dimension.getDimension(), dimension.getOutputName(), "string", relayType.name()));
+      aggregations.add(new RelayAggregation(dimension.getDimension(), dimension.getOutputName(), "string",
+              relayType.name()));
     }
   }
 
@@ -450,25 +440,50 @@ public class GroupByQueryBuilder extends AbstractQueryBuilder {
 
       if (postProcessor instanceof PostAggregationProcessor) {
         TimeFormatFunc postFormatFunc = new TimeFormatFunc("\"" + fieldName + "\"",
-                                                           timeFormat.getSortFormat(),
-                                                           null,
-                                                           null,
-                                                           timeFormat.getFormat(),
-                                                           null,
-                                                           null);
+                timeFormat.getSortFormat(),
+                null,
+                null,
+                timeFormat.getFormat(),
+                null,
+                null);
 
         ((PostAggregationProcessor) postProcessor)
-            .addPostAggregation(
-                new MathPostAggregator(fieldName, postFormatFunc.toExpression(), null)
-            );
+                .addPostAggregation(
+                        new MathPostAggregator(fieldName, postFormatFunc.toExpression(), null)
+                );
       }
+    }
+  }
+
+  /**
+   * Convert sort time format to orignal time format
+   */
+  private void processingInnerTimeField(String fieldName, TimeFieldFormat timeFormat) {
+
+    if (postProcessor == null) {
+      postProcessor = new PostAggregationProcessor();
+    }
+
+    if (postProcessor instanceof PostAggregationProcessor) {
+      TimeFormatFunc postFormatFunc = new TimeFormatFunc("__time",
+              null,
+              null,
+              null,
+              timeFormat.getFormat(),
+              timeFormat.getTimeZone(),
+              timeFormat.getLocale());
+
+      ((PostAggregationProcessor) postProcessor)
+              .addPostAggregation(
+                      new MathPostAggregator(fieldName, postFormatFunc.toExpression(), null)
+              );
     }
   }
 
   public GroupByQueryBuilder count(String name) {
     long count = aggregations.stream()
-                             .filter(aggregation -> aggregation.getName().equals(name))
-                             .count();
+            .filter(aggregation -> aggregation.getName().equals(name))
+            .count();
 
     if (count > 0) {
       return this;
@@ -485,7 +500,8 @@ public class GroupByQueryBuilder extends AbstractQueryBuilder {
     return this;
   }
 
-  public GroupByQueryBuilder advancedFilters(List<app.metatron.discovery.domain.workbook.configurations.filter.Filter> filters) {
+  public GroupByQueryBuilder advancedFilters(
+          List<app.metatron.discovery.domain.workbook.configurations.filter.Filter> filters) {
 
     for (Filter filter : filters) {
       if (filter instanceof MeasurePositionFilter) {    // Convert limit
@@ -519,8 +535,8 @@ public class GroupByQueryBuilder extends AbstractQueryBuilder {
 
         // Add escape character, if exist special character.
         String likeExpr = StringUtils.replaceEach(wildCardFilter.getValue(),
-                                                  new String[]{"\\", "_", "%"},
-                                                  new String[]{"\\\\", "\\_", "\\%"});
+                new String[]{"\\", "_", "%"},
+                new String[]{"\\\\", "\\_", "\\%"});
         ;
         if (wildCardFilter.getContains() == BEFORE) {
           likeExpr = "%" + likeExpr;
@@ -538,8 +554,8 @@ public class GroupByQueryBuilder extends AbstractQueryBuilder {
 
     // count aggregation 이 하나도 없을 경우 추가
     if (aggregations.stream()
-                    .filter(aggregation -> RESERVED_WORD_COUNT.equals(aggregation.getName()))
-                    .count() == 0) {
+            .filter(aggregation -> RESERVED_WORD_COUNT.equals(aggregation.getName()))
+            .count() == 0) {
       aggregations.add(new CountAggregation(RESERVED_WORD_COUNT));
       outputColumns.add(RESERVED_WORD_COUNT);
     }
@@ -547,7 +563,8 @@ public class GroupByQueryBuilder extends AbstractQueryBuilder {
     return this;
   }
 
-  public GroupByQueryBuilder filters(List<app.metatron.discovery.domain.workbook.configurations.filter.Filter> reqFilters) {
+  public GroupByQueryBuilder filters(
+          List<app.metatron.discovery.domain.workbook.configurations.filter.Filter> reqFilters) {
 
     extractPartitions(reqFilters);
 
@@ -579,9 +596,9 @@ public class GroupByQueryBuilder extends AbstractQueryBuilder {
 
     // 디멘젼의 Logical Type 을 판별하여 Sort 비교 타입을 지정하기 위함
     Map<String, Dimension> dimensionMap = dimensions.stream()
-                                                    .collect(Collectors
-                                                                 .toMap(Dimension::getOutputName,
-                                                                        dimension -> dimension));
+            .collect(Collectors
+                    .toMap(Dimension::getOutputName,
+                            dimension -> dimension));
     for (Sort sort : sorts) {
 
       OrderByColumn.COMPARATOR curComparator = OrderByColumn.COMPARATOR.ALPHANUMERIC;
@@ -595,13 +612,16 @@ public class GroupByQueryBuilder extends AbstractQueryBuilder {
           curComparator = OrderByColumn.COMPARATOR.DAYOFWEEK;
         } else if ("MMM".equals(format)) {
           curComparator = OrderByColumn.COMPARATOR.MONTH;
+        } else if ("TIMESTAMP".equals(format)) {
+          sortField = "__time";
+          curComparator = null;
         }
 
       } else {
         if (dimensionMap.containsKey(sortField)) {
           Dimension dimension = dimensionMap.get(sortField);
           if (dimension.getLogicalType() == LogicalType.INTEGER
-              || dimension.getLogicalType() == LogicalType.DOUBLE) {
+                  || dimension.getLogicalType() == LogicalType.DOUBLE) {
             curComparator = OrderByColumn.COMPARATOR.NUMERIC;
           }
           sortField = dimension.getOutputName();
@@ -609,9 +629,9 @@ public class GroupByQueryBuilder extends AbstractQueryBuilder {
       }
 
       orderByColumns.add(new OrderByColumn(sortField,
-                                           sort.getDirection() == ASC ?
-                                               OrderByColumn.DIRECTION.ASCENDING : OrderByColumn.DIRECTION.DESCENDING,
-                                           curComparator));
+              sort.getDirection() == ASC ?
+                      OrderByColumn.DIRECTION.ASCENDING : OrderByColumn.DIRECTION.DESCENDING,
+              curComparator));
     }
 
     limitSpec = new DefaultLimit(reqLimit.getLimit(), orderByColumns);
@@ -639,7 +659,7 @@ public class GroupByQueryBuilder extends AbstractQueryBuilder {
         }
       } else {
         if (dimension.getLogicalType() == LogicalType.INTEGER
-            || dimension.getLogicalType() == LogicalType.DOUBLE) {
+                || dimension.getLogicalType() == LogicalType.DOUBLE) {
           curComparator = OrderByColumn.COMPARATOR.NUMERIC;
         }
       }
@@ -651,9 +671,9 @@ public class GroupByQueryBuilder extends AbstractQueryBuilder {
 
       // Sort 전용 필드와 매핑되는 필드가 있는 경우 Sort 전용 필드로 대치
       orderByColumns.add(new OrderByColumn(sortFieldMap.containsKey(outputName) ?
-                                               sortFieldMap.get(outputName) : outputName,
-                                           OrderByColumn.DIRECTION.ASCENDING,
-                                           curComparator));
+              sortFieldMap.get(outputName) : outputName,
+              OrderByColumn.DIRECTION.ASCENDING,
+              curComparator));
 
     }
   }
@@ -693,12 +713,12 @@ public class GroupByQueryBuilder extends AbstractQueryBuilder {
       }
 
       List<Field> timeFields = reqFields.stream()
-                                        .filter(field -> field.getFormat() instanceof ContinuousTimeFormat)
-                                        .collect(Collectors.toList());
+              .filter(field -> field.getFormat() instanceof ContinuousTimeFormat)
+              .collect(Collectors.toList());
 
       List<Field> measureFields = reqFields.stream()
-                                           .filter(field -> field instanceof MeasureField)
-                                           .collect(Collectors.toList());
+              .filter(field -> field instanceof MeasureField)
+              .collect(Collectors.toList());
 
       if (timeFields.size() != 1) {
         throw new BadRequestException("Only one timestamp field for prediction analysis");
@@ -726,81 +746,89 @@ public class GroupByQueryBuilder extends AbstractQueryBuilder {
   public GroupByQueryBuilder format(SearchResultFormat resultFormat) {
 
     if (resultFormat instanceof PivotResultFormat) {
+
       PivotResultFormat pivotFormat = (PivotResultFormat) resultFormat;
+      pivotFormat.processingGranularity(granularity, postProcessor);
+
       if (pivotFormat.getGroupingSize() != null) {
         this.groupingSet = pivotFormat.toGroupingSet();
       }
+
       this.windowingSpecs.add(pivotFormat.toEnginePivotSpec());
       exclusivePivotColumn(pivotFormat);
+
     } else if (resultFormat instanceof ChartResultFormat) {
       ChartResultFormat chartFormat = (ChartResultFormat) resultFormat;
       SearchResultFormat originalFormat = chartFormat.getOriginalFormat();
-      if (originalFormat != null && originalFormat instanceof PivotResultFormat) {
-        PivotResultFormat pivotFormat = (PivotResultFormat) originalFormat;
 
-        List<String> partitionExpressions = Lists.newArrayList();
-        Number intersectionValue = chartFormat.getOptionValue(ChartResultFormat.OPTION_INTERSECION_VALUE);
-        if (intersectionValue != null) {
-          partitionExpressions.add("_ = _ - " + intersectionValue);
-        }
-
-        if ("treemap".equals(chartFormat.getMode())) {
-          this.groupingSet = pivotFormat.toGroupingSet();
-          // 피봇 키 필드를 피봇필드로 이동 (Tree 를 구하기 위함)
-          PivotResultFormat.Pivot newPivot =
-              new PivotResultFormat.Pivot(new DimensionField(pivotFormat.getKeyFields().get(0)));
-          pivotFormat.getPivots().add(0, newPivot);
-          pivotFormat.setKeyFields(Lists.newArrayList());
-        } else {
-          // Category Value 추가
-          Boolean showCategory = chartFormat.getOptionValue(ChartResultFormat.OPTION_SHOW_CATEGORY);
-          if (BooleanUtils.isTrue(showCategory) && CollectionUtils.isNotEmpty(pivotFormat.getPivots())) {
-            // Custom Grouping Set 지정
-            List<String> allOfGroupByColumn = Lists.newArrayList(pivotFormat.getKeyFields());
-            for (PivotResultFormat.Pivot pivot : pivotFormat.getPivots()) {
-              allOfGroupByColumn.add(pivot.getFieldName());
-            }
-
-            this.groupingSet = new GroupingSet.Names(Lists.newArrayList(allOfGroupByColumn, pivotFormat.getKeyFields()));
-            pivotFormat.setGroupingSize(2);
-          }
-
-          // Percentage 컬럼 추가
-          Boolean showPercentage = chartFormat.getOptionValue(ChartResultFormat.OPTION_SHOW_PERCENTAGE);
-          if (BooleanUtils.isTrue(showPercentage)) {
-            pivotFormat.setIncludePercentage(true);
-            partitionExpressions.addAll(percentPartitionExprs);
-          }
-        }
-
-        PivotWindowingSpec pivotWindowingSpec = pivotFormat.toEnginePivotSpec(
-            partitionExpressions.toArray(new String[partitionExpressions.size()])
-        );
-
-        this.windowingSpecs.add(pivotWindowingSpec);
-
-        exclusivePivotColumn(pivotFormat);
+      if (!(originalFormat instanceof PivotResultFormat)) {
+        return this;
       }
+
+      PivotResultFormat pivotFormat = (PivotResultFormat) originalFormat;
+      pivotFormat.processingGranularity(granularity, postProcessor);
+
+      List<String> partitionExpressions = Lists.newArrayList();
+      Number intersectionValue = chartFormat.getOptionValue(ChartResultFormat.OPTION_INTERSECION_VALUE);
+      if (intersectionValue != null) {
+        partitionExpressions.add("_ = _ - " + intersectionValue);
+      }
+
+      if ("treemap".equals(chartFormat.getMode())) {
+        this.groupingSet = pivotFormat.toGroupingSet();
+        // 피봇 키 필드를 피봇필드로 이동 (Tree 를 구하기 위함)
+        PivotResultFormat.Pivot newPivot =
+                new PivotResultFormat.Pivot(new DimensionField(pivotFormat.getKeyFields().get(0)));
+        pivotFormat.getPivots().add(0, newPivot);
+        pivotFormat.setKeyFields(Lists.newArrayList());
+      } else {
+        // Category Value 추가
+        Boolean showCategory = chartFormat.getOptionValue(ChartResultFormat.OPTION_SHOW_CATEGORY);
+        if (BooleanUtils.isTrue(showCategory) && CollectionUtils.isNotEmpty(pivotFormat.getPivots())) {
+          // Custom Grouping Set 지정
+          List<String> allOfGroupByColumn = Lists.newArrayList(pivotFormat.getKeyFields());
+          for (PivotResultFormat.Pivot pivot : pivotFormat.getPivots()) {
+            allOfGroupByColumn.add(pivot.getFieldName());
+          }
+
+          this.groupingSet = new GroupingSet.Names(
+                  Lists.newArrayList(allOfGroupByColumn, pivotFormat.getReplacedKeyFields()));
+          pivotFormat.setGroupingSize(2);
+        }
+
+        // Percentage 컬럼 추가
+        Boolean showPercentage = chartFormat.getOptionValue(ChartResultFormat.OPTION_SHOW_PERCENTAGE);
+        if (BooleanUtils.isTrue(showPercentage)) {
+          pivotFormat.setIncludePercentage(true);
+          partitionExpressions.addAll(percentPartitionExprs);
+        }
+      }
+
+      PivotWindowingSpec pivotWindowingSpec = pivotFormat.toEnginePivotSpec(
+              partitionExpressions.toArray(new String[partitionExpressions.size()]));
+
+      this.windowingSpecs.add(pivotWindowingSpec);
+      exclusivePivotColumn(pivotFormat);
     }
 
     return this;
   }
 
   private void exclusivePivotColumn(PivotResultFormat format) {
-    // 엔진에서 Pivot을 수행하는 경우 outputColumn 은 구성하지 않음
-    // pivotSpec 에서 정의된 필드만 표현하도록 구성됨
+    // "outputColumn" is ignored if the search query contains "pivotSpec"
+    // Only columns defined in pivotSpec can get as a result
     this.outputColumns = null;
 
-    // pivot 컬럼으로 지정된 필드는 Sort/PostProcessor 제외
+    // Fields specified as pivot columns exclude declarations in Sort / PostProcessor.
     List<String> pivotColumnNames = format.getPivots().stream()
-                                          .map(pivot -> pivot.getFieldName())
-                                          .collect(Collectors.toList());
+            .map(pivot -> pivot.getFieldName())
+            .collect(Collectors.toList());
 
-    // Sort 항목 제거
+    // remove column in sort
     List<OrderByColumn> orderColumns = ((DefaultLimit) limitSpec).getColumns();
     if (CollectionUtils.isNotEmpty(orderColumns)) {
       Map<String, OrderByColumn> orderColumnMap = orderColumns.stream()
-                                                              .collect(Collectors.toMap(OrderByColumn::getDimension, orderByColumn -> orderByColumn));
+              .collect(Collectors.toMap(OrderByColumn::getDimension, orderByColumn -> orderByColumn));
 
       pivotColumnNames.forEach(columnName -> {
         if (orderColumnMap.containsKey(columnName)) {
@@ -809,20 +837,26 @@ public class GroupByQueryBuilder extends AbstractQueryBuilder {
       });
     }
 
-    // PostProcessor 항목 제거
-    if (postProcessor != null && postProcessor instanceof PostAggregationProcessor) {
-      PostAggregationProcessor processor = (PostAggregationProcessor) postProcessor;
-      List<PostAggregation> postAggregations = processor.getPostAggregations();
+    // for removing PostProcessor
+    if (postProcessor instanceof PostAggregationProcessor) {
 
-      if (CollectionUtils.isNotEmpty(postAggregations)) {
-        Map<String, PostAggregation> postAggregationMap = postAggregations.stream()
-                                                                          .collect(Collectors.toMap(PostAggregation::getName, postAggregation -> postAggregation));
+      if (granularity != null) {
+        // remove expression that convert the time format.
+        postProcessor = null;
+      } else {
+        PostAggregationProcessor processor = (PostAggregationProcessor) postProcessor;
+        List<PostAggregation> postAggregations = processor.getPostAggregations();
 
-        pivotColumnNames.forEach(columnName -> {
-          if (postAggregationMap.containsKey(columnName)) {
-            postAggregations.remove(postAggregationMap.get(columnName));
-          }
-        });
+        if (CollectionUtils.isNotEmpty(postAggregations)) {
+          Map<String, PostAggregation> postAggregationMap = postAggregations.stream()
+                  .collect(Collectors.toMap(PostAggregation::getName, postAggregation -> postAggregation));
+
+          pivotColumnNames.forEach(columnName -> {
+            if (postAggregationMap.containsKey(columnName)) {
+              postAggregations.remove(postAggregationMap.get(columnName));
+            }
+          });
+        }
       }
     }
 
@@ -856,17 +890,16 @@ public class GroupByQueryBuilder extends AbstractQueryBuilder {
 
     if (!"count".equals(aggregation.getColumn())) {
       MeasureField measureField = new MeasureField(aggregation.getColumn(),
-                                                   aggregation.getColumn().startsWith("user_defined.") ? "user_defined" : null,
-                                                   aggregation.getType());
+              aggregation.getColumn().startsWith("user_defined.") ? "user_defined" : null,
+              aggregation.getType());
       addAggregationFunction(measureField);
       outputColumns.add(measureField.getAlias());
     }
 
-
     // FixMe: so many duplicated code! T.T
     long cntAggregation = aggregations.stream()
-                                      .filter(aggr -> "count".equals(aggr.getName()))
-                                      .count();
+            .filter(aggr -> "count".equals(aggr.getName()))
+            .count();
 
     if (cntAggregation == 0) {
       aggregations.add(new CountAggregation("count"));
@@ -927,8 +960,8 @@ public class GroupByQueryBuilder extends AbstractQueryBuilder {
     } else {
       for (Dimension dimension : dimensions) {
         orderByColumns.add(new OrderByColumn(dimension.getOutputName(),
-                                             OrderByColumn.DIRECTION.ASCENDING,
-                                             OrderByColumn.COMPARATOR.ALPHANUMERIC));
+                OrderByColumn.DIRECTION.ASCENDING,
+                OrderByColumn.COMPARATOR.ALPHANUMERIC));
       }
       limitSpec = new DefaultLimit(100000, orderByColumns);
       groupByQuery.setLimitSpec(limitSpec);

--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/queries/SelectStreamQueryBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/queries/SelectStreamQueryBuilder.java
@@ -159,7 +159,7 @@ public class SelectStreamQueryBuilder extends AbstractQueryBuilder {
         }
 
         FieldFormat format = dimensionField.getFormat();
-        if (format != null || datasourceField.getLogicalType() == LogicalType.TIMESTAMP) {
+        if (format != null && datasourceField.getLogicalType() == LogicalType.TIMESTAMP) {
           TimeFieldFormat originalTimeFormat = (TimeFieldFormat) originalFormat;
           TimeFieldFormat timeFormat = (TimeFieldFormat) format;
 

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/datasource/data/DataQueryRestIntegrationTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/datasource/data/DataQueryRestIntegrationTest.java
@@ -287,7 +287,7 @@ public class DataQueryRestIntegrationTest extends AbstractRestIntegrationTest {
   @OAuthRequest(username = "polaris", value = {"ROLE_SYSTEM_USER", "PERM_SYSTEM_WRITE_DATASOURCE"})
   public void searchQueryForSalesForDownload() throws JsonProcessingException {
 
-    DataSource dataSource1 = new DefaultDataSource("sales");
+    DataSource dataSource1 = new DefaultDataSource("sales_geo");
 
     // Limit
     Limit limit = new Limit();
@@ -3377,6 +3377,27 @@ public class DataQueryRestIntegrationTest extends AbstractRestIntegrationTest {
             .then()
             .statusCode(HttpStatus.SC_OK)
             .log().all();
+    // @formatter:on
+
+  }
+
+  @Test
+  @OAuthRequest(username = "polaris", value = {"ROLE_SYSTEM_USER", "PERM_SYSTEM_WRITE_DATASOURCE"})
+  public void searchSqlQuery() {
+
+    SqlQueryRequest request = new SqlQueryRequest("select * from asset_trace_poc_asset_model_01 limit 5", null);
+
+    // @formatter:off
+    given()
+        .auth().oauth2(oauth_token)
+        .body(GlobalObjectMapper.writeValueAsString(request))
+        .contentType(ContentType.JSON)
+        .log().all()
+    .when()
+        .post("/api/datasources/query/sql")
+    .then()
+        .log().all()
+        .statusCode(HttpStatus.SC_OK);
     // @formatter:on
 
   }

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/datasource/data/DataQueryRestIntegrationTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/datasource/data/DataQueryRestIntegrationTest.java
@@ -39,6 +39,7 @@ import app.metatron.discovery.domain.workbook.configurations.datasource.*;
 import app.metatron.discovery.domain.workbook.configurations.field.*;
 import app.metatron.discovery.domain.workbook.configurations.filter.*;
 import app.metatron.discovery.domain.workbook.configurations.format.ContinuousTimeFormat;
+import app.metatron.discovery.domain.workbook.configurations.format.CustomDateTimeFormat;
 import app.metatron.discovery.domain.workbook.configurations.format.TimeFieldFormat;
 import app.metatron.discovery.domain.workbook.configurations.widget.shelf.GeoShelf;
 import app.metatron.discovery.domain.workbook.configurations.widget.shelf.LayerView;
@@ -47,6 +48,7 @@ import app.metatron.discovery.domain.workbook.configurations.widget.shelf.Shelf;
 import app.metatron.discovery.query.druid.ShapeFormat;
 import app.metatron.discovery.query.druid.SpatialOperations;
 import app.metatron.discovery.query.druid.aggregations.RelayAggregation;
+import app.metatron.discovery.query.druid.granularities.PeriodGranularity;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -215,23 +217,23 @@ public class DataQueryRestIntegrationTest extends AbstractRestIntegrationTest {
 
     List<Field> projections = Lists.newArrayList(
             new DimensionField("Category"),
-            new MeasureField("Sales", MeasureField.AggregationType.LAST)
+            new MeasureField("Sales", null, null, "LAST", null, "includeTimestamp=true")
     );
 
     SearchQueryRequest request = new SearchQueryRequest(dataSource1, filters, projections, limit);
 
     // @formatter:off
     given()
-            .auth().oauth2(oauth_token)
-            .body(request)
-            .contentType(ContentType.JSON)
-            .log().all()
-            .when()
-            .post("/api/datasources/query/search")
-            .then()
-            .statusCode(HttpStatus.SC_OK)
-            .body("size()", is(3))
-            .log().all();
+      .auth().oauth2(oauth_token)
+      .body(request)
+      .contentType(ContentType.JSON)
+      .log().all()
+    .when()
+      .post("/api/datasources/query/search")
+    .then()
+      .statusCode(HttpStatus.SC_OK)
+      .body("size()", is(3))
+      .log().all();
     // @formatter:on
 
   }
@@ -832,13 +834,13 @@ public class DataQueryRestIntegrationTest extends AbstractRestIntegrationTest {
   @OAuthRequest(username = "polaris", value = {"ROLE_SYSTEM_USER", "PERM_SYSTEM_WRITE_DATASOURCE"})
   public void searchQueryForSalesWithTimestamp() throws JsonProcessingException {
 
-    DataSource dataSource1 = new DefaultDataSource("sales");
+    DataSource dataSource1 = new DefaultDataSource("sales_geo");
 
     // Limit
     Limit limit = new Limit();
     limit.setLimit(1000000);
     limit.setSort(Lists.newArrayList(
-            //        new Sort("ShipDate","ASC")
+            new Sort("ShipDate", "ASC")
     ));
 
     List<Filter> filters = Lists.newArrayList(
@@ -901,7 +903,24 @@ public class DataQueryRestIntegrationTest extends AbstractRestIntegrationTest {
             new MeasureField("Sales", MeasureField.AggregationType.AVG)
     ));
 
-    SearchQueryRequest request = new SearchQueryRequest(dataSource1, filters, pivot1, limit);
+    // Case5, Granularity
+    Pivot pivot5 = new Pivot();
+    TimestampField originalTimeField5 = new TimestampField("OrderDate", "DAY(OrderDate)", null,
+            new PeriodGranularity("P2M", "UTC", "2000-01-01T00:00:00.000Z"),
+            //            new DurationGranularity(Long.toString(1000*60*60*24*60L), "2000-01-01T00:00:00Z"),
+            //            new ContinuousTimeFormat(false, TimeFieldFormat.TimeUnit.DAY.name(), null));
+            new CustomDateTimeFormat(TimeFieldFormat.DEFAULT_DATETIME_FORMAT));
+
+    pivot5.setColumns(Lists.newArrayList(originalTimeField5, new DimensionField("Category")));
+    pivot5.setAggregations(Lists.newArrayList(
+            new MeasureField("Sales", MeasureField.AggregationType.AVG)
+    ));
+
+    limit.setSort(Lists.newArrayList(
+            new Sort("DAY(OrderDate)", "DESC")
+    ));
+
+    SearchQueryRequest request = new SearchQueryRequest(dataSource1, null, pivot5, limit);
 
     // @formatter:off
     given()
@@ -1329,9 +1348,9 @@ public class DataQueryRestIntegrationTest extends AbstractRestIntegrationTest {
 
     // Case 6. 타임 디멘젼
     Pivot pivot6 = new Pivot();
-    TimestampField field1 = new TimestampField("OrderDate", "MONTH(OrderDate)", null,
+    TimestampField field1 = new TimestampField("OrderDate", "MONTH(OrderDate)", null, null,
             new ContinuousTimeFormat(false, "MONTH", null));
-    TimestampField field2 = new TimestampField("OrderDate", "DAY(OrderDate)", null,
+    TimestampField field2 = new TimestampField("OrderDate", "DAY(OrderDate)", null, null,
             new ContinuousTimeFormat(false, "DAY", null));
     pivot6.setColumns(Lists.newArrayList(field1));
     pivot6.setRows(Lists.newArrayList(field2));
@@ -1341,9 +1360,9 @@ public class DataQueryRestIntegrationTest extends AbstractRestIntegrationTest {
 
     // Case 6. 타임 디멘젼
     Pivot pivot7 = new Pivot();
-    TimestampField field3 = new TimestampField("OrderDate", "MONTH(OrderDate)", null,
+    TimestampField field3 = new TimestampField("OrderDate", "MONTH(OrderDate)", null, null,
             new ContinuousTimeFormat(false, "MONTH", null));
-    TimestampField field4 = new TimestampField("OrderDate", "DAY(OrderDate)", null,
+    TimestampField field4 = new TimestampField("OrderDate", "DAY(OrderDate)", null, null,
             new ContinuousTimeFormat(false, "DAY", null));
     pivot7.setColumns(Lists.newArrayList(field3));
     pivot7.setRows(Lists.newArrayList());
@@ -1378,7 +1397,7 @@ public class DataQueryRestIntegrationTest extends AbstractRestIntegrationTest {
   @OAuthRequest(username = "polaris", value = {"ROLE_SYSTEM_USER", "PERM_SYSTEM_WRITE_DATASOURCE"})
   public void searchQueryForSalesWithLineChart() throws JsonProcessingException {
 
-    DataSource dataSource1 = new DefaultDataSource("sales");
+    DataSource dataSource1 = new DefaultDataSource("sales_geo");
 
     // Limit
     Limit limit = new Limit();
@@ -1394,7 +1413,8 @@ public class DataQueryRestIntegrationTest extends AbstractRestIntegrationTest {
     pivot1.setColumns(Lists.newArrayList(new DimensionField("Category"))); //, new DimensionField("Sub-Category")));
     pivot1.setAggregations(Lists.newArrayList(
             new MeasureField("Discount", MeasureField.AggregationType.SUM),
-            new TimestampField("OrderDate", "MONTH(OrderDate)", null, new ContinuousTimeFormat(true, "MONTH", null)
+            new TimestampField("OrderDate", "MONTH(OrderDate)", null, null,
+                    new ContinuousTimeFormat(true, "MONTH", null)
             )));
 
     // Case 2.
@@ -1406,11 +1426,22 @@ public class DataQueryRestIntegrationTest extends AbstractRestIntegrationTest {
             new MeasureField("Discount", MeasureField.AggregationType.SUM)
     ));
 
-    SearchQueryRequest request = new SearchQueryRequest(dataSource1, filters, pivot2, limit);
+    // Case 3.
+    Pivot pivot3 = new Pivot();
+    pivot3.setColumns(Lists.newArrayList(new TimestampField("OrderDate", "P2M(OrderDate)", null,
+            new PeriodGranularity("P2M", "UTC", "2000-01-01T00:00:00.000Z"),
+            new ContinuousTimeFormat(false, TimeFieldFormat.TimeUnit.MONTH.name(), null))));
+    pivot3.setRows(null);
+    pivot3.setAggregations(Lists.newArrayList(
+            new DimensionField("Category"),
+            new MeasureField("Discount", MeasureField.AggregationType.SUM)
+    ));
+
+    SearchQueryRequest request = new SearchQueryRequest(dataSource1, filters, pivot3, limit);
     ChartResultFormat format = new ChartResultFormat("line");
-    //    format.addOptions("showPercentage", true);
-    //    format.addOptions("showCategory", true);
-    format.addOptions("isCumulative", true);
+    format.addOptions("showPercentage", true);
+    //     format.addOptions("showCategory", true);
+    //     format.addOptions("isCumulative", true);
     format.addOptions("addMinMax", true);
     request.setResultFormat(format);
 


### PR DESCRIPTION
### Description
There are cases where fixed granularity cannot be solved when using Search API. Therefore, API was constructed by using the period and duration type granularity options supported by Druid.

**Related Issue** : #3154 
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Using the [Search API](https://github.com/metatron-app/metatron-discovery/blob/master/discovery-server/src/main/asciidoc/api-datasource-query-guide.adoc#search) documentation, run two types of queries as shown below to see if the results were viewed in the intended period.

Case1. ISO8601 Period format
```
{
    "dataSource": {
        "type": "default",
        "name": "sales_geo",
    },
    "filters": [
    ],
    "projections": [
        {
            "type": "timestamp",
            "name": "OrderDate",
            "alias": "DAY(OrderDate)",
            "ref": null,
            "granularity": {
                "type": "period",
                "period": "P2M",
                "timeZone": "UTC",
                "origin": "2000-01-01T00:00:00.000Z"
            },
            "format": {
                "type": "time_format",
                "format": "yyyy-MM-dd HH:mm:ss",
                "timeZone": "UTC",
                "locale": "en"
            }
        },
        {
            "type": "dimension",
            "name": "Category",
            "alias": "Category"
        },
        {
            "type": "measure",
            "name": "Sales",
            "alias": "AVG(Sales)",
            "aggregationType": "AVG",
        }
    ],
    "userFields": [
        
    ],
    "limits": {
        "limit": 1000000,
        "sort": [
            {
                "field": "DAY(OrderDate)",
                "direction": "DESC"
            }
        ]
    }
}
```

Case2. Millisecond 
```
{
    "dataSource": {
        "type": "default",
        "name": "sales_geo",
    },
    "filters": [
    ],
    "projections": [
        {
            "type": "timestamp",
            "name": "OrderDate",
            "alias": "DAY(OrderDate)",
            "ref": null,
            "granularity": {
                "type": "duration",
                "duration": "5184000000",
                "origin": "2000-01-01T00:00:00Z"
            },
            "format": {
                "type": "time_format",
                "format": "yyyy-MM-dd HH:mm:ss",
                "timeZone": "UTC",
                "locale": "en"
            }
        },
        {
            "type": "dimension",
            "name": "Category",
            "alias": "Category"
        },
        {
            "type": "measure",
            "name": "Sales",
            "alias": "AVG(Sales)",
            "aggregationType": "AVG",
        }
    ],
    "userFields": [
        
    ],
    "limits": {
        "limit": 1000000,
        "sort": [
            {
                "field": "DAY(OrderDate)",
                "direction": "DESC"
            }
        ]
    }
}
```


#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
