### PR TITLE
#3602 change aggregation type of ifcountd to thetaSketch

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/aggregations/DistinctSketchAggregation.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/aggregations/DistinctSketchAggregation.java
@@ -34,6 +34,8 @@ public class DistinctSketchAggregation implements Aggregation {
 
   Boolean shouldFinalize;
 
+  String predicate;
+
   public DistinctSketchAggregation() {
   }
 
@@ -41,6 +43,14 @@ public class DistinctSketchAggregation implements Aggregation {
     this.name = name;
     this.fieldName = fieldName;
     this.size = size;
+    this.shouldFinalize = shouldFinalize;
+  }
+
+  public DistinctSketchAggregation(String name, String fieldName, Long size, String predicate, Boolean shouldFinalize) {
+    this.name = name;
+    this.fieldName = fieldName;
+    this.size = size;
+    this.predicate = predicate;
     this.shouldFinalize = shouldFinalize;
   }
 
@@ -69,6 +79,14 @@ public class DistinctSketchAggregation implements Aggregation {
     this.size = size;
   }
 
+  public String getPredicate() {
+    return predicate;
+  }
+
+  public void setPredicate(String predicate) {
+    this.predicate = predicate;
+  }
+
   public Boolean getShouldFinalize() {
     return shouldFinalize;
   }
@@ -79,11 +97,12 @@ public class DistinctSketchAggregation implements Aggregation {
 
   @Override
   public String toString() {
-    return "GenericSumAggregation{" +
-            "name='" + name + '\'' +
-            ", fieldName='" + fieldName + '\'' +
-            ", size='" + size + '\'' +
-            ", shouldFinalize='" + shouldFinalize + '\'' +
-            '}';
+    return "DistinctSketchAggregation{" +
+        "name='" + name + '\'' +
+        ", fieldName='" + fieldName + '\'' +
+        ", size=" + size +
+        ", shouldFinalize=" + shouldFinalize +
+        ", predicate='" + predicate + '\'' +
+        '}';
   }
 }


### PR DESCRIPTION
### Description
Change the aggregation type of IFCOUNTD user calculation formula to thetaSketch type

**Related Issue** : #3602 


### How Has This Been Tested?
1. create dashboard with sales datasource
2. create user custom measure
```
IFCOUNTD( [Region] == 'Central',  [OrderID] )
```
3. Check the debug log to see if ifcountd's aggregation type is changed to thetaSketch.
```
   {
      "type": "thetaSketch",
      "name": "aggregationfunc_000",
      "fieldName": "OrderID",
      "predicate": "Region == 'Central'",
      "size": 65536,
      "shouldFinalize": true
    },
```
#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
