### PR TITLE
Fixed an error that did not draw when there are two map charts in the dashboard

### DIFF
--- a/discovery-frontend/src/app/common/component/chart/type/map-chart/map-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/map-chart/map-chart.component.ts
@@ -439,7 +439,7 @@ export class MapChartComponent extends BaseChart<UIMapOption> implements AfterVi
     ////////////////////////////////////////////////////////
 
     // 엘리먼트 반영
-    this.changeDetect.detectChanges();
+    this.safelyDetectChanges();
 
     // Show data
     this.data.show = true;
@@ -685,9 +685,15 @@ export class MapChartComponent extends BaseChart<UIMapOption> implements AfterVi
     ////////////////////////////////////////////////////////
     // Set attribution
     ////////////////////////////////////////////////////////
-    this.osmLayer.getSource().setAttributions(this.attribution());
-    this.cartoPositronLayer.getSource().setAttributions(this.attribution());
-    this.cartoDarkLayer.getSource().setAttributions(this.attribution());
+    if( this.osmLayer.getSource() ) {
+      this.osmLayer.getSource().setAttributions(this.attribution());
+    }
+    if( this.cartoPositronLayer.getSource() ) {
+      this.cartoPositronLayer.getSource().setAttributions(this.attribution());
+    }
+    if( this.cartoDarkLayer.getSource() ) {
+      this.cartoDarkLayer.getSource().setAttributions(this.attribution());
+    }
 
     ////////////////////////////////////////////////////////
     // Map style
@@ -921,7 +927,7 @@ export class MapChartComponent extends BaseChart<UIMapOption> implements AfterVi
         }
       }
     }
-    this.changeDetect.detectChanges();
+    this.safelyDetectChanges();
 
     const overlayLayerId: string = 'layerId' + (layerIndex + 1);
 
@@ -1889,7 +1895,7 @@ export class MapChartComponent extends BaseChart<UIMapOption> implements AfterVi
         && feature.getProperties()['layerNum'] === -5)) {
       // Disable tooltip
       this.tooltipInfo.enable = false;
-      this.changeDetect.detectChanges();
+      this.safelyDetectChanges();
       if (!_.isUndefined(this.tooltipLayer) && this.tooltipLayer.length > 0) {
         this.tooltipLayer.setPosition(undefined);
       }
@@ -3567,7 +3573,7 @@ export class MapChartComponent extends BaseChart<UIMapOption> implements AfterVi
         }
       }
     }
-    this.changeDetect.detectChanges();
+    this.safelyDetectChanges();
 
     // Map data place fit
     if (this.drawByType === EventType.CHANGE_PIVOT && 'Infinity'.indexOf(source.getExtent()[0]) === -1 &&
@@ -3659,6 +3665,6 @@ export class MapChartComponent extends BaseChart<UIMapOption> implements AfterVi
         this.layerMap[uiLayerIndex].layerValue = this.olmap.getLayers().getArray()[olmapForLoopLayerIndex];
       }
     }
-    this.changeDetect.detectChanges();
+    this.safelyDetectChanges();
   }
 }

--- a/discovery-frontend/src/app/datasource/service/datasource.service.ts
+++ b/discovery-frontend/src/app/datasource/service/datasource.service.ts
@@ -742,7 +742,7 @@ export class DatasourceService extends AbstractService {
 
                 }
 
-                if (!_.isUndefined(chart['lowerCorner']) && !_.isUndefined(chart['upperCorner'])
+                if (chart['lowerCorner'] && chart['upperCorner']
                   && chart['lowerCorner'].indexOf('NaN') === -1 && chart['upperCorner'].indexOf('NaN') === -1) {
                   const spatialFilter = new SpatialFilter();
                   spatialFilter.dataSource = query.shelf.layers[idx].ref;
@@ -796,7 +796,7 @@ export class DatasourceService extends AbstractService {
                 }
 
                 // when they have multiple geo values
-                if (geoFieldArr[idx] > 1) {
+                if (geoFieldArr[idx] > 1 && query.pivot.columns && query.pivot.columns[0]) {
                   layer.format = ({
                     type: FormatType.GEO_BOUNDARY.toString(),
                     geoColumn: query.pivot.columns[0].field.name,


### PR DESCRIPTION
### Description
There is an error where the dashboard is not displayed when there are more than 2 map charts in the dashboard.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
1. Create a dashboard.
2. Create and place two map charts within the dashboard.
3. Check if it is displayed normally on the browsing screen.

#### Need additional checks?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
