### PR TITLE
fix to find secondary axis in combine chart

### DIFF
--- a/discovery-frontend/src/app/common/component/chart/type/combine-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/combine-chart.component.ts
@@ -189,11 +189,14 @@ export class CombineChartComponent extends BaseChart<UICombineChart> implements 
           return (aggrName === axis);
         });
 
-        console.log(axis + ' : ' + idx + ' : ' + axisPivot.isSecondaryAxis);
+        if (undefined !== axisPivot) {
+          console.log(axis + ' : ' + idx + ' : ' + axisPivot.isSecondaryAxis);
 
-        if (undefined !== axisPivot.isSecondaryAxis) {
-          axisIdx = axisPivot.isSecondaryAxis ? 1 : 0;
+          if (undefined !== axisPivot.isSecondaryAxis) {
+            axisIdx = axisPivot.isSecondaryAxis ? 1 : 0;
+          }
         }
+
         if (this.chartOption.yAxis[axisIdx].name) {
           this.chartOption.yAxis[axisIdx].name += CHART_STRING_DELIMITER + axis;
           this.chartOption.yAxis[axisIdx].axisName += CHART_STRING_DELIMITER + axis;


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
fix to find secondary axis in combine chart

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Check whether the previously created combine chart is rendered normally.
2. Check whether the newly created combine chart is rendered normally.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
