### PR TITLE
Improve email template for password reset

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/common/Mailer.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/common/Mailer.java
@@ -101,6 +101,7 @@ public class Mailer {
     String logoPath = (String) clientInfo.getOrDefault("logoFilePath", "/assets/images/mail/icon_logo.png");
     String title = (String) clientInfo.getOrDefault("clientName", this.title);
     String serviceUrl = (String) clientInfo.getOrDefault("clientBaseUrl", metatronProperties.getMail().getBaseUrl());
+    boolean defaultTpl = client == null ? true : false;
 
     Context context = new Context();
     context.setVariable("user", user);
@@ -109,6 +110,7 @@ public class Mailer {
     context.setVariable("title", title);
     context.setVariable("baseUrl", metatronProperties.getMail().getBaseUrl());
     context.setVariable("serviceUrl", serviceUrl);
+    context.setVariable("defaultTpl", defaultTpl);
 
     String templateName;
     if(isAdmin) {

--- a/discovery-server/src/main/java/app/metatron/discovery/common/Mailer.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/common/Mailer.java
@@ -16,6 +16,7 @@ package app.metatron.discovery.common;
 
 import com.google.common.collect.Lists;
 
+import com.google.common.collect.Maps;
 import org.apache.commons.lang3.CharEncoding;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,12 +26,15 @@ import org.springframework.context.MessageSource;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.scheduling.annotation.Async;
+import org.springframework.security.oauth2.provider.ClientDetails;
+import org.springframework.security.oauth2.provider.client.JdbcClientDetailsService;
 import org.springframework.stereotype.Component;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import javax.mail.internet.MimeMessage;
 
@@ -79,15 +83,32 @@ public class Mailer {
     }
   }
 
+  /**
+   * Send mail for providing a temporary password
+   *
+   * @param user
+   * @param client
+   * @param temporaryPassword
+   * @param isAdmin
+   * @param locale
+   */
   @Async
-  public void sendPasswordResetMail(User user, String temporaryPassword, boolean isAdmin) {
-    LOGGER.debug("Sending password reset e-mail to '{}'", user.getEmail());
+  public void sendPasswordResetMail(User user, ClientDetails client, String temporaryPassword, boolean isAdmin, Locale locale) {
+
+    LOGGER.debug("Sending password reset e-mail to '{}'", user.getEmail(), client, locale);
+
+    Map<String, Object> clientInfo = client == null ? Maps.newHashMap() : client.getAdditionalInformation();
+    String logoPath = (String) clientInfo.getOrDefault("logoFilePath", "/assets/images/mail/icon_logo.png");
+    String title = (String) clientInfo.getOrDefault("clientName", this.title);
+    String serviceUrl = (String) clientInfo.getOrDefault("clientBaseUrl", metatronProperties.getMail().getBaseUrl());
 
     Context context = new Context();
     context.setVariable("user", user);
     context.setVariable("temporaryPassword", temporaryPassword);
-    context.setVariable("title", this.getUpperCaseTitle());
+    context.setVariable("logoPath", metatronProperties.getMail().getBaseUrl() + logoPath);
+    context.setVariable("title", title);
     context.setVariable("baseUrl", metatronProperties.getMail().getBaseUrl());
+    context.setVariable("serviceUrl", serviceUrl);
 
     String templateName;
     if(isAdmin) {
@@ -97,7 +118,8 @@ public class Mailer {
     }
 
     String content = templateEngine.process(templateName, context);
-    String subject = this.getUpperCaseTitle() + " temporary password information";
+    String subject = "[" + title + "] "
+            + messageSource.getMessage("message.app.mail.temp.pwd.title", null, locale);
     sendEmail(Lists.newArrayList(user.getEmail()), subject, content, false, true);
   }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/auth/AuthenticationController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/auth/AuthenticationController.java
@@ -599,6 +599,9 @@ public class AuthenticationController {
     if (oauthClientInformation.getPassApprove() != null) {
       additionalInformation.put("passApprove", oauthClientInformation.getPassApprove());
     }
+    if (oauthClientInformation.getClientBaseUrl() != null) {
+      additionalInformation.put("clientBaseUrl", oauthClientInformation.getPassApprove());
+    }
   }
 
   private void logoutProcess(HttpServletRequest request, HttpServletResponse response) {

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/auth/AuthenticationController.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/auth/AuthenticationController.java
@@ -600,7 +600,7 @@ public class AuthenticationController {
       additionalInformation.put("passApprove", oauthClientInformation.getPassApprove());
     }
     if (oauthClientInformation.getClientBaseUrl() != null) {
-      additionalInformation.put("clientBaseUrl", oauthClientInformation.getPassApprove());
+      additionalInformation.put("clientBaseUrl", oauthClientInformation.getClientBaseUrl());
     }
   }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/auth/OauthClientInformation.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/auth/OauthClientInformation.java
@@ -67,6 +67,11 @@ public class OauthClientInformation implements Serializable {
    */
   Boolean passApprove;
 
+  /**
+   * Client service url (Use password reset mail)
+   */
+  String clientBaseUrl;
+
   public String getRedirectUri() {
     return redirectUri;
   }
@@ -189,5 +194,13 @@ public class OauthClientInformation implements Serializable {
 
   public void setPassApprove(Boolean passApprove) {
     this.passApprove = passApprove;
+  }
+
+  public String getClientBaseUrl() {
+    return clientBaseUrl;
+  }
+
+  public void setClientBaseUrl(String clientBaseUrl) {
+    this.clientBaseUrl = clientBaseUrl;
   }
 }

--- a/discovery-server/src/main/resources/messages/messages.properties
+++ b/discovery-server/src/main/resources/messages/messages.properties
@@ -916,6 +916,7 @@ message.app.mail.phone=연락처
 message.app.mail.terms=이용약관
 message.app.mail.privacy=개인정보 보호정책
 message.app.mail.home=<span>{0}</span>으로 이동
+message.app.mail.tologin=로그인 화면으로 이동
 
 message.app.mail.temp.pwd.title=임시 비밀번호 발급
 message.app.mail.temp.pwd.msg=시스템 관리자가 비밀번호를 초기화하였습니다.<br />아래 임시 비밀번호를 확인하시고 로그인 후 비밀번호를 꼭 재설정 해 주시기 바랍니다.

--- a/discovery-server/src/main/resources/messages/messages_en.properties
+++ b/discovery-server/src/main/resources/messages/messages_en.properties
@@ -944,13 +944,14 @@ message.app.oauth.confirm.description.iperror=You have been automatically logged
 #//////////////////////////////////
 message.app.mail.pwd=Password
 message.app.mail.userinfo=User information
-message.app.mail.username=User Name
+message.app.mail.username=Username
 message.app.mail.email=E-Mail
 message.app.mail.fullname=Full Name
 message.app.mail.phone=Phone
 message.app.mail.terms=Terms of service
 message.app.mail.privacy=Privacy Policy
 message.app.mail.home=Go to <span>{0}</span>
+message.app.mail.tologin=Go To Login Page
 
 message.app.mail.temp.pwd.title=Provide temporary password
 message.app.mail.temp.pwd.msg=The system administrator has reset the password.<br />Please check your temporary password below and be sure to reset your password after login.

--- a/discovery-server/src/main/resources/messages/messages_ko.properties
+++ b/discovery-server/src/main/resources/messages/messages_ko.properties
@@ -941,6 +941,7 @@ message.app.mail.phone=연락처
 message.app.mail.terms=이용약관
 message.app.mail.privacy=개인정보 보호정책
 message.app.mail.home=<span>{0}</span>으로 이동
+message.app.mail.tologin=로그인 화면으로 이동
 
 message.app.mail.temp.pwd.title=임시 비밀번호 발급
 message.app.mail.temp.pwd.msg=시스템 관리자가 비밀번호를 초기화하였습니다.<br />아래 임시 비밀번호를 확인하시고 로그인 후 비밀번호를 꼭 재설정 해 주시기 바랍니다.

--- a/discovery-server/src/main/resources/templates/api/email/user_reset_password.html
+++ b/discovery-server/src/main/resources/templates/api/email/user_reset_password.html
@@ -24,7 +24,7 @@
 <table style="width:780px; margin:auto; line-height:1em;border-spacing:0px; border-collapse:separate;">
     <tr>
         <td style="height:220px; background:url('/assets/images/mail/bg_header.png') no-repeat; background-size:100% 100%;  vertical-align:top;"
-            th:style="'height:220px; background-size:100% 100%;  vertical-align:top;'">
+            th:style="'height:220px;' + ${defaultTpl ? 'background:url(''/assets/images/mail/bg_header.png'') no-repeat;' : ''} + ' background-size:100% 100%; vertical-align:top;'">
             <!-- header -->
             <table style="width:100%;border-spacing:0px; border-collapse:separate;">
                 <tr>
@@ -34,12 +34,14 @@
                 </tr>
                 <tr>
                     <td style="padding:38px 0 25px 0; text-align:center; color:#444; font-size:28px;"
-                    th:text="#{message.app.mail.temp.pwd}">
+                        th:style="'padding:38px 0 25px 0; text-align:center;' + ${defaultTpl ? 'color:#fff;': 'color:#444;'} + 'font-size:28px;'"
+                        th:text="#{message.app.mail.temp.pwd}">
                         Provide temporary password
                     </td>
                 </tr>
                 <tr>
                     <td style="font-size:13px; color:#444; line-height:20px; text-align:center;"
+                        th:style="'font-size:13px;' + ${defaultTpl ? 'color:#fff;': 'color:#444;'} + 'line-height:20px; text-align:center;'"
                         th:utext="#{message.app.mail.temp.pwd.self.msg}">
                         We have sent you a temporary password as shown below.<br />
                         Please be sure to reset your password after logging in.

--- a/discovery-server/src/main/resources/templates/api/email/user_reset_password.html
+++ b/discovery-server/src/main/resources/templates/api/email/user_reset_password.html
@@ -29,8 +29,7 @@
             <table style="width:100%;border-spacing:0px; border-collapse:separate;">
                 <tr>
                     <td style="padding:26px 0 0 33px;  vertical-align:top;">
-                        <!--<img src='/app/images/mail/icon_logo.png' th:src="${baseUrl} + '/app/images/mail/icon_logo.png'" />-->
-                        <img src='/assets/images/mail/icon_logo.png' th:src="${title} == 'DEURON' ? ${baseUrl} + '/assets/images/mail/icon_logo2.png' : ${baseUrl} + '/assets/images/mail/icon_logo.png'" />
+                        <img src='/assets/images/mail/icon_logo.png' th:src="${logoPath}" />
                     </td>
                 </tr>
                 <tr>
@@ -104,25 +103,12 @@
                         Name
                     </td>
                 </tr>
-                <tr>
-                    <th style="width:188px; padding:10px 13px; color:#444; font-size:13px; text-align:left; border-bottom:1px solid #ddd; background-color:#f9f9f9; font-weight:normal;">
-                        Phone
-                    </th>
-                    <td style="padding:10px 13px; color:#444; font-size:13px; text-align:left; border-bottom:1px solid #ddd; " th:text="${user.tel}">
-                        Tel.
-                    </td>
-                </tr>
             </table>
         </td>
     </tr>
     <tr>
         <td style="padding:66px 0 70px 0; text-align:center;">
-            <a href="/app/user/login" th:href="${baseUrl}" style="display:inline-block; padding:10px 0; width:228px; border-radius:3px; background-color:#ff8b00; color:#fff; font-size:14px; text-decoration:none; text-align:center;" th:utext="#{message.app.mail.home(${title})}">Go to <span th:text="${title}">Metatron</span></a>
-        </td>
-    </tr>
-    <tr>
-        <td style="padding:44px 0 44px 0; background-color:#ddd; text-align:center; color:#707070; font-size:12px;">
-            COPYRIGHT © <span th:text="${title}">Metatron</span>. All Right Reserved.
+            <a href="/app/user/login" th:href="${serviceUrl}" style="display:inline-block; padding:10px 0; width:300px; border-radius:3px; background-color:#ff8b00; color:#fff; font-size:14px; text-decoration:none; text-align:center;" th:utext="#{message.app.mail.home(${title})}">Go to <span th:text="${title}">Metatron</span></a>
         </td>
     </tr>
 

--- a/discovery-server/src/main/resources/templates/api/email/user_reset_password.html
+++ b/discovery-server/src/main/resources/templates/api/email/user_reset_password.html
@@ -33,13 +33,13 @@
                     </td>
                 </tr>
                 <tr>
-                    <td style="padding:38px 0 25px 0; text-align:center; color:#fff; font-size:28px;"
+                    <td style="padding:38px 0 25px 0; text-align:center; color:#444; font-size:28px;"
                     th:text="#{message.app.mail.temp.pwd}">
                         Provide temporary password
                     </td>
                 </tr>
                 <tr>
-                    <td style="font-size:13px; color:#fff; line-height:20px; text-align:center;"
+                    <td style="font-size:13px; color:#444; line-height:20px; text-align:center;"
                         th:utext="#{message.app.mail.temp.pwd.self.msg}">
                         We have sent you a temporary password as shown below.<br />
                         Please be sure to reset your password after logging in.

--- a/discovery-server/src/main/resources/templates/api/email/user_reset_password.html
+++ b/discovery-server/src/main/resources/templates/api/email/user_reset_password.html
@@ -24,7 +24,7 @@
 <table style="width:780px; margin:auto; line-height:1em;border-spacing:0px; border-collapse:separate;">
     <tr>
         <td style="height:220px; background:url('/assets/images/mail/bg_header.png') no-repeat; background-size:100% 100%;  vertical-align:top;"
-            th:style="'height:220px;' + ${defaultTpl ? 'background:url(''/assets/images/mail/bg_header.png'') no-repeat;' : ''} + ' background-size:100% 100%; vertical-align:top;'">
+            th:style="'height:220px;' + ${defaultTpl ? 'background:url(''' + baseUrl + '/assets/images/mail/bg_header.png'') no-repeat;' : ''} + ' background-size:100% 100%; vertical-align:top;'">
             <!-- header -->
             <table style="width:100%;border-spacing:0px; border-collapse:separate;">
                 <tr>

--- a/discovery-server/src/main/resources/templates/api/email/user_reset_password.html
+++ b/discovery-server/src/main/resources/templates/api/email/user_reset_password.html
@@ -24,7 +24,7 @@
 <table style="width:780px; margin:auto; line-height:1em;border-spacing:0px; border-collapse:separate;">
     <tr>
         <td style="height:220px; background:url('/assets/images/mail/bg_header.png') no-repeat; background-size:100% 100%;  vertical-align:top;"
-            th:style="'height:220px; background:url(' + ${baseUrl} + '/assets/images/mail/bg_header.png) no-repeat; background-size:100% 100%;  vertical-align:top;'">
+            th:style="'height:220px; background-size:100% 100%;  vertical-align:top;'">
             <!-- header -->
             <table style="width:100%;border-spacing:0px; border-collapse:separate;">
                 <tr>

--- a/discovery-server/src/main/resources/templates/api/email/user_reset_password_by_admin.html
+++ b/discovery-server/src/main/resources/templates/api/email/user_reset_password_by_admin.html
@@ -24,7 +24,7 @@
     <table style="width:780px; margin:auto; line-height:1em;border-spacing:0px; border-collapse:separate;">
         <tr>
             <td style="height:220px; background:url('/assets/images/mail/bg_header.png') no-repeat; background-size:100% 100%;  vertical-align:top;"
-                th:style="'height:220px; background:url(' + ${baseUrl} + '/assets/images/mail/bg_header.png) no-repeat; background-size:100% 100%;  vertical-align:top;'">
+                th:style="'height:220px; background-size:100% 100%; vertical-align:top;'">
                 <!-- header -->
                 <table style="width:100%;border-spacing:0px; border-collapse:separate;">
                     <tr>

--- a/discovery-server/src/main/resources/templates/api/email/user_reset_password_by_admin.html
+++ b/discovery-server/src/main/resources/templates/api/email/user_reset_password_by_admin.html
@@ -24,7 +24,7 @@
     <table style="width:780px; margin:auto; line-height:1em;border-spacing:0px; border-collapse:separate;">
         <tr>
             <td style="height:220px; background:url('/assets/images/mail/bg_header.png') no-repeat; background-size:100% 100%;  vertical-align:top;"
-                th:style="'height:220px; background-size:100% 100%; vertical-align:top;'">
+                th:style="'height:220px;' + ${defaultTpl ? 'background:url(''/assets/images/mail/bg_header.png'') no-repeat;' : ''} + ' background-size:100% 100%; vertical-align:top;'">
                 <!-- header -->
                 <table style="width:100%;border-spacing:0px; border-collapse:separate;">
                     <tr>
@@ -34,13 +34,15 @@
                     </tr>
                     <tr>
                         <td style="padding:38px 0 25px 0; text-align:center; color:#444; font-size:28px;"
-                        th:text="#{message.app.mail.temp.pwd.title}">
+                            th:style="'padding:38px 0 25px 0; text-align:center;' + ${defaultTpl ? 'color:#fff;': 'color:#444;'} + 'font-size:28px;'"
+                            th:text="#{message.app.mail.temp.pwd.title}">
                             Provide temporary password
                         </td>
                     </tr>
                     <tr>
                         <td style="font-size:13px; color:#444; line-height:20px; text-align:center;"
-                        th:utext="#{message.app.mail.temp.pwd.msg}">
+                            th:style="'font-size:13px;' + ${defaultTpl ? 'color:#fff;': 'color:#444;'} + 'line-height:20px; text-align:center;'"
+                            th:utext="#{message.app.mail.temp.pwd.msg}">
                             The system administrator has reset the password.<br />
                             Please check your temporary password below and be sure to reset your password after login.
                         </td>

--- a/discovery-server/src/main/resources/templates/api/email/user_reset_password_by_admin.html
+++ b/discovery-server/src/main/resources/templates/api/email/user_reset_password_by_admin.html
@@ -33,13 +33,13 @@
                         </td>
                     </tr>
                     <tr>
-                        <td style="padding:38px 0 25px 0; text-align:center; color:#fff; font-size:28px;"
+                        <td style="padding:38px 0 25px 0; text-align:center; color:#444; font-size:28px;"
                         th:text="#{message.app.mail.temp.pwd.title}">
                             Provide temporary password
                         </td>
                     </tr>
                     <tr>
-                        <td style="font-size:13px; color:#fff; line-height:20px; text-align:center;"
+                        <td style="font-size:13px; color:#444; line-height:20px; text-align:center;"
                         th:utext="#{message.app.mail.temp.pwd.msg}">
                             The system administrator has reset the password.<br />
                             Please check your temporary password below and be sure to reset your password after login.

--- a/discovery-server/src/main/resources/templates/api/email/user_reset_password_by_admin.html
+++ b/discovery-server/src/main/resources/templates/api/email/user_reset_password_by_admin.html
@@ -24,7 +24,7 @@
     <table style="width:780px; margin:auto; line-height:1em;border-spacing:0px; border-collapse:separate;">
         <tr>
             <td style="height:220px; background:url('/assets/images/mail/bg_header.png') no-repeat; background-size:100% 100%;  vertical-align:top;"
-                th:style="'height:220px;' + ${defaultTpl ? 'background:url(''/assets/images/mail/bg_header.png'') no-repeat;' : ''} + ' background-size:100% 100%; vertical-align:top;'">
+                th:style="'height:220px;' + ${defaultTpl ? 'background:url(''' + baseUrl + '/assets/images/mail/bg_header.png'') no-repeat;' : ''} + ' background-size:100% 100%; vertical-align:top;'">
                 <!-- header -->
                 <table style="width:100%;border-spacing:0px; border-collapse:separate;">
                     <tr>

--- a/discovery-server/src/main/resources/templates/api/email/user_reset_password_by_admin.html
+++ b/discovery-server/src/main/resources/templates/api/email/user_reset_password_by_admin.html
@@ -29,8 +29,7 @@
                 <table style="width:100%;border-spacing:0px; border-collapse:separate;">
                     <tr>
                         <td style="padding:26px 0 0 33px;  vertical-align:top;">
-                            <!--<img src='/app/images/mail/icon_logo.png' th:src="${baseUrl} + '/app/images/mail/icon_logo.png'" />-->
-                            <img src='/assets/images/mail/icon_logo.png' th:src="${title} == 'DEURON' ? ${baseUrl} + '/assets/images/mail/icon_logo2.png' : ${baseUrl} + '/assets/images/mail/icon_logo.png'" />
+                            <img src='/assets/images/mail/icon_logo.png' th:src="${logoPath}" />
                         </td>
                     </tr>
                     <tr>
@@ -110,26 +109,12 @@
                             Name
                         </td>
                     </tr>
-                    <tr>
-                        <th style="width:188px; padding:10px 13px; color:#444; font-size:13px; text-align:left; border-bottom:1px solid #ddd; background-color:#f9f9f9; font-weight:normal;"
-                        th:text="#{message.app.mail.phone}">
-                            Phone
-                        </th>
-                        <td style="padding:10px 13px; color:#444; font-size:13px; text-align:left; border-bottom:1px solid #ddd; " th:text="${user.tel}">
-                            Tel.
-                        </td>
-                    </tr>
                 </table>
             </td>
         </tr>
         <tr>
             <td style="padding:66px 0 70px 0; text-align:center;">
-                <a href="/app/user/login" th:href="${baseUrl}" style="display:inline-block; padding:10px 0; width:228px; border-radius:3px; background-color:#ff8b00; color:#fff; font-size:14px; text-decoration:none; text-align:center;" th:utext="#{message.app.mail.home(${title})}">Go to <span th:text="${title}">Metatron</span></a>
-            </td>
-        </tr>
-        <tr>
-            <td style="padding:44px 0 44px 0; background-color:#ddd; text-align:center; color:#707070; font-size:12px;">
-                COPYRIGHT © <span th:text="${title}">Metatron</span>. All Right Reserved.
+                <a href="/app/user/login" th:href="${serviceUrl}" style="display:inline-block; padding:10px 0; width:300px; border-radius:3px; background-color:#ff8b00; color:#fff; font-size:14px; text-decoration:none; text-align:center;" th:utext="#{message.app.mail.home(${title})}">Go to <span th:text="${title}">Metatron</span></a>
             </td>
         </tr>
 

--- a/discovery-server/src/main/resources/templates/api/email/user_signup_approved.html
+++ b/discovery-server/src/main/resources/templates/api/email/user_signup_approved.html
@@ -100,12 +100,7 @@
     </tr>
     <tr>
         <td style="padding:66px 0 70px 0; text-align:center;">
-            <a href="/app/user/login" th:href="${baseUrl}" style="display:inline-block; padding:10px 0; width:228px; border-radius:3px; background-color:#ff8b00; color:#fff; font-size:14px; text-decoration:none; text-align:center;" th:utext="#{message.app.mail.home(${title})}">Go to <span th:text="${title}">Metatron</span></a>
-        </td>
-    </tr>
-    <tr>
-        <td style="padding:44px 0 44px 0; background-color:#ddd; text-align:center; color:#707070; font-size:12px;">
-            COPYRIGHT © <span th:text="${title}">Metatron</span>. All Right Reserved.
+            <a href="/app/user/login" th:href="${baseUrl}" style="display:inline-block; padding:10px 0; width:300px; border-radius:3px; background-color:#ff8b00; color:#fff; font-size:14px; text-decoration:none; text-align:center;" th:utext="#{message.app.mail.home(${title})}">Go to <span th:text="${title}">Metatron</span></a>
         </td>
     </tr>
 

--- a/discovery-server/src/main/resources/templates/api/email/user_signup_approved_by_admin.html
+++ b/discovery-server/src/main/resources/templates/api/email/user_signup_approved_by_admin.html
@@ -123,15 +123,9 @@
     </tr>
     <tr>
         <td style="padding:66px 0 70px 0; text-align:center;">
-            <a href="/app/user/login" th:href="${baseUrl}" style="display:inline-block; padding:10px 0; width:228px; border-radius:3px; background-color:#ff8b00; color:#fff; font-size:14px; text-decoration:none; text-align:center;" th:utext="#{message.app.mail.home(${title})}">Go to <span th:text="${title}">Metatron</span></a>
+            <a href="/app/user/login" th:href="${baseUrl}" style="display:inline-block; padding:10px 0; width:300px; border-radius:3px; background-color:#ff8b00; color:#fff; font-size:14px; text-decoration:none; text-align:center;" th:utext="#{message.app.mail.home(${title})}">Go to <span th:text="${title}">Metatron</span></a>
         </td>
     </tr>
-    <tr>
-        <td style="padding:44px 0 44px 0; background-color:#ddd; text-align:center; color:#707070; font-size:12px;">
-            COPYRIGHT © <span th:text="${title}">Metatron</span>. All Right Reserved.
-        </td>
-    </tr>
-
 </table>
 </body>
 </html>

--- a/discovery-server/src/main/resources/templates/api/email/user_signup_denied.html
+++ b/discovery-server/src/main/resources/templates/api/email/user_signup_denied.html
@@ -118,15 +118,9 @@
         </tr>
         <tr>
             <td style="padding:66px 0 70px 0; text-align:center;">
-                <a href="/app/user/login" th:href="${baseUrl}" style="display:inline-block; padding:10px 0; width:228px; border-radius:3px; background-color:#ff8b00; color:#fff; font-size:14px; text-decoration:none; text-align:center;" th:utext="#{message.app.mail.home(${title})}">Go to <span th:text="${title}">Metatron</span></a>
+                <a href="/app/user/login" th:href="${baseUrl}" style="display:inline-block; padding:10px 0; width:300px; border-radius:3px; background-color:#ff8b00; color:#fff; font-size:14px; text-decoration:none; text-align:center;" th:utext="#{message.app.mail.home(${title})}">Go to <span th:text="${title}">Metatron</span></a>
             </td>
         </tr>
-        <tr>
-            <td style="padding:44px 0 44px 0; background-color:#ddd; text-align:center; color:#707070; font-size:12px;">
-                COPYRIGHT © <span th:text="${title}">Metatron</span>. All Right Reserved.
-            </td>
-        </tr>
-
     </table>
 </body>
 </html>

--- a/discovery-server/src/main/resources/templates/api/email/user_signup_request.html
+++ b/discovery-server/src/main/resources/templates/api/email/user_signup_request.html
@@ -100,15 +100,9 @@
         </tr>
         <tr>
             <td style="padding:66px 0 70px 0; text-align:center;">
-                <a href="/app/user/login" th:href="${baseUrl}" style="display:inline-block; padding:10px 0; width:228px; border-radius:3px; background-color:#ff8b00; color:#fff; font-size:14px; text-decoration:none; text-align:center;" th:utext="#{message.app.mail.home(${title})}">Go to <span th:text="${title}">Metatron</span></a>
+                <a href="/app/user/login" th:href="${baseUrl}" style="display:inline-block; padding:10px 0; width:300px; border-radius:3px; background-color:#ff8b00; color:#fff; font-size:14px; text-decoration:none; text-align:center;" th:utext="#{message.app.mail.home(${title})}">Go to <span th:text="${title}">Metatron</span></a>
             </td>
         </tr>
-        <tr>
-            <td style="padding:44px 0 44px 0; background-color:#ddd; text-align:center; color:#707070; font-size:12px;">
-                COPYRIGHT © <span th:text="${title}">Metatron</span>. All Right Reserved.
-            </td>
-        </tr>
-
     </table>
 </body>
 </html>

--- a/discovery-server/src/main/resources/templates/api/oauth/reset-password.html
+++ b/discovery-server/src/main/resources/templates/api/oauth/reset-password.html
@@ -95,6 +95,15 @@
             }
         }   // func - setStatusInputForm
 
+        function getParameterByName(name) {
+            name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
+            const regex = new RegExp("[\\?&]" + name + "=([^&#]*)");
+            const results = regex.exec(location.search);
+
+            return results == null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "));
+        }
+
+
         function validation() {
 
             const emailReg = /^(\'.*\'|[A-Za-z0-9_-]([A-Za-z0-9_-]|[\+\.])*)@(\[\d{1,3}(\.\d{1,3}){3}]|[A-Za-z0-9][A-Za-z0-9_-]*(\.[A-Za-z0-9][A-Za-z0-9_-]*)+)$/;
@@ -161,7 +170,8 @@
                     url: '/api/users/password/reset',
                     contentType: "application/json; charset=utf-8",
                     data: JSON.stringify({
-                        email: $inputEmail.val()
+                        email: $inputEmail.val(),
+                        clientId: getParameterByName('client_id')
                     }),
                     success: function () {
                         alert('[(#{message.app.oauth.alert.reset.passwd.email.success})]');

--- a/discovery-server/src/test/java/app/metatron/discovery/common/MailerTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/common/MailerTest.java
@@ -35,6 +35,8 @@ public class MailerTest extends AbstractIntegrationTest {
     String mailTo = "kyungtaak@gmail.com";
 
     mailer.sendEmail(Lists.newArrayList(mailTo), "test subject", "test content", false, false);
+
+    Thread.sleep(5000);
   }
 
 }

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/user/UserRestIntegrationTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/user/UserRestIntegrationTest.java
@@ -142,7 +142,7 @@ public class UserRestIntegrationTest extends AbstractRestIntegrationTest {
   @Test
   @OAuthRequest(username = "polaris", value = {"SYSTEM_USER"})
   @Sql("/sql/test_mail_user.sql")
-  public void resetPassword() {
+  public void resetPassword() throws InterruptedException {
 
     Map<String, Object> reqMap = Maps.newHashMap();
     reqMap.put("email" , testEmail);
@@ -159,6 +159,8 @@ public class UserRestIntegrationTest extends AbstractRestIntegrationTest {
       .statusCode(HttpStatus.SC_NO_CONTENT)
       .log().all();
     // @formatter:on
+
+    Thread.sleep(5000);
   }
 
   /**


### PR DESCRIPTION
### Description

Discovery 기반 서비스 운영시 인증 기능에서 전달하는 패스워드 초기화 관련 메일 내용에 대해 개선이 필요하여 아래와 같이 수정해 보았습니다.

_When operating a Discovery-based service, I need to improve the password initialization related email delivered by the authentication function, so I modified it as follows._

→ 메일 내용 내 Copyright 문구 제거 (전체 메일 템플릿 대상)
- Copyright 를 이메일 전달시까지 표시하는것은 무의미하다고 판단되었습니다. 관련하여 각 서비스가 discovery의 인증기능을 활용하는 경우, 각 서비스별 메일 템플릿용 Copyright 문구를 관리해야하는 부담이 있고, 정보를 제공하는 이메일에 Copyright 정보가 필요할지도 의문이 들어 제거하는것으로 제안 드립니다. 

→ _Remove the Copyright phrase in the mail content (for all mail templates)_
- _I thought that it was meaningless to display the copyright in the email content. In relation to this, if each service utilizes the authentication function of discovery, there is a burden to manage the copyright statement for each service's mail template._

→ 비밀 번호 초기화 메일 제목 리소스 번들 적용 
- 메일 제목이 리소스 번들 적용이 되어 있지 않아 적용하였습니다. 

→ _Apply the resource bundle to the subject of the password reset mail_
- _The mail subject was applied because the resource bundle was not applied._


→ 비밀 번호 초기화 메일 템플릿 수정 
- 전화 번호 정보 항목 제거 : 개인정보 이슈 및 외부 로그인 페이지내 가입 페이지에는 전화번호 항목이 존재하지 않아, 일관성 측며에서 정보를 전달하지 않는게 좋을것 같습니다. 
- Client 정보(additionalInformation)를 토대로 정보 구성  : 각 서비스 클라이언트의 정보를 토대로 데이터를 조정하도록 수정하였습니다. 
  > clientName -> title
  > logoFilePath -> logoPath
  > clientBaseUrl -> go to service

→ _Modify password reset mail template_
- _Removal of phone number information: Personal information issues and phone number entries do not exist on the sign-up page in the external login page, so it would be better not to deliver information in terms of consistency._
- _Information configuration based on client information (additionalInformation): Modified to adjust data based on the information of each service client._
  > clientName -> title
  > logoFilePath -> logoPath
  > clientBaseUrl -> go to service_


**Related Issue** : N/A

### How Has This Been Tested?

- 연계할 SMTP 정보, discovery 설정 파일내 기입하여 가동합니다.
  _Prepare SMTP information, write it in the discovery configuration file, and start it._
```
polaris.mail.admin=<administrator email address>
polaris.mail.baseUrl=<Discovery url, ex. https://dev-login.metatron.app>
spring.mail.host=<smtp address>
spring.mail.port=<smtp port>
spring.mail.username=<smtp username>
spring.mail.password=<smtp password>
```
- 인증기능과 연동하는 서비스 정보를 클라이언트내 저장합니다.
  _The service information linked with the authentication function is stored in the client._
```
curl --location --request POST 'https://dev-login.metatron.app/api/oauth/{clientId}' \
--header 'Content-Type: application/json' \
--data-raw '{
    "clientName": "metatron Grandview",
    "logoFilePath": "/static/grandview.png",
    "clientBaseUrl": "https://dev-gview.metatron.app"
}'
```
- 실제 유효한 이메일 주소를 가진 테스트 사용자 등록합니다.
  _Register as a test user with a real valid email address._
- 내부 개발서버를 활용하여, SMTP 및 "polaris_trusted" 클라이언트 정보 저장후, 아래와 같이 외부 로그인 페이지를 호출하여 테스트를 수행합니다. ex) https://dev-login.metatron.app/oauth/authorize?response_type=code&client_id=polaris_trusted&redirect_uri=https%3A%2F%2Fdev-gview.metatron.app%2Fapi%2Foauth%2Flogin&scope=read%20write&state=/app/index.html
  _Using the internal development server, after storing SMTP and "polaris_trusted" client information, the test is performed by calling the external login page as shown below._

#### Need additional checks?

- 외부 로그인 페이지 외 기본 로그인 화면에서 패스워드 재설정 메일은 기본 이메일 템플릿으로 전송합니다. ex) https://dev-login.metatron.app/

- _In case of password reset email from the default login screen other than the external login page, it is sent to the default email template._

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
