### PR TITLE
exclude from login lock when login fail of whitelist users

### DIFF
--- a/discovery-server/src/main/asciidoc/application-config-guide.adoc
+++ b/discovery-server/src/main/asciidoc/application-config-guide.adoc
@@ -180,5 +180,6 @@ polaris:
       minimumUsePeriod: P1D               # The password cannot be changed again within that period. (ISO 8601 Duration Format)
       lockCount: 5                        # The Password must match within that number.
       countOfHistory: -1                  # This is the past history number to compare when changing the password. -1 to Disable
+      excludeLockUsername: [polaris]      # Whitelist except login password lock. (default: admin)
 ----
 

--- a/discovery-server/src/main/java/app/metatron/discovery/common/oauth/CustomDaoAuthenticationProvider.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/common/oauth/CustomDaoAuthenticationProvider.java
@@ -45,9 +45,9 @@ public class CustomDaoAuthenticationProvider extends DaoAuthenticationProvider {
     try {
       super.additionalAuthenticationChecks(userDetails, authentication);
     } catch (BadCredentialsException e) {
-      if (userProperties.getPassword().getLockCount() != null) {
+      if (!userProperties.getPassword().getExcludeLockUsername().contains(request.getParameter("username")) && userProperties.getPassword().getLockCount() != null) {
         Integer failCnt = userService.addFailCount(request.getParameter("username"));
-        if (failCnt != null && userProperties.getPassword().getLockCount() != null) {
+        if (failCnt != null) {
           String message;
           if (failCnt == userProperties.getPassword().getLockCount()) {
             message = messages.getMessage(

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/user/UserPasswordProperties.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/user/UserPasswordProperties.java
@@ -14,7 +14,10 @@
 
 package app.metatron.discovery.domain.user;
 
+import com.google.common.collect.Lists;
+
 import java.io.Serializable;
+import java.util.List;
 
 /**
  *
@@ -28,7 +31,10 @@ public class UserPasswordProperties {
   String minimumUsePeriod;
 
   Integer countOfHistory = -1;
+
   Integer lockCount;
+
+  List<String> excludeLockUsername = Lists.newArrayList();
 
   public UserPasswordProperties() {
     // Empty Constructor
@@ -66,13 +72,20 @@ public class UserPasswordProperties {
     this.countOfHistory = countOfHistory;
   }
 
-  public Integer getLockCount() {
-    return lockCount;
-  }
+  public Integer getLockCount() { return lockCount; }
 
   public void setLockCount(Integer lockCount) {
     this.lockCount = lockCount;
   }
+
+  public List<String> getExcludeLockUsername() {
+    if (!excludeLockUsername.contains("admin")) {
+      excludeLockUsername.add("admin");
+    }
+    return excludeLockUsername;
+  }
+
+  public void setExcludeLockUsername(List<String> excludeLockUsername) { this.excludeLockUsername = excludeLockUsername; }
 
   public static class PasswordStrength implements Serializable {
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
exclude from login lock when login fail of whitelist users including admin

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Add password lock count config to application.yaml
   For testing, the count is 3.
```
polaris:
  user:
    password:
       lockCount: 3   # The Password must match within that number.
```
2. repeat 4 times in a row to try logging in with the wrong password of admin
3. Add password lock whitelist config to application.yaml
    For testing, add 'polaris'
```
polaris:
  user:
    password:
       excludeLockUsername: [polaris]      # Whitelist except login password lock.
```
4. repeat 4 times in a row to try logging in with the wrong password of polaris

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
