### PR TITLE
 support parquet format for staging db

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/HiveTableInformation.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/HiveTableInformation.java
@@ -14,22 +14,26 @@
 
 package app.metatron.discovery.domain.datasource.connection.jdbc;
 
-import app.metatron.discovery.common.datasource.DataType;
-import app.metatron.discovery.domain.datasource.Field;
-import app.metatron.discovery.domain.datasource.ingestion.file.CsvFileFormat;
-import app.metatron.discovery.domain.datasource.ingestion.file.FileFormat;
-import app.metatron.discovery.domain.datasource.ingestion.file.OrcFileFormat;
-import app.metatron.discovery.domain.datasource.ingestion.jdbc.SelectQueryBuilder;
 import com.google.common.collect.Lists;
+
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
 import java.util.Map;
 
+import app.metatron.discovery.common.datasource.DataType;
+import app.metatron.discovery.domain.datasource.Field;
+import app.metatron.discovery.domain.datasource.ingestion.file.CsvFileFormat;
+import app.metatron.discovery.domain.datasource.ingestion.file.FileFormat;
+import app.metatron.discovery.domain.datasource.ingestion.file.OrcFileFormat;
+import app.metatron.discovery.domain.datasource.ingestion.file.ParquetFileFormat;
+import app.metatron.discovery.domain.datasource.ingestion.jdbc.SelectQueryBuilder;
+
 public class HiveTableInformation {
 
   public final static String INPUT_FORMAT_PROP = "InputFormat:";
   public final static String ORC_INPUT_FORMAT = "org.apache.hadoop.hive.ql.io.orc.OrcInputFormat";
+  public final static String PARQUET_INPUT_FORMAT = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat";
   public final static String TEXT_INPUT_FORMAT = "org.apache.hadoop.mapred.TextInputFormat";
   public final static String FIELD_DELIMITER_PROP = "field.delim";
   public final static String PARTITION_INFORMATION_HEADER = "# Partition Information";
@@ -67,6 +71,8 @@ public class HiveTableInformation {
       switch(inputFormat){
         case ORC_INPUT_FORMAT :
           return new OrcFileFormat();
+        case PARQUET_INPUT_FORMAT :
+          return new ParquetFileFormat();
         case TEXT_INPUT_FORMAT :
           String delimiter = (String) this.storageInformation.get(FIELD_DELIMITER_PROP);
           //convert tab delimiter string to character

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/storage/StorageProperties.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/storage/StorageProperties.java
@@ -85,7 +85,7 @@ public class StorageProperties {
     String metastoreUserName;
     String metastorePassword;
 
-    MetaStoreProperties metastore;
+    MetaStoreProperties metastore = new MetaStoreProperties();
 
     public String getHostname() {
       return hostname;

--- a/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/AbstractSpecBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/AbstractSpecBuilder.java
@@ -14,6 +14,18 @@
 
 package app.metatron.discovery.spec.druid.ingestion;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import org.apache.commons.lang3.BooleanUtils;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import app.metatron.discovery.common.datasource.DataType;
 import app.metatron.discovery.domain.datasource.DataSource;
 import app.metatron.discovery.domain.datasource.DataSourceIngestionException;
@@ -22,7 +34,12 @@ import app.metatron.discovery.domain.datasource.ingestion.HdfsIngestionInfo;
 import app.metatron.discovery.domain.datasource.ingestion.HiveIngestionInfo;
 import app.metatron.discovery.domain.datasource.ingestion.IngestionInfo;
 import app.metatron.discovery.domain.datasource.ingestion.LocalFileIngestionInfo;
-import app.metatron.discovery.domain.datasource.ingestion.file.*;
+import app.metatron.discovery.domain.datasource.ingestion.file.CsvFileFormat;
+import app.metatron.discovery.domain.datasource.ingestion.file.ExcelFileFormat;
+import app.metatron.discovery.domain.datasource.ingestion.file.FileFormat;
+import app.metatron.discovery.domain.datasource.ingestion.file.JsonFileFormat;
+import app.metatron.discovery.domain.datasource.ingestion.file.OrcFileFormat;
+import app.metatron.discovery.domain.datasource.ingestion.file.ParquetFileFormat;
 import app.metatron.discovery.domain.datasource.ingestion.jdbc.BatchIngestionInfo;
 import app.metatron.discovery.domain.datasource.ingestion.rule.EvaluationRule;
 import app.metatron.discovery.domain.datasource.ingestion.rule.IngestionRule;
@@ -43,16 +60,6 @@ import app.metatron.discovery.spec.druid.ingestion.index.LuceneIndexStrategy;
 import app.metatron.discovery.spec.druid.ingestion.index.LuceneIndexing;
 import app.metatron.discovery.spec.druid.ingestion.index.SecondaryIndexing;
 import app.metatron.discovery.spec.druid.ingestion.parser.*;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import org.apache.commons.lang3.BooleanUtils;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.format.DateTimeFormat;
-
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import static app.metatron.discovery.domain.datasource.ingestion.jdbc.BatchIngestionInfo.IngestionScope.ALL;
 import static app.metatron.discovery.domain.datasource.ingestion.jdbc.BatchIngestionInfo.IngestionScope.INCREMENTAL;
@@ -240,7 +247,7 @@ public class AbstractSpecBuilder {
       }
     }
 
-    // Set dimnesion field
+    // Set dimension field
     List<Field> dimensionfields = dataSource.getFieldByRole(Field.FieldRole.DIMENSION);
 
     List<Object> dimenstionSchemas = Lists.newArrayList();
@@ -371,10 +378,12 @@ public class AbstractSpecBuilder {
       parser = new OrcParser(parseSpec);
 
     } else if (fileFormat instanceof ParquetFileFormat) {
+      //If timestampSpec.replaceWrongColumn is true, there is an error that is treated as null, should be treated as false
+      timestampSpec.setReplaceWrongColumn(false);
+
       TimeAndDimsParseSpec parseSpec = new TimeAndDimsParseSpec();
       parseSpec.setTimestampSpec(timestampSpec);
       parseSpec.setDimensionsSpec(dimensionsSpec);
-
       parser = new ParquetParser(parseSpec);
 
     } else {


### PR DESCRIPTION
### Description
support parquet format for staging db.

**Related Issue** : 


### How Has This Been Tested?
1. create parquet format table in staging db.
```
CREATE TABLE parquet_test (
 id int,
 category string,
 sales int)
PARTITIONED BY (part string)
STORED AS PARQUET;

desc parquet_test;

INSERT INTO TABLE parquet_test
VALUES 
(0, 'cat1', 100, 'part1'), 
(1, 'cat2', 1100, 'part1'),
(2, 'cat1', 1010, 'part2'), 
(3, 'cat2', 1001, 'part2');
```
2. create datasource with parquet hive table.
3. Check whether parser.type, parser.parseSpec.format, and parser.timestampSpec.replaceWrongColumn of the created ingestion spec are as follows.
```
{
  "type" : "index_hadoop",
  "spec" : {
    "dataSchema" : {
      ...
      "parser" : {
        "type" : "parquet",
        "parseSpec" : {
          "format" : "timeAndDims",
          ...
          },
          "timestampSpec" : {
            ...
            "replaceWrongColumn" : false,
            ...
          }
        }
      },
      ...
    }
  }
}
```

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
