### PR TITLE
#3397 fix user defined field duplicated in multi datasources

### DIFF
--- a/discovery-frontend/src/app/page/page.component.ts
+++ b/discovery-frontend/src/app/page/page.component.ts
@@ -3509,8 +3509,8 @@ export class PageComponent extends AbstractPopupComponent implements OnInit, OnD
     if (boardConf.hasOwnProperty('customFields') && boardConf.customFields.length > 0) {
       // set main datasource fields
       boardConf.customFields
-        .filter(item => item.dataSource === this.widget.configuration.dataSource.engineName ?
-          this.widget.configuration.dataSource.engineName : this.widget.configuration.dataSource.name)
+        .filter(item => item.dataSource === (this.widget.configuration.dataSource.engineName ?
+          this.widget.configuration.dataSource.engineName : this.widget.configuration.dataSource.name))
         .forEach((field: CustomField) => {
           if (field.role === FieldRole.DIMENSION) {
             this.customDimensions.push(field);


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
fix user defined field duplicated in multi datasources

**Related Issue** : #3397 
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. When creating a dashboard, select two or more datasources to create them.
2. Click Create Chart.
3. Create a user defined field from the default datasource in the chart creation popup.
4. After moving to another datasource, check if the user defined field created in step 3 is not visible.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
