### PR TITLE
Addition of processing logic when null is included in Double type result

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/data/result/PivotResultFormat.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/data/result/PivotResultFormat.java
@@ -14,6 +14,31 @@
 
 package app.metatron.discovery.domain.datasource.data.result;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.net.URI;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 import app.metatron.discovery.common.GlobalObjectMapper;
 import app.metatron.discovery.common.MatrixResponse;
 import app.metatron.discovery.domain.datasource.data.QueryTimeExcetpion;
@@ -39,28 +64,6 @@ import app.metatron.discovery.query.druid.postaggregations.MathPostAggregator;
 import app.metatron.discovery.query.druid.postprocessor.PostAggregationProcessor;
 import app.metatron.discovery.query.druid.queries.GroupingSet;
 import app.metatron.discovery.util.EnumUtils;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.File;
-import java.net.URI;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static java.lang.Double.NaN;
 
@@ -375,6 +378,8 @@ public class PivotResultFormat extends SearchResultFormat {
       return jsonNode.isNull() ? null : jsonNode.asDouble();
     else if(jsonNode.isTextual())
       return jsonNode.isNull() ? null : "NaN".equals(jsonNode.asText()) ? NaN : jsonNode.asText();
+    else if(jsonNode.isNull())
+      return null;
     else
       return jsonNode.asText();
   }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/data/result/PivotResultFormat.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/data/result/PivotResultFormat.java
@@ -65,7 +65,9 @@ import app.metatron.discovery.query.druid.postprocessor.PostAggregationProcessor
 import app.metatron.discovery.query.druid.queries.GroupingSet;
 import app.metatron.discovery.util.EnumUtils;
 
+import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.NaN;
+import static java.lang.Double.POSITIVE_INFINITY;
 
 /**
  * Created by kyungtaak on 2016. 8. 21..
@@ -377,7 +379,10 @@ public class PivotResultFormat extends SearchResultFormat {
     else if(jsonNode.isDouble())
       return jsonNode.isNull() ? null : jsonNode.asDouble();
     else if(jsonNode.isTextual())
-      return jsonNode.isNull() ? null : "NaN".equals(jsonNode.asText()) ? NaN : jsonNode.asText();
+      return jsonNode.isNull() ? null :
+          String.valueOf(Double.NaN).equals(jsonNode.asText()) ? NaN :
+              String.valueOf(POSITIVE_INFINITY).equals(jsonNode.asText()) ? POSITIVE_INFINITY :
+                  String.valueOf(NEGATIVE_INFINITY).equals(jsonNode.asText()) ? NEGATIVE_INFINITY : jsonNode.asText();
     else if(jsonNode.isNull())
       return null;
     else

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/datasource/data/result/PivotResultFormatTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/datasource/data/result/PivotResultFormatTest.java
@@ -14,6 +14,15 @@
 
 package app.metatron.discovery.domain.datasource.data.result;
 
+import com.google.common.collect.Lists;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
 import app.metatron.discovery.common.GlobalObjectMapper;
 import app.metatron.discovery.common.MatrixResponse;
 import app.metatron.discovery.domain.datasource.DataSource;
@@ -25,12 +34,6 @@ import app.metatron.discovery.domain.workbook.configurations.field.TimestampFiel
 import app.metatron.discovery.domain.workbook.configurations.format.ContinuousTimeFormat;
 import app.metatron.discovery.domain.workbook.configurations.format.NumberFieldFormat;
 import app.metatron.discovery.query.druid.granularities.SimpleGranularity;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.collect.Lists;
-import org.junit.Assert;
-import org.junit.Test;
-
-import java.util.List;
 
 @SuppressWarnings("rawtypes")
 public class PivotResultFormatTest {
@@ -71,7 +74,7 @@ public class PivotResultFormatTest {
 
     @Test
     public void toResultSetByMatrixTypeForDoubleNan(){
-        String jsonResult = "[{\"Segment\":\"Consumer\",\"SUM(Sales)\":\"NaN\"},{\"Segment\":\"Corporate\",\"SUM(Sales)\":208473.0},{\"Segment\":\"Home Office\",\"SUM(Sales)\":137661.0}]";
+        String jsonResult = "[{\"Segment\":\"Consumer\",\"SUM(Sales)\":\"NaN\"},{\"Segment\":\"Corporate\",\"SUM(Sales)\":null},{\"Segment\":\"Home Office\",\"SUM(Sales)\":137661.0}]";
 
         PivotResultFormat pivotResultFormat = new PivotResultFormat();
         pivotResultFormat.setRequest(new SearchQueryRequest());
@@ -84,6 +87,7 @@ public class PivotResultFormatTest {
         MatrixResponse response = pivotResultFormat.toResultSetByMatrixType(GlobalObjectMapper.readValue(jsonResult, JsonNode.class));
 
         Assert.assertEquals(Double.NaN, (Double) ((MatrixResponse.Column) response.getColumns().get(1)).getValue().get(0), 0.0);
+        Assert.assertNull(((MatrixResponse.Column) response.getColumns().get(1)).getValue().get(1));
     }
 
     @Test


### PR DESCRIPTION
### Description
Addition of processing logic when null is included in Double type result.
Previously, JsonNullNode was treated as String, but changed to treat as null.

**Related Issue** : 

### How Has This Been Tested?
1. Create Dashboard and chart
2. The dimension value whose group by result is null is put on the cross shelf and the data containing null in the result is drawn on the chart.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
