### PR TITLE
F#3691 set countd aggregation in widget

### DIFF
--- a/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
+++ b/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
@@ -59,7 +59,7 @@ import {UIOption} from '@common/component/chart/option/ui-option';
 import {BoardConfiguration, BoardDataSource, DashboardWidgetRelation, LayoutMode} from '@domain/dashboard/dashboard';
 import {BoardSyncOptions, BoardWidgetOptions, WidgetShowType} from '@domain/dashboard/dashboard.globalOptions';
 import {Pivot} from '@domain/workbook/configurations/pivot';
-import {ConnectionType, Datasource, Field} from '@domain/datasource/datasource';
+import {ConnectionType, Datasource, Field, LogicalType} from '@domain/datasource/datasource';
 import {Shelf, ShelfLayers} from '@domain/workbook/configurations/shelf/shelf';
 import {CustomField} from '@domain/workbook/configurations/field/custom-field';
 import {SearchQueryRequest} from '@domain/datasource/data/search-query-request';
@@ -73,6 +73,7 @@ import {WidgetService} from '../../service/widget.service';
 import {FilterUtil} from '../../util/filter.util';
 import {ChartLimitInfo, DashboardUtil} from '../../util/dashboard.util';
 import {AbstractWidgetComponent} from '../abstract-widget.component';
+import {AggregationType} from '@domain/workbook/configurations/field/measure-field';
 
 declare let $;
 declare let moment;
@@ -1199,6 +1200,14 @@ export class PageWidgetComponent extends AbstractWidgetComponent<PageWidget>
     this.widget = _.extend(new PageWidget(), widget) as PageWidget;
     this.widgetConfiguration = this.widget.configuration as PageWidgetConfiguration;
     this.chartType = this.widgetConfiguration.chart.type.toString();
+
+    // Aggregation LogicalType Hashed_Map 체크
+    this.widgetConfiguration.pivot.aggregations.forEach(field => {
+      if( LogicalType.HASHED_MAP === field.field.logicalType ) {
+        field.aggregationType = AggregationType.COUNTD;
+      }
+    });
+
     this.parentWidget = null;
     if (widget.dashBoard.configuration) {
 

--- a/discovery-frontend/src/app/domain/workbook/configurations/field/measure-field.ts
+++ b/discovery-frontend/src/app/domain/workbook/configurations/field/measure-field.ts
@@ -57,5 +57,6 @@ export enum AggregationType {
   // 계산식내 집계함수 포함 경우
   COMPLEX = 'COMPLEX',
 
-  IFCOUNTD = 'IFCOUNTD'
+  IFCOUNTD = 'IFCOUNTD',
+  COUNTD = 'COUNTD'
 }

--- a/discovery-frontend/src/app/page/page-pivot/map/map-page-pivot.component.ts
+++ b/discovery-frontend/src/app/page/page-pivot/map/map-page-pivot.component.ts
@@ -447,7 +447,7 @@ export class MapPagePivotComponent extends PagePivotComponent implements OnInit,
   public changePivot(eventType?: EventType) {
 
     // set layer alias
-    this.shelf.layers[this.uiOption.layerNum].fields = this.shelf.layers[this.uiOption.layerNum].fields.map(this.checkAlias);
+    this.shelf.layers[this.uiOption.layerNum].fields = this.shelf.layers[this.uiOption.layerNum].fields.map(this.checkPivotField);
 
     // 크기 반경
     this.setPointOption();
@@ -484,7 +484,7 @@ export class MapPagePivotComponent extends PagePivotComponent implements OnInit,
       this.uiOption.layerNum = this.shelf.layers.length - 1;
 
       // set layer alias
-      this.shelf.layers[this.uiOption.layerNum].fields = this.shelf.layers[this.uiOption.layerNum].fields.map(this.checkAlias);
+      this.shelf.layers[this.uiOption.layerNum].fields = this.shelf.layers[this.uiOption.layerNum].fields.map(this.checkPivotField);
 
       // layer 생성 (page.component에서 uiOption 전체를 생성함, layer만 추가 하기, 추가 layer 생성하기 위해서 0번째를 복사)
       const addUiOptionLayer = OptionGenerator.initUiOption(this.uiOption)['layers'][0];
@@ -523,7 +523,7 @@ export class MapPagePivotComponent extends PagePivotComponent implements OnInit,
     // set current layer number
     this.uiOption.layerNum = this.shelf.layers.length - 1;
     // set layer alias
-    this.shelf.layers[this.uiOption.layerNum].fields = this.shelf.layers[this.uiOption.layerNum].fields.map(this.checkAlias);
+    this.shelf.layers[this.uiOption.layerNum].fields = this.shelf.layers[this.uiOption.layerNum].fields.map(this.checkPivotField);
     // uiOption layer 제거
     this.uiOption.layers.splice(index, 1);
     // emit

--- a/discovery-frontend/src/app/page/page-pivot/page-pivot.component.ts
+++ b/discovery-frontend/src/app/page/page-pivot/page-pivot.component.ts
@@ -303,9 +303,9 @@ export class PagePivotComponent extends AbstractComponent implements OnInit, OnD
    */
   public changePivot(eventType?: EventType) {
 
-    this.pivot.columns = this.pivot.columns.map(this.checkAlias);
-    this.pivot.rows = this.pivot.rows.map(this.checkAlias);
-    this.pivot.aggregations = this.pivot.aggregations.map(this.checkAlias);
+    this.pivot.columns = this.pivot.columns.map(this.checkPivotField);
+    this.pivot.rows = this.pivot.rows.map(this.checkPivotField);
+    this.pivot.aggregations = this.pivot.aggregations.map(this.checkPivotField);
 
     this.changePivotEvent.emit({pivot: this.pivot, eventType: eventType});
   }
@@ -411,9 +411,9 @@ export class PagePivotComponent extends AbstractComponent implements OnInit, OnD
   public changePivotFilter(): void {
 
     // 데이터
-    this.pivot.columns = this.pivot.columns.map(this.checkAlias);
-    this.pivot.rows = this.pivot.rows.map(this.checkAlias);
-    this.pivot.aggregations = this.pivot.aggregations.map(this.checkAlias);
+    this.pivot.columns = this.pivot.columns.map(this.checkPivotField);
+    this.pivot.rows = this.pivot.rows.map(this.checkPivotField);
+    this.pivot.aggregations = this.pivot.aggregations.map(this.checkPivotField);
 
     // 이벤트 발생
     this.changePivotFilterEvent.emit(this.pivot);
@@ -1770,7 +1770,7 @@ export class PagePivotComponent extends AbstractComponent implements OnInit, OnD
     console.log('onSortSuccess', event);
   }
 
-  protected checkAlias(field: AbstractField) {
+  protected checkPivotField(field: AbstractField) {
 
     if (['measure', 'calculated'].indexOf(field.type) > -1) {
       // TODO 계산식인경우 field.aggregated 여부에 따라 기본값 세팅
@@ -1778,10 +1778,8 @@ export class PagePivotComponent extends AbstractComponent implements OnInit, OnD
         console.log('TODO 계산식인경우 field.aggregated 여부에 따라 기본값 세팅');
       }
 
-      let aggType;
-      if(field.field.logicalType === 'HASHED_MAP') {
-        aggType = AggregationType.COUNT;
-        field.aggregationType = aggType;
+      if(field.field.logicalType === LogicalType.HASHED_MAP) {
+        field.aggregationType = AggregationType.COUNTD;
       }
       // const aggType = _.isUndefined(field.aggregationType) ? 'SUM' : field.aggregationType;
       // field.alias = `${aggType}(${field.name})`;

--- a/discovery-frontend/src/app/page/page-pivot/page-pivot.component.ts
+++ b/discovery-frontend/src/app/page/page-pivot/page-pivot.component.ts
@@ -1777,6 +1777,12 @@ export class PagePivotComponent extends AbstractComponent implements OnInit, OnD
       if (field.type === 'calculated') {
         console.log('TODO 계산식인경우 field.aggregated 여부에 따라 기본값 세팅');
       }
+
+      let aggType;
+      if(field.field.logicalType === 'HASHED_MAP') {
+        aggType = AggregationType.COUNT;
+        field.aggregationType = aggType;
+      }
       // const aggType = _.isUndefined(field.aggregationType) ? 'SUM' : field.aggregationType;
       // field.alias = `${aggType}(${field.name})`;
     }

--- a/discovery-frontend/src/app/page/page-pivot/pivot-context.component.html
+++ b/discovery-frontend/src/app/page/page-pivot/pivot-context.component.html
@@ -103,7 +103,7 @@
           </div>
         </a>
         <!-- 2depth -->
-        <div class="ddp-ui-layer-sub">
+        <div *ngIf="editingField.field.logicalType !== 'HASHED_MAP'" class="ddp-ui-layer-sub">
           <ul class="ddp-list-popup">
             <li *ngFor="let aggType of aggTypeList"
                 [class.ddp-selected]="aggType['id'] == editingField.aggregationType && 'PERCENTILE' !== editingField.aggregationType"

--- a/discovery-frontend/src/app/page/page-pivot/pivot-context.component.ts
+++ b/discovery-frontend/src/app/page/page-pivot/pivot-context.component.ts
@@ -311,7 +311,6 @@ export class PivotContextComponent extends AbstractComponent implements OnInit, 
    * @param aggTypeOption PERCENTILE처럼 3depth의 선택값
    */
   public onChangeAggregationType(aggregationTypeId: string, aggTypeOption: number) {
-
     // 이벤트 버블링 stop
     event.stopPropagation();
 

--- a/discovery-frontend/src/app/page/page.component.ts
+++ b/discovery-frontend/src/app/page/page.component.ts
@@ -2698,11 +2698,16 @@ export class PageComponent extends AbstractPopupComponent implements OnInit, OnD
 
         // 사용자 필드이면서 aggregated가 true인 이미 선반에 올라간 컬럼인경우 제거
         if ('user_expr' === targetField.type && targetField.aggregated && isAlreadyPivot) {
-
+          console.log('delete column');
           this.getPivotComp().removeField(null, alreadyFieldPivot, alreadyPivot, alreadyIndex);
           // 추가
         } else {
-          this.pivot.aggregations.push(pivotFiled);
+
+          // 필드 타입이 HashedMap일 경우 aggregation 을 count 만 허용
+          if(targetField.logicalType != 'HASHED_MAP' || this.pivot.aggregations.length < 1){
+            this.pivot.aggregations.push(pivotFiled);
+          }
+          // this.pivot.aggregations.push(pivotFiled);
           this.pagePivot.convertField(targetField, 'aggregation');
         }
       }

--- a/discovery-frontend/src/app/page/page.component.ts
+++ b/discovery-frontend/src/app/page/page.component.ts
@@ -2698,13 +2698,12 @@ export class PageComponent extends AbstractPopupComponent implements OnInit, OnD
 
         // 사용자 필드이면서 aggregated가 true인 이미 선반에 올라간 컬럼인경우 제거
         if ('user_expr' === targetField.type && targetField.aggregated && isAlreadyPivot) {
-          console.log('delete column');
           this.getPivotComp().removeField(null, alreadyFieldPivot, alreadyPivot, alreadyIndex);
           // 추가
         } else {
 
           // 필드 타입이 HashedMap일 경우 aggregation 을 count 만 허용
-          if(targetField.logicalType != 'HASHED_MAP' || this.pivot.aggregations.length < 1){
+          if(targetField.logicalType != LogicalType.HASHED_MAP || this.pivot.aggregations.length < 1){
             this.pivot.aggregations.push(pivotFiled);
           }
           // this.pivot.aggregations.push(pivotFiled);

--- a/discovery-server/src/main/java/app/metatron/discovery/query/druid/AbstractQueryBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/query/druid/AbstractQueryBuilder.java
@@ -712,7 +712,8 @@ public abstract class AbstractQueryBuilder {
         aggregations.add(new CountAggregation(aliasName));
         break;
       case COUNTD:
-        aggregations.add(new HyperUniqueAggregation(aliasName, fieldName));
+        //aggregations.add(new HyperUniqueAggregation(aliasName, fieldName));
+        aggregations.add(new DistinctSketchAggregation(aliasName, fieldName, 65536L, true));
         break;
       case SUM:
         aggregations.add(new GenericSumAggregation(aliasName, fieldName, dataType));


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
For hashed_map type, countd must be applied unconditionally.

**Related Issue** : #3691 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Create a dashboard using a data source with a hashed_map type.
2. From the created dashboard, go to the chart creation screen and place a hashed_map type field on the shelf.
3. Check if the aggregation type is applied as countd.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
