### PR TITLE
reset password failure count when user is activated

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/user/UserController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/user/UserController.java
@@ -674,6 +674,7 @@ public class UserController {
         if (user.getStatus() == User.Status.ACTIVATED) {
           throw new UserException("Already activated user.");
         }
+        user.setFailCnt(null);
         user.setStatus(User.Status.ACTIVATED);
         break;
       case LOCKED:


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
If the mail server is not linked, the user cannot reset the password.
When the administrator changes the user's status to Activate, it initializes the number of password failures.

**Related Issue** : 
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. add password lock count config to application.yaml
  For testing, the count is 3.
```
polaris:
  user:
    password:
       lockCount: 3   # The Password must match within that number.
```
2. Repeat 3 times in a row to try logging in with the wrong password.
3. Check the login fail message.
4. After logging in to the admin account, change the account whose login failed to Activate.
(Activate -> Inactive -> Activate)
5. Try logging in with the correct password.


#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
