### PR TITLE
masking stagedb connection's user info

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/storage/StorageController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/storage/StorageController.java
@@ -40,7 +40,10 @@ public class StorageController {
           return ResponseEntity.noContent().build();
         }
         StorageProperties.StageDBConnection stageDBConnection = storageProperties.getStagedb();
-
+        //masking username, password
+        stageDBConnection.setUsername(null);
+        stageDBConnection.setPassword(null);
+        stageDBConnection.setMetastore(null);
         return ResponseEntity.ok(stageDBConnection);
       default:
         throw new IllegalArgumentException("Not supported type " + storageType);

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/storage/StorageProperties.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/storage/StorageProperties.java
@@ -196,7 +196,9 @@ public class StorageProperties {
       String schema = null;
       String username = null;
       String password = null;
-      String jdbcUrl = this.getMetastore().includeJdbc() ? this.getMetastore().getJdbc().getUrl() : null;
+      String jdbcUrl = this.getMetastore() != null && this.getMetastore().includeJdbc()
+          ? this.getMetastore().getJdbc().getUrl()
+          : null;
       if(StringUtils.isNotEmpty(jdbcUrl) && jdbcUrl.length() > 5) {
         URI uri = URI.create(jdbcUrl.substring(5));
         host = uri.getHost();


### PR DESCRIPTION
### Description

*IT Security Vulnerability Notes.*
Stagedb access user information is exposed.

**Related Issue** : 

### How Has This Been Tested?
1. login metatron discovery
2. After logging in, check the list of APIs that are called with the dev tool.
3. check '/api/storage/stagedb' API response.
4. Confirm that the response does not contain user information.
<img width="1249" alt="DevTools_-_localhost_4200_app_v2_management_storage_datasource" src="https://user-images.githubusercontent.com/3770446/85971221-8a891b00-ba07-11ea-8e20-f864ca7b77f9.png">


#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
