### PR TITLE
fix query_message column's dataType to MEDIUMTEXT

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourceQueryHistory.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/DataSourceQueryHistory.java
@@ -122,8 +122,7 @@ public class DataSourceQueryHistory extends AbstractHistoryEntity implements Met
   /**
    * 질의 실패시 메시지 표시
    */
-  @Column(name = "query_message")
-  @Size(max = 5000)
+  @Column(name = "query_message", length = 65535, columnDefinition = "MEDIUMTEXT")
   String message;
 
   /**

--- a/discovery-server/src/main/resources/db/changelog/discovery.changelog-3.4.0.xml
+++ b/discovery-server/src/main/resources/db/changelog/discovery.changelog-3.4.0.xml
@@ -313,4 +313,7 @@
         <modifyDataType tableName="dashboard_widget" columnName="widget_conf" newDataType="${mediumtext.type}" />
     </changeSet>
 
+    <changeSet author="minhyun2" id="1605842682963-0">
+        <modifyDataType tableName="datasource_query" columnName="query_message" newDataType="${mediumtext.type}" />
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
If the length of the message caused by data query failure is more than 5000 bytes, an error occurs.
DataType of query_message column has been changed to mediumtext

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Create Dashboard and widget.
2. Executes a query whose message length is 5000 bytes or more due to a data query failure.
3. Additionally, check the data type of the **query_message** column of the **datasource_query** table.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
