### PR TITLE
fix original grid chart css in black theme

### DIFF
--- a/discovery-frontend/src/assets/css/theme_dark/metatron/page.css
+++ b/discovery-frontend/src/assets/css/theme_dark/metatron/page.css
@@ -4039,6 +4039,14 @@
     color:#fff;
 }
 
+.theme-dark .ddp-box-widget .pivot-view .pivot-view-body .pivot-view-wrap .pivot-view-cell {
+  color: #4e5368;
+}
+
+.theme-dark .ddp-box-widget .pivot-view .pivot-view-body .pivot-view-wrap .pivot-view-cell.numeric {
+  color: #297bb8;
+}
+
 .theme-dark .ddp-box-widget .ddp-ui-graph-name {
     position: relative;
     padding: 4px 5px 4px 10px;


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
fix original grid chart css in black theme

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Change black theme.
2. Create a grid chart of the original view type.
3. The text color of the dimension type line is displayed in black.

#### Need additional checks?
Pivot type, original theme

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
