### PR TITLE
#3305 Apply limit clause for sampling druid table

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/query/NativeCriteria.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/dataconnection/query/NativeCriteria.java
@@ -326,7 +326,7 @@ public class NativeCriteria {
 
         break;
 
-      case "HIVE": case "MYSQL": case "PRESTO": case "POSTGRESQL":
+      case "HIVE": case "MYSQL": case "PRESTO": case "POSTGRESQL": case "DRUID" :
         sqlBuilder.append(SPACE).append("LIMIT").append(SPACE).append(limit);
         if(offset != null)
           sqlBuilder.append(SPACE).append("OFFSET").append(SPACE).append(offset);

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcConnectionService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcConnectionService.java
@@ -332,7 +332,7 @@ public class JdbcConnectionService {
                                                          boolean extractColumnName) {
     JdbcAccessor jdbcDataAccessor = DataConnectionHelper.getAccessor(connectInformation);
     Connection conn = jdbcDataAccessor.getConnection(schema, true);
-    String queryString = generateSelectQuery(connectInformation, schema, type, query, partitionList);
+    String queryString = generateSelectQuery(connectInformation, schema, type, query, partitionList, limit);
     LOGGER.debug("selectQueryForIngestion SQL : {} ", queryString);
     return selectQuery(connectInformation, conn, queryString, limit, extractColumnName);
   }
@@ -341,7 +341,8 @@ public class JdbcConnectionService {
                                     String schema,
                                     JdbcIngestionInfo.DataType type,
                                     String query,
-                                    List<Map<String, Object>> partitionList){
+                                    List<Map<String, Object>> partitionList,
+                                    int limit){
     String queryString;
     if (type == JdbcIngestionInfo.DataType.TABLE) {
       JdbcDialect dialect = DataConnectionHelper.lookupDialect(connectInformation);
@@ -349,6 +350,10 @@ public class JdbcConnectionService {
       String tableName = dialect.getTableName(connectInformation, connectInformation.getCatalog(), schema, query);
       String tableAlias = dialect.getTableName(connectInformation, connectInformation.getCatalog(), "", query);
       nativeCriteria.addTable(tableName, tableAlias);
+
+      // limit postfix can be supported only for table type query.
+      if(limit > 0)
+        nativeCriteria.setLimit(limit);
 
       //add projection for partition
       if (partitionList != null && !partitionList.isEmpty()) {

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/MetadataService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/mdm/MetadataService.java
@@ -541,7 +541,7 @@ public class MetadataService implements ApplicationEventPublisherAware {
       type = JdbcIngestionInfo.DataType.TABLE;
     }
 
-    queryString = jdbcConnectionService.generateSelectQuery(jdbcConnection, schema, type, query, null);
+    queryString = jdbcConnectionService.generateSelectQuery(jdbcConnection, schema, type, query, null, 50);
     return queryString;
   }
 

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcConnectionServiceTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcConnectionServiceTest.java
@@ -14,8 +14,10 @@
 
 package app.metatron.discovery.domain.datasource.connection.jdbc;
 
+import app.metatron.discovery.extension.dataconnection.jdbc.JdbcConnectInformation;
 import com.google.common.collect.Lists;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -421,6 +423,23 @@ public class JdbcConnectionServiceTest extends AbstractIntegrationTest {
     for(Map<String, Object> partMap : partitionInfo){
       System.out.println(partMap.get("PART_NAME") + ", " + partMap.get("NUM_ROWS"));
     }
+  }
+
+  @Test
+  public void generateSelectQueryDruidLimitTest(){
+    JdbcConnectInformation connectInformation = new DataConnection("DRUID");
+    String schema = "druid";
+    JdbcIngestionInfo.DataType type = TABLE;
+    String query = "sales_geo";
+    List<Map<String, Object>> partitionList = null;
+    int limit = 50;
+
+    String sql = jdbcConnectionService.generateSelectQuery(connectInformation, schema, type, query, partitionList, limit);
+    Assert.assertEquals("SELECT \"sales_geo\".* FROM druid.\"sales_geo\" \"sales_geo\"  LIMIT 50", sql);
+
+    limit = 0;
+    sql = jdbcConnectionService.generateSelectQuery(connectInformation, schema, type, query, partitionList, limit);
+    Assert.assertEquals("SELECT \"sales_geo\".* FROM druid.\"sales_geo\" \"sales_geo\"", sql);
   }
 
   @Test


### PR DESCRIPTION
### Description
Apply limit clause for sampling druid table

**Related Issue** : <!--- Please link to the issue here. -->

### How Has This Been Tested?
1. Create a dataset in data preparation
2. Select druid type connection.
3. Select druid table and see how many rows are displayed.

#### Need additional checks?
We need to test metadata sample view.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] I have read the **CONTRIBUTING** document.
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
