### PR TITLE
#3717 Added ability to change default size of filter list

### DIFF
--- a/discovery-frontend/src/app/dashboard/filters/inclusion-filter/configure-filters-inclusion.component.html
+++ b/discovery-frontend/src/app/dashboard/filters/inclusion-filter/configure-filters-inclusion.component.html
@@ -29,6 +29,15 @@
       </ul>
     </div>
   </div>
+  <div class="ddp-data-form" style="float:right; margin-top:10px;">
+    조회 :
+    <input type="text" class="ddp-data-input"
+           [ngModel]="itemShowCnt"
+           (keyup)="changeShowNum($event)"
+           input-mask="number"
+           style="width: 80px; border:none; border-bottom: 1px solid #d7d8dc; background-color:#f4f6fc; font-size:12px; text-align: center">
+    개
+  </div>
 </div>
 <!-- // 선택 방식 결정 -->
 

--- a/discovery-frontend/src/app/dashboard/filters/inclusion-filter/configure-filters-inclusion.component.html
+++ b/discovery-frontend/src/app/dashboard/filters/inclusion-filter/configure-filters-inclusion.component.html
@@ -30,13 +30,12 @@
     </div>
   </div>
   <div class="ddp-data-form" style="float:right; margin-top:10px;">
-    조회 :
+    최대 조회 개수:
     <input type="text" class="ddp-data-input"
            [ngModel]="itemShowCnt"
            (keyup)="changeShowNum($event)"
            input-mask="number"
            style="width: 80px; border:none; border-bottom: 1px solid #d7d8dc; background-color:#f4f6fc; font-size:12px; text-align: center">
-    개
   </div>
 </div>
 <!-- // 선택 방식 결정 -->

--- a/discovery-frontend/src/app/dashboard/filters/inclusion-filter/configure-filters-inclusion.component.html
+++ b/discovery-frontend/src/app/dashboard/filters/inclusion-filter/configure-filters-inclusion.component.html
@@ -30,7 +30,7 @@
     </div>
   </div>
   <div class="ddp-data-form" style="float:right; margin-top:10px;">
-    최대 조회 개수:
+    {{'msg.board.li.filter.cnt' | translate}}:
     <input type="text" class="ddp-data-input"
            [ngModel]="itemShowCnt"
            (keyup)="changeShowNum($event)"

--- a/discovery-frontend/src/app/dashboard/filters/inclusion-filter/configure-filters-inclusion.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/inclusion-filter/configure-filters-inclusion.component.ts
@@ -147,9 +147,8 @@ export class ConfigureFiltersInclusionComponent extends AbstractFilterPopupCompo
   @Output()
   public goToSelectField: EventEmitter<any> = new EventEmitter();
 
-  public itemShowCnt: number = 100;
+  public itemShowCnt: number = FilterUtil.CANDIDATE_LIMIT;
   public commonUtil = CommonUtil;
-
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
   | Constructor

--- a/discovery-frontend/src/app/dashboard/filters/inclusion-filter/configure-filters-inclusion.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/inclusion-filter/configure-filters-inclusion.component.ts
@@ -308,6 +308,7 @@ export class ConfigureFiltersInclusionComponent extends AbstractFilterPopupCompo
    */
   public getData(): InclusionFilter {
     const filter: InclusionFilter = this.targetFilter;
+    filter.limit = this.itemShowCnt;
     filter.valueList = this.selectedValues.map(item => item.name);
     filter.candidateValues = this._candidateValues.map(item => item.name);
     filter.definedValues = this._candidateList.filter(item => item.isDefinedValue).map(item => item.name);
@@ -829,7 +830,8 @@ export class ConfigureFiltersInclusionComponent extends AbstractFilterPopupCompo
     if(13 === event.keyCode) {
       this.itemShowCnt = event.target['value'];
       this.datasourceService.getCandidateForFilter(this.targetFilter, this._board,[], this._targetField, null, null, this.itemShowCnt).then(result => {
-        this._candidateList = this._candidateList.filter(item => item.isDefinedValue);  // initialize list
+        this._candidateList = this._candidateList.filter(item => item.isDefinedValue);
+        this._candidateValues = this._candidateList;
         this._setCandidateResult(result, this.targetFilter, this._targetField);
         this.safelyDetectChanges();
         this.loadingHide();

--- a/discovery-frontend/src/app/dashboard/filters/inclusion-filter/configure-filters-inclusion.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/inclusion-filter/configure-filters-inclusion.component.ts
@@ -43,7 +43,7 @@ import {FilterUtil} from '../../util/filter.util';
 import {DashboardUtil} from '../../util/dashboard.util';
 import {DatasourceService} from '../../../datasource/service/datasource.service';
 import {AbstractFilterPopupComponent} from '../abstract-filter-popup.component';
-import {CommonUtil} from "@common/util/common.util";
+import {CommonUtil} from '@common/util/common.util';
 
 @Component({
   selector: 'app-config-filter-inclusion',
@@ -275,6 +275,8 @@ export class ConfigureFiltersInclusionComponent extends AbstractFilterPopupCompo
     if (targetFilter.definedValues && 0 < targetFilter.definedValues.length) {
       this._candidateList = targetFilter.definedValues.map(item => this._stringToCandidate(item, true));
     }
+
+    this.itemShowCnt = targetFilter.limit ? targetFilter.limit : FilterUtil.CANDIDATE_LIMIT;
 
     this.loadingShow();
     this.datasourceService.getCandidateForFilter(targetFilter, board, [], targetField, 'COUNT', this.searchText, this.itemShowCnt)
@@ -828,10 +830,12 @@ export class ConfigureFiltersInclusionComponent extends AbstractFilterPopupCompo
    */
   public changeShowNum(event: KeyboardEvent){
     if(13 === event.keyCode) {
+      this.searchText = '';
       this.itemShowCnt = event.target['value'];
       this.datasourceService.getCandidateForFilter(this.targetFilter, this._board,[], this._targetField, null, null, this.itemShowCnt).then(result => {
         this._candidateList = this._candidateList.filter(item => item.isDefinedValue);
         this._candidateValues = this._candidateList;
+        this.targetFilter.candidateValues = [];
         this._setCandidateResult(result, this.targetFilter, this._targetField);
         this.safelyDetectChanges();
         this.loadingHide();

--- a/discovery-frontend/src/app/dashboard/filters/inclusion-filter/configure-filters-inclusion.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/inclusion-filter/configure-filters-inclusion.component.ts
@@ -43,6 +43,7 @@ import {FilterUtil} from '../../util/filter.util';
 import {DashboardUtil} from '../../util/dashboard.util';
 import {DatasourceService} from '../../../datasource/service/datasource.service';
 import {AbstractFilterPopupComponent} from '../abstract-filter-popup.component';
+import {CommonUtil} from "@common/util/common.util";
 
 @Component({
   selector: 'app-config-filter-inclusion',
@@ -145,6 +146,10 @@ export class ConfigureFiltersInclusionComponent extends AbstractFilterPopupCompo
 
   @Output()
   public goToSelectField: EventEmitter<any> = new EventEmitter();
+
+  public itemShowCnt: number = 100;
+  public commonUtil = CommonUtil;
+
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
   | Constructor
@@ -272,7 +277,7 @@ export class ConfigureFiltersInclusionComponent extends AbstractFilterPopupCompo
     }
 
     this.loadingShow();
-    this.datasourceService.getCandidateForFilter(targetFilter, board, [], targetField, 'COUNT', this.searchText)
+    this.datasourceService.getCandidateForFilter(targetFilter, board, [], targetField, 'COUNT', this.searchText, this.itemShowCnt)
       .then(result => {
         this.targetFilter = targetFilter;
         this._targetField = targetField;
@@ -288,6 +293,7 @@ export class ConfigureFiltersInclusionComponent extends AbstractFilterPopupCompo
           this.selectedValues.push(this._candidateList[0]);
         }
 
+        // this.itemShowCnt = this.candidateListSize > 100 ? 100 : this.candidateListSize;
         this.isShow = true;
         this.safelyDetectChanges();
         this.loadingHide();
@@ -362,7 +368,7 @@ export class ConfigureFiltersInclusionComponent extends AbstractFilterPopupCompo
   public candidateFromSearchText() {
     this.loadingShow();
     const sortBy: string = (this.targetFilter.sort && this.targetFilter.sort.by) ? this.targetFilter.sort.by.toString() : 'COUNT';
-    this.datasourceService.getCandidateForFilter(this.targetFilter, this._board, [], this._targetField, sortBy, this.searchText)
+    this.datasourceService.getCandidateForFilter(this.targetFilter, this._board,[], this._targetField, sortBy, this.searchText,  this.itemShowCnt)
       .then(result => {
         this._setCandidateResult(result, this.targetFilter, this._targetField);
         this.safelyDetectChanges();
@@ -519,7 +525,7 @@ export class ConfigureFiltersInclusionComponent extends AbstractFilterPopupCompo
     this._condition = _.cloneDeep(this.condition);
     this._limitation = _.cloneDeep(this.limitation);
     this.targetFilter.preFilters = [this._wildcard, this._regExpr, this._condition, this._limitation];
-    this.datasourceService.getCandidateForFilter(this.targetFilter, this._board, [], this._targetField).then(result => {
+    this.datasourceService.getCandidateForFilter(this.targetFilter, this._board,[], this._targetField, null, null, this.itemShowCnt).then(result => {
       this._candidateList = this._candidateList.filter(item => item.isDefinedValue);  // initialize list
       this._setCandidateResult(result, this.targetFilter, this._targetField);
       this.safelyDetectChanges();
@@ -602,7 +608,6 @@ export class ConfigureFiltersInclusionComponent extends AbstractFilterPopupCompo
    * @param {boolean} isInitial
    */
   public setCandidatePage(page: number, isInitial: boolean = false) {
-
     if (isInitial) {
       this.pageCandidateList = [];
       this.currentPage = 1;
@@ -611,7 +616,6 @@ export class ConfigureFiltersInclusionComponent extends AbstractFilterPopupCompo
       this.safelyDetectChanges();
     }
     if (this._candidateList && 0 < this._candidateList.length) {
-
       let pagedList: Candidate[] = _.cloneDeep(this._candidateList);
 
       if (this.targetFilter && this.targetFilter.showSelectedItem) {
@@ -657,7 +661,6 @@ export class ConfigureFiltersInclusionComponent extends AbstractFilterPopupCompo
         this.pageCandidateList = pagedList;
       }
     }
-
   } // function - setCandidatePage
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
@@ -819,6 +822,21 @@ export class ConfigureFiltersInclusionComponent extends AbstractFilterPopupCompo
     return this.selectedValues.length === 0;
   }
 
+  /**
+   * 아이템 목록 조회 개수 변경
+   */
+  public changeShowNum(event: KeyboardEvent){
+    if(13 === event.keyCode) {
+      this.itemShowCnt = event.target['value'];
+      this.datasourceService.getCandidateForFilter(this.targetFilter, this._board,[], this._targetField, null, null, this.itemShowCnt).then(result => {
+        this._candidateList = this._candidateList.filter(item => item.isDefinedValue);  // initialize list
+        this._setCandidateResult(result, this.targetFilter, this._targetField);
+        this.safelyDetectChanges();
+        this.loadingHide();
+      });
+    }
+  }
+
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
   | Protected Method
   |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
@@ -897,7 +915,6 @@ export class ConfigureFiltersInclusionComponent extends AbstractFilterPopupCompo
             .map(item => this._stringToCandidate(item, true))
         );
     }
-
     // 목록 설정
     this._candidateList =
       this._candidateList.concat(

--- a/discovery-frontend/src/app/dashboard/filters/inclusion-filter/inclusion-filter-panel.component.ts
+++ b/discovery-frontend/src/app/dashboard/filters/inclusion-filter/inclusion-filter-panel.component.ts
@@ -530,10 +530,9 @@ export class InclusionFilterPanelComponent extends AbstractFilterPanelComponent<
       }
 
       this.datasourceService.getCandidateForFilter(
-        this.filter, this.dashboard, prevFilter, this.field, 'COUNT', this.searchText).then((result) => {
+        this.filter, this.dashboard, prevFilter, this.field, 'COUNT', this.searchText, this.filter.limit).then((result) => {
 
         this._candidateList = [];
-
         // 사용자 정의 값 추가
         this.addDefineValues();
 
@@ -545,7 +544,6 @@ export class InclusionFilterPanelComponent extends AbstractFilterPanelComponent<
           // 일반 필터의 목록 처리
           // 선택된 후보값 목록
           const selectedCandidateValues: string[] = this.filter.candidateValues;
-
           if (selectedCandidateValues && 0 < selectedCandidateValues.length) {
             // 후보값 추가
             selectedCandidateValues.forEach((selectedItem) => {
@@ -609,7 +607,6 @@ export class InclusionFilterPanelComponent extends AbstractFilterPanelComponent<
         this.isShowFilter = true;
       });
     }
-
   } // function - _candidate
 
   // noinspection JSMethodCanBeStatic

--- a/discovery-frontend/src/app/dashboard/util/filter.util.ts
+++ b/discovery-frontend/src/app/dashboard/util/filter.util.ts
@@ -435,7 +435,7 @@ export class FilterUtil {
           'minTime', 'maxTime', 'valueList', 'candidateValues', 'discontinuous', 'granularity'];
         break;
       case 'include' :
-        keyMap = ['selector', 'valueList', 'candidateValues', 'definedValues', 'sort'];
+        keyMap = ['selector', 'valueList', 'candidateValues', 'definedValues', 'sort', 'limit'];
         break;
       case 'timestamp' :
         keyMap = ['selectedTimestamps', 'timeFormat'];

--- a/discovery-frontend/src/app/dashboard/widgets/filter-widget/filter-widget.component.css
+++ b/discovery-frontend/src/app/dashboard/widgets/filter-widget/filter-widget.component.css
@@ -1,0 +1,15 @@
+.ddp-list-search-candidate {
+  padding-bottom: 15px;
+}
+.ddp-list-search-candidate .ddp-search-text {
+  display: inline-block;
+  border-radius: 2px;
+  border: 1px solid #d0d1d9;
+  width: calc( 100% - 100px );
+}
+.ddp-list-search-candidate .ddp-search-text input.ddp-input-search {
+  display:block; width:100%; padding:7px 26px 6px 13px; box-sizing:border-box; border:none; font-size:13px;
+}
+.ddp-list-search-candidate .ddp-btn-line {
+  margin-left: 5px;
+}

--- a/discovery-frontend/src/app/dashboard/widgets/filter-widget/filter-widget.component.html
+++ b/discovery-frontend/src/app/dashboard/widgets/filter-widget/filter-widget.component.html
@@ -68,10 +68,10 @@
                     && (convertToIncludeFilter(filter).selector === inclusionSelectorType.MULTI_LIST
                       || convertToIncludeFilter(filter).selector === inclusionSelectorType.SINGLE_LIST)"
            class="ddp-list-search-candidate">
-        <a (click)="candidateFromSearchText()" class="ddp-btn-line">{{'msg.comm.ui.search-all' | translate}}</a>
         <div class="ddp-search-text">
           <input type="text" class="ddp-input-search" [(ngModel)]="searchText">
         </div>
+        <a (click)="candidateFromSearchText()" class="ddp-btn-line">{{'msg.comm.ui.search-all' | translate}}</a>
       </div>
 
       <!-- 복수 선택 목록 -->

--- a/discovery-frontend/src/app/dashboard/widgets/filter-widget/filter-widget.component.ts
+++ b/discovery-frontend/src/app/dashboard/widgets/filter-widget/filter-widget.component.ts
@@ -64,7 +64,8 @@ declare let moment;
 
 @Component({
   selector: 'filter-widget',
-  templateUrl: './filter-widget.component.html'
+  templateUrl: './filter-widget.component.html',
+  styleUrls: ['./filter-widget.component.css']
 })
 export class FilterWidgetComponent extends AbstractWidgetComponent<FilterWidget> implements OnInit, OnChanges, AfterViewInit, OnDestroy {
 
@@ -499,7 +500,6 @@ export class FilterWidgetComponent extends AbstractWidgetComponent<FilterWidget>
             candidate.count = resultCandidate.count;
             candidate.name = resultCandidate.field;
             candidate.isTemporary = true;
-
             this.candidateList.unshift(candidate);
           }
         });

--- a/discovery-frontend/src/app/datasource/service/datasource.service.ts
+++ b/discovery-frontend/src/app/datasource/service/datasource.service.ts
@@ -176,10 +176,11 @@ export class DatasourceService extends AbstractService {
    * @param {Field | CustomField} field
    * @param {string} sortBy
    * @param {string} searchWord
+   * @param limit
    * @returns {Promise<any>}
    */
   public getCandidateForFilter(filter: Filter, board: Dashboard,
-                               filters?: Filter[], field?: (Field | CustomField), sortBy?: string, searchWord?: string): Promise<any> {
+                               filters?: Filter[], field?: (Field | CustomField), sortBy?: string, searchWord?: string, limit?: number): Promise<any> {
 
     const param: any = {};
     param.dataSource = DashboardUtil.getDataSourceForApi(
@@ -282,7 +283,7 @@ export class DatasourceService extends AbstractService {
 
         param.sortBy = (sortBy) ? sortBy : 'COUNT';
         // param.searchWord = (searchWord) ? searchWord : '';
-        param.limit = FilterUtil.CANDIDATE_LIMIT;
+        param.limit = (limit) ? limit : FilterUtil.CANDIDATE_LIMIT;
 
       } else if ('bound' === filter.type) {
         // Measure Filter

--- a/discovery-frontend/src/app/datasource/service/datasource.service.ts
+++ b/discovery-frontend/src/app/datasource/service/datasource.service.ts
@@ -283,7 +283,13 @@ export class DatasourceService extends AbstractService {
 
         param.sortBy = (sortBy) ? sortBy : 'COUNT';
         // param.searchWord = (searchWord) ? searchWord : '';
-        param.limit = (limit) ? limit : FilterUtil.CANDIDATE_LIMIT;
+        if( limit ) {
+          param.limit = limit;
+        } else if( (filter as InclusionFilter).limit ) {
+          param.limit = (filter as InclusionFilter).limit
+        } else {
+          param.limit = FilterUtil.CANDIDATE_LIMIT;
+        }
 
       } else if ('bound' === filter.type) {
         // Measure Filter

--- a/discovery-frontend/src/app/domain/workbook/configurations/filter/inclusion-filter.ts
+++ b/discovery-frontend/src/app/domain/workbook/configurations/filter/inclusion-filter.ts
@@ -39,6 +39,8 @@ export class InclusionFilter extends Filter {
   // Only show selected item (Optional, for UI)
   public showSelectedItem: boolean;
 
+  public limit: number;
+
   constructor(field: string, valueList: string[] = []) {
     super();
     this.type = 'include';

--- a/discovery-frontend/src/assets/i18n/en.json
+++ b/discovery-frontend/src/assets/i18n/en.json
@@ -1519,6 +1519,7 @@
   "msg.board.li.sel.type" :"Type",
   "msg.board.li.single" :"Single",
   "msg.board.li.multiple" :"Multiple",
+  "msg.board.li.filter.cnt" : "Max Count",
   "msg.board.ui.ui.component" : "UI component",
   "msg.board.li.combobox" :"Combobox",
   "msg.board.li.list" :"List",

--- a/discovery-frontend/src/assets/i18n/ko.json
+++ b/discovery-frontend/src/assets/i18n/ko.json
@@ -1504,6 +1504,7 @@
   "msg.board.li.sel.type":"타입",
   "msg.board.li.single": "단건",
   "msg.board.li.multiple": "다건",
+  "msg.board.li.filter.cnt" : "최대 조회 개수",
   "msg.board.ui.ui.component": "UI 컴포넌트",
   "msg.board.li.combobox": "콤보박스",
   "msg.board.li.list": "리스트",

--- a/discovery-frontend/src/assets/i18n/zh.json
+++ b/discovery-frontend/src/assets/i18n/zh.json
@@ -1462,6 +1462,7 @@
   "msg.board.li.sel.type" :"Type",
   "msg.board.li.single": "单件",
   "msg.board.li.multiple": "多件",
+  "msg.board.li.filter.cnt" : "Max Count",
   "msg.board.ui.ui.component": "UI要素",
   "msg.board.li.combobox": "组合框",
   "msg.board.li.list": "列表",

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/filter/InclusionFilter.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/filter/InclusionFilter.java
@@ -74,6 +74,8 @@ public class InclusionFilter extends Filter {
    */
   Map<String, String> valuePair;
 
+  Integer limit;
+
   public InclusionFilter() {
     // Empty Constructor
   }
@@ -90,7 +92,8 @@ public class InclusionFilter extends Filter {
                          @JsonProperty("preFilters") List<AdvancedFilter> preFilters,
                          @JsonProperty("sort") ItemSort sort,
                          @JsonProperty("showSelectedItem") Boolean showSelectedItem,
-                         @JsonProperty("valuePair") Map<String, String> valuePair) {
+                         @JsonProperty("valuePair") Map<String, String> valuePair,
+                         @JsonProperty("limit") Integer limit) {
     super(dataSource, field, ref);
 
     this.valueList = valueList;
@@ -105,6 +108,7 @@ public class InclusionFilter extends Filter {
     this.sort = sort;
     this.showSelectedItem = showSelectedItem;
     this.valuePair = valuePair;
+    this.limit = limit;
   }
 
   public InclusionFilter(String field, List<String> valueList) {
@@ -205,6 +209,10 @@ public class InclusionFilter extends Filter {
     return showSelectedItem;
   }
 
+  public Integer getLimit() { return limit; }
+
+  public void setLimit(Integer limit) { this.limit = limit; }
+
   @Override
   public String toString() {
     return "InclusionFilter{" +
@@ -215,6 +223,7 @@ public class InclusionFilter extends Filter {
         ", preFilters=" + preFilters +
         ", sort=" + sort +
         ", valuePair=" + valuePair +
+        ", limit=" + limit +
         "} " + super.toString();
   }
 

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/workbook/configurations/filter/InclusionFilterTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/workbook/configurations/filter/InclusionFilterTest.java
@@ -23,7 +23,8 @@ public class InclusionFilterTest {
                                                    null,
                                                    new InclusionFilter.ItemSort("count", "desc"),
                                                    true,
-                                                   null);
+                                                   null,
+                                                    100);
 
     String specStr = GlobalObjectMapper.writeValueAsString(inFilter);
     System.out.println(specStr);


### PR DESCRIPTION
### Description
Added ability to change default size of filter list

**Related Issue** : #3717 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
1. On the Create Dimension Value Filter screen, check if the number of list views can be changed.
2. Check that the changed size are also persisted in panels and widgets.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
