### PR TITLE
Remove token cookie from oauth login process

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/common/web/OauthFilter.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/common/web/OauthFilter.java
@@ -67,6 +67,8 @@ public class OauthFilter implements Filter {
                   .authenticate(new PreAuthenticatedAuthenticationToken(loginToken.getValue(), ""));
           SecurityContextHolder.getContext().setAuthentication(authentication);
           LOGGER.info("authentication is {}", authentication);
+          // 자동로그인 방지
+          CookieManager.removeAllToken(res);
         } catch (OAuth2Exception e) {
           LOGGER.error(e.getSummary());
           req.getRequestDispatcher("/api/oauth/client/login").forward(request, response);


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
When logging out after oauth login, the token set in the cookie is removed to prevent re-login.

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
After logging in to the client through oauth login, when logging out, go back to the oauth login page and check if login is possible again.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
