### PR TITLE
#3968 set right granularity of download grid chart

### DIFF
--- a/discovery-frontend/src/app/page/page-pivot/page-pivot.component.ts
+++ b/discovery-frontend/src/app/page/page-pivot/page-pivot.component.ts
@@ -1356,11 +1356,10 @@ export class PagePivotComponent extends AbstractComponent implements OnInit, OnD
   public onSetGranularity(discontinuous: boolean, unit: string, byUnit?: string) {
 
     // disabled된 granularity 선택시 return
-    if (this.editingField.granularityList &&
+    if (!this.isNullOrUndefined(this.editingField.granularityList) &&
       -1 !== this.editingField.granularityList.indexOf(unit)) {
       return;
     }
-
     this.editingField.format = new Format();
     this.editingField.format.type = String(UIFormatType.TIME_CONTINUOUS);
     this.editingField.format.discontinuous = discontinuous;
@@ -1368,6 +1367,9 @@ export class PagePivotComponent extends AbstractComponent implements OnInit, OnD
     if (discontinuous) {
       this.editingField.format.byUnit = ByTimeUnit[byUnit];
     }
+
+    this.editingField.granularity = TimeUnit[unit];
+    this.editingField.segGranularity = TimeUnit[unit];
 
     this.changePivot(EventType.GRANULARITY);
   }
@@ -1596,7 +1598,7 @@ export class PagePivotComponent extends AbstractComponent implements OnInit, OnD
 
     const $this = $(event.currentTarget);
     // this.$editFieldLayer.show();
-    console.log('openFieldSetting', this.$editFieldLayer.width(), $this.offset());
+    // console.log('openFieldSetting', this.$editFieldLayer.width(), $this.offset());
 
     if ($this.offset().left > $(window).width() / 2) {
       this.$editFieldLayer.css(


### PR DESCRIPTION
### Description
After changing the granularity of the timestamp field of the grid to MONTH and downloading the chart data, the granularity is being downloaded as DAY.

**Related Issue** : #3968 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
After changing the granularity of the timestamp field of the grid to MONTH, check if the granularity is normally applied when the chart data is downloaded.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
