### PR TITLE
#3616 add sorting columns for cumulative option

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/data/result/ChartResultFormat.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/data/result/ChartResultFormat.java
@@ -74,6 +74,7 @@ public class ChartResultFormat extends SearchResultFormat {
   public static final String OPTION_SHOW_CATEGORY = "showCategory";
   public static final String OPTION_SHOW_PERCENTAGE = "showPercentage";
   public static final String OPTION_SHOW_TOTAL_CATEGORY = "showTotalCategory";
+  public static final String OPTION_IS_CUMULATIVE = "isCumulative";
 
   @NotBlank
   String mode;

--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/queries/GroupByQueryBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/queries/GroupByQueryBuilder.java
@@ -840,6 +840,15 @@ public class GroupByQueryBuilder extends AbstractQueryBuilder {
       PivotWindowingSpec pivotWindowingSpec = pivotFormat.toEnginePivotSpec(
               partitionExpressions.toArray(new String[partitionExpressions.size()]));
 
+      // add sorting columns for cumulative option
+      Boolean isCumulative = chartFormat.getOptionValue(ChartResultFormat.OPTION_IS_CUMULATIVE);
+      if (BooleanUtils.isTrue(isCumulative)) {
+        List<OrderByColumn> orderColumns = ((DefaultLimit) limitSpec).getColumns();
+        if (CollectionUtils.isNotEmpty(orderColumns)) {
+          pivotWindowingSpec.setSortingColumns(orderColumns);
+        }
+      }
+
       this.windowingSpecs.add(pivotWindowingSpec);
       exclusivePivotColumn(pivotFormat);
     }


### PR DESCRIPTION
### Description
add sorting columns for cumulative option

**Related Issue** : #3616 
1. create cumulative line chart with "sales" datasource.
2. select option below
![metatron_Discovery](https://user-images.githubusercontent.com/3770446/110745565-c951bf00-827e-11eb-8d51-1cefe282566e.jpg)
3. please check that the accumulated data comes out correctly


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
