### PR TITLE
#3857 Removed the API for querying filter candidate values from the dashboard query screen.

### DIFF
--- a/discovery-frontend/src/app/app.component.ts
+++ b/discovery-frontend/src/app/app.component.ts
@@ -28,6 +28,7 @@ import {EventBroadcaster} from '@common/event/event.broadcaster';
 import {UserSetting} from '@common/value/user.setting.value';
 import {CommonUtil} from '@common/util/common.util';
 import {FormatOptionConverter} from '@common/component/chart/option/converter/format-option-converter';
+import {environment} from '@environments/environment';
 
 @Component({
   selector: 'app-root',
@@ -46,6 +47,13 @@ export class AppComponent implements AfterContentChecked {
               private broadCaster: EventBroadcaster,
               private router: Router,
               protected injector: Injector) {
+
+    if(environment.production) {
+      console.log = () => {};
+      console.warn = () => {};
+      // tslint:disable-next-line:no-console
+      console.info = () => {};
+    }
 
     this.changeDetect = injector.get(ChangeDetectorRef);
 

--- a/discovery-frontend/src/app/workbook/workbook.component.ts
+++ b/discovery-frontend/src/app/workbook/workbook.component.ts
@@ -234,7 +234,6 @@ export class WorkbookComponent extends AbstractComponent implements OnInit, OnDe
     // Init
     super.ngOnInit();
 
-
     // 로딩 표시
     this.loadingShow();
 

--- a/discovery-frontend/src/assets/css/lib/dnd/style.css
+++ b/discovery-frontend/src/assets/css/lib/dnd/style.css
@@ -22,3 +22,30 @@
   opacity:0.7;
   border: 1px dashed #000;
 }
+
+/************************************************************************************************************
+   워크북 내 대시보드 목록 정렬 관련 스타일 지정
+***********************************************************************************************************/
+li.gu-mirror {padding-top:15px;}
+li.gu-mirror a {display:block; position:relative; padding:0 11px 0 37px;}
+li.gu-mirror a span.ddp-icon-number {display:inline-block; position:absolute; top:0; left:20px; color:#90969f; font-size:13px;}
+li.gu-mirror a span.ddp-wrap-image {display:block; position:relative; width:100%; height:156px; margin-bottom:5px; border:1px solid #e7e7ea;}
+li.gu-mirror a span.ddp-wrap-image img {width:100%; height:100%; position:relative; z-index:1;}
+
+li.gu-mirror a span.ddp-wrap-image:after {display:inline-block; position:absolute; top:50%; left:50%; margin:-14px 0 0 -17px; width:34px; height:28px; background:url(../../../images/img_board_default2.png) no-repeat; content:'';}
+
+li.gu-mirror a span.ddp-data-name {display:block; position:relative; width:100%; padding-bottom:10px; padding-left:23px; color:#90969f; font-size:13px; overflow:hidden; white-space:nowrap; text-overflow:ellipsis; word-wrap:normal; box-sizing:border-box;}
+li.gu-mirror a span.ddp-data-name em[class*="ddp-icon-eyes2"] {position:absolute; top:2px; left:0;}
+li.gu-mirror a span.ddp-data-name em.ddp-icon-eyes2 {background-position:-17px top;}
+li.gu-mirror a .ddp-btn-control {display:none;}
+
+li.gu-mirror a span.ddp-ui-number {float:left; width:42px; height:100%; text-align:center; color:#90969f; font-size:14px;}
+li.gu-mirror a .ddp-ui-name {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  word-wrap: normal;
+  box-sizing: border-box;
+}


### PR DESCRIPTION
### Description
Removed the API for querying filter candidate values from the dashboard query screen.

**Related Issue** : #3857 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Create a dashboard that uses filters but does not place widgets.
2. Check if the filter candidate values are inquired during the initial inquiry of the dashboard.
3. Check that the candidate values are normally displayed in the top filter summary information.

#### Need additional checks?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
