### PR TITLE
Fix auto measure range calculation error in stacked chart

### DIFF
--- a/discovery-frontend/src/app/common/component/chart/base-chart.ts
+++ b/discovery-frontend/src/app/common/component/chart/base-chart.ts
@@ -1469,6 +1469,7 @@ export abstract class BaseChart extends AbstractComponent implements OnInit, OnD
 
     } else {
       delete this.chartOption.dataZoom;
+      delete this.chartOption.toolbox.feature.dataZoom;
     }
 
     // 차트옵션 반환


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Fix auto measure range calculation error in stacked chart

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Create a stacked chart.
2. Uncheck Mini-map.
3. Check that the measure range is automatically calculated in the stacked chart and displayed properly on the screen.

#### Need additional checks?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
