### PR TITLE
fix generating query without sqlName property

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcConnectionService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/JdbcConnectionService.java
@@ -479,7 +479,7 @@ public class JdbcConnectionService {
             continue;
           }
           String fieldAlias = field.getName();
-          String fieldName = field.getSqlName();
+          String fieldName = StringUtils.defaultIfEmpty(field.getSqlName(), field.getName());
           if (StringUtils.contains(fieldAlias, ".")) {
             String[] splicedFieldAlias = StringUtils.split(fieldAlias, ".");
             fieldAlias = splicedFieldAlias[splicedFieldAlias.length - 1];


### PR DESCRIPTION
### Description
In the case of a field created by data source field sync, the sqlName attribute is omitted.
At this time, if the data source is reingested, an error occurs in the query generation step.

**Related Issue** : 


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
