### PR TITLE
fix discarding null values ​​in timestamp field

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/AbstractSpecBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/AbstractSpecBuilder.java
@@ -41,6 +41,7 @@ import app.metatron.discovery.domain.datasource.ingestion.file.JsonFileFormat;
 import app.metatron.discovery.domain.datasource.ingestion.file.OrcFileFormat;
 import app.metatron.discovery.domain.datasource.ingestion.file.ParquetFileFormat;
 import app.metatron.discovery.domain.datasource.ingestion.jdbc.BatchIngestionInfo;
+import app.metatron.discovery.domain.datasource.ingestion.rule.DiscardNullRule;
 import app.metatron.discovery.domain.datasource.ingestion.rule.EvaluationRule;
 import app.metatron.discovery.domain.datasource.ingestion.rule.IngestionRule;
 import app.metatron.discovery.domain.datasource.ingestion.rule.ReplaceNullRule;
@@ -244,6 +245,8 @@ public class AbstractSpecBuilder {
           throw new DataSourceIngestionException("[Building Spec] : The datetime format does not match the value to be replaced.", e);
         }
 
+      } else if (rule instanceof DiscardNullRule) {
+        timestampSpec.setMissingValue(null);
       }
     }
 

--- a/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/AbstractSpecBuilder.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/spec/druid/ingestion/AbstractSpecBuilder.java
@@ -246,7 +246,7 @@ public class AbstractSpecBuilder {
         }
 
       } else if (rule instanceof DiscardNullRule) {
-        timestampSpec.setMissingValue(null);
+        timestampSpec.setReplaceWrongColumn(false);
       }
     }
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Fix discarding null values ​​in timestamp field

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Prepare source data that contains null values ​​in the timestamp field.
2. Set it as Time-type column, and select Discard as the Missing setting.
3. Ingestion, and check whether data containing null values ​​are excluded.


#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
