### PR TITLE
Chart and legend colors are displayed differently

### DIFF
--- a/discovery-frontend/src/app/common/component/chart/base-chart.ts
+++ b/discovery-frontend/src/app/common/component/chart/base-chart.ts
@@ -1587,14 +1587,15 @@ export abstract class BaseChart<T extends UIOption> extends AbstractComponent im
         }
 
         this.chartOption.legend.data = legendData;
-        if(this.isNullOrUndefined(this.chartOption.legend.color)){
+        if(this.isNullOrUndefined(this.chartOption.legend.color)
+          || this.chartOption.legend.color.length < this.chartOption.series.length){ // 최종 범례 값이 차트 색보다 많을 경우
           this.chartOption.legend.color = ChartColorList[this.uiOption.color['schema']];
 
         }
 
         // 사용자 색상 설정 리스트에 맞춰 범례 값 색 정의
         if(!this.isNullOrUndefined(this.uiOption.color['mappingArray'])
-          && this.uiOption.color['mappingArray'].length > 0 && this.uiOption.type!='bar'){
+          && this.uiOption.color['mappingArray'].length > 0 && this.uiOption.type=='pie'){
           legendData.forEach((legend, index) => {
             const legendIdx = this.uiOption.color['mappingArray'].findIndex(item => {
               return item['alias'] == legend;

--- a/discovery-frontend/src/app/common/component/chart/option/converter/legend-option-converter.ts
+++ b/discovery-frontend/src/app/common/component/chart/option/converter/legend-option-converter.ts
@@ -62,7 +62,7 @@ export class LegendOptionConverter {
     }
 
     // 차원값이 A x B 가 될 경우, 범례 값이 중복되는 것 삭제
-    if(_.eq(uiOption.color.type, ChartColorType.DIMENSION) && option.legend.show){
+    if(_.eq(uiOption.color.type, ChartColorType.DIMENSION) && option.legend.show && uiOption.fielDimensionList.length > 0){
      option.legend.data = option.legend.data.filter((el,i,a) => i === a.indexOf(el));
     }
 


### PR DESCRIPTION
### Description
Chart and legend colors are displayed differently

**Related Issue** : #3936 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
If you put one dimension value on the cross shelf and set the color setting to the dimension value, the legend color is displayed strangely.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
