### PR TITLE
#3515 change the initial value of time filter on the Engine Monitoring Query tab

### DIFF
--- a/discovery-frontend/src/app/engine-monitoring/query/query.component.ts
+++ b/discovery-frontend/src/app/engine-monitoring/query/query.component.ts
@@ -34,6 +34,7 @@ import * as _ from "lodash";
 import {PageResult} from "../../domain/common/page";
 import {TimezoneService} from "../../data-storage/service/timezone.service";
 import {EngineMonitoringUtil} from "../util/engine-monitoring.util";
+import * as moment from 'moment';
 
 declare let $: any;
 
@@ -107,6 +108,11 @@ export class QueryComponent extends AbstractComponent implements OnInit, OnDestr
             // TODO 추후 criterion component로 이동
             delete searchParams['pseudoParam'];
             // init criterion search param
+            this.criterionComponent.initSearchParams(searchParams);
+          } else {
+            searchParams[Criteria.ListCriterionKey.STARTED_TIME + Criteria.QUERY_DELIMITER + Criteria.KEY_DATETIME_TYPE_SUFFIX] = ['BETWEEN'];
+            searchParams[Criteria.ListCriterionKey.STARTED_TIME + Criteria.QUERY_DELIMITER + 'startedTimeFrom'] = [moment().subtract(1, 'hours').format('YYYY-MM-DDTHH:mm:ss.SSSZ')];
+            searchParams[Criteria.ListCriterionKey.STARTED_TIME + Criteria.QUERY_DELIMITER + 'startedTimeTo'] = [moment().format('YYYY-MM-DDTHH:mm:ss.SSSZ')];
             this.criterionComponent.initSearchParams(searchParams);
           }
           this.pageResult.size = this.page.size;


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
change the initial value of time filter on the Engine Monitoring Query tab to the last hour

**Related Issue** : #3515 
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Go to Engine Monitoring
2. Click on Query tab.
3. Check whether the initial value of the time filter is the last hour.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
