### PR TITLE
Fix query error with dimension alias

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/queries/GroupByQueryBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/queries/GroupByQueryBuilder.java
@@ -42,6 +42,27 @@
 
 package app.metatron.discovery.query.druid.queries;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import app.metatron.discovery.common.GlobalObjectMapper;
 import app.metatron.discovery.common.datasource.LogicalType;
 import app.metatron.discovery.common.exception.BadRequestException;
@@ -55,53 +76,67 @@ import app.metatron.discovery.domain.workbook.configurations.analysis.Analysis;
 import app.metatron.discovery.domain.workbook.configurations.analysis.GeoSpatialOperation;
 import app.metatron.discovery.domain.workbook.configurations.analysis.PredictionAnalysis;
 import app.metatron.discovery.domain.workbook.configurations.datasource.MappingDataSource;
-import app.metatron.discovery.domain.workbook.configurations.field.*;
+import app.metatron.discovery.domain.workbook.configurations.field.DimensionField;
+import app.metatron.discovery.domain.workbook.configurations.field.Field;
+import app.metatron.discovery.domain.workbook.configurations.field.MeasureField;
+import app.metatron.discovery.domain.workbook.configurations.field.TimestampField;
+import app.metatron.discovery.domain.workbook.configurations.field.UserDefinedField;
 import app.metatron.discovery.domain.workbook.configurations.filter.Filter;
-import app.metatron.discovery.domain.workbook.configurations.filter.*;
+import app.metatron.discovery.domain.workbook.configurations.filter.LikeFilter;
+import app.metatron.discovery.domain.workbook.configurations.filter.MeasureInequalityFilter;
+import app.metatron.discovery.domain.workbook.configurations.filter.MeasurePositionFilter;
+import app.metatron.discovery.domain.workbook.configurations.filter.RegExprFilter;
+import app.metatron.discovery.domain.workbook.configurations.filter.WildCardFilter;
 import app.metatron.discovery.domain.workbook.configurations.format.ContinuousTimeFormat;
 import app.metatron.discovery.domain.workbook.configurations.format.DefaultFormat;
 import app.metatron.discovery.domain.workbook.configurations.format.FieldFormat;
 import app.metatron.discovery.domain.workbook.configurations.format.TimeFieldFormat;
 import app.metatron.discovery.domain.workbook.configurations.widget.shelf.LayerView;
 import app.metatron.discovery.domain.workbook.configurations.widget.shelf.MapViewLayer;
-import app.metatron.discovery.query.druid.*;
+import app.metatron.discovery.query.druid.AbstractQueryBuilder;
+import app.metatron.discovery.query.druid.Aggregation;
+import app.metatron.discovery.query.druid.Dimension;
+import app.metatron.discovery.query.druid.Granularity;
+import app.metatron.discovery.query.druid.Having;
+import app.metatron.discovery.query.druid.PostAggregation;
+import app.metatron.discovery.query.druid.PostProcessor;
+import app.metatron.discovery.query.druid.Query;
 import app.metatron.discovery.query.druid.aggregations.CountAggregation;
 import app.metatron.discovery.query.druid.aggregations.RelayAggregation;
 import app.metatron.discovery.query.druid.dimensions.DefaultDimension;
 import app.metatron.discovery.query.druid.dimensions.ExtractionDimension;
 import app.metatron.discovery.query.druid.extractionfns.ExpressionFunction;
 import app.metatron.discovery.query.druid.filters.AndFilter;
-import app.metatron.discovery.query.druid.funtions.*;
+import app.metatron.discovery.query.druid.filters.InFilter;
+import app.metatron.discovery.query.druid.funtions.CaseFunc;
+import app.metatron.discovery.query.druid.funtions.CastFunc;
+import app.metatron.discovery.query.druid.funtions.LookupMapFunc;
+import app.metatron.discovery.query.druid.funtions.RunningSumFunc;
+import app.metatron.discovery.query.druid.funtions.TimeFormatFunc;
 import app.metatron.discovery.query.druid.granularities.SimpleGranularity;
-import app.metatron.discovery.query.druid.havings.*;
+import app.metatron.discovery.query.druid.havings.EqualTo;
+import app.metatron.discovery.query.druid.havings.GreaterThan;
+import app.metatron.discovery.query.druid.havings.GreaterThanOrEqual;
+import app.metatron.discovery.query.druid.havings.LessThan;
+import app.metatron.discovery.query.druid.havings.LessThanOrEqual;
 import app.metatron.discovery.query.druid.limits.DefaultLimit;
 import app.metatron.discovery.query.druid.limits.OrderByColumn;
 import app.metatron.discovery.query.druid.limits.PivotWindowingSpec;
+import app.metatron.discovery.query.druid.limits.WindowingSpec;
 import app.metatron.discovery.query.druid.model.HoltWintersPostProcessor;
 import app.metatron.discovery.query.druid.postaggregations.ExprPostAggregator;
 import app.metatron.discovery.query.druid.postaggregations.MathPostAggregator;
 import app.metatron.discovery.query.druid.postprocessor.PostAggregationProcessor;
 import app.metatron.discovery.query.druid.virtualcolumns.ExprVirtualColumn;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-import org.apache.commons.collections.MapUtils;
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.*;
-import java.util.stream.Collectors;
 
 import static app.metatron.discovery.domain.datasource.data.CandidateQueryRequest.RESULT_VALUE_NAME_PREFIX;
 import static app.metatron.discovery.domain.workbook.configurations.Sort.Direction.ASC;
 import static app.metatron.discovery.domain.workbook.configurations.Sort.Direction.DESC;
 import static app.metatron.discovery.domain.workbook.configurations.field.Field.FIELD_NAMESPACE_SEP;
 import static app.metatron.discovery.domain.workbook.configurations.filter.MeasurePositionFilter.PositionType.BOTTOM;
-import static app.metatron.discovery.domain.workbook.configurations.filter.WildCardFilter.ContainsType.*;
+import static app.metatron.discovery.domain.workbook.configurations.filter.WildCardFilter.ContainsType.AFTER;
+import static app.metatron.discovery.domain.workbook.configurations.filter.WildCardFilter.ContainsType.BEFORE;
+import static app.metatron.discovery.domain.workbook.configurations.filter.WildCardFilter.ContainsType.BOTH;
 import static app.metatron.discovery.query.druid.Query.RESERVED_WORD_COUNT;
 
 /**
@@ -908,6 +943,20 @@ public class GroupByQueryBuilder extends AbstractQueryBuilder {
     return this;
   }
 
+  public Optional<Field> getDimensionFieldWithName(String fieldName){
+    return this.projections.stream()
+                           .filter(projectionField -> projectionField instanceof DimensionField && projectionField.getColunm().equals(fieldName))
+                           .findFirst();
+  }
+
+  public String getDimensionAlias(String fieldName){
+    Optional<Field> field = getDimensionFieldWithName(fieldName);
+    if(field.isPresent()) {
+      return StringUtils.defaultIfEmpty(field.get().getAlias(), fieldName);
+    }
+    return fieldName;
+  }
+
   @Override
   public GroupByQuery build() {
 
@@ -980,6 +1029,33 @@ public class GroupByQueryBuilder extends AbstractQueryBuilder {
     }
 
     groupByQuery.setContext(context);
+
+    // replace filter dimension to dimension alias
+    if(this.filter != null && !this.filter.getFields().isEmpty()){
+      List<app.metatron.discovery.query.druid.Filter> filters = this.filter.getFields();
+      for(app.metatron.discovery.query.druid.Filter filterField : filters) {
+        if(filterField instanceof InFilter){
+          //find projection with fieldName
+          String dimensionWithAlias = getDimensionAlias(((InFilter) filterField).getDimension());
+          ((InFilter) filterField).setDimension(dimensionWithAlias);
+        }
+      }
+    }
+
+    // replace windowingSpec's column name to dimension alias
+    if(this.windowingSpecs != null && !this.windowingSpecs.isEmpty()){
+      for(WindowingSpec windowingSpec : this.windowingSpecs){
+        List<String> partitionColumns = windowingSpec.getPartitionColumns();
+        if(partitionColumns != null && !partitionColumns.isEmpty()){
+          for(int i = 0; i < partitionColumns.size(); ++i){
+            String columnName = partitionColumns.get(i);
+            //find projection with columnName
+            String dimensionWithAlias = getDimensionAlias(columnName);
+            partitionColumns.set(i, dimensionWithAlias);
+          }
+        }
+      }
+    }
 
     return groupByQuery;
 

--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/queries/GroupByQueryBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/queries/GroupByQueryBuilder.java
@@ -1031,7 +1031,7 @@ public class GroupByQueryBuilder extends AbstractQueryBuilder {
     groupByQuery.setContext(context);
 
     // replace filter dimension to dimension alias
-    if(this.filter != null && !this.filter.getFields().isEmpty()){
+    if(this.filter != null && this.filter.getFields() != null && !this.filter.getFields().isEmpty()){
       List<app.metatron.discovery.query.druid.Filter> filters = this.filter.getFields();
       for(app.metatron.discovery.query.druid.Filter filterField : filters) {
         if(filterField instanceof InFilter){


### PR DESCRIPTION
### Description
If the measure field is a user field and an alias is applied to the dimension field, the query result value is different.
Selecting the same shelf, but setting Alias results in different results as shown below.
![metatron_Discovery](https://user-images.githubusercontent.com/3770446/100840081-b463d380-34b8-11eb-940d-3afc7a709d9c.jpg)


**Related Issue** : 


### How Has This Been Tested?
1. AS-IS Select Query
```
{
  "queryType": "groupBy",
  "dataSource": {
    "type": "table",
    "name": "event_log_sample"
  },
  "granularity": "all",
  "intervals": [
    "2020-10-26T00:00:00.000Z/2020-11-29T23:59:59.999Z"
  ],
  "virtualColumns": [
    {
      "type": "expr",
      "outputName": "user_defined.dt_day",
      "expression": "TIME_FORMAT(__time,'yyyy-MM-dd')"
    },
    {
      "type": "expr",
      "outputName": "user_defined.MEASURE_1",
      "expression": "\"cnt\""
    }
  ],
  "dimensions": [
    {
      "type": "default",
      "dimension": "month_week",
      "outputName": "주차"
    },
    {
      "type": "default",
      "dimension": "depth_1",
      "outputName": "화면명"
    }
  ],
  "groupingSets": {
    "type": "names",
    "names": []
  },
  "filter": {
    "type": "and",
    "fields": [
      {
        "type": "in",
        "dimension": "mkt_div_org_nm",
        "values": [
          "대구마케팅본부",
          "부산마케팅본부",
          "서부마케팅본부",
          "수도권마케팅본부",
          "유통사업부",
          "중부마케팅본부"
        ]
      },
      {
        "type": "in",
        "dimension": "depth_1",
        "values": [
          "공통",
          "단말/상품 카달로그"
        ]
      }
    ]
  },
  "aggregations": [
    {
      "type": "sum",
      "name": "aggregationfunc_000",
      "fieldExpression": "user_defined.MEASURE_1",
      "inputType": "double"
    },
    {
      "type": "sum",
      "name": "aggregationfunc_001",
      "fieldExpression": "cnt",
      "inputType": "double"
    },
    {
      "type": "sum",
      "name": "aggregationfunc_002",
      "fieldExpression": "cnt",
      "inputType": "double"
    }
  ],
  "postAggregations": [
    {
      "type": "math",
      "name": "SUM(MEASURE_1)",
      "expression": "aggregationfunc_000",
      "finalize": false
    },
    {
      "type": "math",
      "name": "postaggregationfunc_001",
      "expression": "aggregationfunc_002",
      "finalize": false
    }
  ],
  "limitSpec": {
    "type": "default",
    "windowingSpecs": [
      {
        "partitionColumns": [
          "depth_1"
        ],
        "expressions": [
          "\"MEASURE_3\" = (aggregationfunc_001-$PREV(postaggregationfunc_001))"
        ]
      },
      {
        "partitionColumns": [
          "화면명"
        ],
        "pivotSpec": {
          "separator": "―",
          "tabularFormat": true,
          "appendValueColumn": true,
          "valueColumns": [
            "SUM(MEASURE_1)",
            "MEASURE_3"
          ],
          "pivotColumns": [
            {
              "dimension": "주차",
              "direction": "ascending",
              "dimensionOrder": "alphanumeric"
            }
          ]
        }
      }
    ],
    "limit": 1000,
    "columns": [
      {
        "dimension": "화면명",
        "direction": "ascending",
        "dimensionOrder": "alphanumeric"
      }
    ]
  },
  "context": {
    "queryId": "QUERY-0a4be98f-9a7b-4d20-9b40-152515be8622"
  }
}
```

2. TO-BE Select Query
```
{
    "queryType": "groupBy",
    "dataSource": {
        "type": "table",
        "name": "event_log_sample"
    },
    "intervals": {
        "type": "LegacySegmentSpec",
        "intervals": [
            "2020-10-26T00:00:00.000Z/2020-11-29T23:59:59.999Z"
        ]
    },
    "filter": {
        "type": "and",
        "fields": [
            {
                "type": "in",
                "dimension": "mkt_div_org_nm",
                "values": [
                    "대구마케팅본부",
                    "부산마케팅본부",
                    "서부마케팅본부",
                    "수도권마케팅본부",
                    "유통사업부",
                    "중부마케팅본부"
                ]
            },
            {
                "type": "in",
                "dimension": "화면명",    //   <---- FIXED
                "values": [
                    "공통",
                    "단말/상품 카달로그"
                ]
            }
        ]
    },
    "granularity": {
        "type": "all"
    },
    "dimensions": [
        {
            "type": "default",
            "dimension": "month_week",
            "outputName": "주차"
        },
        {
            "type": "default",
            "dimension": "depth_1",
            "outputName": "화면명"
        }
    ],
    "virtualColumns": [
        {
            "type": "expr",
            "expression": "TIME_FORMAT(__time,'yyyy-MM-dd')",
            "outputName": "user_defined.dt_day"
        },
        {
            "type": "expr",
            "expression": "\"cnt\"",
            "outputName": "user_defined.MEASURE_1"
        }
    ],
    "aggregations": [
        {
            "type": "sum",
            "name": "aggregationfunc_000",
            "fieldExpression": "user_defined.MEASURE_1",
            "inputType": "double"
        },
        {
            "type": "sum",
            "name": "aggregationfunc_001",
            "fieldExpression": "cnt",
            "inputType": "double"
        },
        {
            "type": "sum",
            "name": "aggregationfunc_002",
            "fieldExpression": "cnt",
            "inputType": "double"
        }
    ],
    "postAggregations": [
        {
            "type": "math",
            "name": "SUM(MEASURE_1)",
            "expression": "aggregationfunc_000",
            "finalize": false
        },
        {
            "type": "math",
            "name": "postaggregationfunc_001",
            "expression": "aggregationfunc_002",
            "finalize": false
        }
    ],
    "limitSpec": {
        "type": "default",
        "columns": [
            {
                "direction": "ascending",
                "dimensionOrder": "alphanumeric",
                "dimension": "화면명"
            }
        ],
        "limit": 1000,
        "windowingSpecs": [
            {
                "partitionColumns": [
                    "화면명"                                  //   <---- FIXED
                ],
                "skipSorting": false,
                "expressions": [
                    "\"MEASURE_3\" = (aggregationfunc_001-$PREV(postaggregationfunc_001))"
                ]
            },
            {
                "partitionColumns": [
                    "화면명"
                ],
                "skipSorting": false,
                "pivotSpec": {
                    "pivotColumns": [
                        {
                            "direction": "ascending",
                            "dimensionOrder": "alphanumeric",
                            "dimension": "주차"
                        }
                    ],
                    "valueColumns": [
                        "SUM(MEASURE_1)",
                        "MEASURE_3"
                    ],
                    "separator": "―",
                    "rowExpressions": [],
                    "partitionExpressions": [],
                    "tabularFormat": true,
                    "appendValueColumn": true,
                    "nullValue": ""
                }
            }
        ]
    },
    "context": {
        "timeout": 60000
    },
    "descending": false
}
```

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
