### PR TITLE
add websocket disconnection when is onbeforeunload called

### DIFF
--- a/discovery-frontend/proxy.conf.js
+++ b/discovery-frontend/proxy.conf.js
@@ -8,9 +8,9 @@ const PROXY_CONFIG = [
       "/resources"
     ],
     target: {
-      host: 't1-discovery.metatron.bundang10f.io',
+      host: 'localhost',
       protocol: 'http:',
-      port: 80
+      port: 8180
     },
     secure: false,
     changeOrigin: true,
@@ -23,9 +23,9 @@ const PROXY_CONFIG = [
       "/stomp"
     ],
     target: {
-      host: 't1-discovery.metatron.bundang10f.io',
+      host: 'localhost',
       protocol: 'http:',
-      port: 80
+      port: 8180
     },
     secure: false,
     changeOrigin: true,

--- a/discovery-frontend/src/app/common/component/abstract.component.ts
+++ b/discovery-frontend/src/app/common/component/abstract.component.ts
@@ -193,6 +193,8 @@ export class AbstractComponent implements OnInit, AfterViewInit, OnDestroy, CanC
    */
   @HostListener('window:beforeunload', ['$event'])
   public beforeUnloadHandler(event) {
+    this.disconnectWebSocket();
+
     this.execBeforeUnload();
     if (this.useUnloadConfirm) {
       const confirmationMessage: string = this.translateService.instant('msg.comm.ui.beforeunload');


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
add websocket disconnection when is onbeforeunload called

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Check the websocket disconnection logging when is onbeforeunload called.
2. Check whether the workbench query is normally executed.
3. Check if the activity stream is added normally.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
