### PR TITLE
F#3361 associated linked datasource

### DIFF
--- a/discovery-frontend/src/app/dashboard/util/dashboard.util.ts
+++ b/discovery-frontend/src/app/dashboard/util/dashboard.util.ts
@@ -763,7 +763,7 @@ export class DashboardUtil {
    */
   public static getDataSourceForApi(dataSource: BoardDataSource): BoardDataSource {
     // enginName과 name가 맞지 않으면 오류 발생함
-    dataSource.name = (dataSource.engineName) ? dataSource.engineName : dataSource.name;
+    dataSource.name = isNullOrUndefined(dataSource.engineName) ? dataSource.name : dataSource.engineName;
 
     if (dataSource.hasOwnProperty('joins') && dataSource.joins.length > 0) {
       dataSource.joins.forEach((join) => {

--- a/discovery-frontend/src/app/dashboard/util/dashboard.util.ts
+++ b/discovery-frontend/src/app/dashboard/util/dashboard.util.ts
@@ -367,7 +367,8 @@ export class DashboardUtil {
     const boardDs: BoardDataSource = board.configuration.dataSource;
     let relDsFilters: Filter[] = [];
     if ('multi' === boardDs.type && boardDs.associations) {
-      const srcDs: BoardDataSource = boardDs.dataSources.find(item => item.engineName === engineName);
+      const srcDs: BoardDataSource = boardDs.dataSources.find(item => item.engineName === engineName || (item.connType == 'LINK' && item.engineName.startsWith(engineName + '_')))
+
       relDsFilters = boardDs.associations
         .filter((rel: BoardDataSourceRelation) => (srcDs.engineName === rel.source || srcDs.engineName === rel.target))
         .reduce((acc, rel: BoardDataSourceRelation) => {
@@ -375,18 +376,22 @@ export class DashboardUtil {
           let srcField: string = undefined;
           let relDsEngineName: string = undefined;
           let relField: string = undefined;
+          let relDsType = undefined;
+
           if (rel.source === srcDs.engineName) {
             relDsEngineName = boardDs.dataSources.find(item => item.engineName === rel.target).engineName;
+            relDsType = boardDs.dataSources.find(item => item.engineName === rel.target).connType;
             srcField = Object.keys(rel.columnPair)[0];
             relField = rel.columnPair[srcField];
           } else {
             relDsEngineName = boardDs.dataSources.find(item => item.engineName === rel.source).engineName;
+            relDsType = boardDs.dataSources.find(item => item.engineName === rel.target).connType;
             relField = Object.keys(rel.columnPair)[0];
             srcField = rel.columnPair[relField];
           }
           acc = acc.concat(
             totalFilters
-              .filter((item: Filter) => item.dataSource === relDsEngineName && item.field === relField)
+              .filter((item: Filter) => (item.dataSource === relDsEngineName || (relDsType == 'LINK' && relDsEngineName.startsWith(item.dataSource + '_')) && item.field === relField))
               .map((item: Filter) => {
                 item.dataSource = engineName;
                 item.field = srcField;
@@ -587,7 +592,7 @@ export class DashboardUtil {
     let field: Field;
 
     // 필드 조회
-    let idx = -1;
+    let idx: number;
     if (ref) idx = _.findIndex(fields, {ref, name: fieldName});
     else idx = _.findIndex(fields, {name: fieldName});
 

--- a/discovery-frontend/src/app/dashboard/util/filter.util.ts
+++ b/discovery-frontend/src/app/dashboard/util/filter.util.ts
@@ -121,7 +121,7 @@ export class FilterUtil {
   public static getBoardDataSourceForFilter(filter: Filter, board: Dashboard): BoardDataSource {
     const boardDataSource: BoardDataSource = board.configuration.dataSource;
     if ('multi' === boardDataSource.type) {
-      return boardDataSource.dataSources.find(item => item.engineName === filter.dataSource);
+      return boardDataSource.dataSources.find(item => item.engineName === filter.dataSource || (item.connType == 'LINK' && item.engineName.startsWith(filter.dataSource + '_')));
     } else {
       return boardDataSource;
     }

--- a/discovery-frontend/src/app/page/page.component.ts
+++ b/discovery-frontend/src/app/page/page.component.ts
@@ -4292,7 +4292,15 @@ export class PageComponent extends AbstractPopupComponent implements OnInit, OnD
     if (ChartType.MAP === this.widget.configuration.chart.type) {
       this.boardFilters = this.widget.dashBoard.configuration.filters;
     } else {
-      this.boardFilters = DashboardUtil.getAllFiltersDsRelations(this.widget.dashBoard, this.widget.configuration.dataSource.engineName);
+      // this.boardFilters = DashboardUtil.getAllFiltersDsRelations(this.widget.dashBoard, this.widget.configuration.dataSource.engineName);
+
+      if (ConnectionType.LINK === this.dataSource.connType) {
+        this.boardFilters = DashboardUtil.getAllFiltersDsRelations(this.widget.dashBoard,
+          isNullOrUndefined(this.dataSource.engineName) ? this.dataSource.name : this.dataSource.engineName);
+      } else {
+        this.boardFilters = DashboardUtil.getAllFiltersDsRelations(this.widget.dashBoard,
+          isNullOrUndefined(this.widget.configuration.dataSource.engineName) ? this.widget.configuration.dataSource.name : this.widget.configuration.dataSource.engineName);
+      }
     }
 
     // 해당 필터에 차트 위젯 아이디 설정

--- a/discovery-frontend/src/app/shared/datasource-metadata/service/constant.service.ts
+++ b/discovery-frontend/src/app/shared/datasource-metadata/service/constant.service.ts
@@ -47,7 +47,9 @@ export class ConstantService {
 
   private readonly geoCoordinates: string[] = [
     'EPSG:4326',
-    'EPSG:4301'
+    'EPSG:4301',
+    'EPSG:4326(Not index)',
+    'EPSG:4301(Not index)'
   ];
 
   constructor(private translateService: TranslateService) {

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/datasource/MultiDataSource.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/datasource/MultiDataSource.java
@@ -70,10 +70,16 @@ public class MultiDataSource extends DataSource {
     Preconditions.checkNotNull(name, "Name of datasource is required.");
 
     for (DataSource dataSource : dataSources) {
-      if (name.equals(dataSource.getName())) {
-        return Optional.of(dataSource);
+      String dataSourceName = dataSource.getName();
+
+      if (name.equals(dataSourceName) || (
+              dataSource.getConnType() == app.metatron.discovery.domain.datasource.DataSource.ConnectionType.LINK &&
+                      dataSource.getName().startsWith(name + "_"))
+      ) {
+          return Optional.of(dataSource);
       }
     }
+
     return Optional.empty();
   }
 
@@ -82,15 +88,15 @@ public class MultiDataSource extends DataSource {
    */
   public void electMainDataSource(QueryRequest queryRequest) {
 
-    if (queryRequest != null && queryRequest instanceof SearchQueryRequest) {
+    if (queryRequest instanceof SearchQueryRequest) {
       SearchQueryRequest searchQueryRequest = (SearchQueryRequest) queryRequest;
       Shelf shelf = searchQueryRequest.getShelf();
       Analysis analysis = searchQueryRequest.getAnalysis();
 
-      if (shelf != null && shelf instanceof GeoShelf) {
+      if (shelf instanceof GeoShelf) {
         GeoShelf geoShelf = (GeoShelf) shelf;
         MapViewLayer mainLayer;
-        if (analysis != null && analysis instanceof GeoSpatialAnalysis) {
+        if (analysis instanceof GeoSpatialAnalysis) {
           String mainLayerName = ((GeoSpatialAnalysis) analysis).getMainLayer();
           mainLayer = geoShelf.getLayerByName(mainLayerName)
                               .orElseThrow(() -> new IllegalArgumentException("layer({}) in shelf not found"));

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/workbook/configurations/datasource/MultiDataSourceTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/workbook/configurations/datasource/MultiDataSourceTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.metatron.discovery.domain.workbook.configurations.datasource;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MultiDataSourceTest {
+    @Test
+    public void getDatasourceByName(){
+        List<DataSource> dataSources = new ArrayList<>();
+        DataSource ingestedDataSource = new DefaultDataSource("IngestedDs");
+        ingestedDataSource.setConnType(app.metatron.discovery.domain.datasource.DataSource.ConnectionType.ENGINE);
+
+        DataSource linkedDataSource = new DefaultDataSource("LinkedDs_gsky");
+        linkedDataSource.setConnType(app.metatron.discovery.domain.datasource.DataSource.ConnectionType.LINK);
+
+        dataSources.add(ingestedDataSource);
+        dataSources.add(linkedDataSource);
+        MultiDataSource multiDataSource = new MultiDataSource(dataSources, null);
+
+        //noinspection ResultOfMethodCallIgnored
+        assertThat(multiDataSource.getDatasourceByName("IngestedDs"));
+        //noinspection ResultOfMethodCallIgnored
+        assertThat(multiDataSource.getDatasourceByName("LinkedDs"));
+        //noinspection ResultOfMethodCallIgnored
+        assertThat(multiDataSource.getDatasourceByName("LinkedDs_gsky"));
+    }
+}


### PR DESCRIPTION
### Description
If a dashboard with multiple datasources includes an associated linked datasource, an error occurs when creating a chart.
And I mofied association bug with linked datasources.

**Related Issue** : <!--- Please link to the issue here. -->
https://github.com/metatron-app/metatron-discovery/issues/3361


### How Has This Been Tested?
Go to 'Creating dashboard'
Select two linked type datasource and associate each other.
Creating chart.
No screen displays(Javascript error)

#### Need additional checks?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
