### PR TITLE
fix widget_conf column's dataType to MEDIUMTEXT

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/widget/Widget.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/widget/Widget.java
@@ -85,7 +85,7 @@ public abstract class Widget extends AbstractHistoryEntity implements MetatronDo
   /**
    * Widget Configuration
    */
-  @Column(name = "widget_conf", length = 65535, columnDefinition = "TEXT")
+  @Column(name = "widget_conf", length = 65535, columnDefinition = "MEDIUMTEXT")
   @Basic(fetch = FetchType.LAZY)
   @Spec(target = WidgetConfiguration.class)
   @JsonRawValue

--- a/discovery-server/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/discovery-server/src/main/resources/db/changelog/db.changelog-master.xml
@@ -124,11 +124,19 @@
     <property name="text.type" value="[varchar](MAX)" dbms="mssql"/>
     <property name="text.type" value="CLOB" dbms="oracle"/>
 
+
+    <!-- sql type (mediumtext) -->
+    <property name="mediumtext.type" value="MEDIUMTEXT" dbms="mysql"/>
+    <property name="mediumtext.type" value="CLOB" dbms="h2"/>
+    <property name="mediumtext.type" value="TEXT" dbms="postgresql"/>
+    <property name="mediumtext.type" value="TEXT" dbms="mssql"/>
+    <property name="mediumtext.type" value="CLOB" dbms="oracle"/>
+
     <!-- sql type (clob) -->
     <property name="clob.type" value="LONGTEXT" dbms="mysql"/>
     <property name="clob.type" value="CLOB" dbms="h2"/>
     <property name="clob.type" value="TEXT" dbms="postgresql"/>
-    <property name="clob.type" value="[varchar](MAX)" dbms="mssql"/>
+    <property name="clob.type" value="TEXT" dbms="mssql"/>
     <property name="clob.type" value="CLOB" dbms="oracle"/>
 
 

--- a/discovery-server/src/main/resources/db/changelog/discovery.changelog-3.4.0.xml
+++ b/discovery-server/src/main/resources/db/changelog/discovery.changelog-3.4.0.xml
@@ -309,5 +309,8 @@
         </createIndex>
     </changeSet>
 
+    <changeSet author="sohncw" id="1600259363727-0">
+        <modifyDataType tableName="dashboard_widget" columnName="widget_conf" newDataType="${mediumtext.type}" />
+    </changeSet>
 
 </databaseChangeLog>


### PR DESCRIPTION
### Description
If the widget configuration length exceeds 64kb, an error occurs.

DataType of widget_conf column has been changed to mediumtext

**Related Issue** : 


### How Has This Been Tested?
1. Create Dashboard and widget.
2. Create enough user-defined fields to store data over 64kb.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
