### PR TITLE
#3429 Move spec temporary from parameter to json.

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/BulkLoadSpec.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/BulkLoadSpec.java
@@ -30,6 +30,8 @@ public class BulkLoadSpec implements Serializable {
 
   Map<String, Object> properties;
 
+  boolean temporary;
+
   public BulkLoadSpec() {
   }
 
@@ -38,6 +40,15 @@ public class BulkLoadSpec implements Serializable {
     this.paths = paths;
     this.schema = schema;
     this.tuningConfig = tuningConfig;
+    this.temporary = false;
+  }
+
+  public BulkLoadSpec(String basePath, List<String> paths, DataSchema schema, Map<String, Object> tuningConfig, boolean temporary) {
+    this.basePath = basePath;
+    this.paths = paths;
+    this.schema = schema;
+    this.tuningConfig = tuningConfig;
+    this.temporary = temporary;
   }
 
   public String getBasePath() {
@@ -78,5 +89,13 @@ public class BulkLoadSpec implements Serializable {
 
   public void setProperties(Map<String, Object> properties) {
     this.properties = properties;
+  }
+
+  public boolean isTemporary() {
+    return temporary;
+  }
+
+  public void setTemporary(boolean temporary) {
+    this.temporary = temporary;
   }
 }

--- a/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/BulkLoadSpecBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/BulkLoadSpecBuilder.java
@@ -26,6 +26,8 @@ public class BulkLoadSpecBuilder extends AbstractSpecBuilder {
 
   String basePath;
 
+  boolean temporary;
+
   List<String> paths;
 
   Map<String, Object> tuningConfig;
@@ -62,6 +64,11 @@ public class BulkLoadSpecBuilder extends AbstractSpecBuilder {
     return this;
   }
 
+  public BulkLoadSpecBuilder temporary(boolean temporary) {
+    this.temporary = temporary;
+    return this;
+  }
+
   public BulkLoadSpec build() {
     BulkLoadSpec spec = new BulkLoadSpec();
     spec.setSchema(dataSchema);
@@ -69,6 +76,7 @@ public class BulkLoadSpecBuilder extends AbstractSpecBuilder {
     spec.setPaths(paths);
     spec.setTuningConfig(tuningConfig);
     spec.setProperties(properties);
+    spec.setTemporary(temporary);
 
     return spec;
   }


### PR DESCRIPTION
### Description
Move spec temporary from parameter to json.

**Related Issue** : <!--- Please link to the issue here. -->
https://github.com/metatron-app/metatron-discovery/issues/3429


### How Has This Been Tested?
After creating temporary datasource, see it's type is not temporary.
Discovery always creates non-temporary datasource for HA issue when creating its own temporary datasource. 

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
