### PR TITLE
Add line number column in grid chart

### DIFF
--- a/discovery-frontend/src/app/common/component/chart/option/ui-option/ui-grid-chart.ts
+++ b/discovery-frontend/src/app/common/component/chart/option/ui-option/ui-grid-chart.ts
@@ -62,6 +62,8 @@ export interface UIGridChart extends UIOption {
   // 부분 연산열
   subTotalColumnStyle?: TotalValueStyle;
 
+  rownum?: boolean;
+
   ////////////////////////////////////////////
   // UI 스펙
   ////////////////////////////////////////////

--- a/discovery-frontend/src/app/common/component/chart/type/grid-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/grid-chart.component.ts
@@ -620,6 +620,22 @@ export class GridChartComponent extends BaseChart<UIGridChart> implements OnInit
         }
       }
 
+      if(this.uiOption.rownum && this.uiOption.dataType === GridViewType.PIVOT) {
+        if( data.rows ) {
+          data.rows = data.rows.map( (row,idx) => row + '―' + idx );
+        }
+        if( data.columns ) {
+          data.columns.forEach( col => {
+            col.categoryName.map( (name,idx) => name + '―' + idx );
+            col.seriesName.map( (name,idx) => name + '―' + idx );
+          });
+        }
+
+        // Grid Model
+        ( this.gridModel.yProperties ) || ( this.gridModel.yProperties = [] );
+        this.gridModel.yProperties = this.gridModel.yProperties.concat([{name: 'No'}]);
+      }
+
       this.chart.initialize(data, this.gridModel);
     } catch (e) {
       console.log(e);

--- a/discovery-frontend/src/app/common/component/chart/type/grid-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/grid-chart.component.ts
@@ -620,21 +620,23 @@ export class GridChartComponent extends BaseChart<UIGridChart> implements OnInit
         }
       }
 
+      // 그리드 줄 번호 옵션에 의한 강제 줄 번호 추가 - S
       if(this.uiOption.rownum && this.uiOption.dataType === GridViewType.PIVOT) {
         if( data.rows ) {
-          data.rows = data.rows.map( (row,idx) => row + '―' + idx );
+          data.rows = data.rows.map( (row,idx) => ( idx + 1 ) + '―' + row );
         }
         if( data.columns ) {
           data.columns.forEach( col => {
-            col.categoryName.map( (name,idx) => name + '―' + idx );
-            col.seriesName.map( (name,idx) => name + '―' + idx );
+            col.categoryName.map( (name,idx) => ( idx + 1 ) + '―' + name );
+            col.seriesName.map( (name,idx) => ( idx + 1 ) + '―' + name );
           });
         }
 
         // Grid Model
         ( this.gridModel.yProperties ) || ( this.gridModel.yProperties = [] );
-        this.gridModel.yProperties = this.gridModel.yProperties.concat([{name: 'No'}]);
+        this.gridModel.yProperties = [{name: 'No'}].concat(this.gridModel.yProperties);
       }
+      // 그리드 줄 번호 옵션에 의한 강제 줄 번호 추가 - E
 
       this.chart.initialize(data, this.gridModel);
     } catch (e) {

--- a/discovery-frontend/src/app/common/component/chart/type/grid-chart.component.ts
+++ b/discovery-frontend/src/app/common/component/chart/type/grid-chart.component.ts
@@ -620,13 +620,14 @@ export class GridChartComponent extends BaseChart<UIGridChart> implements OnInit
         }
       }
 
-      // 그리드 줄 번호 옵션에 의한 강제 줄 번호 추가 - S
       if(this.uiOption.rownum && this.uiOption.dataType === GridViewType.PIVOT) {
-        if( data.rows ) {
-          data.rows = data.rows.map( (row,idx) => ( idx + 1 ) + '―' + row );
+        // 그리드 줄 번호 옵션에 의한 강제 줄 번호 추가 - S
+        const cloneData = JSON.parse(JSON.stringify(data));
+        if( cloneData.rows ) {
+          cloneData.rows = cloneData.rows.map( (row,idx) => ( idx + 1 ) + '―' + row );
         }
-        if( data.columns ) {
-          data.columns.forEach( col => {
+        if( cloneData.columns ) {
+          cloneData.columns.forEach( col => {
             col.categoryName.map( (name,idx) => ( idx + 1 ) + '―' + name );
             col.seriesName.map( (name,idx) => ( idx + 1 ) + '―' + name );
           });
@@ -635,10 +636,13 @@ export class GridChartComponent extends BaseChart<UIGridChart> implements OnInit
         // Grid Model
         ( this.gridModel.yProperties ) || ( this.gridModel.yProperties = [] );
         this.gridModel.yProperties = [{name: 'No'}].concat(this.gridModel.yProperties);
+        this.chart.initialize(cloneData, this.gridModel);
+        // 그리드 줄 번호 옵션에 의한 강제 줄 번호 추가 - E
+      } else {
+        this.chart.initialize(data, this.gridModel);
       }
-      // 그리드 줄 번호 옵션에 의한 강제 줄 번호 추가 - E
 
-      this.chart.initialize(data, this.gridModel);
+
     } catch (e) {
       console.log(e);
       // No Data 이벤트 발생

--- a/discovery-frontend/src/app/page/chart-style/common-option.component.html
+++ b/discovery-frontend/src/app/page/chart-style/common-option.component.html
@@ -392,6 +392,27 @@
           <!--  //divide -->
         </div>
         <!-- //wrap divide -->
+
+        <!-- wrap divide -->
+        <div class="ddp-wrap-divide">
+          <!--  divide -->
+          <div class="ddp-divide2">
+            <!-- slider -->
+            <div class="ddp-wrap-option-slider">
+              <span class="ddp-label-slider">{{'msg.page.common.grid.add.rownum' | translate}}</span>
+              <!-- Slide THREE -->
+              <div class="ddp-checkbox-slide ddp-checkbox-automatic2" (click)="addRowNum()">
+                <input type="checkbox" id="checkAnno" [ngModel]="uiOption['rownum']">
+                <label for="checkAnno"><span class="ddp-slide"></span></label>
+              </div>
+              <!-- //Slide THREE -->
+            </div>
+            <!-- //slider -->
+          </div>
+          <!--  //divide -->
+        </div>
+        <!-- //wrap divide -->
+
       </ng-container>
       <!--// [표] -->
 

--- a/discovery-frontend/src/app/page/chart-style/common-option.component.ts
+++ b/discovery-frontend/src/app/page/chart-style/common-option.component.ts
@@ -1485,6 +1485,20 @@ export class CommonOptionComponent extends BaseOptionComponent implements OnInit
   }
 
   /**
+   * 그리드 줄 번호 추가
+   */
+  public addRowNum(): void {
+    const uiOption = (this.uiOption as UIGridChart);
+
+    // rownum 설정 변경
+    uiOption.rownum = !uiOption.rownum;
+
+    this.uiOption = (_.extend({}, this.uiOption, {rownum: uiOption.rownum}) as UIOption);
+
+    this.update();
+  }
+
+  /**
    * grid - 설명 라벨 설정시
    */
   public changeRemarkLabel(param: Annotation): void {

--- a/discovery-frontend/src/assets/i18n/en.json
+++ b/discovery-frontend/src/assets/i18n/en.json
@@ -3655,6 +3655,7 @@
   "msg.page.common.font.color.default": "Default",
   "msg.page.common.symbol.transparency": "Symbol Transparency",
   "msg.page.common.grid.add.remark": "Add Remark",
+  "msg.page.common.grid.add.rownum": "Add row number",
   "msg.page.common.grid.enter.remark": "Remark",
   "msg.page.common.grid.enter.position": "Position",
   "msg.page.common.grid.enter.position.top.right": "Top-Right",

--- a/discovery-frontend/src/assets/i18n/ko.json
+++ b/discovery-frontend/src/assets/i18n/ko.json
@@ -3635,6 +3635,7 @@
   "msg.page.common.font.color.default": "기본",
   "msg.page.common.symbol.transparency": "기호 투명도",
   "msg.page.common.grid.add.remark": "설명 추가",
+  "msg.page.common.grid.add.rownum": "줄 번호 추가",
   "msg.page.common.grid.enter.remark": "설명 입력",
   "msg.page.common.grid.enter.position": "설명 위치",
   "msg.page.common.grid.enter.position.top.right": "상단 우측",

--- a/discovery-frontend/src/assets/i18n/ru.json
+++ b/discovery-frontend/src/assets/i18n/ru.json
@@ -3612,6 +3612,7 @@
     "msg.page.common.font.color.default": "По умолчанию",
     "msg.page.common.symbol.transparency": "Прозрачность символа",
     "msg.page.common.grid.add.remark": "Добавить замечание",
+    "msg.page.common.grid.add.rownum": "Добавить номер строки",
     "msg.page.common.grid.enter.remark": "Замечание",
     "msg.page.common.grid.enter.position": "Позиция",
     "msg.page.common.grid.enter.position.top.right": "Вверху справа",

--- a/discovery-frontend/src/assets/i18n/zh.json
+++ b/discovery-frontend/src/assets/i18n/zh.json
@@ -2782,6 +2782,7 @@
   "msg.page.common.font.color.default": "默认",
   "msg.page.common.symbol.transparency": "记号透明度",
   "msg.page.common.grid.add.remark": "添加说明",
+  "msg.page.common.grid.add.rownum": "添加行号",
   "msg.page.common.grid.enter.remark": "输入说明",
   "msg.page.common.grid.enter.position": "说明位置",
   "msg.page.common.grid.enter.position.top.right": "右上方",


### PR DESCRIPTION
### Description
Add line number column in grid chart

**Related Issue** : <!--- Please link to the issue here. -->
<!--- Metatron project only accepts pull requests related to open issues. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Create a grid chart.
2. In the chart options, turn on the option to add line numbers.
3. Check that line numbers are displayed normally.

#### Need additional checks?


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.

### Additional Context<!-- if not appropriate, remove this topic. -->
