### PR TITLE
#3651 Fixed that the widget filter is changed to a global filter after copying the widget

### DIFF
--- a/discovery-frontend/src/app/dashboard/update-dashboard.component.ts
+++ b/discovery-frontend/src/app/dashboard/update-dashboard.component.ts
@@ -265,6 +265,14 @@ export class UpdateDashboardComponent extends DashboardLayoutComponent implement
         const board: Dashboard = this.dashboard;
         this.widgetService.createWidget(newWidgetInfo, board.id).then(resWidgetInfo => {
           const pageWidget: PageWidget = _.extend(new PageWidget(), resWidgetInfo);
+
+          // 위젯필터가 있는 경우 정보 추가
+          if (pageWidget.configuration.filters) {
+            pageWidget.configuration.filters.forEach(filter => {
+              (filter.ui) || (filter.ui = {});
+              filter.ui.widgetId = pageWidget.id;
+            })
+          }
           this.dashboard = this._addWidget(this.dashboard, pageWidget);
           this.appendWidgetInLayout([pageWidget]);
           this.hideBoardLoading();


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Fixed that the widget filter is changed to a global filter after copying the widget.

**Related Issue** : #3651 
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
See the issue #3651 

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
