### PR TITLE
fix legend color by removing duplicated data

### DIFF
--- a/discovery-frontend/src/app/common/component/chart/option/converter/legend-option-converter.ts
+++ b/discovery-frontend/src/app/common/component/chart/option/converter/legend-option-converter.ts
@@ -14,7 +14,7 @@
 
 import { BaseOption } from '../base-option';
 import { UIOption } from '../ui-option';
-import { Orient } from '../define/common';
+import {ChartColorType, Orient} from '../define/common';
 import { DataZoomType } from '../define/datazoom';
 import * as _ from 'lodash';
 
@@ -59,6 +59,11 @@ export class LegendOptionConverter {
       if (option.legend) {
         option.legend.show = false;
       }
+    }
+
+    // 차원값이 A x B 가 될 경우, 범례 값이 중복되는 것 삭제
+    if(_.eq(uiOption.color.type, ChartColorType.DIMENSION) && option.legend.show){
+     option.legend.data = option.legend.data.filter((el,i,a) => i === a.indexOf(el));
     }
 
     // Grid가 존재하는 경우 범례 표시 여부에 따라 크기 변경


### PR DESCRIPTION
### Description
Fixed an error where the chart's legend and color settings did not match

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Create a chart and display a legend.
2. While changing the color settings, make sure they are applied properly to the legend.

#### Need additional checks?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
