### PR TITLE
Remove 'X' button when showing access log dialog on log-in page

### DIFF
--- a/discovery-server/src/main/resources/templates/api/oauth/login.html
+++ b/discovery-server/src/main/resources/templates/api/oauth/login.html
@@ -546,9 +546,14 @@
                });
     },
     showConfirm: function (title, desc, done, showCancel) {
-      $('#confirm-close').unbind('click').bind('click', function() {
-        $('.popup_common').removeClass('is-show');
-      })
+      if (done === 'showAccessLog') {
+        $('#confirm-close').hide();
+      } else {
+        $('#confirm-close').unbind('click').bind('click', function () {
+          $('.popup_common').removeClass('is-show');
+        })
+      }
+
       if (showCancel) {
         $('#confirm-cancel').show();
         $('#confirm-cancel').unbind('click').bind('click', function() {


### PR DESCRIPTION
### Description
로그인 페이지에서 로그인이 성공한 후 나타나는 Welcome 다이얼로그내 아래 이미지와 같이 "X" 가 노출되어있습니다. 이때 "X" 버튼을 클릭하면 로그인이 완료된 후에도 로그인 화면이 그대로 남겨져있는 문제가 있습니다.  이러한 상황을 방지하고자, X 버튼 제거를 제안 드립니다. 

'X' button is exposed as shown in the image below on the welcome(accesslog) dialog that appears after successful login on the login page. At this time, if you click the "X" button, there is a problem that the login screen remains even after login is completed. To prevent this situation, I suggest removing the 'X' button. 

![image](https://user-images.githubusercontent.com/822255/154215824-1db5a9f5-a770-4ae1-92a9-11216b7e80c3.png)
 
**Related Issue** :  #3905


### How Has This Been Tested?
1. Access external login page ex. https://dev-login.metatron.app/oauth/authorize?response_type=code&client_id=polaris_trusted&redirect_uri=http%3A%2F%2F52.231.101.87%3A8380%2Fapi%2Foauth%2Flogin&scope=trust%20read%20write?client_id=polaris_trusted&redirect_uri=http%3A%2F%2F52.231.101.87%3A8380%2Fapi%2Foauth%2Flogin
2. Login using normal account. ex admin 
3. Confirm welcome dialog without "X" button

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
