### PR TITLE
#3977 remove athena jdbc dependency

### DIFF
--- a/discovery-extensions/athena-connection/README.md
+++ b/discovery-extensions/athena-connection/README.md
@@ -5,11 +5,33 @@ Athena Connection Extension
 ==================================
 Connection Extension for AWS Athena with JDBC.
 
-The Athena JDBC Driver version used is 2.0.2.
-
 For more information, refer to the JDBC Driver Documentation section of the page below.
 
 https://docs.aws.amazon.com/athena/latest/ug/connect-with-jdbc.html
+
+
+How to Compile Athena JDBC Plugin
+==================================
+Step 1. Download the JDBC driver from the link below.
+----------------------------------
+As of writing the guide, the JdbcDriver version is 2.0.27.
+
+Web Page : https://docs.aws.amazon.com/athena/latest/ug/connect-with-jdbc.html
+
+Archived JDBC Driver Link in Page : https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC-2.0.27.1000/AthenaJDBC42_2.0.27.1000.jar
+
+
+Step 2. copy it under athena-connection/src/main/resources/lib.
+----------------------------------
+```
+cp AthenaJDBC42_2.0.27.1000.jar metatron-discovery/discovery-extensions/athena-connection/src/main/resources/lib/
+``` 
+
+Step 3. Execute maven build.
+----------------------------------
+```
+mvn -P extensions-all clean install
+``` 
 
 
 How to connect Athena via JDBC
@@ -20,7 +42,7 @@ There are various ways to configure connection URL.
 
 See the following page for a detailed configure guide.
 
-https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC_2.0.2/docs/Simba+Athena+JDBC+Driver+Install+and+Configuration+Guide.pdf
+https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC-2.0.27.1000/doc/Simba+Athena+JDBC+Connector+Install+and+Configuration+Guide.pdf
 
 Sample using endpoint URL can be configured as below.
 

--- a/discovery-extensions/athena-connection/pom.xml
+++ b/discovery-extensions/athena-connection/pom.xml
@@ -122,13 +122,5 @@
             </plugin>
         </plugins>
     </build>
-    <dependencies>
-        <!-- Athena -->
-        <!-- https://mvnrepository.com/artifact/com.syncron.amazonaws/simba-athena-jdbc-driver -->
-        <dependency>
-            <groupId>com.syncron.amazonaws</groupId>
-            <artifactId>simba-athena-jdbc-driver</artifactId>
-            <version>2.0.2</version>
-        </dependency>
-    </dependencies>
+
 </project>

--- a/discovery-extensions/athena-connection/src/main/assembly/assembly.xml
+++ b/discovery-extensions/athena-connection/src/main/assembly/assembly.xml
@@ -7,8 +7,8 @@
 	<includeBaseDirectory>false</includeBaseDirectory>
 	<dependencySets>
 		<dependencySet>
-            <useProjectArtifact>false</useProjectArtifact>
-            <scope>runtime</scope>
+			<useProjectArtifact>false</useProjectArtifact>
+			<scope>runtime</scope>
 			<outputDirectory>lib</outputDirectory>
 			<includes>
 				<include>*:jar:*</include>
@@ -19,6 +19,13 @@
 		<fileSet>
 			<directory>target/plugin-classes</directory>
 			<outputDirectory>classes</outputDirectory>
+			<excludes>
+				<exclude>lib/**</exclude>
+			</excludes>
+		</fileSet>
+		<fileSet>
+			<directory>target/plugin-classes/lib</directory>
+			<outputDirectory>lib</outputDirectory>
 		</fileSet>
 	</fileSets>
 </assembly>

--- a/discovery-extensions/pom.xml
+++ b/discovery-extensions/pom.xml
@@ -19,7 +19,6 @@
             </activation>
             <modules>
                 <module>mssql-connection</module>
-                <module>athena-connection</module>
             </modules>
         </profile>
         <profile>


### PR DESCRIPTION

### Description
athena jdbc dependency removed from maven central.
Updated README.md so that users can directly download and compile the jdbc driver.

**Related Issue** : #3977 


### How Has This Been Tested?


#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
