### PR TITLE
#3828 Nested object in tuningConfig should be overrided

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/IngestionSpecBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/IngestionSpecBuilder.java
@@ -73,8 +73,8 @@ public class IngestionSpecBuilder extends AbstractSpecBuilder {
   public IngestionSpecBuilder hdfsTuningConfig(Map<String, Object> tuningProperties, Map<String, Object> jobProperties) {
 
     tuningConfig = HadoopTuningConfig.hdfsDefaultConfig();
-
-    ((HadoopTuningConfig) tuningConfig).overrideConfig(tuningProperties, jobProperties);
+    ((HadoopTuningConfig) tuningConfig).addJobProperty(jobProperties);
+    ((HadoopTuningConfig) tuningConfig).overrideConfig(tuningProperties);
 
     addSecondaryIndexing();
 
@@ -85,7 +85,8 @@ public class IngestionSpecBuilder extends AbstractSpecBuilder {
 
     tuningConfig = HadoopTuningConfig.hiveDefaultConfig();
 
-    ((HadoopTuningConfig) tuningConfig).overrideConfig(tuningProperties, jobProperties);
+    ((HadoopTuningConfig) tuningConfig).addJobProperty(jobProperties);
+    ((HadoopTuningConfig) tuningConfig).overrideConfig(tuningProperties);
 
     addSecondaryIndexing();
 

--- a/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/index/IndexSpec.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/index/IndexSpec.java
@@ -31,6 +31,8 @@ public class IndexSpec {
 
   Map<String, SecondaryIndexing> secondaryIndexing;
 
+  Boolean allowNullForNumbers;
+
   public IndexSpec() {
   }
 
@@ -75,6 +77,14 @@ public class IndexSpec {
 
   public void setSecondaryIndexing(Map<String, SecondaryIndexing> secondaryIndexing) {
     this.secondaryIndexing = secondaryIndexing;
+  }
+
+  public Boolean getAllowNullForNumbers() {
+    return allowNullForNumbers;
+  }
+
+  public void setAllowNullForNumbers(Boolean allowNullForNumbers) {
+    this.allowNullForNumbers = allowNullForNumbers;
   }
 
   public static class Bitmap {

--- a/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/tuning/AbstractTuningConfig.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/tuning/AbstractTuningConfig.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.metatron.discovery.spec.druid.ingestion.tuning;
+
+import com.google.common.collect.Maps;
+
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.apache.commons.collections4.MapUtils;
+import org.springframework.beans.BeanWrapper;
+import org.springframework.beans.BeanWrapperImpl;
+import org.springframework.beans.PropertyAccessorFactory;
+
+import java.beans.FeatureDescriptor;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import app.metatron.discovery.domain.datasource.DataSourceErrorCodes;
+import app.metatron.discovery.domain.datasource.DataSourceException;
+import app.metatron.discovery.spec.druid.ingestion.index.IndexSpec;
+
+public abstract class AbstractTuningConfig implements TuningConfig {
+
+  Integer maxRowsInMemory;
+
+  Boolean ignoreInvalidRows;
+
+  Boolean buildV9Directly;
+
+  IndexSpec indexSpec;
+
+  Map<String, String> jobProperties;
+
+
+  public void overrideConfig(Map<String, Object> tuningConfig) {
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    mapper.configure(MapperFeature.USE_BASE_TYPE_AS_DEFAULT_IMPL, true);
+
+    String configJson;
+    try {
+      configJson = mapper.writeValueAsString(tuningConfig);
+      copyProperties(mapper.readValue(configJson, this.getClass()), this, tuningConfig.keySet());
+    } catch (Exception e) {
+      throw new DataSourceException(DataSourceErrorCodes.INGESTION_COMMON_ERROR, e.getMessage());
+    }
+
+  }
+
+  public void addJobProperty(String key, String value) {
+    if (jobProperties == null) {
+      jobProperties = Maps.newHashMap();
+    }
+
+    this.jobProperties.put(key, value);
+  }
+
+  public void addJobProperty(Map<String, Object> jobProperties) {
+
+    if (MapUtils.isNotEmpty(jobProperties)) {
+      for (String key : jobProperties.keySet()) {
+        addJobProperty(key, String.valueOf(jobProperties.get(key)));
+      }
+    }
+  }
+
+  private static void copyProperties(Object source, Object target, Iterable<String> props) {
+
+    BeanWrapper sourceWrap = PropertyAccessorFactory.forBeanPropertyAccess(source);
+    BeanWrapper targetWrap = PropertyAccessorFactory.forBeanPropertyAccess(target);
+
+    props.forEach(p -> targetWrap.setPropertyValue(p, sourceWrap.getPropertyValue(p)));
+
+  }
+
+  public Integer getMaxRowsInMemory() {
+    return maxRowsInMemory;
+  }
+
+  public void setMaxRowsInMemory(Integer maxRowsInMemory) {
+    this.maxRowsInMemory = maxRowsInMemory;
+  }
+
+  public Boolean getIgnoreInvalidRows() {
+    return ignoreInvalidRows;
+  }
+
+  public void setIgnoreInvalidRows(Boolean ignoreInvalidRows) {
+    this.ignoreInvalidRows = ignoreInvalidRows;
+  }
+
+  public Boolean getBuildV9Directly() {
+    return buildV9Directly;
+  }
+
+  public void setBuildV9Directly(Boolean buildV9Directly) {
+    this.buildV9Directly = buildV9Directly;
+  }
+
+  @Override
+  public IndexSpec getIndexSpec() {
+    return indexSpec;
+  }
+
+  @Override
+  public void setIndexSpec(IndexSpec indexSpec) {
+    this.indexSpec = indexSpec;
+  }
+
+  public Map<String, String> getJobProperties() {
+    return jobProperties;
+  }
+
+  public void setJobProperties(Map<String, String> jobProperties) {
+    this.jobProperties = jobProperties;
+  }
+}

--- a/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/tuning/BatchTuningConfig.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/tuning/BatchTuningConfig.java
@@ -14,18 +14,14 @@
 
 package app.metatron.discovery.spec.druid.ingestion.tuning;
 
-import org.apache.commons.beanutils.BeanUtils;
-import org.apache.commons.collections4.MapUtils;
-
 import java.util.Map;
 
-import app.metatron.discovery.spec.druid.ingestion.index.IndexSpec;
 import app.metatron.discovery.spec.druid.ingestion.partition.PartitionSpec;
 
 /**
  *
  */
-public class BatchTuningConfig implements TuningConfig {
+public class BatchTuningConfig extends AbstractTuningConfig {
 
   String workingPath;
 
@@ -33,44 +29,21 @@ public class BatchTuningConfig implements TuningConfig {
 
   PartitionSpec partitionSpec;
 
-  Integer maxRowsInMemory;
-
   Boolean leaveIntermediate;
 
   Boolean cleanupOnFailure;
 
   Boolean overwriteFiles;
 
-  Boolean ignoreInvalidRows;
-
   Boolean useCombiner;
 
-  Boolean buildV9Directly;
-
   Integer numBackgroundPersistThreads;
-
-  IndexSpec indexSpec;
 
   public BatchTuningConfig() {
   }
 
   public BatchTuningConfig(Map<String, Object> tuningConfig) {
     overrideConfig(tuningConfig);
-  }
-
-  public void overrideConfig(Map<String, Object> tuningConfig) {
-
-    this.buildV9Directly = true;
-
-    if(MapUtils.isNotEmpty(tuningConfig)) {
-      for (String key : tuningConfig.keySet()) {
-        try {
-          BeanUtils.setProperty(this, key, tuningConfig.get(key));
-        } catch (Exception e) {
-        }
-      }
-    }
-
   }
 
   public String getWorkingPath() {
@@ -97,14 +70,6 @@ public class BatchTuningConfig implements TuningConfig {
     this.partitionSpec = partitionSpec;
   }
 
-  public Integer getMaxRowsInMemory() {
-    return maxRowsInMemory;
-  }
-
-  public void setMaxRowsInMemory(Integer maxRowsInMemory) {
-    this.maxRowsInMemory = maxRowsInMemory;
-  }
-
   public Boolean getLeaveIntermediate() {
     return leaveIntermediate;
   }
@@ -129,14 +94,6 @@ public class BatchTuningConfig implements TuningConfig {
     this.overwriteFiles = overwriteFiles;
   }
 
-  public Boolean getIgnoreInvalidRows() {
-    return ignoreInvalidRows;
-  }
-
-  public void setIgnoreInvalidRows(Boolean ignoreInvalidRows) {
-    this.ignoreInvalidRows = ignoreInvalidRows;
-  }
-
   public Boolean getUseCombiner() {
     return useCombiner;
   }
@@ -145,29 +102,11 @@ public class BatchTuningConfig implements TuningConfig {
     this.useCombiner = useCombiner;
   }
 
-  public Boolean getBuildV9Directly() {
-    return buildV9Directly;
-  }
-
-  public void setBuildV9Directly(Boolean buildV9Directly) {
-    this.buildV9Directly = buildV9Directly;
-  }
-
   public Integer getNumBackgroundPersistThreads() {
     return numBackgroundPersistThreads;
   }
 
   public void setNumBackgroundPersistThreads(Integer numBackgroundPersistThreads) {
     this.numBackgroundPersistThreads = numBackgroundPersistThreads;
-  }
-
-  @Override
-  public IndexSpec getIndexSpec() {
-    return indexSpec;
-  }
-
-  @Override
-  public void setIndexSpec(IndexSpec indexSpec) {
-    this.indexSpec = indexSpec;
   }
 }

--- a/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/tuning/HadoopTuningConfig.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/tuning/HadoopTuningConfig.java
@@ -14,14 +14,6 @@
 
 package app.metatron.discovery.spec.druid.ingestion.tuning;
 
-import com.google.common.collect.Maps;
-
-import org.apache.commons.beanutils.BeanUtils;
-import org.apache.commons.collections4.MapUtils;
-
-import java.util.Map;
-
-import app.metatron.discovery.spec.druid.ingestion.index.IndexSpec;
 import app.metatron.discovery.spec.druid.ingestion.partition.HashBasedPartition;
 import app.metatron.discovery.spec.druid.ingestion.partition.PartitionSpec;
 import app.metatron.discovery.spec.druid.ingestion.partition.SizedPartition;
@@ -29,17 +21,13 @@ import app.metatron.discovery.spec.druid.ingestion.partition.SizedPartition;
 /**
  * Created by kyungtaak on 2017. 3. 20..
  */
-public class HadoopTuningConfig implements TuningConfig {
+public class HadoopTuningConfig extends AbstractTuningConfig {
 
   String ingestionMode;
 
   Boolean useCombiner;
 
   Boolean combineText;
-
-  Boolean buildV9Directly;
-
-  Long maxRowsInMemory;
 
   Long maxOccupationInMemory;
 
@@ -55,43 +43,13 @@ public class HadoopTuningConfig implements TuningConfig {
 
   Boolean overwriteFiles;
 
-  Boolean ignoreInvalidRows;
-
   Boolean assumeTimeSorted;
 
   PartitionSpec partitionsSpec;
 
-  IndexSpec indexSpec;
-
-  Map<String, String> jobProperties;
-
   public HadoopTuningConfig() {
   }
 
-  public void overrideConfig(Map<String, Object> tuningConfig, Map<String, Object> jobProperties) {
-
-    if(MapUtils.isNotEmpty(tuningConfig)) {
-      for (String key : tuningConfig.keySet()) {
-        try {
-          BeanUtils.setProperty(this, key, tuningConfig.get(key));
-        } catch (Exception e) {
-        }
-      }
-    }
-
-    if (MapUtils.isNotEmpty(jobProperties)) {
-      for (String key : jobProperties.keySet()) {
-        addJobProperty(key, String.valueOf(jobProperties.get(key)));
-      }
-    }
-
-  }
-
-
-  /**
-   *
-   * @return
-   */
   public static HadoopTuningConfig hiveDefaultConfig() {
 
     HadoopTuningConfig config = new HadoopTuningConfig();
@@ -99,7 +57,7 @@ public class HadoopTuningConfig implements TuningConfig {
     config.setIngestionMode("REDUCE_MERGE");
     config.setUseCombiner(false);
     config.setBuildV9Directly(true);
-    config.setMaxRowsInMemory(3000000L);
+    config.setMaxRowsInMemory(3000000);
     config.setMaxOccupationInMemory(1024000000L);
     config.setMaxShardLength(256000000L);
     config.setIgnoreInvalidRows(true);
@@ -117,10 +75,6 @@ public class HadoopTuningConfig implements TuningConfig {
     return config;
   }
 
-  /**
-   *
-   * @return
-   */
   public static HadoopTuningConfig hdfsDefaultConfig() {
 
     HadoopTuningConfig config = new HadoopTuningConfig();
@@ -130,7 +84,7 @@ public class HadoopTuningConfig implements TuningConfig {
     config.setCombineText(false);
     config.setBuildV9Directly(true);
     config.setNumBackgroundPersistThreads(0);
-    config.setMaxRowsInMemory(75000L);
+    config.setMaxRowsInMemory(75000);
     config.setMaxOccupationInMemory(-1L);
     config.setMaxShardLength(-2147483648L);
     config.setLeaveIntermediate(false);
@@ -150,22 +104,6 @@ public class HadoopTuningConfig implements TuningConfig {
     return config;
   }
 
-  public void addJobProperty(String key, String value) {
-    if (jobProperties == null) {
-      jobProperties = Maps.newHashMap();
-    }
-
-    this.jobProperties.put(key, value);
-  }
-
-  public void addJobProperty(Map<String, String> jobProperties) {
-    if (jobProperties == null) {
-      jobProperties = Maps.newHashMap();
-    }
-
-    this.jobProperties.putAll(jobProperties);
-  }
-
   public String getIngestionMode() {
     return ingestionMode;
   }
@@ -180,30 +118,6 @@ public class HadoopTuningConfig implements TuningConfig {
 
   public void setUseCombiner(Boolean useCombiner) {
     this.useCombiner = useCombiner;
-  }
-
-  public Map<String, String> getJobProperties() {
-    return jobProperties;
-  }
-
-  public void setJobProperties(Map<String, String> jobProperties) {
-    this.jobProperties = jobProperties;
-  }
-
-  public Boolean getBuildV9Directly() {
-    return buildV9Directly;
-  }
-
-  public void setBuildV9Directly(Boolean buildV9Directly) {
-    this.buildV9Directly = buildV9Directly;
-  }
-
-  public Long getMaxRowsInMemory() {
-    return maxRowsInMemory;
-  }
-
-  public void setMaxRowsInMemory(Long maxRowsInMemory) {
-    this.maxRowsInMemory = maxRowsInMemory;
   }
 
   public Long getMaxOccupationInMemory() {
@@ -270,14 +184,6 @@ public class HadoopTuningConfig implements TuningConfig {
     this.overwriteFiles = overwriteFiles;
   }
 
-  public Boolean getIgnoreInvalidRows() {
-    return ignoreInvalidRows;
-  }
-
-  public void setIgnoreInvalidRows(Boolean ignoreInvalidRows) {
-    this.ignoreInvalidRows = ignoreInvalidRows;
-  }
-
   public Boolean getAssumeTimeSorted() {
     return assumeTimeSorted;
   }
@@ -294,13 +200,4 @@ public class HadoopTuningConfig implements TuningConfig {
     this.partitionsSpec = partitionsSpec;
   }
 
-  @Override
-  public IndexSpec getIndexSpec() {
-    return indexSpec;
-  }
-
-  @Override
-  public void setIndexSpec(IndexSpec indexSpec) {
-    this.indexSpec = indexSpec;
-  }
 }

--- a/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/tuning/KafkaTuningConfig.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/tuning/KafkaTuningConfig.java
@@ -14,18 +14,10 @@
 
 package app.metatron.discovery.spec.druid.ingestion.tuning;
 
-import app.metatron.discovery.spec.druid.ingestion.index.IndexSpec;
-import org.apache.commons.beanutils.BeanUtils;
-import org.apache.commons.collections4.MapUtils;
-
-import java.util.Map;
-
 /**
  *
  */
-public class KafkaTuningConfig implements TuningConfig {
-
-  Integer maxRowsInMemory;
+public class KafkaTuningConfig extends AbstractTuningConfig {
 
   Integer maxOccupationInMemory;
 
@@ -34,8 +26,6 @@ public class KafkaTuningConfig implements TuningConfig {
   String intermediatePersistPeriod;
 
   Integer maxPendingPersists;
-
-  Boolean buildV9Directly;
 
   Boolean reportParseExceptions;
 
@@ -49,24 +39,7 @@ public class KafkaTuningConfig implements TuningConfig {
 
   String offsetFetchPeriod;
 
-  Boolean ignoreInvalidRows;
-
-  IndexSpec indexSpec;
-
   public KafkaTuningConfig() {
-  }
-
-  public void overrideConfig(Map<String, Object> tuningConfig) {
-
-    if (MapUtils.isNotEmpty(tuningConfig)) {
-      for (String key : tuningConfig.keySet()) {
-        try {
-          BeanUtils.setProperty(this, key, tuningConfig.get(key));
-        } catch (Exception e) {
-        }
-      }
-    }
-
   }
 
   public static KafkaTuningConfig defaultConfig() {
@@ -74,14 +47,6 @@ public class KafkaTuningConfig implements TuningConfig {
     config.setMaxRowsPerSegment(5000000);
 
     return config;
-  }
-
-  public Integer getMaxRowsInMemory() {
-    return maxRowsInMemory;
-  }
-
-  public void setMaxRowsInMemory(Integer maxRowsInMemory) {
-    this.maxRowsInMemory = maxRowsInMemory;
   }
 
   public Integer getMaxOccupationInMemory() {
@@ -114,14 +79,6 @@ public class KafkaTuningConfig implements TuningConfig {
 
   public void setMaxPendingPersists(Integer maxPendingPersists) {
     this.maxPendingPersists = maxPendingPersists;
-  }
-
-  public Boolean getBuildV9Directly() {
-    return buildV9Directly;
-  }
-
-  public void setBuildV9Directly(Boolean buildV9Directly) {
-    this.buildV9Directly = buildV9Directly;
   }
 
   public Boolean getReportParseExceptions() {
@@ -172,21 +129,4 @@ public class KafkaTuningConfig implements TuningConfig {
     this.offsetFetchPeriod = offsetFetchPeriod;
   }
 
-  public Boolean getIgnoreInvalidRows() {
-    return ignoreInvalidRows;
-  }
-
-  public void setIgnoreInvalidRows(Boolean ignoreInvalidRows) {
-    this.ignoreInvalidRows = ignoreInvalidRows;
-  }
-
-  @Override
-  public IndexSpec getIndexSpec() {
-    return indexSpec;
-  }
-
-  @Override
-  public void setIndexSpec(IndexSpec indexSpec) {
-    this.indexSpec = indexSpec;
-  }
 }

--- a/discovery-server/src/test/java/app/metatron/discovery/spec/druid/ingestion/IndexSpecTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/spec/druid/ingestion/IndexSpecTest.java
@@ -34,6 +34,7 @@ import app.metatron.discovery.domain.datasource.Field;
 import app.metatron.discovery.domain.datasource.ingestion.HiveIngestionInfo;
 import app.metatron.discovery.domain.datasource.ingestion.file.OrcFileFormat;
 import app.metatron.discovery.domain.datasource.ingestion.file.ParquetFileFormat;
+import app.metatron.discovery.spec.druid.ingestion.index.IndexSpec;
 import app.metatron.discovery.util.PolarisUtils;
 
 import static app.metatron.discovery.domain.datasource.DataSource.ConnectionType.ENGINE;
@@ -169,4 +170,91 @@ public class IndexSpecTest {
     }
     assertTrue(thrown);
   }
+
+  @Test
+  public void BatchTuningConfigTest() {
+    IngestionSpecBuilder ingestionSpecBuilder = new IngestionSpecBuilder();
+    Map<String, Object> tuningProperties = Maps.newHashMap();
+    tuningProperties.put("workingPath", "data");
+    tuningProperties.put("ignoreInvalidRows", true);
+
+    IndexSpec indexSpec = new IndexSpec();
+    indexSpec.setAllowNullForNumbers(true);
+
+    tuningProperties.put("indexSpec", indexSpec);
+
+    IngestionSpec ingestionSpec = ingestionSpecBuilder.batchTuningConfig(tuningProperties).build();
+
+    String s = GlobalObjectMapper.writeValueAsString(ingestionSpec);
+
+    System.out.println(s);
+
+    DocumentContext jsonContext = JsonPath.parse(s);
+
+    assertThat(jsonContext.read("$['tuningConfig']['type']"), is("index"));
+    assertThat(jsonContext.read("$['tuningConfig']['workingPath']"), is("data"));
+    assertThat(jsonContext.read("$['tuningConfig']['indexSpec']['allowNullForNumbers']"), is(true));
+
+  }
+
+  @Test
+  public void HdfsTuningConfigTest() {
+    IngestionSpecBuilder ingestionSpecBuilder = new IngestionSpecBuilder();
+
+    Map<String, Object> tuningProperties = Maps.newHashMap();
+    tuningProperties.put("ignoreInvalidRows", true);
+
+    IndexSpec indexSpec = new IndexSpec();
+    indexSpec.setAllowNullForNumbers(true);
+
+    tuningProperties.put("indexSpec", indexSpec);
+
+    Map<String, Object> jobProperties = Maps.newHashMap();
+    jobProperties.put("abc", "def");
+    jobProperties.put("mapreduce.map.memory.mb", 1024);
+
+    IngestionSpec ingestionSpec = ingestionSpecBuilder.hdfsTuningConfig(tuningProperties, jobProperties).build();
+
+    String s = GlobalObjectMapper.writeValueAsString(ingestionSpec);
+
+    System.out.println(s);
+
+    DocumentContext jsonContext = JsonPath.parse(s);
+
+    assertThat(jsonContext.read("$['tuningConfig']['type']"), is("hadoop"));
+    assertThat(jsonContext.read("$['tuningConfig']['ignoreInvalidRows']"), is(true));
+    assertThat(jsonContext.read("$['tuningConfig']['indexSpec']['allowNullForNumbers']"), is(true));
+    assertThat(jsonContext.read("$['tuningConfig']['jobProperties']['mapreduce.map.memory.mb']"), is("1024"));
+
+  }
+
+  @Test
+  public void KafkaTuningConfigTest() {
+    KafkaRealTimeIndexBuilder ingestionSpecBuilder = new KafkaRealTimeIndexBuilder();
+
+    Map<String, Object> tuningProperties = Maps.newHashMap();
+    tuningProperties.put("ignoreInvalidRows", true);
+
+    IndexSpec indexSpec = new IndexSpec();
+    indexSpec.setAllowNullForNumbers(true);
+
+    tuningProperties.put("indexSpec", indexSpec);
+
+    Map<String, Object> jobProperties = Maps.newHashMap();
+    jobProperties.put("abc", "def");
+
+    KafkaRealTimeIndex realTimeIndex = ingestionSpecBuilder.tuningConfig(tuningProperties).build();
+
+    String s = GlobalObjectMapper.writeValueAsString(realTimeIndex);
+
+    System.out.println(s);
+
+    DocumentContext jsonContext = JsonPath.parse(s);
+
+    assertThat(jsonContext.read("$['tuningConfig']['type']"), is("kafka"));
+    assertThat(jsonContext.read("$['tuningConfig']['ignoreInvalidRows']"), is(true));
+    assertThat(jsonContext.read("$['tuningConfig']['indexSpec']['allowNullForNumbers']"), is(true));
+
+  }
+
 }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Apache Common's BeanUtils can not convert nested object directly.
So I changed the copying properties logic and enhance some code clairity.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#3828 


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Added unit test
2. Patch an existing datasource and check the nested spec is preserving

#### Need additional checks?



### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
