### PR TITLE
#3925 Reset when changing global filter after adjusting grid chart width

### DIFF
--- a/discovery-frontend/src/app/common/component/chart/type/grid-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/grid-chart.component.ts
@@ -594,6 +594,30 @@ export class GridChartComponent extends BaseChart<UIGridChart> implements OnInit
 
       if( this.isNotUpdateWidth ) {
         this.gridModel.columnWidth = this.chart.getLeafColumnWidth();
+      } else {
+        if( this.gridModel.columnWidth ) {
+          const colWidth = JSON.parse(JSON.stringify(this.gridModel.columnWidth));
+          if( colWidth ) {
+            let isFitWidth: boolean = false;
+            const pixelWidth = Object.keys(colWidth).reduce((acc, key) => {
+              if( 0 < colWidth[key] ) {
+                return acc + colWidth[key];
+              } else {
+                isFitWidth = true;
+                return acc;
+              }
+            }, 0);
+            if( isFitWidth ) {
+              const currWidth = this.$element.find('.chartCanvas').width() - pixelWidth;
+              Object.keys(colWidth).forEach(key => {
+                if( 0 > colWidth[key] ) {
+                  colWidth[key] = colWidth[key] * currWidth;
+                }
+              });
+              this.gridModel.columnWidth = colWidth;
+            }
+          }
+        }
       }
 
       this.chart.initialize(data, this.gridModel);

--- a/discovery-frontend/src/app/common/component/chart/type/grid-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/grid-chart.component.ts
@@ -600,7 +600,7 @@ export class GridChartComponent extends BaseChart<UIGridChart> implements OnInit
           if( colWidth ) {
             let isFitWidth: boolean = false;
             const pixelWidth = Object.keys(colWidth).reduce((acc, key) => {
-              if( 0 < colWidth[key] ) {
+              if( 1 < colWidth[key] ) {
                 return acc + colWidth[key];
               } else {
                 isFitWidth = true;
@@ -610,7 +610,7 @@ export class GridChartComponent extends BaseChart<UIGridChart> implements OnInit
             if( isFitWidth ) {
               const currWidth = this.$element.find('.chartCanvas').width() - pixelWidth;
               Object.keys(colWidth).forEach(key => {
-                if( 0 > colWidth[key] ) {
+                if( 1 > colWidth[key] ) {
                   colWidth[key] = colWidth[key] * currWidth;
                 }
               });

--- a/discovery-frontend/src/app/common/component/chart/type/grid-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/grid-chart.component.ts
@@ -70,6 +70,9 @@ export class GridChartComponent extends BaseChart<UIGridChart> implements OnInit
   @Input()
   public viewMode: boolean = false;
 
+  @Input()
+  public isNotUpdateWidth: boolean = false;
+
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Constructor
    |-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=*/
@@ -588,6 +591,11 @@ export class GridChartComponent extends BaseChart<UIGridChart> implements OnInit
 
     // 차트 데이터 주입
     try {
+
+      if( this.isNotUpdateWidth ) {
+        this.gridModel.columnWidth = this.chart.getLeafColumnWidth();
+      }
+
       this.chart.initialize(data, this.gridModel);
     } catch (e) {
       console.log(e);

--- a/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.html
+++ b/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.html
@@ -275,6 +275,7 @@
     <grid-chart #chart
                 *ngIf="chartType === 'grid' && uiOption" [uiOption]="uiOption" [isUpdateRedraw]="isUpdateRedraw"
                 [userCustomFunction]="userCustomFunction"
+                [isNotUpdateWidth]="isNotUpdateWidth"
                 (uiOptionUpdated)="uiOptionUpdatedHandler($event)"
                 (chartSelectInfo)="chartSelectInfo($event)"
                 (noData)="showNoData()"

--- a/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
+++ b/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
@@ -203,6 +203,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent<PageWidget>
 
   // 그리드에서 사용하는 옵션 ({}을 넣게되면 차트를 그릴때 uiOption값이 없는데도 차트를 그리다가 오류가 발생하므로 제거하였음 by juhee)
   public gridUiOption: UIOption;
+  public isNotUpdateWidth: boolean = false;
 
   /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
    | Public Variables - Input & Output
@@ -734,6 +735,10 @@ export class PageWidgetComponent extends AbstractWidgetComponent<PageWidget>
 
       // 새로고침 다시 그림 여부 설정
       this.isUpdateRedraw = (LayoutMode.EDIT === this.layoutMode);
+
+      if( this.layoutMode !== LayoutMode.EDIT) {
+        this.isNotUpdateWidth = true;
+      }
 
       this.processEnd();
       this._isDuringProcess = false;

--- a/discovery-frontend/src/app/page/page.component.ts
+++ b/discovery-frontend/src/app/page/page.component.ts
@@ -1191,7 +1191,25 @@ export class PageComponent extends AbstractPopupComponent implements OnInit, OnD
       }
 
       if (ChartType.GRID.toString() === this.selectChart && this.chart.chart) {
-        param.configuration.chart.gridColumnWidth = this.chart.chart.getLeafColumnWidth();
+        const chartAreaWidth = $( '.ddp-ui-chart-area' ).width();
+        const leafColWidth = this.chart.chart.getLeafColumnWidth();
+        const totalWidth = Object.keys(leafColWidth).reduce((acc, key) => {
+          return acc + leafColWidth[key];
+        }, 0);
+        if( 10 > Math.abs( chartAreaWidth - totalWidth ) ) {
+          const leftColWidth = this.pivot.rows.reduce((acc, row) => {
+            return acc + leafColWidth[row.name] ? leafColWidth[row.name] : 0;
+          }, 0);
+          const dataAreaWidth = totalWidth - leftColWidth;
+          Object.keys(leafColWidth).forEach(key => {
+            if( -1 === this.pivot.rows.findIndex( row => row.name === key ) ) {
+              leafColWidth[key] = leafColWidth[key] / dataAreaWidth;
+            }
+          });
+          param.configuration.chart.gridColumnWidth = leafColWidth;
+        } else {
+          param.configuration.chart.gridColumnWidth = leafColWidth;
+        }
       }
 
       // 서버에 저장될필요 없는 파라미터 제거
@@ -1222,13 +1240,13 @@ export class PageComponent extends AbstractPopupComponent implements OnInit, OnD
               const configuration = {configuration: pageWidget.configuration, imageUrl: res['imageUrl']};
               this.widgetService
                 .updateWidget(pageWidget.id, configuration)
-                .then(() => {
+                .then((savedPageWidget) => {
+                  pageWidget.imageUrl = savedPageWidget.imageUrl;
                   this.popupService.notiPopup({
                     name: 'create-page-complete',
                     data: pageWidget
                   });
                 });
-
             })
             .catch((err) => {
               console.log('image upload error', err);
@@ -1252,7 +1270,25 @@ export class PageComponent extends AbstractPopupComponent implements OnInit, OnD
       };
 
       if (ChartType.GRID.toString() === this.selectChart && this.chart.chart) {
-        param.configuration.chart['gridColumnWidth'] = this.chart.chart.getLeafColumnWidth();
+        const chartAreaWidth = $( '.ddp-ui-chart-area' ).width();
+        const leafColWidth = this.chart.chart.getLeafColumnWidth();
+        const totalWidth = Object.keys(leafColWidth).reduce((acc, key) => {
+          return acc + leafColWidth[key];
+        }, 0);
+        if( 10 > Math.abs( chartAreaWidth - totalWidth ) ) {
+          const leftColWidth = this.pivot.rows.reduce((acc, row) => {
+            return acc + leafColWidth[row.name] ? leafColWidth[row.name] : 0;
+          }, 0);
+          const dataAreaWidth = totalWidth - leftColWidth;
+          Object.keys(leafColWidth).forEach(key => {
+            if( -1 === this.pivot.rows.findIndex( row => row.name === key ) ) {
+              leafColWidth[key] = leafColWidth[key] / dataAreaWidth;
+            }
+          });
+          param.configuration.chart['gridColumnWidth'] = leafColWidth;
+        } else {
+          param.configuration.chart['gridColumnWidth'] = leafColWidth;
+        }
       }
 
       // 서버에 저장될필요 없는 파라미터 제거


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Reset when changing global filter after adjusting grid chart width

**Related Issue** : #3925 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Create a dashboard with a grid chart and filter widget.
2. Check if the width of the grid chart is maintained when you change the filter on the browse screen.

#### Need additional checks?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
