### PR TITLE
fix CCE expired oauth token

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/scheduling/common/OAuthCacheOutJob.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/scheduling/common/OAuthCacheOutJob.java
@@ -53,17 +53,22 @@ public class OAuthCacheOutJob extends QuartzJobBean {
     LOGGER.info("## Start batch job for checking expired oauth token.");
     SpringCache tokenCache = (SpringCache) cacheManager.getCache("token-cache");
     tokenCache.getNativeCache().forEach((key, cachedToken) -> {
-      Date expiration = ((CachedToken) cachedToken).getExpiration();
-      if(expiration != null && expiration.getTime() < System.currentTimeMillis()){
-        LOGGER.debug("Token expired : {}", key);
-        tokenCacheRepository.removeCachedToken(key.toString());
-      } else {
-        String accessToken = ((CachedToken) cachedToken).getAccessToken();
-        String refreshToken = ((CachedToken) cachedToken).getRefreshToken();
-        if (StringUtils.isBlank(accessToken) && StringUtils.isBlank(refreshToken)) {
+      if (cachedToken instanceof CachedToken) {
+        Date expiration = ((CachedToken) cachedToken).getExpiration();
+        if(expiration != null && expiration.getTime() < System.currentTimeMillis()){
           LOGGER.debug("Token expired : {}", key);
           tokenCacheRepository.removeCachedToken(key.toString());
+        } else {
+          String accessToken = ((CachedToken) cachedToken).getAccessToken();
+          String refreshToken = ((CachedToken) cachedToken).getRefreshToken();
+          if (StringUtils.isBlank(accessToken) && StringUtils.isBlank(refreshToken)) {
+            LOGGER.debug("Token expired : {}", key);
+            tokenCacheRepository.removeCachedToken(key.toString());
+          }
         }
+      } else {
+        LOGGER.debug("Token is NullValue : {}", key);
+        tokenCacheRepository.removeCachedToken(key.toString());
       }
     });
     LOGGER.info("## End batch job for checking expired oauth token.");


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Fixed token not being deleted when logging out
Fix CCE that occurs when the cache entry saved as NULL Value is deleted by searching for expired tokens
```
Caused by: java.lang.ClassCastException: org.infinispan.spring.provider.NullValue cannot be cast to app.metatron.discovery.common.oauth.token.cache.CachedToken
	at app.metatron.discovery.domain.scheduling.common.OAuthCacheOutJob.lambda$executeInternal$0(OAuthCacheOutJob.java:56)
```

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Set to store tokens in cache. (See the PR #3571)
2. Login A account and check if the token is stored in the cache (/api/admin/caches/token-cache).
3. Logout A account and check whether the token stored in the cache has been deleted.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
