### PR TITLE
fix download chart data  with timestamp field that is a dimension role

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/data/SearchQueryRequest.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/data/SearchQueryRequest.java
@@ -70,9 +70,11 @@ import app.metatron.discovery.domain.workbook.configurations.Limit;
 import app.metatron.discovery.domain.workbook.configurations.Pivot;
 import app.metatron.discovery.domain.workbook.configurations.analysis.Analysis;
 import app.metatron.discovery.domain.workbook.configurations.datasource.DataSource;
+import app.metatron.discovery.domain.workbook.configurations.field.DimensionField;
 import app.metatron.discovery.domain.workbook.configurations.field.ExpressionField;
 import app.metatron.discovery.domain.workbook.configurations.field.Field;
 import app.metatron.discovery.domain.workbook.configurations.field.MeasureField;
+import app.metatron.discovery.domain.workbook.configurations.field.TimestampField;
 import app.metatron.discovery.domain.workbook.configurations.field.UserDefinedField;
 import app.metatron.discovery.domain.workbook.configurations.filter.Filter;
 import app.metatron.discovery.domain.workbook.configurations.widget.shelf.Shelf;
@@ -335,6 +337,9 @@ public class SearchQueryRequest extends AbstractQueryRequest implements QueryReq
         // follow ui rule
         field.setAlias(((MeasureField) field).getUserDefinedAlias());
         this.projections.add(field);
+      } else if(field instanceof TimestampField
+          && app.metatron.discovery.domain.datasource.Field.FieldRole.DIMENSION.equals(((TimestampField) field).getSubRole())) {
+          this.projections.add(new DimensionField(field.getName(), field.getAlias(), field.getRef(), field.getFormat()));
       } else {
         this.projections.add(field);
       }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/field/TimestampField.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/workbook/configurations/field/TimestampField.java
@@ -35,6 +35,8 @@ public class TimestampField extends Field {
 
   FieldFormat format;
 
+  app.metatron.discovery.domain.datasource.Field.FieldRole subRole;
+
   public TimestampField() {
   }
 
@@ -82,6 +84,10 @@ public class TimestampField extends Field {
 
   public Granularity getGranularity() {
     return granularity;
+  }
+
+  public app.metatron.discovery.domain.datasource.Field.FieldRole getSubRole() {
+    return subRole;
   }
 
   @JsonIgnore


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
fix download chart data  with timestamp field that is a dimension role

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Create a grid chart using a data source that includes a timestamp field that is a dimension role, 
2. Save table as file.
3. Make sure the correct data is displayed.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
