### PR TITLE
#3436 Fix for invalid initializing measure-filter

### DIFF
--- a/discovery-frontend/src/app/dashboard/filters/bound-filter/bound-filter-panel.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/bound-filter/bound-filter-panel.component.ts
@@ -203,7 +203,7 @@ export class BoundFilterPanelComponent extends AbstractFilterPanelComponent impl
       this.datasourceService.getCandidateForFilter(filter, this.dashboard, this.getFiltersParam(filter), this.field)
         .then((result) => {
           if (result && result.hasOwnProperty('maxValue')) {
-            if ((filter.min === 0 && filter.max === 0) || type === 'reset') {
+            if ((filter.min === Number.MIN_SAFE_INTEGER && filter.max === Number.MAX_SAFE_INTEGER) || type === 'reset') {
               filter.min = result.minValue;
               filter.max = result.maxValue;
             }

--- a/discovery-frontend/src/app/dashboard/filters/bound-filter/configure-filters-bound.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/bound-filter/configure-filters-bound.component.ts
@@ -120,7 +120,7 @@ export class ConfigureFiltersBoundComponent extends AbstractFilterPopupComponent
   private _setBoundFilter(result: any, targetFilter: BoundFilter) {
     const boundFilter: BoundFilter = targetFilter;
     if (result && result.hasOwnProperty('maxValue')) {
-      if ((boundFilter.min === 0 && boundFilter.max === 0) || boundFilter.min == null) {
+      if ((boundFilter.min === Number.MIN_SAFE_INTEGER && boundFilter.max === Number.MAX_SAFE_INTEGER) || boundFilter.min == null) {
         boundFilter.min = result.minValue;
         boundFilter.max = result.maxValue;
       }

--- a/discovery-frontend/src/app/dashboard/util/filter.util.ts
+++ b/discovery-frontend/src/app/dashboard/util/filter.util.ts
@@ -201,8 +201,8 @@ export class FilterUtil {
   public static getBasicBoundFilter(field: Field, importanceType?: string): BoundFilter {
     // 시간 필터
     const boundFilter = new BoundFilter(field.name);
-    boundFilter.max = 0;
-    boundFilter.min = 0;
+    boundFilter.max = Number.MAX_SAFE_INTEGER;
+    boundFilter.min = Number.MIN_SAFE_INTEGER;
     boundFilter.ref = field.ref;
     boundFilter.dataSource = field.dataSource;
 


### PR DESCRIPTION
### Description
The initial maximum and minimum values ​​of the measure filter must not be 0. It should be Number.MIN_SAFE_INTEGER and Number.MAX_SAFE_INTEGER. Otherwise, the wrong filter is applied.

**Related Issue** : <!--- Please link to the issue here. -->
https://github.com/metatron-app/metatron-discovery/issues/3436


### How Has This Been Tested?
See the issue.
https://github.com/metatron-app/metatron-discovery/issues/3436

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
