### PR TITLE
#3367 When temporary datasource exists, read from temporary datasource first

### DIFF
--- a/discovery-frontend/src/app/common/component/data-preview/data.preview.component.html
+++ b/discovery-frontend/src/app/common/component/data-preview/data.preview.component.html
@@ -530,7 +530,7 @@
             </div>
             <!-- //Metadata -->
             <!-- not LINKED source -->
-            <ng-container *ngIf="!isLinkedTypeSource(selectedSource) && !isGeoType(selectedField)">
+            <ng-container *ngIf="isSelectedSourceEnable() && !isGeoType(selectedField)">
               <!-- statistic -->
               <div class="ddp-ui-detail ddp-clear">
                 <div class="ddp-ui-title2">


### PR DESCRIPTION
### Description
When using datasource detail view with linked datasource, we need to check temporary datasource first.
It will improve performance.

**Related Issue** : <!--- Please link to the issue here. -->
https://github.com/metatron-app/metatron-discovery/issues/3367


### How Has This Been Tested?
Go to dashboard.
Click datasource source detail view.
Check discovery reads from temporary datasource(You can also see column detail view with linked datasource).
<img width="1737" alt="스크린샷 2020-09-08 오후 3 03 46" src="https://user-images.githubusercontent.com/526622/92438853-9b62c380-f1e4-11ea-8c71-b40d4b11c15c.png">

#### Need additional checks?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
