### PR TITLE
Fixed NPE error when searching using period granularity

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/data/result/PivotResultFormat.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/data/result/PivotResultFormat.java
@@ -303,7 +303,7 @@ public class PivotResultFormat extends SearchResultFormat {
       }
 
       List<String> rowKeys = Lists.newArrayList();
-      for (String keyField : keyFields) {
+      for (String keyField : replacedKeyFields) {
         rowKeys.add(aNode.get(keyField).textValue());
       }
 
@@ -325,7 +325,7 @@ public class PivotResultFormat extends SearchResultFormat {
         // Escape separator if nodeKey start with separator. ex. -SUM(m1) --SUM(m1)
         fieldName = fieldName.startsWith(separator) ? fieldName.substring(pivots.size()) : fieldName;
 
-        if(keyFields.contains(fieldName))
+        if(replacedKeyFields.contains(fieldName))
           continue;
 
         // Percentage Case

--- a/discovery-server/src/test/java/app/metatron/discovery/core/oauth/OAuthRequest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/core/oauth/OAuthRequest.java
@@ -28,11 +28,11 @@ public @interface OAuthRequest {
     /**
      * The roles for the OAuth access token
      */
-    String[] value() default {"ROLE_EMPLOYEE"};
+    String[] value() default {"ROLE_ADMIN"};
 
     /**
      * The username for the OAuth access token
      */
-    String username() default "employee@techdev.de";
+    String username() default "admin@metatron.app";
 
 }

--- a/discovery-server/src/test/java/app/metatron/discovery/core/oauth/OAuthTestExecutionListener.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/core/oauth/OAuthTestExecutionListener.java
@@ -42,7 +42,7 @@ import java.util.stream.Collectors;
 import static java.util.Arrays.asList;
 
 /**
- * Created by kyungtaak on 2016. 5. 8..
+ * Dummy Token Generator for Integration Test
  */
 public class OAuthTestExecutionListener extends AbstractTestExecutionListener {
 
@@ -55,8 +55,8 @@ public class OAuthTestExecutionListener extends AbstractTestExecutionListener {
   public OAuthTestExecutionListener() {
 
     // TODO no magic constants! These should probably come from the OAuthResourceServer Configuration!
-    clientAuthentication = new OAuth2Request(new HashMap<>(), "polaris-client", null, true,
-            Sets.newHashSet("read", "write"), Sets.newHashSet("polaris"), null, null, null);
+    clientAuthentication = new OAuth2Request(new HashMap<>(), "polaris_trusted", null, true,
+            Sets.newHashSet("read", "write"), null, null, null, null);
   }
 
   @Override

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/datasource/data/DataQueryRestIntegrationTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/datasource/data/DataQueryRestIntegrationTest.java
@@ -913,7 +913,8 @@ public class DataQueryRestIntegrationTest extends AbstractRestIntegrationTest {
 
     pivot5.setColumns(Lists.newArrayList(originalTimeField5, new DimensionField("Category")));
     pivot5.setAggregations(Lists.newArrayList(
-            new MeasureField("Sales", MeasureField.AggregationType.AVG)
+            new MeasureField("Sales", MeasureField.AggregationType.AVG),
+            new MeasureField("Profit", MeasureField.AggregationType.AVG)
     ));
 
     limit.setSort(Lists.newArrayList(
@@ -924,15 +925,15 @@ public class DataQueryRestIntegrationTest extends AbstractRestIntegrationTest {
 
     // @formatter:off
     given()
-            .auth().oauth2(oauth_token)
-            .body(request)
-            .contentType(ContentType.JSON)
-            .log().all()
-            .when()
-            .post("/api/datasources/query/search")
-            .then()
-            .statusCode(HttpStatus.SC_OK)
-            .log().all();
+      .auth().oauth2(oauth_token)
+      .body(request)
+      .contentType(ContentType.JSON)
+      .log().all()
+    .when()
+      .post("/api/datasources/query/search")
+    .then()
+      .log().all()
+      .statusCode(HttpStatus.SC_OK);
     // @formatter:on
 
   }
@@ -1433,8 +1434,9 @@ public class DataQueryRestIntegrationTest extends AbstractRestIntegrationTest {
             new ContinuousTimeFormat(false, TimeFieldFormat.TimeUnit.MONTH.name(), null))));
     pivot3.setRows(null);
     pivot3.setAggregations(Lists.newArrayList(
-            //new DimensionField("Category"),
-            new MeasureField("Discount", MeasureField.AggregationType.SUM)
+            new DimensionField("Category"),
+            new MeasureField("Discount", MeasureField.AggregationType.SUM),
+            new MeasureField("Sales", MeasureField.AggregationType.SUM)
     ));
 
     SearchQueryRequest request = new SearchQueryRequest(dataSource1, filters, pivot3, limit);
@@ -1447,15 +1449,15 @@ public class DataQueryRestIntegrationTest extends AbstractRestIntegrationTest {
 
     // @formatter:off
     given()
-            .auth().oauth2(oauth_token)
-            .contentType(ContentType.JSON)
-            .body(request)
-            .log().all()
-            .when()
-            .post("/api/datasources/query/search")
-            .then()
-            //      .statusCode(HttpStatus.SC_OK)
-            .log().all();
+      .auth().oauth2(oauth_token)
+      .contentType(ContentType.JSON)
+      .body(request)
+      .log().all()
+    .when()
+      .post("/api/datasources/query/search")
+    .then()
+      .log().all()
+      .statusCode(HttpStatus.SC_OK);
     // @formatter:on
 
   }


### PR DESCRIPTION
### Description
Fixed that NPE error occurred when there were two or more aggregation fields in the query when searching using period granularity.

**Related Issue** : N/A
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
In the current timestamp type of column specification, the period type of granularity property is not supported by the UI, so you need to check the result through the Search API.

As shown below, it can be confirmed that no error occurs when calling with the request body content.

Ref. 1 : https://github.com/metatron-app/metatron-discovery/blob/master/.github/USE_REST_API.md
Ref. 2 : https://discovery.metatron.app/docs/api-guide.html#resources-datasource-query

(POST) /api/datasources/query/search

[Request Body]
```
{
    "dataSource": {
        "type": "default",
        "name": "sales_geo"
    },
    "filters": [
        
    ],
    "pivot": {
        "columns": [
            {
                "type": "timestamp",
                "name": "OrderDate",
                "alias": "P6M(OrderDate)",
                "ref": null,
                "granularity": {
                    "type": "period",
                    "period": "P6M",
                    "timeZone": "UTC",
                    "origin": "2000-01-01T00:00:00.000Z"
                },
                "format": {
                    "type": "time_continuous",
                    "discontinuous": false,
                    "unit": "MONTH",
                    "timeZone": "UTC",
                    "locale": "en"
                }
            }
        ],
        "rows": null,
        "aggregations": [
            {
                "type": "dimension",
                "name": "Category",
                "alias": "Category"
            },
            {
                "type": "measure",
                "name": "Discount",
                "alias": "SUM(Discount)",
                "aggregationType": "SUM"
            },
            {
                "type": "measure",
                "name": "Sales",
                "alias": "SUM(Sales)",
                "aggregationType": "SUM"
            }
        ]
    },
    "userFields": [
        
    ],
    "limits": {
        "limit": 1000000,
        "sort": [
            
        ]
    },
    "resultFormat": {
        "type": "chart",
        "mode": "line",
        "options": null,
        "columnDelimeter": "―"
    }
}
```

[Response Body]
```
{
    "rows": [
        "Jan 2011",
        "Jul 2011",
        "Jan 2012",
        "Jul 2012",
        "Jan 2013",
        "Jul 2013",
        "Jan 2014",
        "Jul 2014"
    ],
    "categories": [],
    "columns": [
        {
            "name": "Furniture―SUM(Discount)",
            "value": [
                25.42,
                51.23999999999999,
                24.26,
                52.029999999999994,
                36.220000000000006,
                63.199999999999996,
                40.34,
                76.17999999999998
            ],
            "percentage": []
        },
        {
            "name": "Furniture―SUM(Sales)",
            "value": [
                50719.0,
                106469.0,
                54940.0,
                115578.0,
                64493.0,
                134417.0,
                66650.0,
                148740.0
            ],
            "percentage": []
        },
        {
            "name": "Office Supplies―SUM(Discount)",
            "value": [
                62.19999999999999,
                128.0999999999999,
                68.99999999999997,
                129.8999999999999,
                85.79999999999994,
                151.39999999999986,
                124.1999999999999,
                197.20000000000002
            ],
            "percentage": []
        },
        {
            "name": "Office Supplies―SUM(Sales)",
            "value": [
                45771.0,
                106011.0,
                55388.0,
                81860.0,
                64002.0,
                119529.0,
                87780.0,
                158786.0
            ],
            "percentage": []
        },
        {
            "name": "Technology―SUM(Discount)",
            "value": [
                13.800000000000002,
                34.7,
                20.900000000000006,
                31.0,
                24.300000000000008,
                38.20000000000002,
                28.70000000000001,
                52.8
            ],
            "percentage": []
        },
        {
            "name": "Technology―SUM(Sales)",
            "value": [
                64495.0,
                110790.0,
                47665.0,
                115129.0,
                99497.0,
                126585.0,
                98507.0,
                173553.0
            ],
            "percentage": []
        }
    ],
    "info": {
        "totalCategory": 8
    }
}
```

#### Need additional checks?
Since the part of the process of changing the query result to chart data has been modified, after creating the dashboard, we need to create various charts and check the impact of the query.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
