### PR TITLE
fix grid chart data csv download with double quotes

### DIFF
--- a/discovery-frontend/src/app/common/component/grid/grid.component.ts
+++ b/discovery-frontend/src/app/common/component/grid/grid.component.ts
@@ -187,7 +187,13 @@ export class GridComponent implements AfterViewInit, OnDestroy {
           // } else {
           //   obj.push(column[headerName]);
           // }
-          obj.push('"' + column[headerName] + '"');
+          let value = column[headerName];
+          if (typeof value === 'string') {
+            if (value.indexOf("\"") > -1) {
+              value = value.replace(/\"/g, "\"\"");
+            }
+          }
+          obj.push('"' + value + '"');
         });
         rows.push(obj.join(','));
       });


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
fix grid chart data excel download with double quotes

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Create a grid chart with double quote data.
2. Click Download csv.
3. Check that the csv looks fine in Excel.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
