### PR TITLE
Support thetaSketch type when adding engine datasource

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/common/datasource/DataType.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/common/datasource/DataType.java
@@ -20,6 +20,7 @@ import java.sql.Types;
 
 import app.metatron.discovery.domain.dataprep.teddy.ColumnType;
 import app.metatron.discovery.domain.datasource.Field;
+import app.metatron.discovery.domain.workbook.configurations.field.MeasureField;
 
 /**
  * Created by kyungtaak on 2017. 6. 11..
@@ -76,6 +77,8 @@ public enum DataType {
         return LogicalType.STRUCT;
       case ARRAY:
         return LogicalType.ARRAY;
+      case HASHED_MAP:
+        return LogicalType.HASHED_MAP;
       default:
         return LogicalType.STRING;
     }
@@ -96,10 +99,20 @@ public enum DataType {
       case LONG:
       case FLOAT:
       case DOUBLE:
+      case HASHED_MAP:
         return Field.FieldRole.MEASURE;
     }
 
     return Field.FieldRole.DIMENSION;
+  }
+
+  public MeasureField.AggregationType toAggrType() {
+    switch (this) {
+      case HASHED_MAP:
+        return MeasureField.AggregationType.IFCOUNTD;
+      default:
+        return MeasureField.AggregationType.NONE;
+    }
   }
 
   /**
@@ -209,6 +222,8 @@ public enum DataType {
       case "LONG":
       case "long":
         return LONG;
+      case "thetaSketch":
+        return HASHED_MAP;
       default:
         return UNKNOWN;
     }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/Field.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/Field.java
@@ -269,6 +269,7 @@ public class Field implements MetatronDomain<Long> {
       this.logicalType = this.type.toLogicalType();
     }
     this.role = role == null ? this.type.toRole() : role;
+    this.aggrType = this.type.toAggrType();
     this.seq = seq;
   }
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Support thetaSketch type when adding engine datasource

**Related Issue** : #3644
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Create a datasource using the engine data source including thetaSketch type column.
2. Check whether the thetaSketch type column is displayed as HashedMap.
3. When creating a chart using the created datasource, check that the aggregation type of the column is fixed to COUNTD.


#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
