### PR TITLE
#3382 bugfix non-existing temporary datasource cleansing and some code cleansing

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourceController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourceController.java
@@ -14,6 +14,8 @@
 
 package app.metatron.discovery.domain.datasource;
 
+import app.metatron.discovery.domain.datasource.data.SqlQueryRequest;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -221,6 +223,13 @@ public class DataSourceController {
     if (CollectionUtils.isNotEmpty(temporaries)) {
       DataSourceTemporary temporary = temporaries.get(0);
       LOGGER.info("Already created temporary datasource : {}", temporary.getName());
+
+      //Find real druid data source
+      if(!engineQueryService.isExistsByName(temporary.getName())) {
+        temporary.setStatus(DataSourceTemporary.LoadStatus.DISABLE);
+        temporaryRepository.save(temporary);
+      }
+
       if (temporary.getStatus() == DataSourceTemporary.LoadStatus.ENABLE) {
         // Expired Time 재조정 후 정보 리턴
         temporary.setNextExpireTime(DateTime.now().plusSeconds(temporary.getExpired()));
@@ -345,11 +354,11 @@ public class DataSourceController {
                                                    @RequestParam(value = "includeUnloadedField", required = false) Boolean includeUnloadedField,
                                                    @RequestParam(value = "projection", required = false, defaultValue = "default") String projection) {
 
-    List results = dataSourceService.findMultipleDataSourceIncludeTemporary(ids, includeUnloadedField);
+    List<DataSource> results = dataSourceService.findMultipleDataSourceIncludeTemporary(ids, includeUnloadedField);
 
     return ResponseEntity.ok(ProjectionUtils.toListResource(projectionFactory,
-                                                            dataSourceProjections.getProjectionByName(projection),
-                                                            results));
+            dataSourceProjections.getProjectionByName(projection),
+            results));
   }
 
   /**
@@ -596,7 +605,7 @@ public class DataSourceController {
       return new ArrayList<>();
     } else {
       return segmentMetaData.getColumns().entrySet().stream()
-                            .filter(entry -> ((entry.getKey().equals("__time") || entry.getKey().equals("count")) == false))
+                            .filter(entry -> (!(entry.getKey().equals("__time") || entry.getKey().equals("count"))))
                             .map(entry -> {
                               SegmentMetaDataResponse.ColumnInfo value = entry.getValue();
 
@@ -835,7 +844,7 @@ public class DataSourceController {
                                                @RequestParam(value = "timeZone", required = false, defaultValue = "UTC") String timeZone,
                                                @RequestParam(value = "count", required = false, defaultValue = "5") int count) {
 
-    CronExpression cronExpression = null;
+    CronExpression cronExpression;
     try {
       cronExpression = new CronExpression(expr);
     } catch (ParseException e) {
@@ -866,7 +875,7 @@ public class DataSourceController {
     LogicalType type = wktCheckRequest.getGeoType();
 
     WKTReader wktReader = new WKTReader();
-    Geometry geometry = null;
+    Geometry geometry;
 
     boolean valid = true;
     String message = null;
@@ -916,7 +925,7 @@ public class DataSourceController {
     } else if (c.equals(Polygon.class)) {
       logicalType = LogicalType.GEO_POLYGON;
     } else if (c.equals(MultiLineString.class)) {
-      if (type != null && type == LogicalType.GEO_POLYGON) { // It can be a polygon.
+      if (type == LogicalType.GEO_POLYGON) { // It can be a polygon.
         logicalType = LogicalType.GEO_POLYGON;
       } else {
         logicalType = LogicalType.GEO_LINE;
@@ -1002,7 +1011,7 @@ public class DataSourceController {
                                        @RequestParam(value = "limit", required = false, defaultValue = "100") int limit,
                                        @RequestParam(value = "firstHeaderRow", required = false, defaultValue = "true") boolean firstHeaderRow) {
 
-    IngestionDataResultResponse resultResponse = null;
+    IngestionDataResultResponse resultResponse;
 
     try {
       String filePath = System.getProperty("java.io.tmpdir") + File.separator + fileKey;
@@ -1061,19 +1070,21 @@ public class DataSourceController {
                                       Pageable pageable,
                                       PersistentEntityResourceAssembler resourceAssembler) {
 
-    List<String> statuses = request == null ? null : request.getStatus();
-    List<String> workspaces = request == null ? null : request.getWorkspace();
-    List<String> createdBys = request == null ? null : request.getCreatedBy();
-    List<String> userGroups = request == null ? null : request.getUserGroup();
-    List<String> dataSourceTypes = request == null ? null : request.getDataSourceType();
-    List<String> sourceTypes = request == null ? null : request.getSourceType();
-    List<String> connectionTypes = request == null ? null : request.getConnectionType();
-    DateTime createdTimeFrom = request == null ? null : request.getCreatedTimeFrom();
-    DateTime createdTimeTo = request == null ? null : request.getCreatedTimeTo();
-    DateTime modifiedTimeFrom = request == null ? null : request.getModifiedTimeFrom();
-    DateTime modifiedTimeTo = request == null ? null : request.getModifiedTimeTo();
-    String containsText = request == null ? null : request.getContainsText();
-    List<Boolean> published = request == null ? null : request.getPublished();
+    assert request != null;
+
+    List<String> statuses = request.getStatus();
+    List<String> workspaces = request.getWorkspace();
+    List<String> createdBys = request.getCreatedBy();
+    List<String> userGroups = request.getUserGroup();
+    List<String> dataSourceTypes = request.getDataSourceType();
+    List<String> sourceTypes = request.getSourceType();
+    List<String> connectionTypes = request.getConnectionType();
+    DateTime createdTimeFrom = request.getCreatedTimeFrom();
+    DateTime createdTimeTo = request.getCreatedTimeTo();
+    DateTime modifiedTimeFrom = request.getModifiedTimeFrom();
+    DateTime modifiedTimeTo = request.getModifiedTimeTo();
+    String containsText = request.getContainsText();
+    List<Boolean> published = request.getPublished();
 
     LOGGER.debug("Parameter (status) : {}", statuses);
     LOGGER.debug("Parameter (workspace) : {}", workspaces);
@@ -1267,10 +1278,10 @@ public class DataSourceController {
   ResponseEntity<?> getPreviewFromKafka(@RequestParam(value = "bootstrapServer") String bootstrapServer,
                                        @RequestParam(value = "topic") String topic) {
 
-    Map resultMap = Maps.newHashMap();
+    Map<String, Object> resultMap = Maps.newHashMap();
     IngestionDataResultResponse resultResponse = null;
     try {
-      List kafkaData = dataSourceService.getKafkaPreviewData(bootstrapServer, topic);
+      List<String> kafkaData = dataSourceService.getKafkaPreviewData(bootstrapServer, topic);
       if (CollectionUtils.isNotEmpty(kafkaData)) {
         JsonProcessor jsonProcessor = new JsonProcessor().parse(kafkaData);
         resultResponse = jsonProcessor.ingestionDataResultResponse();

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourceTemporaryRepository.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourceTemporaryRepository.java
@@ -38,6 +38,8 @@ public interface DataSourceTemporaryRepository extends JpaRepository<DataSourceT
 
   List<DataSourceTemporary> findByDataSourceIdOrderByModifiedTimeDesc(String dataSourceId);
 
+  List<DataSourceTemporary> findByStatus(DataSourceTemporary.LoadStatus status);
+
   DataSourceTemporary findByName(String name);
 
   @Transactional

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/engine/EngineQueryService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/engine/EngineQueryService.java
@@ -363,7 +363,7 @@ public class EngineQueryService extends AbstractQueryService implements QuerySer
         resultJoiner.add(GlobalObjectMapper.writeValueAsString(geoJsonResult));
       }
 
-      Query operationQuery = null;
+      Query operationQuery;
       if (geoSpatialAnalysis.enableChoropleth()) {
         GroupByQuery mainLayerQuery = GroupByQuery.builder(request.getDataSource())
                 .layer(mainLayer)
@@ -728,7 +728,7 @@ public class EngineQueryService extends AbstractQueryService implements QuerySer
   }
 
   /**
-   * @param request
+   * @param request request information for summary of datasource
    * @return
    */
   @Override
@@ -750,7 +750,7 @@ public class EngineQueryService extends AbstractQueryService implements QuerySer
 
   /**
    * @param request
-   * @return
+   * @return covariance values with each other measures.
    */
   @Override
   public Object covariance(CovarianceQueryRequest request) {
@@ -853,7 +853,7 @@ public class EngineQueryService extends AbstractQueryService implements QuerySer
     String result = engineRepository.query(queryString, String.class).orElseThrow(
             () -> new ResourceNotFoundException(dataSourceName));
 
-    List<SegmentMetaDataResponse> metaData = null;
+    List<SegmentMetaDataResponse> metaData;
     try {
       metaData = GlobalObjectMapper.getDefaultMapper()
               .readValue(result, new TypeReference<List<SegmentMetaDataResponse>>() {
@@ -894,5 +894,11 @@ public class EngineQueryService extends AbstractQueryService implements QuerySer
     }
 
     return GlobalObjectMapper.getDefaultMapper().convertValue(node.get(0), Map.class);
+  }
+
+  public boolean isExistsByName(String dataSourceName){
+    Object result = this.sql(new SqlQueryRequest("show tables in druid like '" + dataSourceName + "'", null));
+
+    return result instanceof ArrayNode && ((ArrayNode) result).size() > 0;
   }
 }


### PR DESCRIPTION
### Description
If Druid is shutdown anomaly after creating a temporary data source, Discovery does not know the data source has been disabled and tries to get data from it.

**Related Issue** : <!--- Please link to the issue here. -->
https://github.com/metatron-app/metatron-discovery/issues/3382

### How Has This Been Tested?
1. Create linked datasource.
2. Create dashboard from created linked datasource.
3. Restart Druid.
4. Check to reload message appears.

#### Need additional checks?
Discovery needs to know the temporary datasource is disabled and reload it.
Discovery reload process is unstable in my local environment. We need to check stability of re-ingestion process.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
