### PR TITLE
fix creating new custom fields when re-entering the chart editing page

### DIFF
--- a/discovery-frontend/src/app/dashboard/component/custom-field/custom-field.component.ts
+++ b/discovery-frontend/src/app/dashboard/component/custom-field/custom-field.component.ts
@@ -656,7 +656,7 @@ export class CustomFieldComponent extends AbstractComponent implements OnInit, O
       } else {
         customField = new CustomField();
         customField.role = (this.selectedColumnType === ColumnType.MEASURE) ? FieldRole.MEASURE : FieldRole.DIMENSION;
-        customField.dataSource = this.dataSource.engineName;
+        customField.dataSource = this.dataSource.engineName ? this.dataSource.engineName : this.dataSource.name;
       }
 
       customField.alias = this.columnName;


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Fix creating new custom fields when re-entering the chart editing page

**Related Issue** : #3314 
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Create a new dashboard.
2. Create a new chart with a new custom fields.
3. Go to the chart edit popup window created using the custom field.
4. Create a new custom field.
5. The custom field is visible in the data column list.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
