### PR TITLE
#3374 Prediction of line chart does not work.

### DIFF
--- a/discovery-frontend/src/app/page/component/analysis/service/analysis.prediction.service.ts
+++ b/discovery-frontend/src/app/page/component/analysis/service/analysis.prediction.service.ts
@@ -209,6 +209,7 @@ export class AnalysisPredictionService extends AbstractService implements OnInit
     // 고급분석 API 호출시 필요한 부가 정보들
     const param: Analysis = new Analysis();
     param.dataSource = _.cloneDeep(widgetConf.dataSource);
+    param.dataSource.name = (param.dataSource.name != param.dataSource.engineName)?param.dataSource.engineName:param.dataSource.name;
     param.limits = _.cloneDeep(widgetConf.limit);
     param.resultFormat = {'type': 'chart', 'mode': 'line', 'columnDelimeter': '―'};
     param.pivot = _.cloneDeep(widgetConf.pivot);
@@ -374,8 +375,7 @@ export class AnalysisPredictionService extends AbstractService implements OnInit
     const additionLowerSeries = _.cloneDeep(upperSeries);
     additionLowerSeries.name = `${targetSeries.name}${this.predictionLineTypePrefix}${AnalysisPredictionService.predictionLineTypeAdditional}`;
     const additionLowerSeriesData = lowerSeriesData.map((value, dataIdx) => {
-      const returnValue = value == null ? lower[dataIdx] : null;
-      return returnValue;
+      return value == null ? lower[dataIdx] : null;
     });
     additionLowerSeries.value = defSeriesData.concat(additionLowerSeriesData);
     return additionLowerSeries;

--- a/discovery-frontend/src/app/page/component/analysis/service/analysis.prediction.service.ts
+++ b/discovery-frontend/src/app/page/component/analysis/service/analysis.prediction.service.ts
@@ -209,7 +209,7 @@ export class AnalysisPredictionService extends AbstractService implements OnInit
     // 고급분석 API 호출시 필요한 부가 정보들
     const param: Analysis = new Analysis();
     param.dataSource = _.cloneDeep(widgetConf.dataSource);
-    param.dataSource.name = (param.dataSource.name != param.dataSource.engineName)?param.dataSource.engineName:param.dataSource.name;
+    param.dataSource.name = (param.dataSource.engineName && param.dataSource.name != param.dataSource.engineName)?param.dataSource.engineName:param.dataSource.name;
     param.limits = _.cloneDeep(widgetConf.limit);
     param.resultFormat = {'type': 'chart', 'mode': 'line', 'columnDelimeter': '―'};
     param.pivot = _.cloneDeep(widgetConf.pivot);

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/data/result/PivotResultFormat.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/data/result/PivotResultFormat.java
@@ -266,7 +266,6 @@ public class PivotResultFormat extends SearchResultFormat {
     Map<String, List<List<Object>>> valueMap = Maps.newLinkedHashMap();
 
     boolean analysisResults = (request.getAnalysis() != null);
-    int keyFieldCnt = keyFields.size();
 
     ArrayNode analysisNode = null;
     String analysisKey = null;
@@ -319,13 +318,7 @@ public class PivotResultFormat extends SearchResultFormat {
         // Escape separator if nodeKey start with separator. ex. -SUM(m1) --SUM(m1)
         fieldName = fieldName.startsWith(separator) ? fieldName.substring(pivots.size()) : fieldName;
 
-        for(String keyField : keyFields)
-          if(fieldName.equals(keyField)) {
-            isKeyField = true;
-            break;
-          }
-
-        if(isKeyField)
+        if(keyFields.contains(fieldName))
           continue;
 
         // Percentage Case
@@ -365,6 +358,10 @@ public class PivotResultFormat extends SearchResultFormat {
     }
 
     return response;
+  }
+
+  protected boolean isContains(List<String> strList, String item){
+    return strList.contains(item);
   }
 
   private Object getTypedValue(JsonNode jsonNode) {

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/data/result/PivotResultFormat.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/data/result/PivotResultFormat.java
@@ -65,6 +65,7 @@ import java.util.stream.Collectors;
 /**
  * Created by kyungtaak on 2016. 8. 21..
  */
+@SuppressWarnings("rawtypes")
 @JsonTypeName("dpivot")
 public class PivotResultFormat extends SearchResultFormat {
 
@@ -197,17 +198,15 @@ public class PivotResultFormat extends SearchResultFormat {
               Optional<Sort> findSort = this.getRequest().getLimits().getSort()
                       .stream().filter(sort -> sort.getField().equalsIgnoreCase(pivot.getFieldName()))
                       .findFirst();
-              if (findSort.isPresent()) {
-                pivotColumn.setDirection(
-                        findSort.get().getDirection() == Sort.Direction.DESC ?
-                                PivotColumn.Direction.DESCENDING : PivotColumn.Direction.ASCENDING);
-              }
+              findSort.ifPresent(sort -> pivotColumn.setDirection(
+                      sort.getDirection() == Sort.Direction.DESC ?
+                              PivotColumn.Direction.DESCENDING : PivotColumn.Direction.ASCENDING));
 
               return pivotColumn;
             }).collect(Collectors.toList()));
 
     pivotSpec.setValueColumns(aggregations.stream()
-            .map(aggregation -> aggregation.getFieldName())
+            .map(Aggregation::getFieldName)
             .collect(Collectors.toList()));
 
     for (String expression : expressions) {
@@ -291,32 +290,48 @@ public class PivotResultFormat extends SearchResultFormat {
     for (JsonNode aNode : node) {
       Iterator<Map.Entry<String, JsonNode>> fields = aNode.fields();
       if (analysisResults) {
-        Map.Entry<String, JsonNode> nodeMap = fields.next();
-        if (nodeMap.getValue().asText().equals(analysisKey)) {
+        if (aNode.get("version").textValue().equals(analysisKey)) {
           analysisNode.add(aNode);
           continue;
         }
       }
 
       List<String> rowKeys = Lists.newArrayList();
-      for (int i = 0; i < keyFieldCnt; i++) {
-        Map.Entry<String, JsonNode> nodeMap = fields.next();
-        rowKeys.add(nodeMap.getValue().asText());
+      for (String keyField : keyFields) {
+        rowKeys.add(aNode.get(keyField).textValue());
       }
+
       String categoryName = StringUtils.join(rowKeys, separator);
       rows.add(categoryName);
+      Iterator<String> fieldNames = aNode.fieldNames();
 
-      while (fields.hasNext()) {
-        Map.Entry<String, JsonNode> nodeMap = fields.next();
-        String nodeKey = nodeMap.getKey();
+      while (fieldNames.hasNext()) {
+        String fieldName = fieldNames.next();
+        boolean isKeyField = false;
+
+        if(fieldName.equals("version"))
+          continue;
+
+        JsonNode nodeValue = aNode.get(fieldName);
+
+//        Map.Entry<String, JsonNode> nodeMap = fields.next();
+//        String nodeKey = fieldName;
         // Escape separator if nodeKey start with separator. ex. -SUM(m1) --SUM(m1)
-        nodeKey = nodeKey.startsWith(separator) ? nodeKey.substring(pivots.size()) : nodeKey;
-        JsonNode nodeValue = nodeMap.getValue();
+        fieldName = fieldName.startsWith(separator) ? fieldName.substring(pivots.size()) : fieldName;
+
+        for(String keyField : keyFields)
+          if(fieldName.equals(keyField)) {
+            isKeyField = true;
+            break;
+          }
+
+        if(isKeyField)
+          continue;
 
         // Percentage Case
-        if (includePercentage && StringUtils.endsWith(nodeKey, ChartResultFormat.POSTFIX_PERCENTAGE)) {
+        if (includePercentage && StringUtils.endsWith(fieldName, ChartResultFormat.POSTFIX_PERCENTAGE)) {
           String originalKey = StringUtils
-                  .substring(nodeKey, 0, nodeKey.length() - ChartResultFormat.POSTFIX_PERCENTAGE.length());
+                  .substring(fieldName, 0, fieldName.length() - ChartResultFormat.POSTFIX_PERCENTAGE.length());
           if (grouped && categoryMap.containsKey(originalKey)) {
             List<List<Object>> values = categoryMap.get(originalKey);
             values.get(1).add(getTypedValue(nodeValue));
@@ -329,12 +344,12 @@ public class PivotResultFormat extends SearchResultFormat {
           }
           // Normal Value Case
         } else {
-          if (grouped && categoryMap.containsKey(nodeKey)) {
-            categoryMap.get(nodeKey).get(0).add(getTypedValue(nodeValue));
-          } else if (valueMap.containsKey(nodeKey)) {
-            valueMap.get(nodeKey).get(0).add(getTypedValue(nodeValue));
+          if (grouped && categoryMap.containsKey(fieldName)) {
+            categoryMap.get(fieldName).get(0).add(getTypedValue(nodeValue));
+          } else if (valueMap.containsKey(fieldName)) {
+            valueMap.get(fieldName).get(0).add(getTypedValue(nodeValue));
           } else {
-            valueMap.put(nodeKey,
+            valueMap.put(fieldName,
                     Lists.newArrayList(Lists.newArrayList(getTypedValue(nodeValue)),
                             Lists.newArrayList()));
           }
@@ -380,15 +395,15 @@ public class PivotResultFormat extends SearchResultFormat {
       // 예측 대상 필드 구하고,
       PredictionAnalysis predictionAnalysis = (PredictionAnalysis) analysis;
 
-      List<String> parameterNames = null;
+      List<String> parameterNames;
       if (CollectionUtils.isEmpty(predictionAnalysis.getForecast().getParameters())) {
         parameterNames = request.getProjections().stream()
                 .filter(field -> field instanceof MeasureField)
-                .map(field -> field.getAlias())
+                .map(Field::getAlias)
                 .collect(Collectors.toList());
       } else {
         parameterNames = predictionAnalysis.getForecast().getParameters().stream()
-                .map(hyperParameter -> hyperParameter.getField())
+                .map(PredictionAnalysis.HyperParameter::getField)
                 .collect(Collectors.toList());
       }
       // 각 요소별 데이터 초기화
@@ -452,9 +467,9 @@ public class PivotResultFormat extends SearchResultFormat {
       return result;
 
     } else if (analysis instanceof TrendAnalysis) {
-
+      //Todo: trend analysis
     } else if (analysis instanceof ClusterAnalysis) {
-
+      //Todo: Cluster analysis(Kmeans)
     }
 
     return null;

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/datasource/data/result/PivotResultFormatTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/datasource/data/result/PivotResultFormatTest.java
@@ -1,14 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package app.metatron.discovery.domain.datasource.data.result;
 
 import app.metatron.discovery.common.GlobalObjectMapper;
 import app.metatron.discovery.common.MatrixResponse;
 import app.metatron.discovery.domain.datasource.DataSource;
 import app.metatron.discovery.domain.datasource.data.SearchQueryRequest;
+import app.metatron.discovery.domain.workbook.configurations.analysis.PredictionAnalysis;
+import app.metatron.discovery.domain.workbook.configurations.analysis.Style;
+import app.metatron.discovery.domain.workbook.configurations.field.MeasureField;
+import app.metatron.discovery.domain.workbook.configurations.field.TimestampField;
+import app.metatron.discovery.domain.workbook.configurations.format.ContinuousTimeFormat;
+import app.metatron.discovery.domain.workbook.configurations.format.NumberFieldFormat;
+import app.metatron.discovery.query.druid.granularities.SimpleGranularity;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Lists;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.List;
+
+@SuppressWarnings("rawtypes")
 public class PivotResultFormatTest {
     @Test
     public void toResultSetByMatrixTypeForString(){
@@ -22,8 +46,9 @@ public class PivotResultFormatTest {
         pivotResultFormat.setPivots(Lists.newArrayList());
         pivotResultFormat.setSeparator("-");
 
-        MatrixResponse response = pivotResultFormat.toResultSetByMatrixType(GlobalObjectMapper.readValue(jsonResult, JsonNode.class));
+        @SuppressWarnings("rawtypes") MatrixResponse response = pivotResultFormat.toResultSetByMatrixType(GlobalObjectMapper.readValue(jsonResult, JsonNode.class));
 
+        //noinspection rawtypes
         Assert.assertEquals("2014-11-12 00", ((MatrixResponse.Column) response.getColumns().get(0)).getValue().get(0).toString());
     }
 
@@ -59,5 +84,36 @@ public class PivotResultFormatTest {
         MatrixResponse response = pivotResultFormat.toResultSetByMatrixType(GlobalObjectMapper.readValue(jsonResult, JsonNode.class));
 
         Assert.assertEquals(1, ((Integer)((MatrixResponse.Column) response.getColumns().get(1)).getValue().get(0)).doubleValue(), 0);
+    }
+
+    @Test
+    public void toResultSetByMatrixTypeForPrediction() {
+        String jsonResult = "[{\"version\":\"v1\",\"SUM(Profit)\":2803.0,\"OrderDate\":\"Apr 2014\"},{\"version\":\"v1\",\"SUM(Profit)\":6275.0,\"OrderDate\":\"May 2014\"},{\"version\":\"v1\",\"SUM(Profit)\":8091.0,\"OrderDate\":\"Jun 2014\"},{\"version\":\"v1\",\"SUM(Profit)\":6622.0,\"OrderDate\":\"Jul 2014\"},{\"version\":\"v1\",\"SUM(Profit)\":8886.0,\"OrderDate\":\"Aug 2014\"},{\"version\":\"v1\",\"SUM(Profit)\":11391.0,\"OrderDate\":\"Sep 2014\"},{\"version\":\"v1\",\"SUM(Profit)\":9438.0,\"OrderDate\":\"Oct 2014\"},{\"version\":\"v1\",\"SUM(Profit)\":9683.0,\"OrderDate\":\"Nov 2014\"},{\"version\":\"v1\",\"SUM(Profit)\":8537.0,\"OrderDate\":\"Dec 2014\"},{\"version\":\"predict\",\"SUM(Profit)\":[1083.659510378634,5650.380935758498,10217.10236113836],\"SUM(Profit).params\":[1.0,0.0,0.921985595473179],\"OrderDate\":\"Jan 2015\"},{\"version\":\"predict\",\"SUM(Profit)\":[3300.3245649513483,10538.406775418302,17776.488985885255],\"SUM(Profit).params\":[1.0,0.0,0.921985595473179],\"OrderDate\":\"Feb 2015\"},{\"version\":\"predict\",\"SUM(Profit)\":[2381.9377137135525,11515.38056447328,20648.823415233008],\"SUM(Profit).params\":[1.0,0.0,0.921985595473179],\"OrderDate\":\"Mar 2015\"}]";
+
+        PivotResultFormat pivotResultFormat = new PivotResultFormat();
+        pivotResultFormat.setRequest(new SearchQueryRequest());
+        pivotResultFormat.setConnType(DataSource.ConnectionType.ENGINE);
+        pivotResultFormat.setResultType(SearchResultFormat.ResultType.MATRIX);
+        pivotResultFormat.setKeyFields(Lists.newArrayList());
+        pivotResultFormat.getKeyFields().add("OrderDate");
+        pivotResultFormat.setPivots(Lists.newArrayList());
+        pivotResultFormat.setSeparator("-");
+
+        PredictionAnalysis analysis = new PredictionAnalysis();
+        List<PredictionAnalysis.HyperParameter> parameters = Lists.newArrayList();
+        analysis.setForecast(new PredictionAnalysis.Forecast(null, new Style()));
+        pivotResultFormat.getRequest().setAnalysis(analysis);
+
+        pivotResultFormat.getRequest().setProjections(Lists.newArrayList());
+        pivotResultFormat.getRequest().getProjections().add(new TimestampField("OrderDate", null, null, new SimpleGranularity("DAY"), new ContinuousTimeFormat(false, "MONTH", null )));
+        pivotResultFormat.getRequest().getProjections().add(new MeasureField("Profit", "SUM(Profit)", null, "SUM", new NumberFieldFormat(2, true, "NONE", null), null));
+
+        MatrixResponse response = pivotResultFormat.toResultSetByMatrixType(GlobalObjectMapper.readValue(jsonResult, JsonNode.class));
+
+        Assert.assertEquals("Apr 2014", response.getRows().get(0));
+        Assert.assertEquals("Column length is incorrect", 1, response.getColumns().size());
+        Assert.assertEquals("SUM(Profit)", ((MatrixResponse.Column)response.getColumns().get(0)).getName());
+
+        Assert.assertEquals("First element of SUM(Profit) is incorrect", 2803, (Double) ((MatrixResponse.Column) response.getColumns().get(0)).getValue().get(0), 0.0);
     }
 }


### PR DESCRIPTION
### Description
If I use the prediction function of line chart, it occurs error.

**Related Issue** : <!--- Please link to the issue here. -->
https://github.com/metatron-app/metatron-discovery/issues/3374


### How Has This Been Tested?
1. Go to 'Draw line chart'
2. Click on 'Prediction'
3. You can see the prediction line for every series of line chart.

#### Need additional checks?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
