### PR TITLE
#4069 Add exclusion condition to save activity stream

### DIFF
--- a/discovery-server/src/main/asciidoc/application-config-guide.adoc
+++ b/discovery-server/src/main/asciidoc/application-config-guide.adoc
@@ -191,5 +191,10 @@ polaris:
     client-id: polaris_client                  # If you have a client ID for mobile service, you can specify it.
   mapbox:
     accesstoken:                          # mapbox accesstoken
+  activity_stream:
+    excludes:                             # exclusion conditions not to save activity stream, list of key/value object
+      -
+        action: ARRIVE                    # key : activity stream properties (action, actorId, remoteHost, objectId, etc..)
+        ...
 ----
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/activities/ActivityStream.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/activities/ActivityStream.java
@@ -271,6 +271,27 @@ public class ActivityStream implements MetatronDomain<Long> {
     this.orgCode = orgCode;
   }
 
+  @Override
+  public String toString() {
+    return "ActivityStream{" +
+            "id=" + id +
+            ", action=" + action +
+            ", actor='" + actor + '\'' +
+            ", actorType=" + actorType +
+            ", objectId='" + objectId + '\'' +
+            ", objectType=" + objectType +
+            ", objectContent='" + objectContent + '\'' +
+            ", targetId='" + targetId + '\'' +
+            ", targetType=" + targetType +
+            ", generatorType=" + generatorType +
+            ", generatorName='" + generatorName + '\'' +
+            ", publishedTime=" + publishedTime +
+            ", result='" + result + '\'' +
+            ", remoteHost='" + remoteHost + '\'' +
+            ", orgCode='" + orgCode + '\'' +
+            '}';
+  }
+
   public enum GeneratorType {
     UNKNOWN, WEBAPP, EXTENSIONS
   }

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/activities/ActivityStreamConfiguration.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/activities/ActivityStreamConfiguration.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.metatron.discovery.domain.activities;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+import java.util.Map;
+
+@Configuration
+@ConfigurationProperties(prefix = "polaris.activity_stream")
+public class ActivityStreamConfiguration {
+
+    List<Map<String, String>> excludes;
+
+    public ActivityStreamConfiguration() {
+    }
+
+    public void setExcludes(List<Map<String, String>> excludes) {
+        this.excludes = excludes;
+    }
+
+    public List<Map<String, String>> getExcludes() {
+        return excludes;
+    }
+}

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/activities/ActivityStreamService.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/activities/ActivityStreamService.java
@@ -131,7 +131,7 @@ public class ActivityStreamService {
       for (String key : excludesCondition.keySet()) {
         try {
           Object value = PropertyUtils.getProperty(activityStream, key);
-          judge = excludesCondition.get(key).equals(value == null ? null : value.toString()) ? true : false;
+          judge = excludesCondition.get(key).equals(value == null ? null : value.toString());
         } catch (Exception e) {
           judge = false;
         } finally {

--- a/discovery-server/src/main/resources/application.yaml
+++ b/discovery-server/src/main/resources/application.yaml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: local,h2-default-db,logging-console-debug,scheduling #, initial #, bcrypt-encoder, encode-password-initial, datasource-filter-sample
+    active: local,h2-default-db,logging-console-debug,scheduling, initial #, bcrypt-encoder, encode-password-initial, datasource-filter-sample
   application:
     name: ${METATRON_NAME:metatron}
   datasource:
@@ -378,6 +378,12 @@ polaris:
   mobile:
     resource-path: classpath:resource-mobile/
     client-id: polaris_client
+  activity_stream:
+    excludes:
+      -
+        action: ARRIVE
+        remoteHost: 0:0:0:0:0:0:0:1
+        objectId : polaris_trusted
 
 ---
 # (mysql DB 생성 script)

--- a/discovery-server/src/test/java/app/metatron/discovery/AbstractIntegrationTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/AbstractIntegrationTest.java
@@ -32,7 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = MetatronDiscoveryApplication.class)
 @WebAppConfiguration
-@ActiveProfiles({"local", "h2-in-memory-db", "logging-console-debug", "spark-local-standalone", "initial"})
+@ActiveProfiles({"local", "h2-in-memory-db", "logging-console-debug", "initial"})
 @Transactional
 public abstract class AbstractIntegrationTest {
   

--- a/discovery-server/src/test/java/app/metatron/discovery/domain/activities/ActivityStreamServiceTest.java
+++ b/discovery-server/src/test/java/app/metatron/discovery/domain/activities/ActivityStreamServiceTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.metatron.discovery.domain.activities;
+
+import app.metatron.discovery.AbstractIntegrationTest;
+import app.metatron.discovery.domain.activities.spec.ActivityType;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ActivityStreamServiceTest extends AbstractIntegrationTest {
+
+    @Autowired
+    ActivityStreamService activityStreamService;
+
+    @Test
+    public void match_value_by_exclude_conditions() {
+
+        ActivityStream testActivityStream1 = new ActivityStream();
+        testActivityStream1.setAction(ActivityType.ARRIVE);
+        testActivityStream1.setRemoteHost("0:0:0:0:0:0:0:1");
+        testActivityStream1.setObjectId("polaris_trusted");
+
+        Assert.assertTrue(activityStreamService.checkByExclusionConditions(testActivityStream1));
+
+        ActivityStream testActivityStream2 = new ActivityStream();
+        testActivityStream2.setAction(ActivityType.ARRIVE);
+        testActivityStream2.setRemoteHost("0:0:0:0:0:0:0:1");
+        testActivityStream2.setObjectId("test");
+
+        Assert.assertFalse(activityStreamService.checkByExclusionConditions(testActivityStream2));
+
+        ActivityStream testActivityStream3 = new ActivityStream();
+        testActivityStream3.setAction(ActivityType.ARRIVE);
+        testActivityStream3.setRemoteHost("0:0:0:0:0:0:0:1");
+        testActivityStream3.setObjectId(null);
+
+        Assert.assertFalse(activityStreamService.checkByExclusionConditions(testActivityStream3));
+    }
+}


### PR DESCRIPTION
### Description

At the time the Activity Stream is recorded, it is not saved by using the pre-given exception condition in configuration.

_Activity Stream 이 기록되는 시점에 미리 주어진 예외 설정을 활용하여 기록 되지 않도록 구성하였습니다._ 

**Related Issue** : #4069 


### How Has This Been Tested?

주어진 로컬 머신에서 테스트 한다고 가정합니다.

1. 주어진 로컬 설정 그대로 discovery server 를 가동합니다.  사전에 설정파일내 예외 조건이 걸려 있습니다.
```
polaris:
  activity_stream:
    excludes:
      -
        action: ARRIVE
        remoteHost: 0:0:0:0:0:0:0:1
        objectId : polaris_trusted
```

3. 아래와 같이 토큰 발급을 요청합니다. 
```
curl http://localhost:8180/oauth/token -d grant_type=password -d client_id=polaris_trusted -d client_secret=secret -d scope='read write' -d username=admin -d password=admin
```
4. 아래 예시 처럼 서버내 디버그 로그를 확인하여 실제 로컬 머신의 remoteHost 정보를 얻어 remoteHost 내 기입후 재시작 합니다.
```
2022-07-19 06:18:43.005 DEBUG [127.0.0.1-polaris_trusted] [http-nio-8180-exec-1] a.m.d.d.a.ActivityStreamService          : Add activity stream : ActivityStream{id=null, action=ARRIVE, actor='admin', actorType=PERSON, objectId='polaris_trusted', objectType=UNKNOWN, objectContent='{"requestURI":"/oauth/token","grantType":"password"}', targetId='null', targetType=null, generatorType=WEBAPP, generatorName='curl/7.79.1', publishedTime=2022-07-19T06:18:43.005Z, result='SUCCESS', remoteHost='127.0.0.1', orgCode='null'}
```
5.   3번 의 과정으로 토큰을 발급 받고 아래 URL 을 호출하여 토큰 발급 과정이 결과값이 없음을 확인합니다.
```
curl --location --request GET 'http://localhost:8180/api/activities' \
--header 'Authorization: Bearer {access token}' \
```

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
