### PR TITLE
fix error for calculating user-defined field

### DIFF
--- a/discovery-frontend/src/app/datasource/service/datasource.service.ts
+++ b/discovery-frontend/src/app/datasource/service/datasource.service.ts
@@ -324,7 +324,7 @@ export class DatasourceService extends AbstractService {
 
     if (pageConf.customFields) {
       query.userFields = CommonUtil.objectToArray(pageConf.customFields).filter(item => {
-        return item.dataSource === pageConf.dataSource.engineName;
+        return item.dataSource === pageConf.dataSource.engineName || item.dataSource === pageConf.dataSource.name;
       });
     }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/data/result/PivotResultFormat.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/data/result/PivotResultFormat.java
@@ -156,9 +156,24 @@ public class PivotResultFormat extends SearchResultFormat {
       if (CollectionUtils.isNotEmpty(postAggregations)
               && postAggregations.get(0) instanceof MathPostAggregator) {
         MathPostAggregator postAggregation = (MathPostAggregator) postAggregations.get(0);
-        String expression = "\"__time\" = " + postAggregation.getExpression();
 
-        addExpression(new PivotSpec.ConditionExpression(expression));
+        /*
+         * To handle the granularity configuration, there is a limitation in displaying the alias value of the timestamp field.
+         * If the pivot column does not exist, aliasing is possible according to the order,
+         * but if it does exist, it is difficult to process and it is passed as'__time' value.
+         * Unfortunately, when processing the Pivot result due to the current structure,
+         * it can be properly processed only when the key column is only one field of the timestamp type.
+         */
+        StringBuilder exprBuilder = new StringBuilder();
+        exprBuilder.append("\"");
+        if (CollectionUtils.isEmpty(pivots)) {
+          exprBuilder.append(granularity.getAlias());
+        } else {
+          exprBuilder.append("__time");
+        }
+        exprBuilder.append("\" = ").append(postAggregation.getExpression());
+
+        addExpression(new PivotSpec.ConditionExpression(exprBuilder.toString()));
       }
     }
   }

--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/AbstractQueryBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/AbstractQueryBuilder.java
@@ -781,21 +781,36 @@ public abstract class AbstractQueryBuilder {
         aggregations.add(new VarianceAggregation(aliasName, fieldName));
         break;
       case FIRST:
-        aggregations.add(new RelayAggregation(aliasName, fieldName, "double", RelayAggregation.RelayType.TIME_MIN.name()));
+        aggregations
+                .add(new RelayAggregation(aliasName, fieldName, "double", RelayAggregation.RelayType.TIME_MIN.name()));
         break;
       case LAST:
-        aggregations.add(new RelayAggregation(aliasName, fieldName, "double", RelayAggregation.RelayType.TIME_MAX.name()));
+        aggregations
+                .add(new RelayAggregation(aliasName, fieldName, "double", RelayAggregation.RelayType.TIME_MAX.name()));
         break;
     }
 
     return;
   }
 
+  /**
+   * Add aggregation by user-defined field
+   *
+   * @param field
+   */
   protected void addUserDefinedAggregationFunction(MeasureField field) {
 
     ExpressionField expressionField = (ExpressionField) userFieldsMap.get(field.getName());
 
-    String curExpr = expressionField.getExpr();
+    String curExpr;
+    if (expressionField.isAggregated()) {
+      curExpr = expressionField.getExpr();
+      virtualColumns.remove(field.getColunm());
+      unUsedVirtualColumnName.remove(field.getColunm());
+    } else {
+      curExpr = field.getColunm();
+      unUsedVirtualColumnName.remove(field.getColunm());
+    }
 
     switch (field.getAggregationType()) {
 
@@ -836,8 +851,8 @@ public abstract class AbstractQueryBuilder {
         break;
     }
 
-    ComputationalField.makeAggregationFunctionsIn(field, aggregations
-            , postAggregations, windowingSpecs, userFieldsMap, context);
+    ComputationalField.makeAggregationFunctionsIn(field, curExpr,
+            aggregations, postAggregations, windowingSpecs, userFieldsMap, context);
 
   }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/queries/GroupByQueryBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/queries/GroupByQueryBuilder.java
@@ -310,10 +310,9 @@ public class GroupByQueryBuilder extends AbstractQueryBuilder {
           aggregations.add(new RelayAggregation(engineColumnName, aliasName, "double", relayType.name()));
         } else {
           if (UserDefinedField.REF_NAME.equals(refName) && virtualColumns.containsKey(fieldName)) {
+            // Set up aggregations by user-defined field
             addUserDefinedAggregationFunction(measureField);
 
-            virtualColumns.remove(fieldName);
-            unUsedVirtualColumnName.remove(fieldName);
           } else {
             addAggregationFunction(measureField);
 


### PR DESCRIPTION
### Description
In some cases, the following error occurs when creating a custom field using an expression.
```
QueryTimeExcetpion: [{"error":"Instantiation of [simple type, class io.druid.query.groupby.GroupByQuery] value failed: Missing fields [xxx] for postAggregator [SUM(yyy}]
```
In the case of a calculation expression that does not use an aggregation operation, it is common.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
- Create a dashboard connected to the "Sales" data source.
- Create a user-defined field "aaa" by creating an expression ("Sales + 1"). At this time, you should not use a separate aggregate operation function. (avgof, sumof...)
- Place another dimension value (ex. Category) and user-defined "aaa" on the chart shelf and select the aggregation "AVG" on the shelf.
- Check if the chart is displayed normally.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
