### PR TITLE
remove websocket retry message toast

### DIFF
--- a/discovery-frontend/src/app/common/component/abstract.component.ts
+++ b/discovery-frontend/src/app/common/component/abstract.component.ts
@@ -797,7 +797,8 @@ export class AbstractComponent implements OnInit, AfterViewInit, OnDestroy, CanC
     this._webSocketReConnectCnt = this._webSocketReConnectCnt + 1;
     // 초기화 -> 연결 재 시도
     if (20 === this._webSocketReConnectCnt) {
-      Alert.error(this.translateService.instant(this.translateService.instant('msg.bench.alert.socket.link.fail.retry')));
+      //Alert.error(this.translateService.instant(this.translateService.instant('msg.bench.alert.socket.link.fail.retry')));
+      console.error(this.translateService.instant(this.translateService.instant('msg.bench.alert.socket.link.fail.retry')));
       (isReload) && (window.location.reload());
     }
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
remove websocket retry message toast

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. If websocket reconnection is attempted more than 20 times, the existing toast pop-up is removed.
#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
