### PR TITLE
Fix config overriding when tuningConfig is null

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/tuning/AbstractTuningConfig.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/tuning/AbstractTuningConfig.java
@@ -55,12 +55,18 @@ public abstract class AbstractTuningConfig implements TuningConfig {
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     String configJson;
-    try {
-      configJson = mapper.writeValueAsString(tuningConfig);
-      copyProperties(mapper.readValue(configJson, this.getClass()), this, tuningConfig.keySet());
-    } catch (Exception e) {
-      throw new DataSourceException(DataSourceErrorCodes.INGESTION_COMMON_ERROR, e.getMessage());
+
+    if (tuningConfig != null) {
+      try {
+        configJson = mapper.writeValueAsString(tuningConfig);
+        copyProperties(mapper.readValue(configJson, this.getClass()), this, tuningConfig.keySet());
+      } catch (Exception e) {
+        throw new DataSourceException(DataSourceErrorCodes.INGESTION_COMMON_ERROR, e.getMessage());
+      }
+    } else {
+      LOGGER.info("There were no tuningConfigs. Skip overriding.");
     }
+
 
   }
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
When overriding the tuningConfig for the real-time datasource, 
an error occurs if the tugningConfig does not exist.

So skip the overriding method when the tuningConfig is null.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->
#3828 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
already applied to the GV environment and prove it.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
