### PR TITLE
Using MapParser instead of ParquetParser due to library conflict in druid

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/AbstractSpecBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/AbstractSpecBuilder.java
@@ -384,7 +384,10 @@ public class AbstractSpecBuilder {
       TimeAndDimsParseSpec parseSpec = new TimeAndDimsParseSpec();
       parseSpec.setTimestampSpec(timestampSpec);
       parseSpec.setDimensionsSpec(dimensionsSpec);
-      parser = new ParquetParser(parseSpec);
+
+      //Using MapParser instead of ParquetParser due to library conflict in druid
+//      parser = new ParquetParser(parseSpec);
+      parser = new MapParser(parseSpec);
 
     } else {
       throw new IllegalArgumentException("Not supported format.");

--- a/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/parser/MapParser.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/parser/MapParser.java
@@ -1,0 +1,28 @@
+/*
+ *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package app.metatron.discovery.spec.druid.ingestion.parser;
+
+public class MapParser extends StringParser implements Parser {
+
+  public MapParser() {
+  }
+
+  public MapParser(ParseSpec parseSpec) {
+    super(parseSpec);
+  }
+
+}

--- a/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/parser/Parser.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/parser/Parser.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
     @JsonSubTypes.Type(value = StringParser.class, name = "string"),
     @JsonSubTypes.Type(value = OrcParser.class, name = "orc"),
     @JsonSubTypes.Type(value = ParquetParser.class, name = "parquet"),
+    @JsonSubTypes.Type(value = MapParser.class, name = "map"),
 })
 public interface Parser {
 }

--- a/discovery-server/src/test/java/app/metatron/discovery/spec/druid/ingestion/IndexSpecTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/spec/druid/ingestion/IndexSpecTest.java
@@ -158,7 +158,7 @@ public class IndexSpecTest {
     DocumentContext jsonContext = JsonPath.parse(GlobalObjectMapper.writeValueAsString(ingestionSpec));
 
     assertThat(jsonContext.read("$['ioConfig']['type']"), is("hadoop"));
-    assertThat(jsonContext.read("$['dataSchema']['parser']['type']"), is("parquet"));
+    assertThat(jsonContext.read("$['dataSchema']['parser']['type']"), is("map"));
     assertThat(jsonContext.read("$['dataSchema']['parser']['parseSpec']['timestampSpec']['replaceWrongColumn']"), is(false));
 
     boolean thrown = false;


### PR DESCRIPTION
### Description
Currently, when loading data through StagingDB (Parquet type), a library conflict problem in Druid occurs.
So, should not use ParquetParser, but MapParser.

**Related Issue** : 

### How Has This Been Tested?
* AS-IS
```
dataSchema.parser.type : parquet
```

* TO-BE
```
dataSchema.parser.type : map
```

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
