### PR TITLE
#3456 Replace private workspace name with user's fullname

### DIFF
--- a/discovery-frontend/src/app/workspace/workspace.component.ts
+++ b/discovery-frontend/src/app/workspace/workspace.component.ts
@@ -1553,7 +1553,7 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
         // 워크스페이스 데이터
         this.workspace = workspace;
         // 워크스페이스 이름
-        this.workspaceName = workspace.name;
+        this.workspaceName = (workspace.publicType === PublicType.PRIVATE && workspace.createdBy && workspace.createdBy.fullName)? workspace.createdBy.fullName + '\'s Workspace': workspace.name;
         // 워크스페이스 설명
         this.workspaceDescription = workspace.description;
         // 워크스페이스 소유자
@@ -1732,7 +1732,7 @@ export class WorkspaceComponent extends AbstractComponent implements OnInit, OnD
    * @private
    */
   private _getDisplayItems(): Book[] {
-    let filteredList: Book[] = [];
+    let filteredList: Book[];
     if (this.isRoot) {
       filteredList = this.workspace.books.filter((book: Book) => book.name.toLowerCase().includes(this.srchText.toLowerCase()));
     } else {


### PR DESCRIPTION
### Description
Replace private workspace name with the user's full name, not the username.

**Related Issue** : <!--- Please link to the issue here. -->
https://github.com/metatron-app/metatron-discovery/issues/3456


### How Has This Been Tested?
1. Change the user's full name to "Test user".
2. Check the user's own workspace has been changed to "Test user's workspace".

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
