### PR TITLE
#4044 fix map position when filters are changed

### DIFF
--- a/discovery-frontend/src/app/common/component/chart/type/map-chart/map-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/map-chart/map-chart.component.ts
@@ -923,12 +923,13 @@ export class MapChartComponent extends BaseChart<UIMapOption> implements AfterVi
     }
     this.changeDetect.detectChanges();
 
-    const overlayLayerId: string = 'layerId' + (layerIndex + 1);
+    if( -1 < 'Infinity'.indexOf(source.getExtent()[0]) ) {
+      this.setUiExtent(this.olmap);
+    }
 
     // Map data place fit
-    if (((this.drawByType === EventType.CHART_TYPE || this.olmap.getOverlayById(overlayLayerId) == null)
-      && isLogicalType
-      && this.shelf.layers[layerIndex].fields[this.shelf.layers[layerIndex].fields.length - 1].field.logicalType != null) && 'Infinity'.indexOf(source.getExtent()[0]) === -1
+    if (( isLogicalType && this.shelf.layers[layerIndex].fields[this.shelf.layers[layerIndex].fields.length - 1].field.logicalType != null)
+      && 'Infinity'.indexOf(source.getExtent()[0]) === -1
       && (_.isUndefined(this.uiOption['layers'][layerIndex]['changeCoverage']) || this.uiOption['layers'][layerIndex]['changeCoverage'])) {
       this.olmap.getView().fit(source.getExtent());
     } else {
@@ -938,6 +939,7 @@ export class MapChartComponent extends BaseChart<UIMapOption> implements AfterVi
         this.olmap.getView().setZoom(this.uiOption.chartZooms[0].count);
       }
     }
+
   }
 
   /**
@@ -2822,7 +2824,7 @@ export class MapChartComponent extends BaseChart<UIMapOption> implements AfterVi
 
     if ((_.isUndefined(mapUIOption.lowerCorner) && _.isUndefined(mapUIOption.upperCorner)) || that.preZoomSize === 0 || that.isResize) {
       this.preZoomSize = mapUIOption.zoomSize;
-      this.setUiExtent(event);
+      this.setUiExtentByEvent(event);
       this.isResize = false;
       return;
     }
@@ -2844,7 +2846,7 @@ export class MapChartComponent extends BaseChart<UIMapOption> implements AfterVi
       });
 
       // map ui lat, lng
-      this.setUiExtent(event);
+      this.setUiExtentByEvent(event);
       if (mapUIOption.upperCorner.indexOf('NaN') !== -1 || mapUIOption.lowerCorner.indexOf('NaN') !== -1 || isAllChangeCoverage) {
         // coverage value reset
         mapUIOption.layers.forEach((layer) => {
@@ -3250,10 +3252,17 @@ export class MapChartComponent extends BaseChart<UIMapOption> implements AfterVi
   /**
    * current map ui lat, lng setting
    */
-  private setUiExtent(event) {
-    const mapUIOption = this.uiOption as UIMapOption;
+  private setUiExtentByEvent(event) {
     if (event) {
-      const map = event.map;
+      this.setUiExtent(event.map);
+    }
+  }
+
+  /**
+   * current map ui lat, lng setting
+   */
+  private setUiExtent(map) {
+      const mapUIOption = this.uiOption as UIMapOption;
       let mapExtent = map.getView().calculateExtent(map.getSize());
 
       // projection 값 체크
@@ -3272,7 +3281,6 @@ export class MapChartComponent extends BaseChart<UIMapOption> implements AfterVi
       // 좌측 하단
       mapUIOption.lowerCorner = this.wrapLon(bottomLeft[0]) + ' ' + bottomLeft[1];
       // mapUIOption.lowerCorner = mapExtent[0] + ' ' + bottomLeft[1];  // EPSG 4326 좌표
-    }
   }
 
   /**

--- a/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
+++ b/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
@@ -144,6 +144,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent<PageWidget>
   public parentWidget: Widget;
 
   public widgetConfiguration: PageWidgetConfiguration = new PageWidgetConfiguration();
+  public preWidgetConfiguration: PageWidgetConfiguration;
 
   public chartType: string;
 
@@ -1219,8 +1220,6 @@ export class PageWidgetComponent extends AbstractWidgetComponent<PageWidget>
    * @private
    */
   private _setWidget(widget: PageWidget) {
-
-    const prevWidget = _.cloneDeep(this.widget);
     this.widget = _.extend(new PageWidget(), widget) as PageWidget;
     this.widgetConfiguration = this.widget.configuration as PageWidgetConfiguration;
     this.chartType = this.widgetConfiguration.chart.type.toString();
@@ -1241,10 +1240,6 @@ export class PageWidgetComponent extends AbstractWidgetComponent<PageWidget>
 
       if (ChartType.MAP === (this.widget.configuration as PageWidgetConfiguration).chart.type) {
 
-        if (prevWidget.configuration.filters != this.widgetConfiguration.filters) {
-          this.widgetConfiguration.chart['lowerCorner'] = null;
-          this.widgetConfiguration.chart['upperCorner'] = null;
-        }
 
         if ('default' === this.widgetConfiguration.dataSource.type) {
           // Pivot 내 누락된 필드 정보 설정
@@ -1487,8 +1482,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent<PageWidget>
         targetDs = DashboardUtil.getDataSourceFromBoardDataSource(this.widget.dashBoard, boardConf.dataSource);
       }
 
-      if ((this.isNullOrUndefined(this.widgetConfiguration.chart['lowerCorner']) || 0 === this.widgetConfiguration.filters.length)
-        && targetDs.summary) {
+      if (this.isNullOrUndefined(this.widgetConfiguration.chart['lowerCorner']) && targetDs.summary) {
         this.widgetConfiguration.chart['lowerCorner'] = targetDs.summary['geoLowerCorner'];
         this.widgetConfiguration.chart['upperCorner'] = targetDs.summary['geoUpperCorner'];
       }

--- a/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
+++ b/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
@@ -1220,6 +1220,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent<PageWidget>
    */
   private _setWidget(widget: PageWidget) {
 
+    const prevWidget = _.cloneDeep(this.widget);
     this.widget = _.extend(new PageWidget(), widget) as PageWidget;
     this.widgetConfiguration = this.widget.configuration as PageWidgetConfiguration;
     this.chartType = this.widgetConfiguration.chart.type.toString();
@@ -1239,6 +1240,11 @@ export class PageWidgetComponent extends AbstractWidgetComponent<PageWidget>
       }
 
       if (ChartType.MAP === (this.widget.configuration as PageWidgetConfiguration).chart.type) {
+
+        if (prevWidget.configuration.filters != this.widgetConfiguration.filters) {
+          this.widgetConfiguration.chart['lowerCorner'] = null;
+          this.widgetConfiguration.chart['upperCorner'] = null;
+        }
 
         if ('default' === this.widgetConfiguration.dataSource.type) {
           // Pivot 내 누락된 필드 정보 설정
@@ -1481,7 +1487,8 @@ export class PageWidgetComponent extends AbstractWidgetComponent<PageWidget>
         targetDs = DashboardUtil.getDataSourceFromBoardDataSource(this.widget.dashBoard, boardConf.dataSource);
       }
 
-      if (this.isNullOrUndefined(this.widgetConfiguration.chart['lowerCorner']) && targetDs.summary) {
+      if ((this.isNullOrUndefined(this.widgetConfiguration.chart['lowerCorner']) || 0 === this.widgetConfiguration.filters.length)
+        && targetDs.summary) {
         this.widgetConfiguration.chart['lowerCorner'] = targetDs.summary['geoLowerCorner'];
         this.widgetConfiguration.chart['upperCorner'] = targetDs.summary['geoUpperCorner'];
       }

--- a/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
+++ b/discovery-frontend/src/app/dashboard/widgets/page-widget/page-widget.component.ts
@@ -1439,6 +1439,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent<PageWidget>
 
     // 현재 위젯에서 발생시킨 필터정보 제외처리
     const currentSelectionFilters: Filter[] = this.changeExternalFilterList(selectionFilters);
+    const isChangedSelectionFilter: boolean = this._currentSelectionFilterString !== JSON.stringify(currentSelectionFilters);
 
     // Hierarchy View 설정
     if (this.parentWidget) {
@@ -1482,9 +1483,16 @@ export class PageWidgetComponent extends AbstractWidgetComponent<PageWidget>
         targetDs = DashboardUtil.getDataSourceFromBoardDataSource(this.widget.dashBoard, boardConf.dataSource);
       }
 
-      if (this.isNullOrUndefined(this.widgetConfiguration.chart['lowerCorner']) && targetDs.summary) {
-        this.widgetConfiguration.chart['lowerCorner'] = targetDs.summary['geoLowerCorner'];
-        this.widgetConfiguration.chart['upperCorner'] = targetDs.summary['geoUpperCorner'];
+      if( null == selectionFilters || 0 === selectionFilters.length ) {
+        if (this.isNullOrUndefined(this.widgetConfiguration.chart['lowerCorner']) && targetDs.summary) {
+          this.widgetConfiguration.chart['lowerCorner'] = targetDs.summary['geoLowerCorner'];
+          this.widgetConfiguration.chart['upperCorner'] = targetDs.summary['geoUpperCorner'];
+        }
+      } else {
+        if( isChangedSelectionFilter ) {
+          this.widgetConfiguration.chart['lowerCorner'] = undefined;
+          this.widgetConfiguration.chart['upperCorner'] = undefined;
+        }
       }
     }
 
@@ -1611,8 +1619,7 @@ export class PageWidgetComponent extends AbstractWidgetComponent<PageWidget>
 
     // 차트 클리어 여부 판단
     const isClear: boolean = (this.chart && 'function' === typeof this.chart.clear
-      && (this._currentSelectionFilterString !== JSON.stringify(currentSelectionFilters)
-        || this._currentGlobalFilterString !== JSON.stringify(cloneGlobalFilters)));
+      && (isChangedSelectionFilter || this._currentGlobalFilterString !== JSON.stringify(cloneGlobalFilters)));
 
     // 필터 정보 저장
     this._currentSelectionFilters = currentSelectionFilters;

--- a/discovery-frontend/src/app/datasource/service/datasource.service.ts
+++ b/discovery-frontend/src/app/datasource/service/datasource.service.ts
@@ -54,7 +54,7 @@ import {Pivot} from '@domain/workbook/configurations/pivot';
 import {TimezoneService} from '../../data-storage/service/timezone.service';
 import {Shelf} from '@domain/workbook/configurations/shelf/shelf';
 import {RegExprFilter} from '@domain/workbook/configurations/filter/reg-expr-filter';
-// import {SpatialFilter} from '@domain/workbook/configurations/filter/spatial-filter';
+import {SpatialFilter} from '@domain/workbook/configurations/filter/spatial-filter';
 import {Criteria} from '@domain/datasource/criteria';
 import {TimeDateFilter} from '@domain/workbook/configurations/filter/time-date-filter';
 import {TimeListFilter} from '@domain/workbook/configurations/filter/time-list-filter';
@@ -742,17 +742,17 @@ export class DatasourceService extends AbstractService {
 
                 }
 
-                // if (!_.isUndefined(chart['lowerCorner']) && !_.isUndefined(chart['upperCorner'])
-                //   && chart['lowerCorner'].indexOf('NaN') === -1 && chart['upperCorner'].indexOf('NaN') === -1) {
-                //   const spatialFilter = new SpatialFilter();
-                //   spatialFilter.dataSource = query.shelf.layers[idx].ref;
-                //   // spatialFilter.ref = query.shelf.layers[idx].ref;
-                //   spatialFilter.field = layer.field.name;
-                //   // 최초 default 값 sales-geo 초기값으로 고정 (빈값일 경우 에러리턴)
-                //   spatialFilter.lowerCorner = chart['lowerCorner'];
-                //   spatialFilter.upperCorner = chart['upperCorner'];
-                //   query.filters.push(spatialFilter);
-                // }
+                if (!_.isUndefined(chart['lowerCorner']) && !_.isUndefined(chart['upperCorner'])
+                  && chart['lowerCorner'].indexOf('NaN') === -1 && chart['upperCorner'].indexOf('NaN') === -1) {
+                  const spatialFilter = new SpatialFilter();
+                  spatialFilter.dataSource = query.shelf.layers[idx].ref;
+                  // spatialFilter.ref = query.shelf.layers[idx].ref;
+                  spatialFilter.field = layer.field.name;
+                  // 최초 default 값 sales-geo 초기값으로 고정 (빈값일 경우 에러리턴)
+                  spatialFilter.lowerCorner = chart['lowerCorner'];
+                  spatialFilter.upperCorner = chart['upperCorner'];
+                  query.filters.push(spatialFilter);
+                }
 
               }
 

--- a/discovery-frontend/src/app/datasource/service/datasource.service.ts
+++ b/discovery-frontend/src/app/datasource/service/datasource.service.ts
@@ -54,7 +54,7 @@ import {Pivot} from '@domain/workbook/configurations/pivot';
 import {TimezoneService} from '../../data-storage/service/timezone.service';
 import {Shelf} from '@domain/workbook/configurations/shelf/shelf';
 import {RegExprFilter} from '@domain/workbook/configurations/filter/reg-expr-filter';
-import {SpatialFilter} from '@domain/workbook/configurations/filter/spatial-filter';
+// import {SpatialFilter} from '@domain/workbook/configurations/filter/spatial-filter';
 import {Criteria} from '@domain/datasource/criteria';
 import {TimeDateFilter} from '@domain/workbook/configurations/filter/time-date-filter';
 import {TimeListFilter} from '@domain/workbook/configurations/filter/time-list-filter';
@@ -742,17 +742,17 @@ export class DatasourceService extends AbstractService {
 
                 }
 
-                if (!_.isUndefined(chart['lowerCorner']) && !_.isUndefined(chart['upperCorner'])
-                  && chart['lowerCorner'].indexOf('NaN') === -1 && chart['upperCorner'].indexOf('NaN') === -1) {
-                  const spatialFilter = new SpatialFilter();
-                  spatialFilter.dataSource = query.shelf.layers[idx].ref;
-                  // spatialFilter.ref = query.shelf.layers[idx].ref;
-                  spatialFilter.field = layer.field.name;
-                  // 최초 default 값 sales-geo 초기값으로 고정 (빈값일 경우 에러리턴)
-                  spatialFilter.lowerCorner = chart['lowerCorner'];
-                  spatialFilter.upperCorner = chart['upperCorner'];
-                  query.filters.push(spatialFilter);
-                }
+                // if (!_.isUndefined(chart['lowerCorner']) && !_.isUndefined(chart['upperCorner'])
+                //   && chart['lowerCorner'].indexOf('NaN') === -1 && chart['upperCorner'].indexOf('NaN') === -1) {
+                //   const spatialFilter = new SpatialFilter();
+                //   spatialFilter.dataSource = query.shelf.layers[idx].ref;
+                //   // spatialFilter.ref = query.shelf.layers[idx].ref;
+                //   spatialFilter.field = layer.field.name;
+                //   // 최초 default 값 sales-geo 초기값으로 고정 (빈값일 경우 에러리턴)
+                //   spatialFilter.lowerCorner = chart['lowerCorner'];
+                //   spatialFilter.upperCorner = chart['upperCorner'];
+                //   query.filters.push(spatialFilter);
+                // }
 
               }
 

--- a/discovery-frontend/src/app/page/page.component.ts
+++ b/discovery-frontend/src/app/page/page.component.ts
@@ -2284,6 +2284,15 @@ export class PageComponent extends AbstractPopupComponent implements OnInit, OnD
     // }
 
     if (filter.ui.widgetId) {
+      // 필터가 업데이트 됐을 때 서버가 조회해야할 map location 초기화
+      const comparedFilter = this.widgetConfiguration.filters.find(configFilter => configFilter.field === filter.field);
+
+      if(_.eq(this.selectChart, ChartType.MAP) &&
+        (this.isNullOrUndefined(comparedFilter) || comparedFilter['valueList'].toString() !== filter['valueList'].toString())) {
+        if(this.selectChart)
+        this.widgetConfiguration.chart['lowerCorner'] = undefined;
+        this.widgetConfiguration.chart['upperCorner'] = undefined;
+      }
       this._setChartFilter(filter, isSetPanel);   // 차트 필터 설정
     }
     this.drawChart({type: EventType.FILTER}); // 차트 다시그리기
@@ -2311,6 +2320,11 @@ export class PageComponent extends AbstractPopupComponent implements OnInit, OnD
         return;
       } else {
         this.widgetConfiguration.filters.splice(idx, 1);
+        // 필터가 제거 됐을 때 서버가 조회해야할 map location 초기화
+        if(_.eq(this.selectChart, ChartType.MAP)){
+          this.widgetConfiguration.chart['lowerCorner'] = undefined;
+          this.widgetConfiguration.chart['upperCorner'] = undefined;
+        }
       }
 
       // 이미 생성된 위젯인 경우만 제거(API)


### PR DESCRIPTION
### Description
If you remove the filter after limiting to the number of data, it will be fixed at the initial filtering position

**Related Issue** : #4044 <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
1. Create a map chart.
2. Apply filters to the chart and check the display coverage of the map.
3. Turn off the filter and check whether the display range of the map fits the data.

#### Need additional checks?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
